### PR TITLE
docs: update enterprise plan to v1.2 — Phase 1 complete

### DIFF
--- a/docs/enterprise-plan.md
+++ b/docs/enterprise-plan.md
@@ -1,6 +1,6 @@
 # Mitzo Enterprise Engineering Plan
 
-**Version:** 1.1
+**Version:** 1.2
 **Date:** 2026-04-02
 **Scope:** Documentation only — no code changes until explicitly requested
 
@@ -8,100 +8,86 @@
 
 ## Executive Summary
 
-Mitzo is a functional, ~4,776-LOC mobile-first Claude Code interface built on Node.js/Express/TypeScript (backend) and React 19/Vite/TypeScript (frontend). The architecture works today, but carries the technical debt typical of a rapid prototype that was never hardened for production. Six categories of risk stand out:
+Mitzo is a functional, mobile-first Claude Code interface built on Node.js/Express/TypeScript (backend) and React 19/Vite/TypeScript (frontend). It runs in production via pm2 on a personal server, with Pushover + ntfy push notifications, worktree isolation, MCP tool integration, and extended thinking visibility. The architecture works, but the two central files (`chat.ts` at 575 LOC, `ChatView.tsx` at 542 LOC) remain god objects that absorb every new feature.
 
-1. **Concentration risk** — two files (`chat.ts`, `ChatView.tsx`) own disproportionate surface area. A bug or feature change in either cascades widely.
-2. **Observability gaps** — 22 silent `catch` blocks and 19 raw `console.*` calls mean failures are invisible in production logs.
-3. **Testing blindspots** — 0% frontend component coverage, no route-layer tests, no integration or e2e tests. The 118 existing tests cover only isolated server utilities.
-4. **Type erosion** — 30 `any` occurrences (5 in production code), untyped WebSocket messages on the frontend, and no runtime validation of HTTP requests/responses mean TypeScript's guarantees stop at the module boundary.
-5. **Security posture** — no rate limiting, CSRF protection, or request size limits; the NTFY auth token is embedded in action URLs (visible in server logs).
-6. **CI immaturity** — the pipeline lints and unit-tests, but has no e2e tests, security scanning, bundle size budgets, or deployment step.
+**Phase 1 (Foundation) is complete.** Constants centralized, structured logger in place, silent catches fixed, error boundaries added, CI pipeline restructured to run all steps independently. Four risks remain:
 
-The six phases below address these risks in dependency order: each phase unblocks the next. The entire plan can be executed incrementally without a rewrite.
+1. **Concentration risk** — `chat.ts` (575 LOC) and `ChatView.tsx` (542 LOC) are larger than at plan creation. Every feature lands in these two files. Modularization is overdue.
+2. **Testing blindspots** — 151 tests across 18 files (up from 118/12), but still no route-layer tests, no WS integration tests, no e2e tests. Frontend component tests have started (MessageBubble, paste-images, model-preference) but coverage is thin.
+3. **Type erosion** — `any` in production code, untyped WS messages, no runtime validation. Model catalog duplicated between server (`AVAILABLE_MODELS`) and frontend (hardcoded `<option>` values).
+4. **Security posture** — no rate limiting, CSRF, or request size limits. NTFY auth token still in action URLs. Pushover reuses `NTFY_AUTH_TOKEN` as query param.
+
+CI is now green and structurally sound (all steps run independently). Branch discipline enforced via `.cursor/rules/ci-discipline.mdc`.
+
+The five remaining phases address these risks in dependency order.
 
 ---
 
 ## Current State Baseline
 
-Measured against the codebase as of 2026-04-01. These numbers define the "before" — success criteria reference them directly.
+Measured against the codebase as of 2026-04-02 (post-Phase 1, post-parity-output work).
 
 ### Codebase Size
 
