### PR TITLE
feat: persist model selection across sessions

### DIFF
--- a/frontend/src/lib/__tests__/model-preference.test.ts
+++ b/frontend/src/lib/__tests__/model-preference.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DEFAULT_MODEL } from '../constants';
+
+// Mock localStorage before importing the module under test
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: vi.fn((key: string) => store[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    store[key] = value;
+  }),
+  clear: vi.fn(() => {
+    for (const key of Object.keys(store)) delete store[key];
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete store[key];
+  }),
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+import { getPreferredModel, setPreferredModel, PREFERRED_MODEL_KEY } from '../model-preference';
+
+describe('model-preference', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it('returns DEFAULT_MODEL when nothing is stored', () => {
+    expect(getPreferredModel()).toBe(DEFAULT_MODEL);
+  });
+
+  it('returns the stored model after setPreferredModel', () => {
+    setPreferredModel('claude-opus-4-6');
+    expect(getPreferredModel()).toBe('claude-opus-4-6');
+  });
+
+  it('persists to localStorage under the correct key', () => {
+    setPreferredModel('claude-haiku-4-5');
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(PREFERRED_MODEL_KEY, 'claude-haiku-4-5');
+  });
+
+  it('returns DEFAULT_MODEL if localStorage throws', () => {
+    localStorageMock.getItem.mockImplementationOnce(() => {
+      throw new Error('quota exceeded');
+    });
+    expect(getPreferredModel()).toBe(DEFAULT_MODEL);
+  });
+});

--- a/frontend/src/lib/model-preference.ts
+++ b/frontend/src/lib/model-preference.ts
@@ -1,0 +1,19 @@
+import { DEFAULT_MODEL } from './constants';
+
+export const PREFERRED_MODEL_KEY = 'mitzo-preferred-model';
+
+export function getPreferredModel(): string {
+  try {
+    return localStorage.getItem(PREFERRED_MODEL_KEY) || DEFAULT_MODEL;
+  } catch {
+    return DEFAULT_MODEL;
+  }
+}
+
+export function setPreferredModel(modelId: string): void {
+  try {
+    localStorage.setItem(PREFERRED_MODEL_KEY, modelId);
+  } catch {
+    // localStorage unavailable — silently ignore
+  }
+}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -14,8 +14,8 @@ import {
   SCROLL_RESTORE_DELAY_MS,
   CHAT_CACHE_KEY_PREFIX,
   LAST_SESSION_KEY,
-  DEFAULT_MODEL,
 } from '../lib/constants';
+import { getPreferredModel, setPreferredModel } from '../lib/model-preference';
 import type { Message, PermissionRequest, ImageAttachment } from '../types/chat';
 
 export function ChatView() {
@@ -27,7 +27,11 @@ export function ChatView() {
   const [running, setRunning] = useState(false);
   const [permission, setPermission] = useState<PermissionRequest | null>(null);
   const [currentSessionId, setCurrentSessionId] = useState<string | undefined>(sessionId);
-  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [model, setModelState] = useState(getPreferredModel);
+  const setModel = useCallback((id: string) => {
+    setModelState(id);
+    setPreferredModel(id);
+  }, []);
   const [mode, setMode] = useState<'ask' | 'agent' | 'auto'>(
     searchParams.get('extraTools') ? 'auto' : 'agent',
   );


### PR DESCRIPTION
## Summary

- Model selection was resetting to Sonnet every new session (hardcoded `DEFAULT_MODEL` in `useState`)
- Added `model-preference.ts` — reads/writes `localStorage` to persist the user's last-selected model
- ChatView now initializes from `getPreferredModel()` and saves on change via `setPreferredModel()`

## Test plan

- [x] 4 unit tests for `model-preference` (default, persistence, storage key, error handling)
- [ ] Manual: select Opus, start a session, close, start new session — should default to Opus
- [ ] Manual: clear browser data — should fall back to Sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)