### PR TITLE
fix(ui): differentiate header refresh icons

### DIFF
--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -186,7 +186,7 @@ export function SessionList() {
             disabled={checking}
             title="Check for server updates"
           >
-            {checking ? '…' : '⟳'}
+            {checking ? '…' : '☁↑'}
           </button>
           <button className="refresh-ui-btn" onClick={refreshUI} title="Clear cache and reload">
             ↺

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -184,14 +184,21 @@ textarea:focus {
 }
 
 .check-update-btn {
-  font-size: 1rem;
+  font-size: 0.85rem;
   padding: 0.35rem 0.55rem;
   border-radius: 8px;
   background: transparent;
   border: none;
   color: var(--text-dim);
   cursor: pointer;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
+}
+
+.check-update-btn:active {
+  color: var(--text);
 }
 
 .check-update-btn:disabled {


### PR DESCRIPTION
## Summary
- Update check button: `⟳` → `☁↑` (cloud + up arrow, visually distinct from reload)
- Cache reload button: `↺` unchanged
- CSS: aligned `check-update-btn` styles with `refresh-ui-btn` (consistent `line-height`, `tap-highlight`, `active` state, slightly smaller font for the two-char icon)

## Test plan
- [ ] Home screen header shows two visually distinct icons
- [ ] `☁↑` triggers update check (spins to `…` while checking)
- [ ] `↺` clears cache and reloads as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)