### PR TITLE
docs: update README, CLAUDE.md, and SECURITY.md for current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ npm run lint         # ESLint (server + frontend)
 npm run lint:fix     # ESLint with auto-fix
 npm run format       # Prettier (write)
 npm run format:check # Prettier (check only)
-npm test             # Vitest
+npm test             # Vitest (81 tests)
 ```
 
 Pre-commit hooks (husky + lint-staged) run lint and format on staged files. Conventional commit messages enforced via commitlint.
@@ -25,8 +25,12 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 
 **Backend** (`server/`) — Node.js + Express + TypeScript, run via `tsx`
 
-- `index.ts` — Express app, mounts routes, HTTP server + WebSocket. Runs stale worktree cleanup on startup.
-- `chat.ts` — Agent SDK integration. Each chat session gets an isolated git worktree (see below). Manages permission handling, mode switching, and streaming.
+- `index.ts` — Express app, mounts routes, HTTP server + WebSocket. Sends `client_id` on WS connect for session reattach. Runs stale worktree cleanup on startup.
+- `chat.ts` — Agent SDK integration. Manages session lifecycle via `SessionRegistry`, permission handling, mode switching, streaming. Loads MCP servers on startup. Sends `session_info` (branch, cwd, worktree flag) before SDK messages.
+- `session-registry.ts` — `SessionRegistry` class: decouples session lifecycle from WebSocket. Supports detach (WS disconnect), reattach (WS reconnect), and TTL-based abort for abandoned sessions (2 min).
+- `mcp-config.ts` — Reads MCP server configs from `~/.cursor/mcp.json` (or `MCP_CONFIG_PATH`). Filters to stdio servers, excludes disabled entries, passes to `query()`.
+- `content-blocks.ts` — Shared parsing of SDK content blocks (text, tool_use, tool_result). Used by both the streaming loop and the session history API.
+- `tool-summary.ts` — Human-readable summarization of tool inputs for the permission UI.
 - `worktree.ts` — Git worktree lifecycle: create, remove, cleanup stale, list.
 - `permissions.ts` — Permission request/response registry. Passes SDK `suggestions` through for "Always Allow".
 - `notify.ts` — ntfy push notifications for permission prompts.
@@ -34,18 +38,35 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 
 **Frontend** (`frontend/`) — React 19 + Vite + TypeScript
 
-- Three pages: `Login`, `SessionList` (quick actions + history), `ChatView` (streaming chat)
-- Auth check via `ProtectedRoute` wrapper that calls `/api/auth/check`
-- Vite dev server proxies `/api` and `/ws` to backend (port 3100)
+- `types/chat.ts` — Shared types: `Message`, `Session`, `ImageAttachment`, `PermissionRequest`, `GroupedItem`.
+- `lib/` — Shared utilities: `groupMessages`, `formatTime`, `truncate`, `resizeImage`.
+- Pages: `Login`, `SessionList` (quick actions + history + swipe-to-dismiss), `ChatView` (streaming chat + sandbox toggle + branch pill), `FileViewer` (directory browser + markdown viewer).
+- Components: `MessageBubble`, `ToolPill`, `ToolGroup`, `PermissionBanner`, `ChatInput`.
+- Auth check via `ProtectedRoute` wrapper that calls `/api/auth/check`.
+- Vite dev server proxies `/api` and `/ws` to backend (port 3100).
 
-**Worktree isolation:**
+**Session resilience:**
 
-- Each new chat session (without explicit `cwd` or `resume`) gets its own git worktree at `${REPO_PATH}-sessions/session-<clientId>/`, branched from the current HEAD of `REPO_PATH`.
-- Controlled by `WORKTREE_ENABLED` env var (default: `true`) and per-session `worktree` field in the WebSocket payload.
-- The worktree is removed when the session ends (WebSocket close or stop).
-- Stale worktrees older than 7 days are cleaned up on server startup.
-- Sessions with explicit `cwd` (e.g., quick actions targeting other repos) skip worktree creation.
-- `GET /api/worktrees` lists active worktrees for debugging.
+- WebSocket disconnect detaches (not aborts) the session via `SessionRegistry`.
+- New WebSocket can reattach to a detached session using the `client_id` sent on connect.
+- Detached sessions auto-abort after 2 minutes.
+- Frontend tracks `serverClientId` and `wasRunning` to auto-reattach on reconnect.
+
+**Worktree isolation (opt-in):**
+
+- Worktrees are off by default. Enabled per-session via the "WT" toggle in the chat header.
+- `WORKTREE_ENABLED` env var is the ceiling — if `false`, worktrees are disabled entirely.
+- When enabled: worktree created at `${REPO_PATH}-sessions/session-<id>/`, branched from HEAD.
+- Server sends `session_info` with branch name, cwd, and worktree flag. Frontend shows branch pill.
+- Stale worktrees (>7 days) cleaned up on startup.
+- Sessions with explicit `cwd` or `resume` skip worktree creation.
+
+**MCP integration:**
+
+- On startup, `loadMcpServers()` reads `~/.cursor/mcp.json` (or `MCP_CONFIG_PATH`).
+- Stdio servers are passed as `mcpServers` in the Agent SDK `query()` options.
+- Claude sessions get all configured MCP tools (Jira, GitLab, etc.) automatically.
+- `GET /api/config` exposes server names (not credentials) to the frontend.
 
 **Key conventions:**
 
@@ -53,9 +74,13 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 - Frontend and backend have separate `package.json`, `tsconfig.json`, and `node_modules`
 - `REPO_PATH` env var controls the default repo (required — set in `.env`)
 - No hardcoded machine-specific paths in source code
+- Types are in `frontend/src/types/`, not in page files
+- Components import from `types/` and `lib/`, never from page files
 
 ## Code Style
 
 - Write minimal, clean code. This project is open source — others will read and contribute to it.
 - No machine-specific paths or configuration. Everything must be generic and portable.
 - Keep files short and focused. Prefer clarity over cleverness.
+- Use `err: unknown` + `instanceof Error` checks, not `err: any`.
+- Conventional commits: `feat`, `fix`, `refactor`, `docs`, `build`, `chore`.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 A mobile-first web interface for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) via the [Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk). Run it on a home server, access it from your phone over [Tailscale](https://tailscale.com).
 
-Each chat session gets its own isolated git worktree, so you can run multiple sessions against the same repo without conflicts.
-
 ## What It Does
 
 - **Chat with Claude** from any device — streaming responses, tool calls, markdown rendering
 - **Permission control** — Ask (read-only), Agent (approve tools), Auto (full autonomy), switchable mid-chat
-- **Worktree isolation** — each session branches from your repo's HEAD into its own directory, cleaned up on close
+- **MCP tool integration** — reads MCP server configs from `~/.cursor/mcp.json` and passes them to Claude sessions (Jira, GitLab, etc.)
+- **File browser** — browse repo files and view markdown with full rendering
+- **Sandbox mode** — opt-in git worktree isolation per session, visible in the header
+- **Session resilience** — WebSocket disconnects don't kill sessions; auto-reattach on reconnect
 - **Quick actions** — preconfigured one-tap commands (run scripts, fetch data, triage inbox)
 - **Push notifications** — get notified via [ntfy](https://ntfy.sh) when Claude needs input
-- **Session history** — resume past conversations from the Agent SDK session store
+- **Session history** — resume past conversations, deduplicated, swipe-to-dismiss
 - **Model selection** — switch between Sonnet, Opus, and Haiku per conversation
+- **Image attachments** — send photos/screenshots to Claude from your phone camera
 
 ## Architecture
 
@@ -25,28 +27,40 @@ Phone (over Tailscale)
 Server (Node.js + TypeScript)
   │
   ├── Agent SDK: Claude Code sessions
-  ├── Git worktrees: per-session isolation
+  ├── MCP servers: loaded from Cursor config
+  ├── Git worktrees: opt-in per-session isolation
   └── Passphrase + JWT auth
 ```
 
 **Backend** (`server/`) — Express + TypeScript, run via `tsx`
 