-| File                                | LOC | Role                            |
-| ----------------------------------- | --: | ------------------------------- |
-| `server/chat.ts`                    | 535 | Chat orchestration (god object) |
-| `frontend/src/pages/ChatView.tsx`   | 470 | Chat UI (god component)         |
-| `server/index.ts`                   | 384 | Express routes + WS handler     |
-| `frontend/src/pages/FileViewer.tsx` | 303 | File browser + editor           |
-| `server/session-registry.ts`        | 146 | Session state management        |
+| File                                    | LOC | Role                            |
+| --------------------------------------- | --: | ------------------------------- |
+| `server/chat.ts`                        | 575 | Chat orchestration (god object) |
+| `frontend/src/pages/ChatView.tsx`       | 542 | Chat UI (god component)         |
+| `server/index.ts`                       | 436 | Express routes + WS handler     |
+| `frontend/src/pages/FileViewer.tsx`     | 305 | File browser + editor           |
+| `frontend/src/pages/SessionList.tsx`    | 248 | Home screen + session list      |
+| `frontend/src/components/ChatInput.tsx` | 179 | Message input + image paste     |
+| `server/session-registry.ts`            | 147 | Session state management        |
+| `server/worktree.ts`                    | 145 | Git worktree lifecycle          |
 
-### Error Handling
+New modules since v1.1: `server/pushover.ts` (56), `server/git-version.ts` (43), `frontend/src/components/ThinkingBlock.tsx` (28), `frontend/src/lib/model-preference.ts`, `frontend/src/lib/paste-images.ts`, `scripts/deploy.sh`.
 
-| Category                   |  Count | Description                                                  |
-| -------------------------- | -----: | ------------------------------------------------------------ |
-| Empty `.catch(() => {})`   |      5 | Promise swallows (ChatView, SessionList, FileViewer)         |
-| Empty `catch {}` blocks    |      5 | All in `worktree.ts`                                         |
-| Comment-only catch bodies  |     10 | `index.ts`, `chat.ts`, `mcp-server/tools.ts`, `ChatView.tsx` |
-| Single-console-log catches |      2 | `ChatInput.tsx`, `notify.ts`                                 |
-| **Total silent catches**   | **22** |                                                              |
+### Phase 1 Status: COMPLETE
 
-### Type Safety
-
-| Metric                              |                   Count |
-| ----------------------------------- | ----------------------: |
-| `any` occurrences (production code) |                       5 |
-| `any` occurrences (test code)       |                      25 |
-| `any` occurrences (total)           |                      30 |
-| Runtime validation (Zod)            | 0 routes, 0 WS messages |
+| Deliverable                                                                    | Status |
+| ------------------------------------------------------------------------------ | ------ |
+| Constants centralized (`server/constants.ts`, `frontend/src/lib/constants.ts`) | Done   |
+| Structured logger (`server/logger.ts`)                                         | Done   |
+| Silent catch blocks fixed (22 → 0)                                             | Done   |
+| Error boundaries (ChatView, FileViewer, full app)                              | Done   |
+| CI restructured (all steps run independently via `if: always()`)               | Done   |
+| CI discipline rule (`.cursor/rules/ci-discipline.mdc`)                         | Done   |
+| Branch workflow enforced (never push to main)                                  | Done   |
 
 ### Testing
 
-| Metric                        | Count |
-| ----------------------------- | ----: |
-| Test files                    |    12 |
-| Test cases (`it()`)           |   118 |
-| Frontend component test files |     0 |
-| Frontend page test files      |     0 |
-| Route-layer test files        |     0 |
-| WebSocket integration tests   |     0 |
-| E2E test files                |     0 |
-
-### Observability
-
-| Metric                                     | Count |
-| ------------------------------------------ | ----: |
-| Raw `console.log/error` calls in `server/` |    19 |
-| Structured logger instances                |     0 |
-| Request-ID correlation                     |  None |
-
-### Constants
-
-| Status                        |                                                                      Count |
-| ----------------------------- | -------------------------------------------------------------------------: |
-| Already named (local to file) |                      3 (`DETACHED_TTL_MS`, `BRANCH_PREFIX`, `STALE_HOURS`) |
-| Inline magic numbers          |                                                                         11 |
-| Duplicated across files       | 3 (`TOOL_RESULT_MAX_CHARS`, `GIT_BRANCH_TIMEOUT_MS`, `SESSION_LIST_LIMIT`) |
+| Metric                        |                                             Count |
+| ----------------------------- | ------------------------------------------------: |
+| Test files                    |                                                18 |
+| Test cases (`it()`)           |                                               151 |
+| Frontend component test files |                       1 (`MessageBubble.test.ts`) |
+| Frontend lib test files       | 3 (`ws-pool`, `paste-images`, `model-preference`) |
+| Frontend page test files      |                                                 0 |
+| Route-layer test files        |                                                 0 |
+| WebSocket integration tests   |                                                 0 |
+| E2E test files                |                                                 0 |
 
 ### Security & CI
 
