### PR TITLE
feat: compact tool pill UI with auto-grouping

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Message } from '../pages/ChatView';
@@ -8,8 +7,6 @@ interface Props {
 }
 
 export function MessageBubble({ message }: Props) {
-  const [expanded, setExpanded] = useState(false);
-
   if (message.role === 'user') {
     return (
       <div className="msg-bubble msg-bubble--user">
@@ -21,35 +18,6 @@ export function MessageBubble({ message }: Props) {
           </div>
         )}
         {message.text && <div className="msg-bubble-content">{message.text}</div>}
-      </div>
-    );
-  }
-
-  if (message.role === 'tool') {
-    return (
-      <div className="msg-bubble msg-bubble--tool">
-        <button className="msg-tool-header" onClick={() => setExpanded((e) => !e)}>
-          <span className="msg-tool-name">{message.toolName}</span>
-          <span className="msg-tool-chevron">{expanded ? '▾' : '▸'}</span>
-        </button>
-        {expanded && (
-          <div className="msg-tool-detail">
-            <div className="msg-tool-section">
-              <span className="msg-tool-label">Input</span>
-              <pre className="msg-tool-pre">{message.toolInput}</pre>
-            </div>
-            {message.toolResult !== undefined && (
-              <div className="msg-tool-section">
-                <span className="msg-tool-label">Result</span>
-                <pre className="msg-tool-pre">{message.toolResult}</pre>
-              </div>
-            )}
-            {message.toolResult === undefined && <div className="msg-tool-running">Running...</div>}
-          </div>
-        )}
-        {!expanded && message.toolResult === undefined && (
-          <div className="msg-tool-running-inline">Running...</div>
-        )}
       </div>
     );
   }