-| File             | Purpose                                                                  |
-| ---------------- | ------------------------------------------------------------------------ |
-| `index.ts`       | Express app, routes, WebSocket server, startup cleanup                   |
-| `chat.ts`        | Agent SDK `query()` integration, worktree lifecycle, permission handling |
-| `worktree.ts`    | Git worktree create/remove/cleanup/list                                  |
-| `permissions.ts` | Permission request registry, SDK suggestion passthrough                  |
-| `notify.ts`      | ntfy push notifications                                                  |
-| `auth.ts`        | Passphrase login, JWT (HS256), cookie auth                               |
+| File                  | Purpose                                                         |
+| --------------------- | --------------------------------------------------------------- |
+| `index.ts`            | Express app, routes, WebSocket server, startup cleanup          |
+| `chat.ts`             | Agent SDK integration, session lifecycle, permission handling   |
+| `session-registry.ts` | Session lifecycle decoupled from WebSocket (detach/reattach)    |
+| `mcp-config.ts`       | Loads MCP server configs from Cursor mcp.json                   |
+| `worktree.ts`         | Git worktree create/remove/cleanup/list                         |
+| `permissions.ts`      | Permission request registry, SDK suggestion passthrough         |
+| `notify.ts`           | ntfy push notifications                                         |
+| `auth.ts`             | Passphrase login, JWT (HS256), cookie auth                      |
+| `content-blocks.ts`   | SDK message content block parsing (shared between stream + API) |
+| `tool-summary.ts`     | Human-readable tool input summarization                         |
 
 **Frontend** (`frontend/`) — React 19 + Vite + TypeScript
 
