### PR TITLE
fix: defer message_end until all content blocks are closed

### DIFF
--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -260,6 +260,38 @@ describe('runQueryLoop', () => {
     expect(sessionEnds).toHaveLength(1);
   });
 
+  it('defers message_end until all blocks are closed', async () => {
+    const events: Record<string, unknown>[] = [
+      { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-defer' } } },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'hi' },
+        },
+      },
+      // assistant fires BEFORE content_block_stop
+      { type: 'assistant', message: { content: [] }, session_id: 'sess-defer' },
+      // block_stop arrives after assistant
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'result', session_id: 'sess-defer' },
+    ];
+
+    await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
+
+    const sent = ws.sent;
+    const blockEndIdx = sent.findIndex((m) => m.type === 'block_end' && m.blockType === 'text');
+    const messageEndIdx = sent.findIndex((m) => m.type === 'message_end');
+    expect(blockEndIdx).toBeGreaterThan(-1);
+    expect(messageEndIdx).toBeGreaterThan(-1);
+    expect(blockEndIdx).toBeLessThan(messageEndIdx);
+  });
+
   it('does not emit old-style text or text_delta events', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-nodupe' } } },

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -57,9 +57,20 @@ export async function runQueryLoop(
   let blockCounter = 0;
   let currentMessageId: string | null = null;
   let doneSent = false;
+  let openBlockCount = 0;
+  let pendingMessageEnd: Record<string, unknown> | null = null;
 
   function nextBlockId(): string {
     return `b${blockCounter++}`;
+  }
+
+  function tryFlushMessageEnd(ws: WebSocket, session: { currentSnapshot: unknown | null }) {
+    if (pendingMessageEnd && openBlockCount === 0) {
+      send(ws, pendingMessageEnd);
+      pendingMessageEnd = null;
+      currentMessageId = null;
+      (session as { currentSnapshot: null }).currentSnapshot = null;
+    }
   }
 
   log.info('query loop started', { clientId });
@@ -73,17 +84,13 @@ export async function runQueryLoop(
       log.debug('sdk event', { clientId, type: msg.type });
 
       if (msg.type === 'assistant') {
-        // Turn complete. Emit message_end and clear snapshot.
+        // Turn complete — defer message_end until all blocks are closed.
         if (currentMessageId) {
-          send(
-            currentWs,
-            v2('message_end', {
-              messageId: currentMessageId,
-              ...(msg.session_id ? { sessionId: msg.session_id } : {}),
-            }),
-          );
-          currentMessageId = null;
-          currentSession.currentSnapshot = null;
+          pendingMessageEnd = v2('message_end', {
+            messageId: currentMessageId,
+            ...(msg.session_id ? { sessionId: msg.session_id } : {}),
+          });
+          tryFlushMessageEnd(currentWs, currentSession);
         }
         // Capture session ID on first assistant event.
         if (!currentSession.sessionId && msg.session_id) {
@@ -103,6 +110,8 @@ export async function runQueryLoop(
           toolInputBuffers.clear();
           blockIdByIndex.clear();
           blockCounter = 0;
+          openBlockCount = 0;
+          pendingMessageEnd = null;
           // Use API message ID if available, otherwise generate one.
           const apiMsg = evt.message as Record<string, unknown> | undefined;
           currentMessageId = (apiMsg?.id as string | undefined) ?? `msg-${Date.now()}`;
@@ -114,6 +123,7 @@ export async function runQueryLoop(
           const index = evt.index as number;
           const blockId = nextBlockId();
           blockIdByIndex.set(index, blockId);
+          openBlockCount++;
 
           const blockType = contentBlock?.type as string | undefined;
           log.debug('content block start', { clientId, blockType });
@@ -268,6 +278,8 @@ export async function runQueryLoop(
               );
             }
           }
+          openBlockCount = Math.max(0, openBlockCount - 1);
+          tryFlushMessageEnd(currentWs, currentSession);
         }
       } else if (msg.type === 'user') {
         // Tool results injected by the SDK after tool execution.


### PR DESCRIPTION
## Summary

The `assistant` SDK event can fire before all `content_block_stop` events, especially with streaming-input mode. This caused two bugs:

- **Bug A: blocks lost from finished messages** — `message_end` triggered `finishCurrent()` which froze in-flight blocks with `done=false`, empty `toolInput`, no `toolResult`. Tool pills showed "Running..." permanently and text blocks got orphaned.
- **Bug B: empty tool pills** — `toolInput` and `done` only arrive on `block_end`. If `block_end` races after `message_end`, the pill never updates.

Both bugs are one fix: track `openBlockCount` (incremented on `content_block_start`, decremented on `content_block_stop`). When `assistant` arrives, stash the `message_end` payload and only flush once `openBlockCount` hits zero.

Diagnosed collaboratively — the Mitzo phone agent identified the root cause during a live debugging session.

## Test plan

- [x] 206 tests pass (1 new: verifies `block_end` precedes `message_end` when `assistant` fires early)
- [x] `tsc --noEmit` clean, pre-commit hooks pass
- [ ] Start a chat that triggers tool calls — pills should show name immediately, input on completion, result after execution
- [ ] Verify finished messages retain all blocks (text + tools) after `message_end`
- [ ] Reattach after iOS background still works


Made with [Cursor](https://cursor.com)