### PR TITLE
test(chat): add unit tests for session message reconstruction

### DIFF
--- a/server/__tests__/reconstruct-messages.test.ts
+++ b/server/__tests__/reconstruct-messages.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { reconstructMessages } from '../chat.js';
+import type { RawSdkMessage } from '../chat.js';
+
+describe('reconstructMessages', () => {
+  it('returns empty array for empty input', () => {
+    expect(reconstructMessages([])).toEqual([]);
+  });
+
+  it('reconstructs user prompts stored as plain strings', () => {
+    const raw: RawSdkMessage[] = [
+      { type: 'user', message: { id: 'u1', content: 'Hello, help me with this' } },
+    ];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('user');
+    expect(result[0].blocks).toHaveLength(1);
+    expect(result[0].blocks[0].blockType).toBe('text');
+    expect(result[0].blocks[0].content).toBe('Hello, help me with this');
+  });
+
+  it('reconstructs assistant messages with text content blocks', () => {
+    const raw: RawSdkMessage[] = [
+      {
+        type: 'assistant',
+        message: { id: 'a1', content: [{ type: 'text', text: 'Here is my response' }] },
+      },
+    ];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].blocks[0].content).toBe('Here is my response');
+  });
+
+  it('reconstructs assistant messages with tool_use blocks', () => {
+    const raw: RawSdkMessage[] = [
+      {
+        type: 'assistant',
+        message: {
+          id: 'a1',
+          content: [
+            { type: 'tool_use', name: 'Read', id: 'tc-1', input: { file_path: '/tmp/f.ts' } },
+          ],
+        },
+      },
+    ];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].blocks[0].blockType).toBe('tool_use');
+    expect(result[0].blocks[0].toolName).toBe('Read');
+    expect(result[0].blocks[0].toolId).toBe('tc-1');
+  });
+
+  it('attaches tool results from user-type SDK messages to matching tool blocks', () => {
+    const raw: RawSdkMessage[] = [
+      {
+        type: 'assistant',
+        message: {
+          id: 'a1',
+          content: [{ type: 'tool_use', name: 'Bash', id: 'tc-1', input: { command: 'ls' } }],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'tc-1', content: 'file1\nfile2' }],
+        },
+      },
+    ];
+    const result = reconstructMessages(raw);
+    const assistantMsg = result.find((m) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+    expect(assistantMsg!.blocks[0].toolResult).toBe('file1\nfile2');
+  });
+
+  it('filters out user messages that only contain tool_result blocks', () => {
+    const raw: RawSdkMessage[] = [
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'tc-1', content: 'output' }],
+        },
+      },
+    ];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips messages with empty string content', () => {
+    const raw: RawSdkMessage[] = [{ type: 'user', message: { id: 'u1', content: '' } }];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips messages with undefined content', () => {
+    const raw: RawSdkMessage[] = [{ type: 'user', message: { id: 'u1' } }];
+    const result = reconstructMessages(raw);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles a full multi-turn conversation', () => {
+    const raw: RawSdkMessage[] = [
+      { type: 'user', message: { id: 'u1', content: 'List my files' } },
+      {
+        type: 'assistant',
+        message: {
+          id: 'a1',
+          content: [
+            { type: 'text', text: 'Let me check.' },
+            { type: 'tool_use', name: 'Bash', id: 'tc-1', input: { command: 'ls' } },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'tc-1', content: 'README.md\nsrc/' }],
+        },
+      },
+      {
+        type: 'assistant',
+        message: { id: 'a2', content: [{ type: 'text', text: 'You have README.md and src/.' }] },
+      },
+      { type: 'user', message: { id: 'u2', content: 'Thanks!' } },
+    ];
+
+    const result = reconstructMessages(raw);
+
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatchObject({ role: 'user', blocks: [{ content: 'List my files' }] });
+    expect(result[1]).toMatchObject({ role: 'assistant' });
+    expect(result[1].blocks).toHaveLength(2);
+    expect(result[1].blocks[0].content).toBe('Let me check.');
+    expect(result[1].blocks[1].toolResult).toBe('README.md\nsrc/');
+    expect(result[2]).toMatchObject({
+      role: 'assistant',
+      blocks: [{ content: 'You have README.md and src/.' }],
+    });
+    expect(result[3]).toMatchObject({ role: 'user', blocks: [{ content: 'Thanks!' }] });
+  });
+
+  it('generates unique block IDs across messages', () => {
+    const raw: RawSdkMessage[] = [
+      { type: 'user', message: { id: 'u1', content: 'First' } },
+      { type: 'user', message: { id: 'u2', content: 'Second' } },
+    ];
+    const result = reconstructMessages(raw);
+    const ids = result.flatMap((m) => m.blocks.map((b) => b.blockId));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -408,95 +408,103 @@ export async function getSessions() {
   return deduped.slice(0, SESSION_LIST_LIMIT);
 }
 
+export interface RawSdkMessage {
+  type: string;
+  message?: Record<string, unknown>;
+}
+
+export interface RestoredMessage {
+  messageId: string;
+  role: string;
+  blocks: Array<{
+    blockId: string;
+    blockType: string;
+    content: string;
+    toolName?: string;
+    toolId?: string;
+    toolInput?: string;
+    toolResult?: string;
+  }>;
+}
+
+export function reconstructMessages(rawMessages: RawSdkMessage[]): RestoredMessage[] {
+  let blockCounter = 0;
+
+  const toolResultMap = new Map<string, string>();
+  for (const m of rawMessages) {
+    const content = m.message?.content;
+    if (!Array.isArray(content)) continue;
+    const parsed = parseContentBlocks(content);
+    for (const tr of parsed.toolResults) {
+      toolResultMap.set(tr.toolId, tr.result);
+    }
+  }
+
+  const messages: RestoredMessage[] = [];
+
+  for (const m of rawMessages) {
+    const content = m.message?.content;
+    const role = m.type === 'assistant' ? 'assistant' : 'user';
+    const msgId = (m.message?.id as string) ?? `restored-${Date.now()}-${blockCounter}`;
+    const blocks: RestoredMessage['blocks'] = [];
+
+    if (typeof content === 'string') {
+      if (content) {
+        blocks.push({
+          blockId: `rb${blockCounter++}`,
+          blockType: 'text',
+          content,
+        });
+      }
+    } else if (Array.isArray(content)) {
+      const parsed = parseContentBlocks(content);
+      if (!parsed.text && parsed.toolCalls.length === 0) continue;
+
+      if (parsed.text) {
+        blocks.push({
+          blockId: `rb${blockCounter++}`,
+          blockType: 'text',
+          content: parsed.text,
+        });
+      }
+
+      for (const tc of parsed.toolCalls) {
+        blocks.push({
+          blockId: `rb${blockCounter++}`,
+          blockType: 'tool_use',
+          content: '',
+          toolName: tc.toolName,
+          toolId: tc.toolId,
+          toolInput: tc.input,
+          toolResult: toolResultMap.get(tc.toolId),
+        });
+      }
+    } else {
+      continue;
+    }
+
+    if (blocks.length === 0) continue;
+    messages.push({ messageId: msgId, role, blocks });
+  }
+
+  return messages;
+}
+
 export async function getMessages(sessionId: string) {
-  let rawMessages: Array<{ type: string; message?: Record<string, unknown> }> = [];
+  let rawMessages: RawSdkMessage[] = [];
   for (const dir of getSessionDirs()) {
     try {
       rawMessages = (await getSessionMessages(sessionId, {
         dir,
         limit: SESSION_MESSAGES_LIMIT,
-      })) as typeof rawMessages;
+      })) as RawSdkMessage[];
       if (rawMessages.length > 0) break;
     } catch {
       // Session not in this dir — try next
     }
   }
   try {
-    let blockCounter = 0;
-
-    // First pass: collect all tool results from user-type SDK messages.
-    const toolResultMap = new Map<string, string>();
-    for (const m of rawMessages) {
-      const content = m.message?.content;
-      if (!Array.isArray(content)) continue;
-      const parsed = parseContentBlocks(content);
-      for (const tr of parsed.toolResults) {
-        toolResultMap.set(tr.toolId, tr.result);
-      }
-    }
-
-    // Second pass: build v2 FinishedMessage[] from assistant/user turns.
-    const messages: Array<{
-      messageId: string;
-      role: string;
-      blocks: Array<{
-        blockId: string;
-        blockType: string;
-        content: string;
-        toolName?: string;
-        toolId?: string;
-        toolInput?: string;
-        toolResult?: string;
-      }>;
-    }> = [];
-
-    for (const m of rawMessages) {
-      const content = m.message?.content;
-      const role = m.type === 'assistant' ? 'assistant' : 'user';
-      const msgId = (m.message?.id as string) ?? `restored-${Date.now()}-${blockCounter}`;
-      const blocks: (typeof messages)[number]['blocks'] = [];
-
-      // User prompts are stored as plain strings by the SDK.
-      if (typeof content === 'string') {
-        if (content) {
-          blocks.push({
-            blockId: `rb${blockCounter++}`,
-            blockType: 'text',
-            content,
-          });
-        }
-      } else if (Array.isArray(content)) {
-        const parsed = parseContentBlocks(content);
-        if (!parsed.text && parsed.toolCalls.length === 0) continue;
-
-        if (parsed.text) {
-          blocks.push({
-            blockId: `rb${blockCounter++}`,
-            blockType: 'text',
-            content: parsed.text,
-          });
-        }
-
-        for (const tc of parsed.toolCalls) {
-          blocks.push({
-            blockId: `rb${blockCounter++}`,
-            blockType: 'tool_use',
-            content: '',
-            toolName: tc.toolName,
-            toolId: tc.toolId,
-            toolInput: tc.input,
-            toolResult: toolResultMap.get(tc.toolId),
-          });
-        }
-      } else {
-        continue;
-      }
-
-      if (blocks.length === 0) continue;
-      messages.push({ messageId: msgId, role, blocks });
-    }
-
-    return messages;
+    return reconstructMessages(rawMessages);
   } catch (err: unknown) {
     log.warn('failed to parse session messages', {
       sessionId,


### PR DESCRIPTION
## Summary

- Extracts `reconstructMessages()` from `getMessages()` as a pure function that can be unit tested without SDK or disk dependencies.
- Adds 10 tests covering the message reconstruction logic, specifically the fixes from recent PRs:
  - User prompts stored as plain strings (#57)
  - Assistant messages with text and tool_use blocks
  - Tool result attachment from SDK user-type messages
  - Filtering of tool-result-only messages (so they don't show as empty user bubbles)
  - Empty/undefined content edge cases
  - Full multi-turn conversation round-trip
  - Block ID uniqueness

## Test plan

- [x] All 355 tests pass
- [x] TypeScript clean
- [x] No behavioral change — pure refactor of `getMessages` internals


Made with [Cursor](https://cursor.com)