-| Page          | Purpose                                       |
-| ------------- | --------------------------------------------- |
-| `Login`       | Passphrase entry                              |
-| `SessionList` | Quick action grid + session history           |
-| `ChatView`    | Streaming chat, mode pills, permission banner |
+| Page          | Purpose                                                                    |
+| ------------- | -------------------------------------------------------------------------- |
+| `Login`       | Passphrase entry                                                           |
+| `SessionList` | Quick action grid + session history (swipe-to-dismiss)                     |
+| `ChatView`    | Streaming chat, mode pills, sandbox toggle, branch pill, permission banner |
+| `FileViewer`  | Directory browser + markdown/code file viewer                              |
+
+| Directory     | Purpose                                                             |
+| ------------- | ------------------------------------------------------------------- |
+| `types/`      | Shared TypeScript types (Message, Session, etc.)                    |
+| `lib/`        | Shared utilities (groupMessages, formatTime, truncate, resizeImage) |
+| `components/` | MessageBubble, ToolPill, ToolGroup, PermissionBanner, ChatInput     |
 
 ## Prerequisites
 
@@ -70,14 +84,15 @@ cp .env.example .env
 
 ### Environment variables
 
-| Variable               | Description                                 | Required |
-| ---------------------- | ------------------------------------------- | -------- |
-| `AUTH_PASSPHRASE`      | Login passphrase                            | Yes      |
-| `AUTH_SECRET`          | JWT signing key (min 32 chars)              | Yes      |
-| `REPO_PATH`            | Default repo for chat sessions              | Yes      |
-| `PORT`                 | Server port (default: `3100`)               | No       |
-| `WORKTREE_ENABLED`     | Enable worktree isolation (default: `true`) | No       |
-| `COOKIE_MAX_AGE_HOURS` | Auth cookie expiry (default: `24`)          | No       |
+| Variable               | Description                                             | Required |
+| ---------------------- | ------------------------------------------------------- | -------- |
+| `AUTH_PASSPHRASE`      | Login passphrase                                        | Yes      |
+| `AUTH_SECRET`          | JWT signing key (min 32 chars)                          | Yes      |
+| `REPO_PATH`            | Default repo for chat sessions                          | Yes      |
+| `PORT`                 | Server port (default: `3100`)                           | No       |
+| `WORKTREE_ENABLED`     | Allow worktree creation (default: `true`)               | No       |
+| `MCP_CONFIG_PATH`      | Path to MCP config file (default: `~/.cursor/mcp.json`) | No       |
+| `COOKIE_MAX_AGE_HOURS` | Auth cookie expiry (default: `24`)                      | No       |
 
 See `.env.example` for the full list including ntfy and Vertex AI options.
 
@@ -114,13 +129,38 @@ pm2 save && pm2 startup
 
 No HTTPS needed — Tailscale encrypts everything via WireGuard.
 