--- a/frontend/src/components/ToolGroup.tsx
+++ b/frontend/src/components/ToolGroup.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { ToolPill } from './ToolPill';
+import type { Message } from '../pages/ChatView';
+
+interface Props {
+  tools: Message[];
+}
+
+export function ToolGroup({ tools }: Props) {
+  const allDone = tools.every((t) => t.toolResult !== undefined);
+  const [expanded, setExpanded] = useState(!allDone);
+
+  useEffect(() => {
+    if (allDone) setExpanded(false);
+  }, [allDone]);
+
+  const doneCount = tools.filter((t) => t.toolResult !== undefined).length;
+
+  return (
+    <div className="tool-group">
+      <button className="tool-group-header" onClick={() => setExpanded((e) => !e)}>
+        <div className="tool-group-dots">
+          {tools.map((t, i) => (
+            <span
+              key={i}
+              className={`tool-pill-dot ${t.toolResult !== undefined ? 'tool-pill-dot--done' : 'tool-pill-dot--pending'}`}
+            />
+          ))}
+        </div>
+        <span className="tool-group-label">
+          {allDone ? `${tools.length} tool calls` : `${doneCount}/${tools.length} running...`}
+        </span>
+        <span className="tool-group-chevron">{expanded ? '▾' : '▸'}</span>
+      </button>
+      {expanded && (
+        <div className="tool-group-list">
+          {tools.map((t, i) => (
+            <ToolPill key={t.toolId || i} message={t} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import type { Message } from '../pages/ChatView';
+
+interface Props {
+  message: Message;
+}
+
+export function ToolPill({ message }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const done = message.toolResult !== undefined;
+  const input = message.toolInput || '';
+  const truncatedInput = input.length > 60 ? input.slice(0, 60) + '...' : input;
+
+  return (
+    <div className={`tool-pill ${done ? 'tool-pill--done' : 'tool-pill--running'}`}>
+      <button className="tool-pill-header" onClick={() => setExpanded((e) => !e)}>
+        <span
+          className={`tool-pill-dot ${done ? 'tool-pill-dot--done' : 'tool-pill-dot--pending'}`}
+        />
+        <span className="tool-pill-name">{message.toolName}</span>
+        <span className="tool-pill-input">{truncatedInput}</span>
+        {!done && <span className="tool-pill-status">Running...</span>}
+        {expanded && <span className="tool-pill-chevron">▾</span>}
+      </button>
+      {expanded && (
+        <div className="tool-pill-detail">
+          <div className="tool-pill-section">
+            <span className="tool-pill-label">Input</span>
+            <pre className="tool-pill-pre">{input}</pre>
+          </div>
+          {done && (
+            <div className="tool-pill-section">
+              <span className="tool-pill-label">Result</span>
+              <pre className="tool-pill-pre">{message.toolResult}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { MessageBubble } from '../components/MessageBubble';
+import { ToolPill } from '../components/ToolPill';
+import { ToolGroup } from '../components/ToolGroup';
 import { PermissionBanner } from '../components/PermissionBanner';
 import { ChatInput, type ImageAttachment } from '../components/ChatInput';
 
@@ -13,6 +15,36 @@ export interface Message {
   toolInput?: string;
   toolResult?: string;
   streaming?: boolean;
+}
+
+type GroupedItem = { type: 'message'; message: Message } | { type: 'tool-group'; tools: Message[] };
+
+function groupMessages(messages: Message[]): GroupedItem[] {
+  const result: GroupedItem[] = [];
+  let toolBuffer: Message[] = [];
+
+  function flushTools() {
+    if (toolBuffer.length === 0) return;
+    if (toolBuffer.length >= 3) {
+      result.push({ type: 'tool-group', tools: toolBuffer });
+    } else {
+      for (const t of toolBuffer) {
+        result.push({ type: 'message', message: t });
+      }
+    }
+    toolBuffer = [];
+  }
+
+  for (const msg of messages) {
+    if (msg.role === 'tool') {
+      toolBuffer.push(msg);
+    } else {
+      flushTools();
+      result.push({ type: 'message', message: msg });
+    }
+  }
+  flushTools();
+  return result;
 }
 
 interface PermissionRequest {
@@ -291,6 +323,8 @@ export function ChatView() {
     }
   }
 
+  const grouped = useMemo(() => groupMessages(messages), [messages]);
+
   return (
     <div className="chat-page">
       <header className="chat-header">
@@ -332,9 +366,16 @@ export function ChatView() {
 
       <div className="chat-messages" ref={scrollRef}>
         {messages.length === 0 && !running && <p className="chat-empty">Send a message to start</p>}
-        {messages.map((msg, i) => (
-          <MessageBubble key={i} message={msg} />
-        ))}
+        {grouped.map((item, i) => {
+          if (item.type === 'tool-group') {
+            return <ToolGroup key={`tg-${i}`} tools={item.tools} />;
+          }
+          const msg = item.message;
+          if (msg.role === 'tool') {
+            return <ToolPill key={msg.toolId || `t-${i}`} message={msg} />;
+          }
+          return <MessageBubble key={`m-${i}`} message={msg} />;
+        })}
       </div>
 
       {permission && (

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -669,108 +669,192 @@ textarea:focus {
   margin: 0.5em 0;
 }
 
-/* ===== Tool Cards ===== */
+/* ===== Tool Pills ===== */
 
-.tool-card {
+.tool-pill {
   align-self: flex-start;
   width: 100%;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
+  font-size: 0.75rem;
   overflow: hidden;
-  font-size: 0.8rem;
 }
 
-.tool-card-header {
+.tool-pill-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  width: 100%;
   cursor: pointer;
+  background: transparent;
+  border: none;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
-  transition: background 0.1s;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  font-family: inherit;
+  min-width: 0;
 }
 
-.tool-card-header:active {
+.tool-pill-header:active {
   background: rgba(255, 255, 255, 0.03);
 }
 
-.tool-card-icon {
-  font-size: 0.9rem;
-  flex-shrink: 0;
-  width: 1.4rem;
-  text-align: center;
-}
-
-.tool-card-name {
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
-}
-
-.tool-card-input {
-  flex: 1;
-  min-width: 0;
-  color: var(--text-dim);
-  font-family: var(--code-font);
-  font-size: 0.75rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: right;
-}
-
-.tool-card-chevron {
-  color: var(--text-dim);
-  font-size: 0.65rem;
-  flex-shrink: 0;
-  transition: transform 0.15s;
-}
-
-.tool-card--expanded .tool-card-chevron {
-  transform: rotate(90deg);
-}
-
-.tool-card-status {
+.tool-pill-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
-.tool-card-status--success {
+.tool-pill-dot--done {
   background: var(--success);
 }
-.tool-card-status--error {
-  background: var(--danger);
-}
-.tool-card-status--pending {
+
+.tool-pill-dot--pending {
   background: var(--text-dim);
+  animation: pulse-dot 1.2s ease-in-out infinite;
 }
 
-.tool-card-result {
-  display: none;
-  padding: 0.5rem 0.75rem;
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+.tool-pill-name {
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.tool-pill-input {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-dim);
+  font-family: var(--code-font);
+  font-size: 0.7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-pill-status {
+  color: var(--text-dim);
+  font-size: 0.65rem;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.tool-pill-chevron {
+  color: var(--text-dim);
+  font-size: 0.6rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.tool-pill--done .tool-pill-header {
+  opacity: 0.6;
+}
+
+.tool-pill--done:hover .tool-pill-header,
+.tool-pill--done:active .tool-pill-header {
+  opacity: 1;
+}
+
+.tool-pill-detail {
+  padding: 0.4rem 0.6rem;
   border-top: 1px solid var(--border);
   background: var(--code-bg);
 }
 
-.tool-card--expanded .tool-card-result {
-  display: block;
+.tool-pill-section {
+  margin-bottom: 0.35rem;
 }
 
-.tool-card-result pre {
+.tool-pill-section:last-child {
+  margin-bottom: 0;
+}
+
+.tool-pill-label {
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+}
+
+.tool-pill-pre {
   font-family: var(--code-font);
-  font-size: 0.75rem;
-  line-height: 1.45;
+  font-size: 0.7rem;
+  line-height: 1.4;
   color: var(--text-dim);
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 200px;
+  max-height: 150px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  margin: 0;
+  margin: 0.15rem 0 0;
+}
+
+/* ===== Tool Group ===== */
+
+.tool-group {
+  align-self: flex-start;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.tool-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  color: var(--text-dim);
+  font-size: 0.75rem;
+  font-family: inherit;
+}
+
+.tool-group-header:active {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tool-group-dots {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.tool-group-label {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+}
+
+.tool-group-chevron {
+  margin-left: auto;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+}
+
+.tool-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 0 0 0.25rem;
+  background: var(--surface);
+  border-radius: 0 0 6px 6px;
 }
 
 /* ===== Permission Banner ===== */


### PR DESCRIPTION
## Summary

Replaces the bulky tool call cards (which dominated the viewport on mobile) with compact single-line pills that auto-group.

**Before:** Each tool call was a multi-line card taking ~3+ lines. 8 Read calls = entire screen filled with cards, no visible response.

**After:**
- **Individual pills:** `[dot] Read server/chat.ts` — one line. Shows "Running..." while active, fades to green dot when done. Tap to expand for full input/result.
- **Auto-grouping:** 3+ consecutive tool calls collapse into a single row: `[dots] 5 tool calls [v]`. Tap to expand.
- **Smart state:** Groups stay expanded while tools are running, auto-collapse when all finish.
- Text messages break grouping, so you always see Claude's responses immediately.

## Test plan

- [ ] Start a chat that triggers multiple tool calls (e.g., "what files are in this repo?")
- [ ] Verify individual tool calls show as compact pills, not cards
- [ ] Verify 3+ consecutive calls collapse into a group
- [ ] Verify group expands on tap, shows individual pills inside
- [ ] Verify group auto-collapses when all tools finish
- [ ] Verify tapping a done pill expands to show the result
- [ ] Verify text messages appear between tool groups correctly

Made with [Cursor](https://cursor.com)