### PR TITLE
fix: auto-reconnect WebSocket and show connection state

### DIFF
--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -35,9 +35,13 @@ export function ChatView() {
     searchParams.get('extraTools') ? 'auto' : 'agent',
   );
 
+  const [connected, setConnected] = useState(false);
+
   const wsRef = useRef<WebSocket | null>(null);
   const streamBuf = useRef('');
   const scrollRef = useRef<HTMLDivElement>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intentionalClose = useRef(false);
 
   const scrollToBottom = useCallback(() => {
     requestAnimationFrame(() => {
@@ -102,10 +106,14 @@ export function ChatView() {
       .catch(() => {});
   }, [sessionId, scrollToBottom]);
 
-  useEffect(() => {
+  const connectWs = useCallback(() => {
     const proto = location.protocol === 'https:' ? 'wss' : 'ws';
     const ws = new WebSocket(`${proto}://${location.host}/ws/chat`);
     wsRef.current = ws;
+
+    ws.onopen = () => {
+      setConnected(true);
+    };
 
     ws.onmessage = (event) => {
       const msg = JSON.parse(event.data);
@@ -193,19 +201,52 @@ export function ChatView() {
     };
 
     ws.onclose = () => {
+      setConnected(false);
       setRunning(false);
+      wsRef.current = null;
+
+      if (!intentionalClose.current) {
+        const delay = Math.min(2000 + Math.random() * 1000, 5000);
+        reconnectTimer.current = setTimeout(connectWs, delay);
+      }
     };
 
-    return () => {
+    ws.onerror = () => {
       ws.close();
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [finalizeStream, scrollToBottom]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    intentionalClose.current = false;
+    connectWs();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && !wsRef.current) {
+        connectWs();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      intentionalClose.current = true;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      wsRef.current?.close();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [connectWs]);
 
   const initialPrompt = searchParams.get('prompt') || undefined;
 
   function sendMessage(text: string, images?: ImageAttachment[]) {
     const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', text: '**Connection lost.** Reconnecting...' },
+      ]);
+      connectWs();
+      return;
+    }
 
     const previews = images?.map((img) => img.preview);
     setMessages((prev) => [...prev, { role: 'user', text, images: previews }]);
@@ -256,6 +297,11 @@ export function ChatView() {
         <button className="chat-header-back" onClick={() => navigate('/')}>
           &larr;
         </button>
+        {!connected && (
+          <span className="chat-header-offline" title="Reconnecting...">
+            !
+          </span>
+        )}
         <select
           className="chat-model-select"
           value={model}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -406,6 +406,31 @@ textarea:focus {
   color: #fff;
 }
 
+.chat-header-offline {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: var(--danger);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  animation: pulse-offline 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-offline {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
 .chat-header-stop {
   font-size: 0.8rem;
   padding: 0.35rem 0.75rem;


### PR DESCRIPTION
## Summary

Fixes the bug where messages sent after a WebSocket disconnect silently disappear. Common on mobile when the phone sleeps, Tailscale reconnects, or the tab is backgrounded.

- WebSocket auto-reconnects on disconnect with jittered backoff (2-5s)
- Reconnects immediately on `visibilitychange` (phone waking up)
- Pulsing red `!` indicator in the chat header when disconnected
- Sending on a dead connection shows "Connection lost. Reconnecting..." instead of silently failing
- Intentional navigation away skips reconnect (no zombie connections)

## Test plan

- [ ] Open chat, send a message, verify normal flow works
- [ ] Kill the server (`pkill -f tsx`), verify red indicator appears
- [ ] Restart server, verify indicator clears and chat resumes
- [ ] Lock phone for 30s, unlock, verify reconnect happens
- [ ] Try sending while disconnected — verify error message appears

Made with [Cursor](https://cursor.com)