### PR TITLE
fix(security): disable upgrade-insecure-requests in CSP

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -39,6 +39,7 @@ app.use(
         styleSrc: ["'self'", "'unsafe-inline'"],
         connectSrc: ["'self'", 'ws:', 'wss:'],
         imgSrc: ["'self'", 'data:'],
+        upgradeInsecureRequests: null,
       },
     },
   }),


### PR DESCRIPTION
## Summary
- Helmet's default CSP includes `upgrade-insecure-requests` which forces browsers to upgrade all HTTP requests to HTTPS
- Mitzo runs on HTTP over Tailscale — this directive causes a blank white page because all asset loads fail silently
- Setting `upgradeInsecureRequests: null` removes the directive while keeping all other CSP protections

## Test plan
- [ ] Verify app loads on HTTP (no blank white page)
- [ ] Verify CSP header no longer contains `upgrade-insecure-requests`
- [ ] Verify other CSP directives still present (script-src, style-src, etc.)

Made with [Cursor](https://cursor.com)