### PR TITLE
fix: worktree UX redesign + session expired loop fix

### DIFF
--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -21,8 +21,12 @@ export function ChatView() {
   const [mode, setMode] = useState<'ask' | 'agent' | 'auto'>(
     searchParams.get('extraTools') ? 'auto' : 'agent',
   );
+  const [sandbox, setSandbox] = useState(false);
+  const [branch, setBranch] = useState<string | null>(null);
+  const [isWorktree, setIsWorktree] = useState(false);
 
   const [connected, setConnected] = useState(false);
+  const hasStarted = messages.some((m) => m.role === 'user');
 
   const wsRef = useRef<WebSocket | null>(null);
   const streamBuf = useRef('');
@@ -156,6 +160,11 @@ export function ChatView() {
             setRunning(false);
             break;
 
+          case 'session_info':
+            setBranch(msg.branch as string);
+            setIsWorktree(msg.worktree as boolean);
+            break;
+
           case 'session_id':
             setCurrentSessionId(msg.sessionId as string);
             break;
@@ -242,7 +251,9 @@ export function ChatView() {
             }
             setRunning(false);
             wasRunning.current = false;
-            if (msg.sessionId) setCurrentSessionId(msg.sessionId as string);
+            if (msg.sessionId && !currentSessionId) {
+              setCurrentSessionId(msg.sessionId as string);
+            }
             break;
           }
 
@@ -251,7 +262,14 @@ export function ChatView() {
             setRunning(false);
             wasRunning.current = false;
             if ((msg.error as string)?.includes('No conversation found')) {
+              const staleId = currentSessionId;
               setCurrentSessionId(undefined);
+              if (staleId) {
+                sessionStorage.removeItem(`mitzo-chat-${staleId}`);
+              }
+              if (sessionId) {
+                navigate('/chat', { replace: true });
+              }
               setMessages((prev) => [
                 ...prev,
                 {
@@ -329,6 +347,7 @@ export function ChatView() {
     if (images?.length) {
       payload.images = images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
     }
+    if (sandbox && !currentSessionId) payload.worktree = true;
 
     const cwd = searchParams.get('cwd');
     if (cwd) payload.cwd = cwd;
@@ -398,6 +417,25 @@ export function ChatView() {
             </button>
           ))}
         </div>
+        <button
+          className={`chat-header-sandbox${sandbox || isWorktree ? ' chat-header-sandbox--active' : ''}`}
+          onClick={() => setSandbox((s) => !s)}
+          disabled={hasStarted}
+          title={
+            isWorktree
+              ? 'Running in sandbox worktree'
+              : sandbox
+                ? 'Sandbox on — will create worktree'
+                : 'Sandbox off — using base repo'
+          }
+        >
+          {isWorktree ? 'WT' : sandbox ? 'WT' : 'WT'}
+        </button>
+        {branch && (
+          <span className={`chat-header-branch${isWorktree ? ' chat-header-branch--wt' : ''}`}>
+            {branch}
+          </span>
+        )}
         {running && (
           <button className="chat-header-stop" onClick={handleStop}>
             Stop

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -428,6 +428,62 @@ textarea:focus {
   color: #fff;
 }
 
+.chat-header-branch {
+  font-family: var(--code-font);
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  background: var(--bg);
+  padding: 0.2rem 0.45rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  max-width: 7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.chat-header-branch--wt {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(108, 99, 255, 0.1);
+}
+
+.chat-header-sandbox {
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.25rem 0.45rem;
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  flex-shrink: 0;
+  min-width: unset;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.chat-header-sandbox:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.chat-header-sandbox--active {
+  background: rgba(108, 99, 255, 0.15);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.chat-header-sandbox:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .chat-header-offline {
   display: flex;
   align-items: center;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1,5 +1,6 @@
 import { query, listSessions, getSessionMessages } from '@anthropic-ai/claude-agent-sdk';
 import type { WebSocket } from 'ws';
+import { execFileSync } from 'child_process';
 import { writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -74,13 +75,7 @@ function resolveWorktree(
   options: { resume?: string; cwd?: string; worktree?: boolean },
 ): { cwd: string; worktreePath?: string } {
   if (
-    !(
-      WORKTREE_ENABLED &&
-      options.worktree !== false &&
-      !options.cwd &&
-      !options.resume &&
-      BASE_REPO
-    )
+    !(WORKTREE_ENABLED && options.worktree === true && !options.cwd && !options.resume && BASE_REPO)
   ) {
     return { cwd: baseCwd };
   }
@@ -94,6 +89,20 @@ function resolveWorktree(
     console.error('[worktree] creation failed, using base repo:', message);
     send(ws, { type: 'error', error: `Worktree creation failed (using base repo): ${message}` });
     return { cwd: baseCwd };
+  }
+}
+
+function getBranch(cwd: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      cwd,
+      stdio: 'pipe',
+      timeout: 5_000,
+    })
+      .toString()
+      .trim();
+  } catch {
+    return 'unknown';
   }
 }
 
@@ -207,6 +216,14 @@ export async function startChat(
     mode,
     sessionAllowList: new Set<string>(),
     worktreePath,
+  });
+
+  const branch = getBranch(cwd);
+  send(ws, {
+    type: 'session_info',
+    branch,
+    cwd,
+    worktree: !!worktreePath,
   });
 
   const q = query({


### PR DESCRIPTION
## Summary

**Bug fix: session expired loop**
- After a server restart, resuming a stale session caused infinite "Session expired" messages
- Root cause: sessionStorage and URL param re-seeded the stale session ID after clearing
- Fix: clear sessionStorage entry, navigate away from stale URL, guard done handler

**Worktree UX redesign**
- Worktrees now default to OFF (was on-by-default)
- New "WT" sandbox toggle in chat header — opt-in worktree creation
- Toggle disabled after first message (cannot switch mid-session)
- Server sends session_info message with branch name, cwd, and worktree flag
- Branch pill in header shows current git branch (monospace, always visible)
- Worktree sessions get accent-colored branch pill for visual distinction

## Test plan
- [x] 81 tests passing
- [x] tsc --noEmit clean
- [x] ESLint --quiet clean
- [ ] Manual: open old session — should show "Session expired" once, not loop
- [ ] Manual: new chat — should show branch pill with "main", no worktree
- [ ] Manual: toggle WT on, send message — should show worktree branch

Made with [Cursor](https://cursor.com)