### PR TITLE
fix: session restore crash — getMessages returns v2 format, guard stale caches

### DIFF
--- a/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
+++ b/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
@@ -446,6 +446,46 @@ describe('USER_SEND', () => {
   });
 });
 
+// ─── RESTORE ──────────────────────────────────────────────────────────────────
+
+describe('RESTORE', () => {
+  it('restores valid v2 messages', () => {
+    const messages = [
+      {
+        messageId: 'msg-1',
+        role: 'user' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hello' }],
+      },
+    ];
+    const state = chatMessagesReducer(INITIAL, { type: 'RESTORE', messages });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-1');
+  });
+
+  it('filters out v1-format messages missing messageId and blocks', () => {
+    const legacyMessages = [
+      { role: 'user', text: 'hello' },
+      { role: 'assistant', text: 'hi' },
+    ] as unknown as import('../../types/chat').FinishedMessage[];
+    const state = chatMessagesReducer(INITIAL, { type: 'RESTORE', messages: legacyMessages });
+    expect(state.messages).toHaveLength(0);
+  });
+
+  it('keeps valid messages and drops invalid ones in a mixed array', () => {
+    const mixed = [
+      { role: 'user', text: 'old format' },
+      {
+        messageId: 'msg-2',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'valid' }],
+      },
+    ] as unknown as import('../../types/chat').FinishedMessage[];
+    const state = chatMessagesReducer(INITIAL, { type: 'RESTORE', messages: mixed });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-2');
+  });
+});
+
 // ─── Multi-turn sequence ──────────────────────────────────────────────────────
 
 describe('full turn sequence', () => {

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -254,8 +254,12 @@ export function chatMessagesReducer(
     case 'SESSION_INFO':
       return { ...state, branch: action.branch, isWorktree: action.isWorktree };
 
-    case 'RESTORE':
-      return { ...state, messages: action.messages };
+    case 'RESTORE': {
+      const valid = action.messages.filter(
+        (m) => m && typeof m.messageId === 'string' && Array.isArray(m.blocks),
+      );
+      return { ...state, messages: valid };
+    }
 
     case 'USER_SEND':
       return {

--- a/frontend/src/lib/__tests__/groupMessages.test.ts
+++ b/frontend/src/lib/__tests__/groupMessages.test.ts
@@ -124,4 +124,12 @@ describe('groupBlocks', () => {
   it('returns empty array for empty input', () => {
     expect(groupBlocks([])).toHaveLength(0);
   });
+
+  it('returns empty array when blocks is undefined', () => {
+    expect(groupBlocks(undefined as unknown as FinishedBlock[])).toHaveLength(0);
+  });
+
+  it('returns empty array when blocks is null', () => {
+    expect(groupBlocks(null as unknown as FinishedBlock[])).toHaveLength(0);
+  });
 });

--- a/frontend/src/lib/groupMessages.ts
+++ b/frontend/src/lib/groupMessages.ts
@@ -6,6 +6,7 @@ export type GroupedBlock =
   | { type: 'tool-group'; tools: FinishedBlock[]; key: string };
 
 export function groupBlocks(blocks: FinishedBlock[]): GroupedBlock[] {
+  if (!Array.isArray(blocks)) return [];
   const result: GroupedBlock[] = [];
   let toolBuffer: FinishedBlock[] = [];
 

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -84,15 +84,22 @@ export function ChatView() {
     if (cached) {
       try {
         const restored = JSON.parse(cached);
-        if (restored.length > 0) {
+        const isV2 =
+          Array.isArray(restored) &&
+          restored.length > 0 &&
+          typeof restored[0].messageId === 'string' &&
+          Array.isArray(restored[0].blocks);
+        if (isV2) {
           dispatch({ type: 'RESTORE', messages: restored });
           setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
+        } else {
+          localStorage.removeItem(cacheKey);
         }
       } catch {
-        // Corrupted cache — fall through
+        localStorage.removeItem(cacheKey);
       }
     }
-    if (!cached) {
+    if (!cached || !localStorage.getItem(cacheKey)) {
       fetch(`/api/sessions/${sessionId}/messages`)
         .then((r) => (r.ok ? r.json() : []))
         .then((msgs: unknown[]) => {
@@ -269,7 +276,7 @@ export function ChatView() {
           // Assistant turn — render grouped blocks
           return (
             <div key={msg.messageId} className="msg-turn">
-              {grouped!.map((item, i) => {
+              {(grouped ?? []).map((item, i) => {
                 if (item.type === 'tool-group') {
                   return <ToolGroup key={item.key} tools={item.tools} />;
                 }

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -396,21 +396,66 @@ export async function getMessages(sessionId: string) {
     }
   }
   try {
-    return rawMessages
-      .map((m) => {
-        const content = m.message?.content;
-        if (!Array.isArray(content)) return null;
-        const parsed = parseContentBlocks(content);
-        return {
-          role: m.type,
-          text: parsed.text || undefined,
-          toolCalls: parsed.toolCalls.length > 0 ? parsed.toolCalls : undefined,
-          toolResults: parsed.toolResults.length > 0 ? parsed.toolResults : undefined,
+    let blockCounter = 0;
+    const messages: Array<{
+      messageId: string;
+      role: string;
+      blocks: Array<{
+        blockId: string;
+        blockType: string;
+        content: string;
+        toolName?: string;
+        toolId?: string;
+        toolInput?: string;
+      }>;
+    }> = [];
+
+    for (const m of rawMessages) {
+      const content = m.message?.content;
+      if (!Array.isArray(content)) continue;
+      const parsed = parseContentBlocks(content);
+      if (!parsed.text && parsed.toolCalls.length === 0) continue;
+
+      const role = m.type === 'assistant' ? 'assistant' : 'user';
+      const msgId = (m.message?.id as string) ?? `restored-${Date.now()}-${blockCounter}`;
+      const blocks: Array<{
+        blockId: string;
+        blockType: string;
+        content: string;
+        toolName?: string;
+        toolId?: string;
+        toolInput?: string;
+      }> = [];
+
+      if (parsed.text) {
+        blocks.push({
+          blockId: `rb${blockCounter++}`,
+          blockType: 'text',
+          content: parsed.text,
+        });
+      }
+
+      for (const tc of parsed.toolCalls) {
+        const bid = `rb${blockCounter++}`;
+        const toolBlock: (typeof blocks)[number] = {
+          blockId: bid,
+          blockType: 'tool_use',
+          content: '',
+          toolName: tc.toolName,
+          toolId: tc.toolId,
+          toolInput: tc.input,
         };
-      })
-      .filter(
-        (m): m is NonNullable<typeof m> => m !== null && !!(m.text || m.toolCalls || m.toolResults),
-      );
+        const tr = parsed.toolResults.find((r) => r.toolId === tc.toolId);
+        if (tr) {
+          (toolBlock as Record<string, unknown>).toolResult = tr.result;
+        }
+        blocks.push(toolBlock);
+      }
+
+      messages.push({ messageId: msgId, role, blocks });
+    }
+
+    return messages;
   } catch (err: unknown) {
     log.warn('failed to parse session messages', {
       sessionId,


### PR DESCRIPTION
## Summary

- **Server `getMessages()`** was returning v1-format objects (`{ role, text, toolCalls }`) while the v2 frontend expects `FinishedMessage` (`{ messageId, role, blocks: FinishedBlock[] }`). Navigating to an existing session caused `groupBlocks()` to iterate `undefined`, crashing with "undefined is not an object (evaluating 'n')" in the minified build.
- **RESTORE reducer** now filters out messages missing `messageId`/`blocks`, so stale pre-v2 localStorage caches degrade gracefully.
- **ChatView** validates localStorage shape, evicts stale caches, and falls through to the API. `groupBlocks()` guards non-array input.

## Test plan

- [x] 205 tests pass (5 new: RESTORE guard x3, groupBlocks undefined/null guard x2)
- [x] `tsc --noEmit` clean
- [x] Pre-commit hooks (eslint + prettier) pass
- [ ] Navigate to an existing session from home screen on iOS — should render messages instead of crashing
- [ ] New chat sessions still stream correctly
- [ ] Reattach after iOS background still works


Made with [Cursor](https://cursor.com)