+## MCP server integration
+
+Mitzo reads MCP server configurations from `~/.cursor/mcp.json` (the same file Cursor uses). Stdio-type servers are loaded on startup and passed to every Claude session via the Agent SDK's `mcpServers` option. Disabled servers are excluded.
+
+Override the config path with the `MCP_CONFIG_PATH` environment variable.
+
+The server logs which MCP servers were loaded on startup:
+
+```
+[mcp] loaded 1 server(s): atlassian
+```
+
+## Sandbox mode (worktrees)
+
+Worktrees are **off by default**. Toggle the "WT" button in the chat header before sending your first message to opt in.
+
+When sandbox mode is on:
+
+1. Mitzo creates a git worktree at `${REPO_PATH}-sessions/session-<id>/`
+2. The worktree branches from the current HEAD of your repo
+3. Claude works in the isolated worktree
+4. The chat header shows the branch name with an accent indicator
+5. Stale worktrees (>7 days) are pruned on server startup
+
+Disable worktree creation entirely with `WORKTREE_ENABLED=false` in `.env`.
+
 ## Push notifications
 
 Get notified when Claude needs tool approval:
 
 ```bash
 # Add ntfy config to .env:
-NTFY_ENABLED=true
 NTFY_URL=https://ntfy.sh
 NTFY_TOPIC=your-secret-topic
 BASE_URL=http://<tailscale-ip>:3100
@@ -130,28 +170,22 @@ BASE_URL=http://<tailscale-ip>:3100
 ./scripts/setup-hooks.sh
 ```
 
-## How worktrees work
+## Session resilience
 
-When you start a new chat (without a custom `cwd` or resuming a session):
-
-1. Mitzo creates a git worktree at `${REPO_PATH}-sessions/session-<id>/`
-2. The worktree branches from the current HEAD of your repo
-3. Claude works in the isolated worktree — edits, commits, everything
-4. When the session ends, the worktree and branch are cleaned up
-5. Stale worktrees (>7 days) are pruned on server startup
-
-Disable with `WORKTREE_ENABLED=false` in `.env`, or per-session via the WebSocket payload.
+WebSocket disconnects (phone sleep, Tailscale hiccup) no longer kill active sessions. The server detaches the session and keeps the Agent SDK query running. When the phone reconnects, the new WebSocket reattaches to the in-flight session. Detached sessions auto-abort after 2 minutes if no reattach arrives.
 
 ## Tech stack
 
-| Component | Technology                   |
-| --------- | ---------------------------- |
-| Backend   | Node.js, Express, TypeScript |
-| Frontend  | React 19, Vite, TypeScript   |
-| AI        | Claude Agent SDK             |
-| Auth      | JWT via jose                 |
-| Isolation | Git worktrees                |
-| Tests     | Vitest                       |
+| Component | Technology                          |
+| --------- | ----------------------------------- |
+| Backend   | Node.js, Express, TypeScript        |
+| Frontend  | React 19, Vite, TypeScript          |
+| AI        | Claude Agent SDK                    |
+| MCP       | Cursor-compatible stdio servers     |
+| Auth      | JWT via jose                        |
+| Isolation | Git worktrees (opt-in)              |
+| Tests     | Vitest (81 tests)                   |
+| Quality   | ESLint, Prettier, husky, commitlint |
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,13 +16,14 @@ Given that deployment model, the security posture prioritizes simplicity over de
 
 ## Secrets Management
 
