### PR TITLE
docs: rewrite README — concise, no fluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,264 +1,128 @@
 # Mitzo
 
-> **v0.1.0** — [Release notes](https://github.com/dimakis/mitzo/releases/tag/v0.1.0)
+Claude Code on your phone. A self-hosted web UI built on the [Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk), designed for mobile over [Tailscale](https://tailscale.com).
 
-A mobile-first web interface for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) via the [Agent SDK](https://docs.anthropic.com/en/docs/claude-code/sdk). Run it on a home server, access it from your phone over [Tailscale](https://tailscale.com).
-
-<!-- Screenshots: replace placeholders after capturing on phone -->
 <!-- ![Home Screen](docs/screenshots/home.png) -->
 <!-- ![Chat with Tools](docs/screenshots/chat-tools.png) -->
 
-## What It Does
+## Features
 
-- **Chat with Claude** from any device — streaming responses, tool calls, markdown rendering
-- **Tiered permission control** — Tools classified by risk (safe/standard/elevated/unknown). Ask mode is read-only, Agent auto-allows file edits but prompts for shell access, Auto adds shell. Rich SDK context (title, description, tier badge) in permission prompts. Switchable mid-chat.
-- **MCP tool integration** — reads MCP server configs from `~/.cursor/mcp.json` and passes them to Claude sessions (Jira, GitLab, etc.)
-- **File browser** — browse repo files, view markdown with full rendering, edit markdown files in-browser, switch between worktree roots, branch indicator
-- **Sandbox mode** — opt-in git worktree isolation per session, visible in the header
-- **Session resilience** — WebSocket disconnects don't kill sessions; auto-reattach on reconnect. Messages buffered while navigating away are replayed on return.
-- **Quick actions** — configurable one-tap commands via `.mitzo.json` in your repo (run scripts, fetch data, triage inbox)
-- **Push notifications** — get notified via [ntfy](https://ntfy.sh) when Claude needs input
-- **Session history** — resume past conversations, deduplicated, swipe-to-dismiss
-- **Model selection** — switch between Sonnet, Opus, and Haiku per conversation
-- **Image attachments** — send photos/screenshots to Claude from your phone camera
+- **Streaming chat** with thinking blocks, tool pills, and markdown
+- **Three modes** — Ask (read-only), Agent (file edits allowed), Auto (shell too). Switch mid-chat.
+- **MCP tools** — reads `~/.cursor/mcp.json`, passes servers to every session
+- **File browser** — view and edit repo files, switch between worktree roots
+- **Worktree sandbox** — opt-in git worktree isolation per session
+- **Session resilience** — phone sleeps, WS drops, session survives. Reattach on reconnect. Message snapshot recovery for iOS silent drops.
+- **Quick actions** — one-tap commands via `.mitzo.json`
+- **Push notifications** — ntfy + Pushover (Apple Watch) when Claude needs approval
+- **Image attachments** — send photos/screenshots from your camera
+- **Session history** — resume past conversations, swipe to dismiss
+
+## Quick start
+
+```bash
+git clone https://github.com/dimakis/mitzo.git && cd mitzo
+npm install && cd frontend && npm install && cd ..
+cp .env.example .env  # set AUTH_PASSPHRASE, AUTH_SECRET, REPO_PATH
+npm run build && npm start
+# http://localhost:3100
+```
+
+Access from your phone: install [Tailscale](https://tailscale.com/download) on server and phone, then open `http://<tailscale-ip>:3100`. No HTTPS needed — Tailscale encrypts via WireGuard.
 
 ## Architecture
 
 ```
-Phone (over Tailscale)
-  │
-  ├── HTTP: REST API (Express)
-  └── WebSocket: v2 streaming protocol
-  │
-Server (Node.js + TypeScript)
-  │
-  ├── Agent SDK → v2 event translator (query-loop)
-  ├── Session registry: detach/reattach/snapshot
-  ├── MCP servers: loaded from Cursor config
-  ├── Git worktrees: opt-in per-session isolation
-  └── Passphrase + JWT auth
+Phone (Tailscale) ──┬── HTTP: REST API
+                    └── WebSocket: v2 streaming protocol
+                        │
+                    Server (Node + TypeScript)
+                        │
+                        ├── query-loop: SDK events → v2 protocol
+                        ├── session-registry: detach/reattach/snapshot
+                        ├── MCP servers from Cursor config
+                        ├── git worktrees (opt-in)
+                        └── passphrase + JWT auth
 ```
 
-### v2 Message Protocol
+The server translates raw SDK stream events into a v2 block lifecycle protocol (`block_start` → `block_delta` → `block_end`). Explicit turn boundaries (`message_start`/`message_end`), deferred finalization, and message snapshots for reconnect recovery. See [docs/design/message-protocol-v2.md](docs/design/message-protocol-v2.md).
 
-The server translates raw SDK events into an explicit block lifecycle protocol. Every content block has a defined start → delta → end lifecycle. No client-side inference from timing or event absence.
+### Backend (`server/`) — 20 modules
 
-- `message_start` / `message_end` — assistant turn boundaries
-- `block_start` / `block_delta` / `block_end` — content block lifecycle (text, thinking, tool_use)
-- `tool_result` — paired with tool_use blocks via toolId
-- `message_snapshot` — full state recovery on iOS silent-drop reconnect
-- Deferred `message_end` — server tracks open blocks and only finalizes when all are closed
+| Core                    | Purpose                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------- |
+| `query-loop.ts`         | SDK → v2 event translator. Deferred `message_end`, snapshot state, block lifecycle. |
+| `chat.ts`               | Agent SDK `query()`, prompt assembly, streaming-input queue, session restore API    |
+| `session-registry.ts`   | Session state: detach, reattach, rekey, TTL abort, snapshot storage                 |
+| `permission-handler.ts` | `canUseTool` callback — auto-allow by tier, prompt via WS + push notifications      |
+| `async-queue.ts`        | `AsyncIterable` queue for follow-up messages and interrupt                          |
 
-See [docs/design/message-protocol-v2.md](docs/design/message-protocol-v2.md) for the full spec.
+| Supporting                                                                     | Purpose                                           |
+| ------------------------------------------------------------------------------ | ------------------------------------------------- |
+| `tool-tiers.ts`                                                                | Risk classification + mode/tier auto-allow matrix |
+| `tool-summary.ts`                                                              | Summarizes tool inputs for pill display           |
+| `permissions.ts`                                                               | Request/response registry                         |
+| `content-blocks.ts`                                                            | SDK content block parsing                         |
+| `mcp-config.ts`                                                                | Loads Cursor MCP config                           |
+| `worktree.ts`                                                                  | Git worktree lifecycle                            |
+| `repo-config.ts`                                                               | `.mitzo.json` reader                              |
+| `auth.ts`                                                                      | Passphrase + JWT                                  |
+| `notify.ts` / `pushover.ts`                                                    | Push notifications                                |
+| `logger.ts` / `constants.ts` / `git-version.ts` / `port-check.ts` / `index.ts` | Infrastructure                                    |
 
-### Backend (`server/`)
+### Frontend (`frontend/`) — React 19 + Vite
 
-Express + TypeScript, run via `tsx`.
+Four pages (`Login`, `SessionList`, `ChatView`, `FileViewer`), a `useReducer`-based message state machine (`useChatMessages`), module-level WebSocket pool with 500-message buffer, and components for thinking blocks, tool pills, tool groups, and permission banners.
 
-| File                    | Purpose                                                            |
-| ----------------------- | ------------------------------------------------------------------ |
-| `index.ts`              | Express app, routes, WebSocket server, startup cleanup             |
-| `chat.ts`               | Agent SDK integration, session lifecycle, prompt assembly          |
-| `query-loop.ts`         | SDK event → v2 protocol translator, deferred message_end, snapshot |
-| `session-registry.ts`   | Session state, detach/reattach, snapshot storage                   |
-| `permission-handler.ts` | canUseTool callback builder for SDK permission flow                |
-| `async-queue.ts`        | AsyncIterable queue for streaming-input (follow-up, interrupt)     |
-| `tool-tiers.ts`         | Tool risk classification and mode-aware auto-allow matrix          |
-| `tool-summary.ts`       | Human-readable tool input summarization (SDK field names)          |
-| `permissions.ts`        | Permission request registry, SDK suggestion passthrough            |
-| `content-blocks.ts`     | SDK content block parsing (stream + session restore API)           |
-| `mcp-config.ts`         | Loads MCP server configs from Cursor mcp.json                      |
-| `worktree.ts`           | Git worktree create/remove/cleanup/list                            |
-| `repo-config.ts`        | Reads `.mitzo.json` for quick actions, venv paths, tier overrides  |
-| `notify.ts`             | ntfy push notifications                                            |
-| `pushover.ts`           | Pushover notifications (Apple Watch)                               |
-| `auth.ts`               | Passphrase login, JWT (HS256), cookie auth                         |
-| `git-version.ts`        | Local/remote commit comparison for update detection                |
-| `logger.ts`             | Structured logger with LOG_LEVEL filtering                         |
-| `constants.ts`          | Server-wide constants (timeouts, limits, defaults)                 |
-| `port-check.ts`         | Port-in-use guard — prevents duplicate server instances            |
+## Environment
 
-### Frontend (`frontend/`)
+| Variable           | Description                                     | Required |
+| ------------------ | ----------------------------------------------- | -------- |
+| `AUTH_PASSPHRASE`  | Login passphrase                                | Yes      |
+| `AUTH_SECRET`      | JWT signing key (min 32 chars)                  | Yes      |
+| `REPO_PATH`        | Default repo for sessions                       | Yes      |
+| `PORT`             | Server port (default: `3100`)                   | No       |
+| `WORKTREE_ENABLED` | Allow worktrees (default: `true`)               | No       |
+| `MCP_CONFIG_PATH`  | MCP config path (default: `~/.cursor/mcp.json`) | No       |
 
-React 19 + Vite + TypeScript.
+See `.env.example` for the full list.
 
-| Page          | Purpose                                                                    |
-| ------------- | -------------------------------------------------------------------------- |
-| `Login`       | Passphrase entry                                                           |
-| `SessionList` | Quick action grid + session history (swipe-to-dismiss)                     |
-| `ChatView`    | Streaming chat, mode pills, sandbox toggle, branch pill, permission banner |
-| `FileViewer`  | Directory browser, markdown viewer/editor, worktree selector               |
+## `.mitzo.json`
 
-| Directory     | Purpose                                                                                                       |
-| ------------- | ------------------------------------------------------------------------------------------------------------- |
-| `types/`      | v2 types: StreamingBlock, FinishedMessage, PlanItem                                                           |
-| `hooks/`      | useChatMessages (reducer), useChatSession, useChatConnection, usePermission, useFileNavigation, useFileEditor |
-| `lib/`        | ws-pool, groupMessages, formatTime, constants, paste-images, model-preference                                 |
-| `components/` | MessageBubble, ThinkingBlock, ToolPill, ToolGroup, PermissionBanner, ChatInput, ErrorBoundary, MitzoLogo      |
-
-### MCP Server (`mcp-server/`)
-
-Optional MCP server subproject exposing repo-specific tools to Claude sessions. Build with `npm run build:mcp`, configure with `npm run setup-mcp`.
-
-## Prerequisites
-
-- **Node.js** 22+
-- **Git** (for worktree support)
-- **Claude Code** CLI installed and authenticated
-- **Tailscale** (for remote access)
-
-## Setup
-
-```bash
-git clone https://github.com/dimakis/mitzo.git
-cd mitzo
-
-npm install
-cd frontend && npm install && cd ..
-
-cp .env.example .env
-# Edit .env — set AUTH_PASSPHRASE, AUTH_SECRET, and REPO_PATH
-```
-
-### Environment variables
-
-| Variable               | Description                                             | Required |
-| ---------------------- | ------------------------------------------------------- | -------- |
-| `AUTH_PASSPHRASE`      | Login passphrase                                        | Yes      |
-| `AUTH_SECRET`          | JWT signing key (min 32 chars)                          | Yes      |
-| `REPO_PATH`            | Default repo for chat sessions                          | Yes      |
-| `PORT`                 | Server port (default: `3100`)                           | No       |
-| `WORKTREE_ENABLED`     | Allow worktree creation (default: `true`)               | No       |
-| `MCP_CONFIG_PATH`      | Path to MCP config file (default: `~/.cursor/mcp.json`) | No       |
-| `COOKIE_MAX_AGE_HOURS` | Auth cookie expiry (default: `24`)                      | No       |
-
-See `.env.example` for the full list including ntfy and Vertex AI options.
-
-## Running
-
-### Development
-
-```bash
-npm run dev
-# Backend: http://localhost:3100
-# Frontend: http://localhost:5173 (proxies API to backend)
-```
-
-### Production
-
-```bash
-npm run build
-npm start
-# http://localhost:3100 (serves frontend + API)
-```
-
-### With pm2
-
-```bash
-pm2 start npm --name mitzo -- start
-pm2 save && pm2 startup
-```
-
-## Accessing from your phone
-
-1. Install [Tailscale](https://tailscale.com/download) on your server and phone
-2. `tailscale up` on both
-3. Open `http://<tailscale-ip>:3100` on your phone
-
-No HTTPS needed — Tailscale encrypts everything via WireGuard.
-
-## MCP server integration
-
-Mitzo reads MCP server configurations from `~/.cursor/mcp.json` (the same file Cursor uses). Stdio-type servers are loaded on startup and passed to every Claude session via the Agent SDK's `mcpServers` option. Disabled servers are excluded.
-
-Override the config path with the `MCP_CONFIG_PATH` environment variable.
-
-The server logs which MCP servers were loaded on startup:
-
-```
-[mcp] loaded 1 server(s): atlassian
-```
-
-## Sandbox mode (worktrees)
-
-Worktrees are **off by default**. Toggle the "WT" button in the chat header before sending your first message to opt in.
-
-When sandbox mode is on:
-
-1. Mitzo creates a git worktree at `${REPO_PATH}-sessions/session-<id>/`
-2. The worktree branches from the current HEAD of your repo
-3. Claude works in the isolated worktree
-4. The chat header shows the branch name with an accent indicator
-5. Stale worktrees (>7 days) are pruned on server startup
-
-Disable worktree creation entirely with `WORKTREE_ENABLED=false` in `.env`.
-
-## Push notifications
-
-Get notified when Claude needs tool approval:
-
-```bash
-# Add ntfy config to .env:
-NTFY_URL=https://ntfy.sh
-NTFY_TOPIC=your-secret-topic
-BASE_URL=http://<tailscale-ip>:3100
-
-# Configure Claude Code hooks:
-./scripts/setup-mcp.sh
-./scripts/setup-hooks.sh
-```
-
-## Session resilience
-
-WebSocket disconnects (phone sleep, Tailscale hiccup) don't kill active sessions. The server detaches the session and keeps the Agent SDK query running. When the phone reconnects, the new WebSocket reattaches to the in-flight session. Detached sessions auto-abort after 10 minutes if no reattach arrives.
-
-The frontend uses a module-level WebSocket pool (`ws-pool.ts`) that survives React component unmount/remount. Navigating between pages doesn't close the connection. Messages that arrive while a chat component is unmounted are buffered in the pool and replayed when you navigate back — no context lost.
-
-## Repo configuration (`.mitzo.json`)
-
-Place a `.mitzo.json` in your repo root to customize Mitzo for your project:
+Drop this in your repo root for quick actions and Python venv support:
 
 ```json
 {
   "quickActions": [
     {
       "label": "Run Tests",
-      "desc": "Full test suite",
-      "prompt": "Run the test suite and report results.",
+      "desc": "Full suite",
+      "prompt": "Run tests and report.",
       "extraTools": "Bash"
     }
   ],
-  "venvPaths": ["my-project/.venv/bin"]
+  "venvPaths": [".venv/bin"]
 }
 ```
 
-| Field          | Type  | Description                                                                                                             |
-| -------------- | ----- | ----------------------------------------------------------------------------------------------------------------------- |
-| `quickActions` | array | Quick action buttons on the home screen. Each needs `label` and `desc`; optional `prompt`, `path`, `cwd`, `extraTools`. |
-| `venvPaths`    | array | Relative paths to Python venvs. Added to `PATH` for Agent SDK sessions.                                                 |
+## Development
 
-Without a `.mitzo.json`, Mitzo shows a minimal home screen with Chat and Files.
+```bash
+npm run dev          # backend + frontend concurrently
+npm test             # vitest (209 tests)
+npm run lint         # eslint
+npm run format:check # prettier
+```
 
-## Tech stack
+Pre-commit: husky + lint-staged + commitlint (conventional commits).
 
-| Component | Technology                          |
-| --------- | ----------------------------------- |
-| Backend   | Node.js, Express, TypeScript        |
-| Frontend  | React 19, Vite, TypeScript          |
-| AI        | Claude Agent SDK                    |
-| MCP       | Cursor-compatible stdio servers     |
-| Auth      | JWT via jose                        |
-| Isolation | Git worktrees (opt-in)              |
-| Tests     | Vitest (209 tests, 22 files)        |
-| Quality   | ESLint, Prettier, husky, commitlint |
+## Tech
 
-## Security
-
-See [SECURITY.md](SECURITY.md) for the threat model, secrets handling, and known limitations.
+Node.js, Express, React 19, Vite, TypeScript, Claude Agent SDK, Vitest, ESLint, Prettier.
 
 ## Attribution
 
-Mitzo evolved from [claude-command-center](https://github.com/Afstkla/claude-command-center) by [Afstkla](https://github.com/Afstkla). The original project used tmux for session management; Mitzo replaced that with the Claude Agent SDK for direct programmatic control.
+Evolved from [claude-command-center](https://github.com/Afstkla/claude-command-center) by [Afstkla](https://github.com/Afstkla). The original used tmux; Mitzo uses the Agent SDK directly.
 
 ## License
 


### PR DESCRIPTION
Same information, half the lines. Removed verbose sections (session resilience, sandbox mode, push notifications, MCP integration as standalone sections), AI-generated padding, and redundant explanations. Consolidated into a scannable reference.

Merge, then I'll cut v0.1.1.

Made with [Cursor](https://cursor.com)