-| Item                                     | Status                                  |
-| ---------------------------------------- | --------------------------------------- |
-| Rate limiting                            | None                                    |
-| CSRF protection                          | None (partial via `sameSite: 'strict'`) |
-| Request size limits                      | None (`express.json()` unlimited)       |
-| Security headers (helmet)                | Not installed                           |
-| CI: lint + typecheck + unit test + build | Yes                                     |
-| CI: e2e tests                            | No                                      |
-| CI: security scanning                    | No                                      |
-| CI: coverage reporting                   | No                                      |
-| CI: bundle size tracking                 | No                                      |
+| Item                                     | Status                                                   |
+| ---------------------------------------- | -------------------------------------------------------- |
+| Rate limiting                            | None                                                     |
+| CSRF protection                          | None (partial via `sameSite: 'strict'`)                  |
+| Request size limits                      | None (`express.json()` unlimited)                        |
+| Security headers (helmet)                | Not installed                                            |
+| Notification tokens                      | NTFY token in URLs; Pushover reuses `NTFY_AUTH_TOKEN`    |
+| CI: lint + typecheck + unit test + build | Yes (all steps independent)                              |
+| CI: e2e tests                            | No                                                       |
+| CI: security scanning                    | No                                                       |
+| CI: coverage reporting                   | No                                                       |
+| CI: bundle size tracking                 | No                                                       |
+| Deployment                               | `scripts/deploy.sh` (git pull + npm build + pm2 restart) |
 
 ---
 
-## Phase 1: Foundation — Error Handling, Logging, Constants
+## Phase 1: Foundation — Error Handling, Logging, Constants ✓ COMPLETE
 
-**Priority: Highest. Unblocks all other phases.**
-**Goal:** Make failures visible, eliminate magic numbers, establish shared vocabulary.
+**Completed 2026-04-02.** Constants centralized, structured logger deployed, 22 silent catches fixed, error boundaries added, CI restructured, branch discipline enforced.
 
 ### Rationale
 
@@ -159,11 +145,11 @@ Add a React error boundary wrapping `ChatView` and `FileViewer`. Without this, a
 
 ### Phase 1 Success Criteria
 
-- [ ] Zero inline magic numbers in server or frontend code — all imported from `constants.ts`
-- [ ] Zero raw `console.*` calls in `server/` — all routed through `logger.*`
-- [ ] Silent catch count reduced from 22 to 0 (each either logs or rethrows)
-- [ ] React error boundary wraps all routes — blank-screen crash impossible
-- [ ] All 118+ existing tests pass, including the fixed `notify.test.ts`
+- [x] Zero inline magic numbers in server or frontend code — all imported from `constants.ts`
+- [x] Zero raw `console.*` calls in `server/` — all routed through `logger.*`
+- [x] Silent catch count reduced from 22 to 0 (each either logs or rethrows)
+- [x] React error boundary wraps all routes — blank-screen crash impossible
+- [x] All 151 tests pass (up from 118 at plan creation)
 
 ---
 
@@ -174,7 +160,7 @@ Add a React error boundary wrapping `ChatView` and `FileViewer`. Without this, a
 
 ### 2.1 Split `startChat()` in `chat.ts`
 
-`startChat()` at 160+ LOC performs four distinct jobs. Extract each into a named function:
+`startChat()` at ~200 LOC performs five distinct jobs (image staging, tool list construction, query config, permission handling with ntfy + Pushover, SDK event loop with thinking resolution). Extract each into a named function:
 
 | Extract                                | Into                                              | Description    |
 | -------------------------------------- | ------------------------------------------------- | -------------- |
@@ -193,7 +179,7 @@ Add a React error boundary wrapping `ChatView` and `FileViewer`. Without this, a
 
 ### 2.2 Refactor `ChatView.tsx` — Hook Extraction
 
