### PR TITLE
fix(chat): always reconcile session messages with API on restore

### DIFF
--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -342,6 +342,8 @@ export function useChatMessages(
   const currentSessionIdRef = useRef(currentSessionId);
   currentSessionIdRef.current = currentSessionId;
   const reattachAbort = useRef<AbortController | null>(null);
+  const messagesRef = useRef(state.messages);
+  messagesRef.current = state.messages;
 
   useEffect(() => {
     const id = currentSessionIdRef.current;
@@ -352,6 +354,21 @@ export function useChatMessages(
       // localStorage quota exceeded — non-fatal
     }
   }, [state.messages, currentSessionId]);
+
+  // Flush latest messages to localStorage on unmount so navigating away
+  // mid-conversation doesn't leave a stale or empty cache.
+  useEffect(() => {
+    return () => {
+      const id = currentSessionIdRef.current;
+      const msgs = messagesRef.current;
+      if (!id || msgs.length === 0) return;
+      try {
+        localStorage.setItem(`${CHAT_CACHE_KEY_PREFIX}${id}`, JSON.stringify(msgs));
+      } catch {
+        // localStorage quota exceeded — non-fatal
+      }
+    };
+  }, []);
 
   const handleWsMessage = useCallback(
     (msg: WsMsg) => {

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -90,16 +90,16 @@ export function ChatView() {
     }
   }, [msgState.messages, msgState.current]);
 
-  // Restore messages from cache or API when sessionId changes.
-  // AbortController prevents a slow response for session A from overwriting
-  // session B's messages when the user navigates quickly between sessions.
+  // Restore messages when sessionId changes. Show cached data instantly,
+  // then always reconcile with the API to catch anything the cache missed
+  // (e.g. messages that streamed in after the last cache write).
   useEffect(() => {
     if (!sessionId) return;
 
     const controller = new AbortController();
     const cacheKey = `${CHAT_CACHE_KEY_PREFIX}${sessionId}`;
     const cached = localStorage.getItem(cacheKey);
-    let restoredFromCache = false;
+    let cacheCount = 0;
 
     if (cached) {
       try {
@@ -112,7 +112,7 @@ export function ChatView() {
         if (isV2) {
           dispatch({ type: 'RESTORE', messages: restored });
           setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
-          restoredFromCache = true;
+          cacheCount = restored.length;
         } else {
           localStorage.removeItem(cacheKey);
         }
@@ -121,22 +121,22 @@ export function ChatView() {
       }
     }
 
-    if (!restoredFromCache) {
-      dispatch({ type: 'RESTORE', messages: [] });
-      fetch(`/api/sessions/${sessionId}/messages`, { signal: controller.signal })
-        .then((r) => (r.ok ? r.json() : []))
-        .then((msgs: unknown[]) => {
-          if (controller.signal.aborted) return;
-          if (msgs.length > 0) {
-            dispatch({
-              type: 'RESTORE',
-              messages: msgs as import('../types/chat').FinishedMessage[],
-            });
-            setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
-          }
-        })
-        .catch(() => {});
-    }
+    // Always fetch from API — if the response has more messages than the
+    // cache (or the cache was empty), replace with the authoritative data.
+    fetch(`/api/sessions/${sessionId}/messages`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((msgs: unknown[]) => {
+        if (controller.signal.aborted) return;
+        const apiMsgs = msgs as import('../types/chat').FinishedMessage[];
+        if (apiMsgs.length > 0 && apiMsgs.length >= cacheCount) {
+          dispatch({ type: 'RESTORE', messages: apiMsgs });
+          setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
+        }
+      })
+      .catch(() => {});
 
     return () => controller.abort();
   }, [sessionId, dispatch, forceScrollToBottom]);


### PR DESCRIPTION
## Summary

- When navigating back to a previous session, the localStorage cache was the **sole** restore source. If the cache was stale (saved before the conversation finished, or before `SESSION_END` flushed `current` to `messages`), earlier messages were missing — the conversation appeared to start mid-stream.
- Now the restore flow is: show cached data instantly for perceived speed, then **always** fetch from the API in the background. If the API returns more messages than the cache had, replace with the authoritative data.
- Additionally, messages are now flushed to localStorage on component unmount (not just on state changes), so navigating away mid-conversation preserves the latest state.

## Root Cause

The save-to-cache effect fired on `state.messages` changes, but during streaming, content accumulates in `state.current` (not `messages`) until `MESSAGE_END`. If the user navigated away before the turn completed, or the component unmounted during streaming, the cache was stale. On return, the stale cache was used without API verification.

## Test plan

- [ ] Start a long agent conversation from `/chat`
- [ ] Navigate back to session list mid-conversation
- [ ] Return to the session — verify all messages are present (not just the tail)
- [ ] Wait for conversation to finish, navigate away, return — verify full restore
- [ ] Hard refresh on `/chat/:id` — verify messages load from API


Made with [Cursor](https://cursor.com)