### PR TITLE
fix(ui): revert ThinkingBlock guard, finalize thinking on DONE, bust SW cache

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'mitzo-shell-v2';
+const CACHE = 'mitzo-shell-v3';
 
 // On install: take control immediately
 self.addEventListener('install', () => self.skipWaiting());

--- a/frontend/src/components/ThinkingBlock.tsx
+++ b/frontend/src/components/ThinkingBlock.tsx
@@ -10,7 +10,7 @@ export function ThinkingBlock({ message }: Props) {
   const text = message.text || '';
   const isStreaming = !!message.streaming;
 
-  if (!text) return null;
+  if (!text && !isStreaming) return null;
 
   return (
     <div className={`thinking-block ${isStreaming ? 'thinking-block--streaming' : ''}`}>

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -145,10 +145,14 @@ export function chatMessagesReducer(
       };
 
     case 'DONE': {
-      const last = state.messages[state.messages.length - 1];
       let msgs = state.messages;
-      if (last?.role === 'assistant' && last.streaming) {
-        msgs = [...msgs.slice(0, -1), { role: 'assistant' as const, text: last.text || '' }];
+      const lastMsg = msgs[msgs.length - 1];
+      if (lastMsg?.role === 'thinking' && lastMsg.streaming) {
+        msgs = finalizeThinking(msgs, lastMsg.text || '');
+      }
+      const prevLast = msgs[msgs.length - 1];
+      if (prevLast?.role === 'assistant' && prevLast.streaming) {
+        msgs = [...msgs.slice(0, -1), { role: 'assistant' as const, text: prevLast.text || '' }];
       }
       return { ...state, messages: msgs, running: false };
     }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -44,6 +44,7 @@ export async function runQueryLoop(
   // Buffer tool_use blocks streamed via content_block_start/delta/stop events.
   // Keyed by content block index (resets per API message via message_start).
   const toolInputBuffers = new Map<number, { name: string; id: string; inputBuf: string }>();
+  let doneSent = false;
 
   try {
     for await (const msg of q) {
@@ -67,6 +68,7 @@ export async function runQueryLoop(
         }
       } else if (msg.type === 'result') {
         if (msg.session_id) send(currentWs, { type: 'session_id', sessionId: msg.session_id });
+        doneSent = true;
         send(currentWs, { type: 'done', sessionId: msg.session_id });
       } else if (msg.type === 'stream_event') {
         const evt = msg.event as Record<string, unknown> | undefined;
@@ -139,7 +141,7 @@ export async function runQueryLoop(
     if (finalSession) {
       const finalWs = finalSession.ws;
       registry.remove(clientId);
-      if (finalWs.readyState === finalWs.OPEN) {
+      if (!doneSent && finalWs.readyState === finalWs.OPEN) {
         send(finalWs, { type: 'done', sessionId: finalSession.sessionId });
       }
     }


### PR DESCRIPTION
## Summary
- **ThinkingBlock revert**: `if (!text)` back to `if (!text && !isStreaming)` — the previous fix hid thinking blocks during streaming before first delta arrived
- **DONE handler**: finalize streaming thinking messages on session end — prevents orphaned invisible thinking entries on abort or fast responses
- **SW cache v3**: forces stale frontend cache eviction on all clients — likely root cause of "fixes deploy but nothing changes" pattern
- **Double DONE**: query-loop was sending `done` from both the result handler AND the finally block — now tracks and sends only once

## Test plan
- [ ] Thinking blocks visible during streaming ("Thinking..." label)
- [ ] Thinking blocks remain visible and expandable after streaming ends
- [ ] Tool pills visible during streaming
- [ ] Tool pills compact into expandable group after streaming ends
- [ ] Aborting mid-thinking doesn't leave invisible orphan entries
- [ ] Hard refresh after deploy picks up new code (SW v3 evicts v2 cache)
- [ ] 167/168 tests pass (notify.test.ts failure is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)