-`ChatView.tsx` at 461 LOC does six things simultaneously: session identity management, WebSocket subscription and message routing, message state accumulation, streaming buffer management, permission state, and send/stop logic. Extract into four custom hooks. See the **ChatView Hook Extraction Plan** section for signatures.
+`ChatView.tsx` at 542 LOC does seven things simultaneously: session identity management, WebSocket subscription and message routing (including thinking blocks), message state accumulation, streaming + thinking buffer management, permission state, model persistence, and send/stop logic. Extract into four custom hooks. See the **ChatView Hook Extraction Plan** section for signatures.
 
 | Task                                                    | Files Affected                   | Complexity |
 | ------------------------------------------------------- | -------------------------------- | ---------- |
@@ -240,14 +226,15 @@ Move tool tier configuration to a format extensible from `.mitzo.json` without c
 
 ### Phase 2 Success Criteria
 
-- [ ] `chat.ts` reduced from 535 LOC to <300 (orchestrator + imports only)
-- [ ] `ChatView.tsx` reduced from 470 LOC to <120 (composition + JSX only)
-- [ ] `FileViewer.tsx` reduced from 303 LOC to <120
-- [ ] `startChat()` split into 4+ named functions, each independently testable
+- [ ] `chat.ts` reduced from 575 LOC to <300 (orchestrator + imports only)
+- [ ] `ChatView.tsx` reduced from 542 LOC to <150 (composition + JSX only)
+- [ ] `FileViewer.tsx` reduced from 305 LOC to <120
+- [ ] `startChat()` split into 5+ named functions, each independently testable
 - [ ] `buildPermissionHandler` in its own module with its own test file
 - [ ] `ChatView` state managed via `useReducer` with typed actions — no implicit state machine
+- [ ] Thinking block state (`thinkingBuf`, finalization logic) encapsulated in reducer, not inline
 - [ ] Tool tier overrides work from `.mitzo.json` without code changes
-- [ ] All existing tests still pass after every extraction
+- [ ] All 151+ existing tests still pass after every extraction
 
 ---
 
@@ -258,20 +245,20 @@ Move tool tier configuration to a format extensible from `.mitzo.json` without c
 
 ### 3.1 Frontend Component Tests
 
-Add React Testing Library + jsdom to the frontend test setup.
+`MessageBubble.test.ts` already exists with 2 tests. Extend coverage to remaining components.
 
-| Component                | Test Scope                                                          | Complexity |
-| ------------------------ | ------------------------------------------------------------------- | ---------- |
-| `PermissionBanner`       | Renders tiers correctly; calls `onRespond` with correct args; timer | S          |
-| `MessageBubble`          | Renders user/assistant/tool roles; streaming indicator              | S          |
-| `ToolGroup` / `ToolPill` | Grouping renders correctly; expand/collapse                         | S          |
-| `ChatInput`              | Send on Enter; disabled when running; image attachment limit        | M          |
-| `ErrorBoundary`          | Catches render errors; shows fallback                               | S          |
+| Component                | Test Scope                                                          | Status                  |
+| ------------------------ | ------------------------------------------------------------------- | ----------------------- |
+| `MessageBubble`          | Renders user/assistant/tool roles; newline formatting               | Partial (2 tests exist) |
+| `PermissionBanner`       | Renders tiers correctly; calls `onRespond` with correct args; timer | Not started             |
+| `ToolGroup` / `ToolPill` | Grouping renders correctly; expand/collapse; raw input display      | Not started             |
+| `ThinkingBlock`          | Expand/collapse; streaming vs finalized state                       | Not started             |
+| `ChatInput`              | Send on Enter; disabled when running; image paste; attachment limit | Not started             |
+| `ErrorBoundary`          | Catches render errors; shows fallback                               | Not started             |
 
-| Task                                                                                             | Files Affected                       | Complexity |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------ | ---------- |
-| Add `@testing-library/react`, `@testing-library/user-event`, `jsdom` to frontend devDependencies | `frontend/package.json`              | S          |
-| Write component tests                                                                            | `frontend/src/components/__tests__/` | M          |
+| Task                                                                      | Files Affected                       | Complexity |
+| ------------------------------------------------------------------------- | ------------------------------------ | ---------- |
+| Extend existing MessageBubble tests; add tests for remaining 5 components | `frontend/src/components/__tests__/` | M          |
 
 ### 3.2 Custom Hook Tests
 
@@ -324,11 +311,11 @@ The full chat lifecycle has never been tested end-to-end. Use `ws` client librar
 
 ### Phase 3 Success Criteria
 
