### PR TITLE
fix: correct SDK field names in tool summaries, flush message_end before session_end

### DIFF
--- a/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
+++ b/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
@@ -356,6 +356,30 @@ describe('SESSION_END', () => {
     const state = chatMessagesReducer(running, { type: 'SESSION_END' });
     expect(state.running).toBe(false);
   });
+
+  it('force-finalizes current into messages if session ends with in-flight message', () => {
+    let state = chatMessagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-orphan' });
+    state = chatMessagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-orphan',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = chatMessagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-orphan',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'partial text',
+    });
+    // SESSION_END without MESSAGE_END — current should be force-finalized
+    state = chatMessagesReducer(state, { type: 'SESSION_END' });
+    expect(state.current).toBeNull();
+    expect(state.running).toBe(false);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-orphan');
+    expect(state.messages[0].blocks[0].content).toBe('partial text');
+  });
 });
 
 // ─── MESSAGE_SNAPSHOT ─────────────────────────────────────────────────────────

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -194,8 +194,18 @@ export function chatMessagesReducer(
       return { ...state, messages: [...state.messages, finished], current: null };
     }
 
-    case 'SESSION_END':
-      return { ...state, running: false, current: state.current ?? null };
+    case 'SESSION_END': {
+      if (state.current) {
+        const finished = finishCurrent(state.current);
+        return {
+          ...state,
+          running: false,
+          messages: [...state.messages, finished],
+          current: null,
+        };
+      }
+      return { ...state, running: false };
+    }
 
     case 'MESSAGE_SNAPSHOT': {
       // Reconstruct in-flight state from server snapshot on reattach.

--- a/server/__tests__/content-blocks.test.ts
+++ b/server/__tests__/content-blocks.test.ts
@@ -40,7 +40,7 @@ describe('parseContentBlocks', () => {
 
   it('extracts tool_use blocks', () => {
     const blocks = [
-      { type: 'tool_use', name: 'Read', id: 'tc-1', input: { path: '/tmp/file.ts' } },
+      { type: 'tool_use', name: 'Read', id: 'tc-1', input: { file_path: '/tmp/file.ts' } },
     ];
     const result = parseContentBlocks(blocks);
     expect(result.toolCalls).toHaveLength(1);

--- a/server/__tests__/tool-summary.getRawInput.test.ts
+++ b/server/__tests__/tool-summary.getRawInput.test.ts
@@ -3,13 +3,13 @@ import { getRawInput } from '../tool-summary.js';
 
 describe('getRawInput', () => {
   it('returns write type for Write tool', () => {
-    const result = getRawInput('Write', { path: 'foo.ts', contents: 'hello world' });
+    const result = getRawInput('Write', { file_path: 'foo.ts', content: 'hello world' });
     expect(result).toEqual({ type: 'write', path: 'foo.ts', contents: 'hello world' });
   });
 
   it('returns diff type for StrReplace tool', () => {
     const result = getRawInput('StrReplace', {
-      path: 'bar.ts',
+      file_path: 'bar.ts',
       old_string: 'old code',
       new_string: 'new code',
     });
@@ -23,7 +23,7 @@ describe('getRawInput', () => {
 
   it('returns diff type for Edit tool', () => {
     const result = getRawInput('Edit', {
-      path: 'baz.ts',
+      file_path: 'baz.ts',
       old_string: 'a',
       new_string: 'b',
     });
@@ -41,7 +41,7 @@ describe('getRawInput', () => {
   });
 
   it('returns undefined for Read tool', () => {
-    expect(getRawInput('Read', { path: 'foo.ts' })).toBeUndefined();
+    expect(getRawInput('Read', { file_path: 'foo.ts' })).toBeUndefined();
   });
 
   it('returns undefined for Grep tool', () => {
@@ -54,13 +54,17 @@ describe('getRawInput', () => {
 
   it('caps contents at RAW_INPUT_MAX_CHARS', () => {
     const bigContent = 'x'.repeat(60_000);
-    const result = getRawInput('Write', { path: 'big.ts', contents: bigContent });
+    const result = getRawInput('Write', { file_path: 'big.ts', content: bigContent });
     expect(result?.contents?.length).toBeLessThanOrEqual(50_000);
   });
 
   it('caps old_string and new_string at RAW_INPUT_MAX_CHARS', () => {
     const big = 'y'.repeat(60_000);
-    const result = getRawInput('StrReplace', { path: 'f.ts', old_string: big, new_string: big });
+    const result = getRawInput('StrReplace', {
+      file_path: 'f.ts',
+      old_string: big,
+      new_string: big,
+    });
     expect(
       (result?.old_string?.length || 0) + (result?.new_string?.length || 0),
     ).toBeLessThanOrEqual(100_000);

--- a/server/__tests__/tool-summary.test.ts
+++ b/server/__tests__/tool-summary.test.ts
@@ -3,20 +3,22 @@ import { summarizeToolInput } from '../tool-summary.js';
 
 describe('summarizeToolInput', () => {
   it('summarizes Read tool with file path', () => {
-    expect(summarizeToolInput('Read', { path: '/home/user/file.ts' })).toBe('/home/user/file.ts');
+    expect(summarizeToolInput('Read', { file_path: '/home/user/file.ts' })).toBe(
+      '/home/user/file.ts',
+    );
   });
 
   it('summarizes Write tool with path and content length', () => {
     const result = summarizeToolInput('Write', {
-      path: '/tmp/out.txt',
-      contents: 'hello world',
+      file_path: '/tmp/out.txt',
+      content: 'hello world',
     });
     expect(result).toBe('/tmp/out.txt (11 chars)');
   });
 
   it('summarizes Edit/StrReplace tool with path', () => {
-    expect(summarizeToolInput('Edit', { path: '/src/index.ts' })).toBe('/src/index.ts');
-    expect(summarizeToolInput('StrReplace', { path: '/src/index.ts' })).toBe('/src/index.ts');
+    expect(summarizeToolInput('Edit', { file_path: '/src/index.ts' })).toBe('/src/index.ts');
+    expect(summarizeToolInput('StrReplace', { file_path: '/src/index.ts' })).toBe('/src/index.ts');
   });
 
   it('summarizes Bash tool with truncated command', () => {
@@ -30,14 +32,14 @@ describe('summarizeToolInput', () => {
   it('summarizes Glob tool with pattern and directory', () => {
     expect(
       summarizeToolInput('Glob', {
-        glob_pattern: '**/*.ts',
-        target_directory: '/src',
+        pattern: '**/*.ts',
+        path: '/src',
       }),
     ).toBe('**/*.ts in /src');
   });
 
   it('summarizes Glob tool with default directory', () => {
-    expect(summarizeToolInput('Glob', { glob_pattern: '*.js' })).toBe('*.js in workspace');
+    expect(summarizeToolInput('Glob', { pattern: '*.js' })).toBe('*.js in workspace');
   });
 
   it('summarizes Grep tool with pattern and path', () => {
@@ -80,5 +82,6 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Read', {})).toBe('');
     expect(summarizeToolInput('Write', {})).toBe(' (0 chars)');
     expect(summarizeToolInput('Bash', {})).toBe('');
+    expect(summarizeToolInput('Glob', {})).toBe(' in workspace');
   });
 });

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -100,6 +100,51 @@ export async function runQueryLoop(
       } else if (msg.type === 'result') {
         log.info('result received', { clientId, sessionId: msg.session_id });
         if (msg.session_id) send(currentWs, { type: 'session_id', sessionId: msg.session_id });
+        // Force-close any open blocks and flush pending message_end before session_end.
+        if (pendingMessageEnd) {
+          for (const [index, bid] of blockIdByIndex) {
+            if (openBlockCount <= 0) break;
+            const snap = currentSession.currentSnapshot?.blocks.find((b) => b.blockId === bid);
+            if (snap && !snap.done) {
+              snap.done = true;
+              const toolEntry = toolInputBuffers.get(index);
+              if (toolEntry) {
+                toolInputBuffers.delete(index);
+                let toolInput: Record<string, unknown> = {};
+                try {
+                  toolInput = JSON.parse(toolEntry.inputBuf || '{}');
+                } catch {
+                  /* empty */
+                }
+                send(
+                  currentWs,
+                  v2('block_end', {
+                    messageId: currentMessageId,
+                    blockId: bid,
+                    blockType: 'tool_use',
+                    toolName: toolEntry.name,
+                    toolId: toolEntry.id,
+                    input: summarizeToolInput(toolEntry.name, toolInput),
+                  }),
+                );
+              } else {
+                send(
+                  currentWs,
+                  v2('block_end', {
+                    messageId: currentMessageId,
+                    blockId: bid,
+                    blockType: snap.blockType,
+                  }),
+                );
+              }
+              openBlockCount = Math.max(0, openBlockCount - 1);
+            }
+          }
+          send(currentWs, pendingMessageEnd);
+          pendingMessageEnd = null;
+          currentMessageId = null;
+          currentSession.currentSnapshot = null;
+        }
         doneSent = true;
         send(currentWs, v2('session_end', { sessionId: msg.session_id }));
       } else if (msg.type === 'stream_event') {

--- a/server/tool-summary.ts
+++ b/server/tool-summary.ts
@@ -17,14 +17,14 @@ export function getRawInput(
     case 'Write':
       return {
         type: 'write',
-        path: String(input.path || ''),
-        contents: String(input.contents || '').slice(0, RAW_INPUT_MAX_CHARS),
+        path: String(input.file_path || ''),
+        contents: String(input.content || '').slice(0, RAW_INPUT_MAX_CHARS),
       };
     case 'Edit':
     case 'StrReplace':
       return {
         type: 'diff',
-        path: String(input.path || ''),
+        path: String(input.file_path || ''),
         old_string: String(input.old_string || '').slice(0, RAW_INPUT_MAX_CHARS),
         new_string: String(input.new_string || '').slice(0, RAW_INPUT_MAX_CHARS),
       };
@@ -42,16 +42,16 @@ export function getRawInput(
 export function summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
   switch (toolName) {
     case 'Read':
-      return `${input.path || ''}`;
+      return `${input.file_path || ''}`;
     case 'Write':
-      return `${input.path || ''} (${String(input.contents || '').length} chars)`;
+      return `${input.file_path || ''} (${String(input.content || '').length} chars)`;
     case 'Edit':
     case 'StrReplace':
-      return `${input.path || ''}`;
+      return `${input.file_path || ''}`;
     case 'Bash':
       return `${String(input.command || '').slice(0, TOOL_SUMMARY_MAX_CHARS)}`;
     case 'Glob':
-      return `${input.glob_pattern || ''} in ${input.target_directory || 'workspace'}`;
+      return `${input.pattern || ''} in ${input.path || 'workspace'}`;
     case 'Grep':
       return `/${input.pattern || ''}/ in ${input.path || 'workspace'}`;
     case 'WebSearch':


### PR DESCRIPTION
## Summary

Two fixes, both diagnosed by the Mitzo phone agent during live debugging:

- **Tool pills show empty input/output**: `tool-summary.ts` used wrong SDK field names (`path` instead of `file_path`, `contents` instead of `content`, `glob_pattern` instead of `pattern`). Every `summarizeToolInput()` call returned empty strings. Updated both `summarizeToolInput()` and `getRawInput()` to match Claude Code SDK conventions.

- **"Thought but never replied"**: If the `result` SDK event fired while `pendingMessageEnd` hadn't flushed (blocks still open), `session_end` was sent before `message_end`. The frontend `SESSION_END` reducer didn't finalize `current`, so the in-flight message was lost. Server now force-closes open blocks and flushes `message_end` before `session_end`. Frontend `SESSION_END` also force-finalizes `current` as belt-and-suspenders.

## Test plan

- [x] 207 tests pass (1 new: SESSION_END force-finalizes orphaned current)
- [x] `tsc --noEmit` clean, pre-commit hooks pass
- [ ] Tool pills should show file paths, command text, patterns in input section
- [ ] Tool pills should show results after execution
- [ ] Thinking + text response should both render (no lost text after thinking)
- [ ] Verify on fresh session after cache clear


Made with [Cursor](https://cursor.com)