-| Secret                          | Storage                             | Exposure                                                                              |
-| ------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
-| `AUTH_PASSPHRASE`               | `.env` (gitignored)                 | Never logged, never sent to SDK                                                       |
-| `AUTH_SECRET` (JWT signing key) | `.env` (gitignored)                 | Never logged, never sent to SDK                                                       |
-| `NTFY_AUTH_TOKEN`               | `.env` (gitignored)                 | Used in ntfy API calls and permission endpoint auth. Never sent to SDK                |
-| Vertex AI credentials           | GCP Application Default Credentials | `ANTHROPIC_VERTEX_PROJECT_ID` is a project name (not sensitive), actual auth uses ADC |
-| `REPO_PATH`                     | `.env` (gitignored)                 | Exposed to frontend via `/api/config` (non-sensitive — it's a local path)             |
+| Secret                          | Storage                             | Exposure                                                                                                                                                    |
+| ------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_PASSPHRASE`               | `.env` (gitignored)                 | Never logged, never sent to SDK                                                                                                                             |
+| `AUTH_SECRET` (JWT signing key) | `.env` (gitignored)                 | Never logged, never sent to SDK                                                                                                                             |
+| `NTFY_AUTH_TOKEN`               | `.env` (gitignored)                 | Used in ntfy API calls and permission endpoint auth. Never sent to SDK                                                                                      |
+| Vertex AI credentials           | GCP Application Default Credentials | `ANTHROPIC_VERTEX_PROJECT_ID` is a project name (not sensitive), actual auth uses ADC                                                                       |
+| `REPO_PATH`                     | `.env` (gitignored)                 | Exposed to frontend via `/api/config` (non-sensitive — it's a local path)                                                                                   |
+| MCP server credentials          | `~/.cursor/mcp.json`                | Read by `mcp-config.ts`, passed to Agent SDK subprocess. Server names (not tokens) exposed via `/api/config`. Credentials never logged or sent to frontend. |
 
 The `sdkEnv()` function in `chat.ts` explicitly deletes `AUTH_PASSPHRASE`, `AUTH_SECRET`, and `NTFY_AUTH_TOKEN` from the environment before passing it to the Agent SDK, preventing accidental exposure to Claude sessions.
 
@@ -39,11 +40,20 @@ Both are acceptable given the Tailscale-only access model.
 
 Each chat session spawns a Claude Code process via the Agent SDK with:
 
-- `cwd` set to a worktree (isolated per session) or the base repo
-- Project-level settings from `.cursor/rules/` (read from the worktree)
+- `cwd` set to the base repo (default) or a worktree (if sandbox mode is enabled)
+- Project-level settings from `.cursor/rules/` (read from the cwd)
+- MCP servers loaded from `~/.cursor/mcp.json` (stdio-type only, disabled servers excluded)
 - Environment variables with secrets stripped
 
 Claude sessions have full filesystem access within their `cwd`. This is by design — the Agent SDK's permission system (`canUseTool`) controls tool-level access, and the user approves or denies from the UI.
+
+## Session Resilience
+
+WebSocket disconnects detach (not abort) the active session via `SessionRegistry`. The Agent SDK query continues running server-side. A reconnected WebSocket can reattach within a 2-minute TTL. After the TTL, abandoned sessions are aborted and cleaned up. This prevents session state accumulation from repeated disconnects.
+
+## File Viewer
+
+The `/api/files` and `/api/files/read` endpoints restrict access to paths under `REPO_PATH` and its worktree sessions directory. Path traversal is blocked by `resolve()` + `startsWith()` checks.
 
 ## Known Limitations
 
@@ -51,3 +61,4 @@ Claude sessions have full filesystem access within their `cwd`. This is by desig
 - **No rate limiting**: brute-force passphrase attempts are possible (mitigated by Tailscale network restriction).
 - **No CSRF protection**: `sameSite: strict` mitigates most CSRF vectors, but there's no explicit CSRF token.
 - **Single-user**: no user accounts, roles, or audit logging. The passphrase is shared across all access.
+- **MCP credentials in mcp.json**: MCP server tokens (e.g., Jira API tokens) are stored in `~/.cursor/mcp.json`. This file is not managed by Mitzo — it's the user's existing Cursor configuration. Mitzo reads it but never modifies or copies it.


### PR DESCRIPTION
## Summary

All three docs were stale — described worktrees as on-by-default, didn't mention SessionRegistry, MCP integration, file viewer, session dedup, sandbox toggle, branch pills, or the extracted types/lib/modules.

- **README**: rewrote feature list, architecture tables (10 server files, 4 pages, types/ + lib/), added MCP, sandbox, session resilience sections, updated env vars
- **CLAUDE.md**: complete rewrite of architecture section covering all modules, code style conventions
- **SECURITY.md**: added MCP credentials, session resilience, file viewer path restrictions

## Test plan

- [x] No code changes — docs only

Made with [Cursor](https://cursor.com)