-- [ ] Frontend component test files > 0 (target: 5+ components covered)
+- [ ] Frontend component test files cover all 7 components (MessageBubble, PermissionBanner, ToolGroup, ToolPill, ThinkingBlock, ChatInput, ErrorBoundary)
 - [ ] Custom hook tests exist for all 4 extracted hooks
 - [ ] Route-layer tests cover all HTTP endpoints via `supertest`
 - [ ] WebSocket integration tests cover connect, stop, auth, and reattach flows
-- [ ] Total test count exceeds 180 (from current 118)
+- [ ] Total test count exceeds 200 (from current 151)
 - [ ] `index.ts` exports `app` separately from server startup (testability gate)
 
 ---
@@ -373,15 +360,16 @@ Define a discriminated union for all server-to-client WebSocket messages.
 
 ### 4.5 Shared Type Package
 
-`ToolTier` and model IDs are duplicated between server and frontend. A `shared/` workspace package eliminates drift.
+`ToolTier`, model IDs, and WS message types are duplicated between server and frontend. The model catalog is particularly fragile — `AVAILABLE_MODELS` in `chat.ts` and hardcoded `<option>` values in `ChatView.tsx` must be kept in sync manually. A `shared/` workspace package eliminates drift.
 
-| Task                                                               | Files Affected                                                  | Complexity |
-| ------------------------------------------------------------------ | --------------------------------------------------------------- | ---------- |
-| Create `shared/` workspace package with `tsconfig.json`            | New `shared/` directory                                         | M          |
-| Move `ToolTier`, `ModelId`, and WS message types to `shared/`      | `shared/src/types.ts`                                           | M          |
-| Update `tsconfig.json` and `package.json` for workspace references | Root, `server/`, `frontend/`                                    | M          |
-| Replace local type definitions with `shared/` imports              | `tool-tiers.ts`, `ChatView.tsx`, `ws-pool.ts`, `ws-messages.ts` | M          |
-| Add `shared/` build step to CI                                     | `.github/workflows/ci.yml`                                      | S          |
+| Task                                                                                             | Files Affected                                  | Complexity |
+| ------------------------------------------------------------------------------------------------ | ----------------------------------------------- | ---------- |
+| Create `shared/` workspace package with `tsconfig.json`                                          | New `shared/` directory                         | M          |
+| Move `ToolTier`, model catalog, and WS message types to `shared/`                                | `shared/src/types.ts`                           | M          |
+| Update `tsconfig.json` and `package.json` for workspace references                               | Root, `server/`, `frontend/`                    | M          |
+| Replace `AVAILABLE_MODELS` in `chat.ts` and `<option>` list in `ChatView.tsx` with shared import | `chat.ts`, `ChatView.tsx`                       | M          |
+| Replace local type definitions with `shared/` imports                                            | `tool-tiers.ts`, `ws-pool.ts`, `ws-messages.ts` | M          |
+| Add `shared/` build step to CI                                                                   | `.github/workflows/ci.yml`                      | S          |
 
 **Note:** `zod` is already available in `mcp-server/package.json`. The shared package can re-export Zod schemas that serve as both runtime validators (server) and type sources (frontend via `z.infer`), making 4.1–4.4 schemas reusable without duplication.
 
@@ -413,14 +401,14 @@ Define a discriminated union for all server-to-client WebSocket messages.
 | Add `express-rate-limit`                                | `package.json` | S          |
 | Apply limiters to login, permission/respond, WS upgrade | `index.ts`     | M          |
 
-### 5.2 NTFY Token URL Exposure
+### 5.2 Notification Token Exposure
 
-The NTFY auth token is in action URLs as a query parameter — visible in server access logs and HTTP referrer headers.
+The NTFY auth token is in action URLs as a query parameter — visible in server access logs and HTTP referrer headers. Pushover (`pushover.ts`) reuses the same `NTFY_AUTH_TOKEN` for its deep-link URLs, doubling the exposure surface.
 
