### PR TITLE
fix: defer message_end until all content blocks are closed

### DIFF
--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -260,6 +260,38 @@ describe('runQueryLoop', () => {
     expect(sessionEnds).toHaveLength(1);
   });
 
+  it('defers message_end until all blocks are closed', async () => {
+    const events: Record<string, unknown>[] = [
+      { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-defer' } } },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'hi' },
+        },
+      },
+      // assistant fires BEFORE content_block_stop
+      { type: 'assistant', message: { content: [] }, session_id: 'sess-defer' },
+      // block_stop arrives after assistant
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'result', session_id: 'sess-defer' },
+    ];
+
+    await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
+
+    const sent = ws.sent;
+    const blockEndIdx = sent.findIndex((m) => m.type === 'block_end' && m.blockType === 'text');
+    const messageEndIdx = sent.findIndex((m) => m.type === 'message_end');
+    expect(blockEndIdx).toBeGreaterThan(-1);
+    expect(messageEndIdx).toBeGreaterThan(-1);
+    expect(blockEndIdx).toBeLessThan(messageEndIdx);
+  });
+
   it('does not emit old-style text or text_delta events', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-nodupe' } } },

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -57,9 +57,20 @@ export async function runQueryLoop(
   let blockCounter = 0;
   let currentMessageId: string | null = null;
   let doneSent = false;
+  let openBlockCount = 0;
+  let pendingMessageEnd: Record<string, unknown> | null = null;
 
   function nextBlockId(): string {
     return `b${blockCounter++}`;
+  }
+
+  function tryFlushMessageEnd(ws: WebSocket, session: { currentSnapshot: unknown | null }) {
+    if (pendingMessageEnd && openBlockCount === 0) {
+      send(ws, pendingMessageEnd);
+      pendingMessageEnd = null;
+      currentMessageId = null;
+      (session as { currentSnapshot: null }).currentSnapshot = null;
+    }
   }
 
   log.info('query loop started', { clientId });
@@ -73,17 +84,13 @@ export async function runQueryLoop(
       log.debug('sdk event', { clientId, type: msg.type });
 
       if (msg.type === 'assistant') {
-        // Turn complete. Emit message_end and clear snapshot.
+        // Turn complete — defer message_end until all blocks are closed.
         if (currentMessageId) {
-          send(
-            currentWs,
-            v2('message_end', {
-              messageId: currentMessageId,
-              ...(msg.session_id ? { sessionId: msg.session_id } : {}),
-            }),
-          );
-          currentMessageId = null;
-          currentSession.currentSnapshot = null;
+          pendingMessageEnd = v2('message_end', {
+            messageId: currentMessageId,
+            ...(msg.session_id ? { sessionId: msg.session_id } : {}),
+          });
+          tryFlushMessageEnd(currentWs, currentSession);
         }
         // Capture session ID on first assistant event.
         if (!currentSession.sessionId && msg.session_id) {
@@ -103,6 +110,8 @@ export async function runQueryLoop(
           toolInputBuffers.clear();
           blockIdByIndex.clear();
           blockCounter = 0;
+          openBlockCount = 0;
+          pendingMessageEnd = null;
           // Use API message ID if available, otherwise generate one.
           const apiMsg = evt.message as Record<string, unknown> | undefined;
           currentMessageId = (apiMsg?.id as string | undefined) ?? `msg-${Date.now()}`;
@@ -114,6 +123,7 @@ export async function runQueryLoop(
           const index = evt.index as number;
           const blockId = nextBlockId();
           blockIdByIndex.set(index, blockId);
+          openBlockCount++;
 
           const blockType = contentBlock?.type as string | undefined;
           log.debug('content block start', { clientId, blockType });
@@ -268,6 +278,8 @@ export async function runQueryLoop(
               );
             }
           }
+          openBlockCount = Math.max(0, openBlockCount - 1);
+          tryFlushMessageEnd(currentWs, currentSession);
         }
       } else if (msg.type === 'user') {
         // Tool results injected by the SDK after tool execution.


### PR DESCRIPTION
## Summary
- Defers `message_end` emission until all `content_block_stop` events have fired, fixing tool blocks and text being orphaned from finished messages
- Adds session restore fixes — `getMessages` returns v2 format, guards against stale localStorage caches
- Pairs tool results with tool calls in session restore

## Root cause
The `assistant` SDK event fires before all `content_block_stop` events. Server was mapping `assistant` → `message_end` directly, causing `block_end` events to arrive after the message was already finalized. Frontend's `finishCurrent()` would capture the message without those blocks.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Tests pass (`npm test`)
- [ ] Tool pills render with names during streaming
- [ ] Tool pills show input summary after completion
- [ ] Tools persist in finished messages (scroll up and they're still there)
- [ ] Session resume doesn't crash
- [ ] Follow-up messages appear in UI