### PR TITLE
feat: Pushover notifier for Apple Watch notifications

### DIFF
--- a/server/__tests__/pushover.test.ts
+++ b/server/__tests__/pushover.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Set env before importing module
+const ORIG_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.PUSHOVER_USER_KEY = 'test-user-key';
+  process.env.PUSHOVER_API_TOKEN = 'test-api-token';
+  process.env.BASE_URL = 'http://localhost:3100';
+  mockFetch.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  process.env = { ...ORIG_ENV };
+  vi.clearAllMocks();
+});
+
+const { isConfigured, sendPushoverNotification } = await import('../pushover.js');
+
+describe('isConfigured', () => {
+  it('returns true when both keys are set', () => {
+    expect(isConfigured()).toBe(true);
+  });
+});
+
+describe('sendPushoverNotification', () => {
+  it('posts to Pushover API with correct payload', async () => {
+    await sendPushoverNotification('Test title', 'Test message');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://api.pushover.net/1/messages.json');
+
+    const body = JSON.parse(opts.body);
+    expect(body.token).toBe('test-api-token');
+    expect(body.user).toBe('test-user-key');
+    expect(body.title).toBe('Test title');
+    expect(body.message).toBe('Test message');
+  });
+
+  it('includes url and url_title when provided', async () => {
+    await sendPushoverNotification('Title', 'Message', 'http://example.com', 'Open');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.url).toBe('http://example.com');
+    expect(body.url_title).toBe('Open');
+  });
+
+  it('does not throw if fetch fails', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network error'));
+    await expect(sendPushoverNotification('Title', 'Message')).resolves.not.toThrow();
+  });
+
+  it('does nothing when not configured', async () => {
+    delete process.env.PUSHOVER_USER_KEY;
+    await sendPushoverNotification('Title', 'Message');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -11,6 +11,10 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { registerPending, resolvePending, removePending, hasPending } from './permissions.js';
 import { sendPermissionNotification, isConfigured as ntfyConfigured } from './notify.js';
+import {
+  sendPermissionNotification as pushoverSendPermission,
+  isConfigured as pushoverConfigured,
+} from './pushover.js';
 import { createWorktree } from './worktree.js';
 import { SessionRegistry, type MitzoMode } from './session-registry.js';
 import { summarizeToolInput, getRawInput } from './tool-summary.js';
@@ -261,9 +265,12 @@ function buildPermissionHandler(clientId: string) {
         tier,
       });
 
-      if (ntfyConfigured()) {
+      if (ntfyConfigured() || pushoverConfigured()) {
         setTimeout(() => {
-          if (hasPending(permId)) sendPermissionNotification(toolName, inputSummary, permId);
+          if (hasPending(permId)) {
+            if (ntfyConfigured()) sendPermissionNotification(toolName, inputSummary, permId);
+            if (pushoverConfigured()) pushoverSendPermission(toolName, inputSummary, permId);
+          }
         }, NTFY_NOTIFICATION_DELAY_MS);
       }
 

--- a/server/pushover.ts
+++ b/server/pushover.ts
@@ -1,0 +1,56 @@
+import { createLogger } from './logger.js';
+
+const log = createLogger('pushover');
+
+const PUSHOVER_API_URL = 'https://api.pushover.net/1/messages.json';
+
+export function isConfigured(): boolean {
+  return !!(process.env.PUSHOVER_API_TOKEN && process.env.PUSHOVER_USER_KEY);
+}
+
+export async function sendPushoverNotification(
+  title: string,
+  message: string,
+  url?: string,
+  urlTitle?: string,
+): Promise<void> {
+  const token = process.env.PUSHOVER_API_TOKEN;
+  const user = process.env.PUSHOVER_USER_KEY;
+  if (!token || !user) return;
+
+  const payload: Record<string, string> = {
+    token,
+    user,
+    title,
+    message,
+  };
+
+  if (url) payload.url = url;
+  if (urlTitle) payload.url_title = urlTitle;
+
+  try {
+    await fetch(PUSHOVER_API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err: unknown) {
+    log.error('failed to send pushover notification', {
+      error: err instanceof Error ? err.message : err,
+    });
+  }
+}
+
+export async function sendPermissionNotification(
+  toolName: string,
+  toolInput: string,
+  permId: string,
+): Promise<void> {
+  const baseUrl = process.env.BASE_URL;
+  if (!isConfigured() || !baseUrl) return;
+
+  const ntfyToken = process.env.NTFY_AUTH_TOKEN || '';
+  const mitzoUrl = `${baseUrl}/api/permission/${permId}/respond?decision=once&token=${ntfyToken}`;
+
+  await sendPushoverNotification(`Mitzo: ${toolName}`, toolInput, mitzoUrl, 'Open Mitzo');
+}


### PR DESCRIPTION
## Summary

- Adds `server/pushover.ts` alongside the existing `notify.ts` (ntfy) notifier
- Both fire concurrently on permission prompts when configured — no either/or
- Pushover delivers natively to Apple Watch via its watchOS companion app
- Supports optional deep-link URL back into Mitzo (Tailscale-accessible)

## Setup

Add to `.env`:
```
PUSHOVER_USER_KEY=your_user_key
PUSHOVER_API_TOKEN=your_app_token
```

## Test plan

- [x] 5 unit tests — isConfigured, payload structure, url/url_title, error handling, unconfigured no-op
- [ ] Manual: trigger a permission prompt → notification should arrive on Apple Watch
- [ ] Manual: tap notification → opens Mitzo in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)