-| Task                                                                   | Files Affected              | Complexity |
-| ---------------------------------------------------------------------- | --------------------------- | ---------- |
-| Replace query-param token with HMAC-signed, time-limited action tokens | `notify.ts`, `index.ts`     | M          |
-| Use a separate `NTFY_ACTION_SECRET` distinct from `NTFY_AUTH_TOKEN`    | `notify.ts`, `.env.example` | S          |
+| Task                                                                   | Files Affected                             | Complexity |
+| ---------------------------------------------------------------------- | ------------------------------------------ | ---------- |
+| Replace query-param token with HMAC-signed, time-limited action tokens | `notify.ts`, `pushover.ts`, `index.ts`     | M          |
+| Use a separate `ACTION_SECRET` distinct from `NTFY_AUTH_TOKEN`         | `notify.ts`, `pushover.ts`, `.env.example` | S          |
 
 ### 5.3 CSRF Protection
 
@@ -508,20 +496,17 @@ No size budget currently. A 1MB JS bundle on a mobile connection is a UX failure
 | Upload coverage to Codecov                          | `.github/workflows/ci.yml` | S          |
 | Set coverage thresholds for new code                | `vitest.config.ts`         | M          |
 
-### 6.5 Deployment Step
+### 6.5 Deployment Hardening
 
-Build → full test suite → deploy to staging on merge to `main` → manual approval for production.
+Mitzo runs on a single host via `pm2`. `scripts/deploy.sh` already handles `git pull --ff-only`, `npm install`, `npm run build`, and `pm2 restart mitzo` with a delayed restart to avoid self-kill. The foundation exists — harden it.
 
-Mitzo runs on a single host (personal server). The deployment pipeline doesn't need Kubernetes or cloud orchestration — it needs reliability and rollback safety.
-
-| Task                                                            | Files Affected             | Complexity |
-| --------------------------------------------------------------- | -------------------------- | ---------- |
-| Create `Dockerfile` with multi-stage build (build → runtime)    | New `Dockerfile`           | M          |
-| Add `docker-compose.yml` for local parity with production       | New `docker-compose.yml`   | S          |
-| Add `deploy` job to CI: build image → push to GHCR → SSH deploy | `.github/workflows/ci.yml` | L          |
-| Add health check endpoint (`GET /health`)                       | `index.ts`                 | S          |
-| Add rollback script (pull previous image tag, restart)          | New `scripts/rollback.sh`  | S          |
-| Document deployment and rollback procedures                     | `docs/deployment.md`       | M          |
+| Task                                                                 | Files Affected             | Complexity |
+| -------------------------------------------------------------------- | -------------------------- | ---------- |
+| Add health check endpoint (`GET /health`)                            | `index.ts`                 | S          |
+| Add pre-deploy CI gate (deploy only if CI green)                     | `.github/workflows/ci.yml` | M          |
+| Add rollback to `deploy.sh` (stash current hash, restore on failure) | `scripts/deploy.sh`        | S          |
+| Add `pm2` ecosystem config for consistent process management         | New `ecosystem.config.cjs` | S          |
+| Document deployment and rollback procedures                          | `docs/deployment.md`       | M          |
 
 ### Phase 6 Success Criteria
 
@@ -641,9 +626,11 @@ interface ChatMessagesState {
 }
 
 type ChatMessagesAction =
+  | { type: 'THINKING_START' }
+  | { type: 'THINKING_DELTA'; text: string }
   | { type: 'TEXT_DELTA'; text: string }
   | { type: 'TEXT'; text: string }
-  | { type: 'TOOL_CALL'; toolName: string; toolId: string; input: string }
+  | { type: 'TOOL_CALL'; toolName: string; toolId: string; input: string; rawInput?: RawToolInput }
   | { type: 'TOOL_RESULT'; toolId: string; result: string }
   | { type: 'PERMISSION_REQUEST'; payload: PermissionRequest }
   | { type: 'PERMISSION_TIMEOUT'; permId: string }
@@ -799,26 +786,30 @@ Phase 6 (CI/CD) ← after Phase 3
 
 ## Effort Summary
 
