### PR TITLE
feat(server): structured logging for query loop

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,5 +1,15 @@
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const configuredLevel: LogLevel =
+  (process.env.LOG_LEVEL as LogLevel) in LEVEL_ORDER ? (process.env.LOG_LEVEL as LogLevel) : 'info';
+
 interface LogEntry {
   level: LogLevel;
   module: string;
@@ -8,6 +18,8 @@ interface LogEntry {
 }
 
 function emit(entry: LogEntry): void {
+  if (LEVEL_ORDER[entry.level] < LEVEL_ORDER[configuredLevel]) return;
+
   const { level, module, message, ...context } = entry;
   const prefix = `[${module}]`;
   const hasContext = Object.keys(context).length > 0;

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -46,11 +46,15 @@ export async function runQueryLoop(
   const toolInputBuffers = new Map<number, { name: string; id: string; inputBuf: string }>();
   let doneSent = false;
 
+  log.info('query loop started', { clientId });
+
   try {
     for await (const msg of q) {
       const currentSession = registry.get(clientId);
       if (!currentSession) break;
       const currentWs = currentSession.ws;
+
+      log.debug('sdk event', { clientId, type: msg.type });
 
       if (msg.type === 'assistant') {
         const message = msg.message as Record<string, unknown> | undefined;
@@ -67,16 +71,20 @@ export async function runQueryLoop(
           send(currentWs, { type: 'session_id', sessionId: msg.session_id });
         }
       } else if (msg.type === 'result') {
+        log.info('result received', { clientId, sessionId: msg.session_id });
         if (msg.session_id) send(currentWs, { type: 'session_id', sessionId: msg.session_id });
         doneSent = true;
         send(currentWs, { type: 'done', sessionId: msg.session_id });
       } else if (msg.type === 'stream_event') {
         const evt = msg.event as Record<string, unknown> | undefined;
+        log.debug('stream event', { clientId, evtType: evt?.type });
         if (evt?.type === 'message_start') {
           toolInputBuffers.clear();
         } else if (evt?.type === 'content_block_start') {
           const contentBlock = evt.content_block as Record<string, unknown> | undefined;
+          log.debug('content block start', { clientId, blockType: contentBlock?.type });
           if (contentBlock?.type === 'thinking') {
+            log.info('thinking block detected', { clientId });
             send(currentWs, { type: 'thinking_start' });
           } else if (contentBlock?.type === 'tool_use') {
             toolInputBuffers.set(evt.index as number, {
@@ -90,6 +98,7 @@ export async function runQueryLoop(
           if (delta?.type === 'text_delta') {
             send(currentWs, { type: 'text_delta', text: delta.text });
           } else if (delta?.type === 'thinking_delta') {
+            log.debug('thinking delta', { clientId });
             send(currentWs, { type: 'thinking_delta', text: delta.thinking });
           } else if (delta?.type === 'input_json_delta') {
             const entry = toolInputBuffers.get(evt.index as number);
@@ -105,6 +114,7 @@ export async function runQueryLoop(
             } catch {
               // malformed JSON — use empty input
             }
+            log.info('tool call', { clientId, tool: entry.name, toolId: entry.id });
             send(currentWs, {
               type: 'tool_call',
               toolName: entry.name,
@@ -134,6 +144,7 @@ export async function runQueryLoop(
     const currentSession = registry.get(clientId);
     if (currentSession && !abortController.signal.aborted) {
       const message = err instanceof Error ? err.message : 'Unknown error';
+      log.warn('query loop error', { clientId, error: message });
       send(currentSession.ws, { type: 'error', error: message });
     }
   } finally {
@@ -145,5 +156,6 @@ export async function runQueryLoop(
         send(finalWs, { type: 'done', sessionId: finalSession.sessionId });
       }
     }
+    log.info('query loop ended', { clientId, doneSent });
   }
 }


### PR DESCRIPTION
## Summary
- Adds `LOG_LEVEL` env var support to `server/logger.ts` (debug < info < warn < error, default: info)
- Adds structured logging throughout `query-loop.ts` — SDK event types, thinking block detection, tool calls, errors, loop lifecycle
- Zero observability previously — this is permanent infrastructure, not temporary debug logging

## Test plan
- [x] All 167 tests pass (1 pre-existing notify test failure unrelated)
- [ ] Deploy with `LOG_LEVEL=debug`, send a message, confirm event types appear in pm2 logs
- [ ] Verify thinking block detection logs (or confirms they're absent from SDK — root cause of missing UI pills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)