### PR TITLE
fix(chat): restore user prompts in session message history

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -452,34 +452,47 @@ export async function getMessages(sessionId: string) {
 
     for (const m of rawMessages) {
       const content = m.message?.content;
-      if (!Array.isArray(content)) continue;
-      const parsed = parseContentBlocks(content);
-      if (!parsed.text && parsed.toolCalls.length === 0) continue;
-
       const role = m.type === 'assistant' ? 'assistant' : 'user';
       const msgId = (m.message?.id as string) ?? `restored-${Date.now()}-${blockCounter}`;
       const blocks: (typeof messages)[number]['blocks'] = [];
 
-      if (parsed.text) {
-        blocks.push({
-          blockId: `rb${blockCounter++}`,
-          blockType: 'text',
-          content: parsed.text,
-        });
+      // User prompts are stored as plain strings by the SDK.
+      if (typeof content === 'string') {
+        if (content) {
+          blocks.push({
+            blockId: `rb${blockCounter++}`,
+            blockType: 'text',
+            content,
+          });
+        }
+      } else if (Array.isArray(content)) {
+        const parsed = parseContentBlocks(content);
+        if (!parsed.text && parsed.toolCalls.length === 0) continue;
+
+        if (parsed.text) {
+          blocks.push({
+            blockId: `rb${blockCounter++}`,
+            blockType: 'text',
+            content: parsed.text,
+          });
+        }
+
+        for (const tc of parsed.toolCalls) {
+          blocks.push({
+            blockId: `rb${blockCounter++}`,
+            blockType: 'tool_use',
+            content: '',
+            toolName: tc.toolName,
+            toolId: tc.toolId,
+            toolInput: tc.input,
+            toolResult: toolResultMap.get(tc.toolId),
+          });
+        }
+      } else {
+        continue;
       }
 
-      for (const tc of parsed.toolCalls) {
-        blocks.push({
-          blockId: `rb${blockCounter++}`,
-          blockType: 'tool_use',
-          content: '',
-          toolName: tc.toolName,
-          toolId: tc.toolId,
-          toolInput: tc.input,
-          toolResult: toolResultMap.get(tc.toolId),
-        });
-      }
-
+      if (blocks.length === 0) continue;
       messages.push({ messageId: msgId, role, blocks });
     }
 


### PR DESCRIPTION
## Summary

- User prompts were completely missing from restored session histories. The SDK stores user messages with `content` as a **plain string**, while assistant messages use an array of content blocks. The `getMessages` API had `if (!Array.isArray(content)) continue;` which skipped every user prompt.
- Now handles both formats: plain strings (user prompts) and content block arrays (assistant turns, tool results).

## Root Cause

```js
// Before — skips all user prompts
if (!Array.isArray(content)) continue;

// After — handles string content for user messages
if (typeof content === 'string') { /* build text block */ }
else if (Array.isArray(content)) { /* existing logic */ }
```

## Test plan

- [ ] Open any previous session — verify user prompts now appear
- [ ] Check a session with image attachments — user message text should show
- [ ] Check a multi-turn session — all user messages present between assistant turns
- [ ] Verify tool result messages (SDK-injected `user` type with only `tool_result` blocks) are still filtered out


Made with [Cursor](https://cursor.com)