### PR TITLE
feat: server update detection with manual check and banner

### DIFF
--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -110,22 +110,46 @@ export function SessionList() {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [quickActions, setQuickActions] = useState<QuickAction[]>(DEFAULT_ACTIONS);
   const [loading, setLoading] = useState(true);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [checking, setChecking] = useState(false);
 
   useEffect(() => {
     Promise.all([
       fetch('/api/sessions')
         .then((r) => r.json())
-        .catch(() => []), // Network error — show empty list
+        .catch(() => []),
       fetch('/api/config')
         .then((r) => r.json())
-        .catch(() => ({})), // Network error — use default config
+        .catch(() => ({})),
+      fetch('/api/version')
+        .then((r) => r.json())
+        .catch(() => ({})),
     ])
-      .then(([sessData, config]) => {
+      .then(([sessData, config, version]) => {
         setSessions(sessData);
         setQuickActions(buildQuickActions(config.quickActions));
+        if (version?.updateAvailable) setUpdateAvailable(true);
       })
       .finally(() => setLoading(false));
   }, []);
+
+  async function checkForUpdates() {
+    setChecking(true);
+    try {
+      const res = await fetch('/api/version/check', { method: 'POST' });
+      const data = await res.json();
+      setUpdateAvailable(data.updateAvailable);
+    } catch {
+      // Network error — ignore
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  function handleDeployAction() {
+    const deploy = quickActions.find((a) => a.label === 'Deploy Mitzo');
+    if (deploy) handleQuickAction(deploy);
+  }
 
   function dismissSession(id: string) {
     setSessions((prev) => prev.filter((s) => s.id !== id));
@@ -156,6 +180,14 @@ export function SessionList() {
       <header className="session-list-header">
         <h1>Mitzo</h1>
         <div className="session-list-header-actions">
+          <button
+            className="check-update-btn"
+            onClick={checkForUpdates}
+            disabled={checking}
+            title="Check for server updates"
+          >
+            {checking ? '…' : '⟳'}
+          </button>
           <button className="refresh-ui-btn" onClick={refreshUI} title="Clear cache and reload">
             ↺
           </button>
@@ -164,6 +196,12 @@ export function SessionList() {
           </button>
         </div>
       </header>
+
+      {updateAvailable && (
+        <button className="update-banner" onClick={handleDeployAction}>
+          Update available — Deploy Mitzo
+        </button>
+      )}
 
       <div className="quick-grid">
         {quickActions.map((action) => (

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -183,6 +183,41 @@ textarea:focus {
   gap: 0.5rem;
 }
 
+.check-update-btn {
+  font-size: 1rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.check-update-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.update-banner {
+  display: block;
+  width: 100%;
+  padding: 0.55rem 1rem;
+  background: var(--accent);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-align: center;
+  border: none;
+  cursor: pointer;
+  touch-action: manipulation;
+  letter-spacing: 0.01em;
+}
+
+.update-banner:active {
+  opacity: 0.85;
+}
+
 .refresh-ui-btn {
   font-size: 1.1rem;
   padding: 0.35rem 0.55rem;

--- a/server/__tests__/git-version.test.ts
+++ b/server/__tests__/git-version.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock child_process before importing module under test
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+import { getLocalCommit, getRemoteCommit, isUpdateAvailable } from '../git-version.js';
+
+const mockExec = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getLocalCommit', () => {
+  it('returns the current HEAD commit hash', () => {
+    mockExec.mockReturnValueOnce(Buffer.from('abc1234\n'));
+    expect(getLocalCommit()).toBe('abc1234');
+  });
+
+  it('returns null on error', () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('not a git repo');
+    });
+    expect(getLocalCommit()).toBeNull();
+  });
+});
+
+describe('getRemoteCommit', () => {
+  it('returns the remote main commit hash after fetch', () => {
+    mockExec.mockReturnValueOnce(Buffer.from('')); // git fetch
+    mockExec.mockReturnValueOnce(Buffer.from('def5678\n')); // rev-parse
+    expect(getRemoteCommit()).toBe('def5678');
+  });
+
+  it('returns null if fetch fails', () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('network error');
+    });
+    expect(getRemoteCommit()).toBeNull();
+  });
+});
+
+describe('isUpdateAvailable', () => {
+  it('returns true when local and remote differ', () => {
+    mockExec.mockReturnValueOnce(Buffer.from('abc1234\n')); // local
+    mockExec.mockReturnValueOnce(Buffer.from('')); // fetch
+    mockExec.mockReturnValueOnce(Buffer.from('def5678\n')); // remote
+    expect(isUpdateAvailable()).toBe(true);
+  });
+
+  it('returns false when local and remote match', () => {
+    mockExec.mockReturnValueOnce(Buffer.from('abc1234\n')); // local
+    mockExec.mockReturnValueOnce(Buffer.from('')); // fetch
+    mockExec.mockReturnValueOnce(Buffer.from('abc1234\n')); // remote
+    expect(isUpdateAvailable()).toBe(false);
+  });
+
+  it('returns false when either check fails', () => {
+    mockExec.mockImplementationOnce(() => {
+      throw new Error('git error');
+    });
+    expect(isUpdateAvailable()).toBe(false);
+  });
+});

--- a/server/git-version.ts
+++ b/server/git-version.ts
@@ -1,0 +1,43 @@
+import { execFileSync } from 'child_process';
+
+const GIT_TIMEOUT_MS = 5_000;
+const REMOTE = 'origin';
+const BRANCH = 'main';
+
+export function getLocalCommit(): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      stdio: 'pipe',
+      timeout: GIT_TIMEOUT_MS,
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+export function getRemoteCommit(): string | null {
+  try {
+    execFileSync('git', ['fetch', REMOTE, BRANCH, '--quiet'], {
+      stdio: 'pipe',
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return execFileSync('git', ['rev-parse', `${REMOTE}/${BRANCH}`], {
+      stdio: 'pipe',
+      timeout: GIT_TIMEOUT_MS,
+    })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+export function isUpdateAvailable(): boolean {
+  const local = getLocalCommit();
+  if (!local) return false;
+  const remote = getRemoteCommit();
+  if (!remote) return false;
+  return local !== remote;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,6 +27,7 @@ import {
 } from './chat.js';
 import { cleanupStaleWorktrees, listWorktrees } from './worktree.js';
 import { GIT_BRANCH_TIMEOUT_MS, HEARTBEAT_INTERVAL_MS, PORT_DEFAULT } from './constants.js';
+import { getLocalCommit, isUpdateAvailable } from './git-version.js';
 import { createLogger } from './logger.js';
 
 const log = createLogger('server');
@@ -46,7 +47,34 @@ try {
 } catch {
   // Expected when frontend hasn't been built yet
 }
-app.get('/api/version', (_req, res) => res.json({ hash: buildHash }));
+
+const startupCommit = getLocalCommit();
+let updateAvailable = false;
+
+function broadcastUpdateAvailable() {
+  const msg = JSON.stringify({ type: 'update_available' });
+  wss.clients.forEach((client) => {
+    if (client.readyState === client.OPEN) client.send(msg);
+  });
+}
+
+function runUpdateCheck() {
+  const wasAvailable = updateAvailable;
+  updateAvailable = isUpdateAvailable();
+  if (updateAvailable && !wasAvailable) {
+    log.info('update available — broadcasting to clients');
+    broadcastUpdateAvailable();
+  }
+}
+
+app.get('/api/version', (_req, res) =>
+  res.json({ hash: buildHash, commit: startupCommit, updateAvailable }),
+);
+
+app.post('/api/version/check', authMiddleware, (_req, res) => {
+  runUpdateCheck();
+  res.json({ updateAvailable });
+});
 
 // Token-auth endpoint for ntfy action buttons (before cookie auth middleware)
 import { resolvePending } from './permissions.js';
@@ -400,5 +428,9 @@ checkPort(PORT).then((inUse) => {
         error: err instanceof Error ? err.message : 'unknown',
       });
     }
+
+    // Periodic update check every 2 minutes
+    const UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 1000;
+    setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
   });
 });


### PR DESCRIPTION
## Summary

- `git-version.ts` — utility comparing local HEAD vs `origin/main` via `git fetch`
- `/api/version` — extended to include `commit` hash and `updateAvailable` flag
- `/api/version/check` — POST endpoint for on-demand git fetch + compare
- Server broadcasts `update_available` over WebSocket when behind remote; periodic check runs every 2 minutes
- SessionList: subtle **⟳** button in the header for manual on-demand check
- Accent banner appears when updates are available — taps directly into the **Deploy Mitzo** quick action

## Test plan

- [x] 7 unit tests for `git-version.ts` (local commit, remote commit, update detection, error handling)
- [ ] Manual: merge a PR to main → tap ⟳ → banner should appear
- [ ] Manual: tap banner → Deploy Mitzo quick action fires
- [ ] Manual: after deploy, server restarts clean, banner gone on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)