### PR TITLE
fix(ui): fix expand-after-compact for tool groups and thinking blocks

### DIFF
--- a/frontend/src/components/ThinkingBlock.tsx
+++ b/frontend/src/components/ThinkingBlock.tsx
@@ -10,7 +10,7 @@ export function ThinkingBlock({ message }: Props) {
   const text = message.text || '';
   const isStreaming = !!message.streaming;
 
-  if (!text && !isStreaming) return null;
+  if (!text) return null;
 
   return (
     <div className={`thinking-block ${isStreaming ? 'thinking-block--streaming' : ''}`}>

--- a/frontend/src/components/ToolGroup.tsx
+++ b/frontend/src/components/ToolGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ToolPill } from './ToolPill';
 import type { Message } from '../types/chat';
 
@@ -9,9 +9,13 @@ interface Props {
 export function ToolGroup({ tools }: Props) {
   const allDone = tools.every((t) => t.toolResult !== undefined);
   const [expanded, setExpanded] = useState(!allDone);
+  const autoCollapsed = useRef(false);
 
   useEffect(() => {
-    if (allDone) setExpanded(false);
+    if (allDone && !autoCollapsed.current) {
+      autoCollapsed.current = true;
+      setExpanded(false);
+    }
   }, [allDone]);
 
   const doneCount = tools.filter((t) => t.toolResult !== undefined).length;

--- a/frontend/src/lib/__tests__/groupMessages.test.ts
+++ b/frontend/src/lib/__tests__/groupMessages.test.ts
@@ -111,4 +111,46 @@ describe('groupMessages', () => {
       expect(afterDone[1].type).toBe('tool-group');
     });
   });
+
+  describe('stable keys', () => {
+    it('tool-group has a key derived from first tool id', () => {
+      const msgs = [user(), tool('abc'), tool('def'), tool('ghi')];
+      const grouped = groupMessages(msgs);
+      const group = grouped[1];
+      expect(group.type).toBe('tool-group');
+      if (group.type === 'tool-group') {
+        expect(group.key).toBe('abc');
+      }
+    });
+
+    it('key is stable across re-runs with same messages', () => {
+      const msgs = [user(), tool('x1'), tool('x2'), tool('x3')];
+      const a = groupMessages(msgs);
+      const b = groupMessages(msgs);
+      if (a[1].type === 'tool-group' && b[1].type === 'tool-group') {
+        expect(a[1].key).toBe(b[1].key);
+      }
+    });
+
+    it('two separate groups have different keys', () => {
+      const msgs = [
+        user(),
+        tool('a1'),
+        tool('a2'),
+        tool('a3'),
+        assistant(),
+        tool('b1'),
+        tool('b2'),
+        tool('b3'),
+      ];
+      const grouped = groupMessages(msgs);
+      const groups = grouped.filter((g) => g.type === 'tool-group');
+      expect(groups).toHaveLength(2);
+      if (groups[0].type === 'tool-group' && groups[1].type === 'tool-group') {
+        expect(groups[0].key).toBe('a1');
+        expect(groups[1].key).toBe('b1');
+        expect(groups[0].key).not.toBe(groups[1].key);
+      }
+    });
+  });
 });

--- a/frontend/src/lib/groupMessages.ts
+++ b/frontend/src/lib/groupMessages.ts
@@ -8,7 +8,11 @@ export function groupMessages(messages: Message[], streaming = false): GroupedIt
   function flushTools() {
     if (toolBuffer.length === 0) return;
     if (!streaming && toolBuffer.length >= TOOL_GROUP_THRESHOLD) {
-      result.push({ type: 'tool-group', tools: toolBuffer });
+      result.push({
+        type: 'tool-group',
+        tools: toolBuffer,
+        key: toolBuffer[0].toolId ?? `tg-${result.length}`,
+      });
     } else {
       for (const t of toolBuffer) {
         result.push({ type: 'message', message: t });

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -238,7 +238,7 @@ export function ChatView() {
         )}
         {grouped.map((item, i) => {
           if (item.type === 'tool-group') {
-            return <ToolGroup key={`tg-${i}`} tools={item.tools} />;
+            return <ToolGroup key={`tg-${item.key}`} tools={item.tools} />;
           }
           const msg = item.message;
           if (msg.role === 'thinking') {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1018,6 +1018,7 @@ textarea:focus {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  touch-action: manipulation;
   padding: 0.3rem 0.6rem;
   width: 100%;
   cursor: pointer;
@@ -1086,6 +1087,7 @@ textarea:focus {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  touch-action: manipulation;
   padding: 0.4rem 0.6rem;
   width: 100%;
   cursor: pointer;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -22,7 +22,7 @@ export interface Message {
 
 export type GroupedItem =
   | { type: 'message'; message: Message }
-  | { type: 'tool-group'; tools: Message[] };
+  | { type: 'tool-group'; tools: Message[]; key: string };
 
 export type ToolTier = 'safe' | 'standard' | 'elevated' | 'unknown';
 


### PR DESCRIPTION
## Summary
- **Stable ToolGroup keys**: `groupMessages` now sets `key = first toolId` on tool-group items. `ChatView` uses this instead of the array index — prevents full remount when streaming ends and tools compact
- **ToolGroup auto-collapse guard**: replaced `useEffect` with a ref-guarded version so the auto-collapse fires only once. After that, the user can expand/collapse freely
- **ThinkingBlock blank jump**: changed `if (!text && !isStreaming)` → `if (!text)` — block doesn't enter the DOM until the first `thinking_delta` arrives, eliminating the blank-space scroll jump on `thinking_start`
- **iOS tap fix**: added `touch-action: manipulation` to `.tool-group-header` and `.thinking-block-header` — removes 300ms tap delay and scroll-gesture ambiguity on mobile

## Test plan
- [ ] Tools compact after streaming — ToolGroup starts collapsed
- [ ] Tapping the group header expands it and stays expanded
- [ ] Tapping again collapses — can toggle freely
- [ ] No blank scroll jump at the start of a thinking block
- [ ] ThinkingBlock appears and is expandable after streaming
- [ ] All 168 tests pass (notify.test.ts failure is pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)