-| Phase     | Title              | Estimated Effort | Unlocks                |
-| --------- | ------------------ | ---------------- | ---------------------- |
-| 1         | Foundation         | 3–5 days         | Everything             |
-| 2         | Modularization     | 5–8 days         | Phases 3, 4            |
-| 3         | Testing            | 7–10 days        | Phase 6 CI gates       |
-| 4         | Type Safety        | 4–6 days         | Production reliability |
-| 5         | Security Hardening | 3–5 days         | Production deployment  |
-| 6         | CI/CD Enhancement  | 3–5 days         | Continuous quality     |
-| **Total** |                    | **25–39 days**   |                        |
+| Phase         | Title              | Estimated Effort | Unlocks                | Status       |
+| ------------- | ------------------ | ---------------- | ---------------------- | ------------ |
+| 1             | Foundation         | 3–5 days         | Everything             | **COMPLETE** |
+| 2             | Modularization     | 5–8 days         | Phases 3, 4            | Next         |
+| 3             | Testing            | 7–10 days        | Phase 6 CI gates       | Pending      |
+| 4             | Type Safety        | 4–6 days         | Production reliability | Pending      |
+| 5             | Security Hardening | 3–5 days         | Production deployment  | Pending      |
+| 6             | CI/CD Enhancement  | 3–5 days         | Continuous quality     | Pending      |
+| **Remaining** |                    | **22–34 days**   |                        |              |
 
-Phases 3, 4, and 5 can be parallelized after Phase 2 completes, reducing wall-clock time to approximately 15–20 days.
+Phases 3, 4, and 5 can be parallelized after Phase 2 completes, reducing wall-clock time to approximately 12–17 days remaining.
 
 ---
 
 ## Risk Register
 
-| Risk                                                                | Likelihood | Impact | Mitigation                                                                            |
-| ------------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------- |
-| Hook extraction introduces subtle state ordering bugs               | Medium     | High   | Extract one hook at a time; full manual smoke test after each                         |
-| Zod schemas break existing clients during Phase 4                   | Low        | Medium | Use `safeParse` returning 400, not throwing; monitor for 1 week                       |
-| Rate limiting blocks legitimate mobile users with dynamic IPs       | Low        | Medium | Start conservative limits; loosen based on monitoring                                 |
-| NTFY token rotation requires coordinating server config and ntfy.sh | Medium     | Low    | Document rotation procedure; use `NTFY_ACTION_SECRET` distinct from `NTFY_AUTH_TOKEN` |
-| Playwright e2e tests are flaky in CI                                | Medium     | Medium | Use `--retries=2`; fix flaky tests before adding to required PR gate                  |
+| Risk                                                              | Likelihood   | Impact | Mitigation                                                                 |
+| ----------------------------------------------------------------- | ------------ | ------ | -------------------------------------------------------------------------- |
+| Hook extraction introduces subtle state ordering bugs             | Medium       | High   | Extract one hook at a time; full manual smoke test after each              |
+| Thinking block state transitions break during extraction          | Medium       | High   | `thinkingBuf` finalization logic is complex; test explicitly in reducer    |
+| Parallel AI sessions create merge conflicts on shared files       | **Realized** | Medium | Established: all work on branches, CI-green before merge, rebase workflow  |
+| AI sessions push to main bypassing CI                             | **Realized** | High   | Fixed: `.cursor/rules/ci-discipline.mdc`, branch protection, no exceptions |
+| CI failure hides downstream results (tests never run)             | **Realized** | High   | Fixed: `if: always()` on typecheck/test/build steps, summary step          |
+| Zod schemas break existing clients during Phase 4                 | Low          | Medium | Use `safeParse` returning 400, not throwing; monitor for 1 week            |
+| Rate limiting blocks legitimate mobile users with dynamic IPs     | Low          | Medium | Start conservative limits; loosen based on monitoring                      |
+| Notification token rotation requires coordinating ntfy + Pushover | Medium       | Low    | Document rotation procedure; use shared `ACTION_SECRET`                    |
+| Playwright e2e tests are flaky in CI                              | Medium       | Medium | Use `--retries=2`; fix flaky tests before adding to required PR gate       |


### PR DESCRIPTION
## Summary

- Mark Phase 1 as complete with checked success criteria
- Refresh baseline numbers to current state (575/542 LOC god objects, 151 tests/18 files)
- Account for new modules: pushover, git-version, ThinkingBlock, model-preference, paste-images, deploy.sh
- Update ChatView hook extraction plan for thinking blocks and raw tool input
- Replace Docker deployment section with actual pm2 + deploy.sh setup
- Add model catalog to shared types scope (Phase 4.5)
- Update risk register with three realized risks and their mitigations
- Refresh effort estimates (22-34 days remaining)

## Test plan

Doc-only change. CI verifies formatting.

Made with [Cursor](https://cursor.com)