### PR TITLE
fix(chat): update URL when session ID is assigned mid-conversation

### DIFF
--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -53,6 +53,21 @@ export function ChatView() {
     [sessionId, navigate, sessionActions],
   );
 
+  // When a session ID is assigned mid-conversation (started from /chat),
+  // update the URL so refreshes and back-navigation land on /chat/:id
+  // and can restore messages from cache or the API.
+  // Uses replaceState to avoid a React Router remount that would kill
+  // the live streaming view.
+  const handleSessionAssigned = useCallback(
+    (id: string) => {
+      sessionActions.setCurrentSessionId(id);
+      if (!sessionId && window.location.pathname === '/chat') {
+        window.history.replaceState(null, '', `/chat/${id}`);
+      }
+    },
+    [sessionId, sessionActions],
+  );
+
   const {
     state: msgState,
     dispatch,
@@ -61,7 +76,7 @@ export function ChatView() {
   } = useChatMessages(
     poolKey,
     sessionState.currentSessionId,
-    sessionActions.setCurrentSessionId,
+    handleSessionAssigned,
     handleSessionExpired,
   );
 


### PR DESCRIPTION
## Summary

- Sessions started from `/chat` receive their SDK session ID asynchronously via WebSocket, but the URL was never updated to `/chat/:id`. If the phone locked mid-conversation and the agent finished while disconnected, refreshing the page lost the entire conversation — the restore logic (localStorage cache + API fallback) needs the session ID in the URL.
- Adds a `handleSessionAssigned` callback that calls `window.history.replaceState` to update the URL without triggering a React Router remount of the active streaming view.

## Root Cause

1. Agent finishes while WS is dead (phone locked) → session removed from server registry → Pushover notification sent
2. Phone unlocks → WS reconnects → reattach fails (session gone) → `reattach_failed` handler tries API fetch
3. User refreshes → all React state lost → URL is still `/chat` with no session ID → nothing to restore → empty page

## Test plan

- [ ] Start a new chat from `/chat` (not `/chat/:id`)
- [ ] Verify URL updates to `/chat/<session-id>` after the first assistant response
- [ ] Lock phone during an active agent run, wait for completion notification, unlock
- [ ] Verify conversation is visible after unlock (reattach or API restore)
- [ ] Refresh the page — verify conversation restores from cache
- [ ] Navigate to session list and back to the session — verify messages load


Made with [Cursor](https://cursor.com)