### PR TITLE
fix(chat): harden session restore to prevent message loss

### DIFF
--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -25,6 +25,99 @@ beforeEach(() => {
 });
 
 describe('chatMessagesReducer', () => {
+  it('RESTORE with interrupted flag appends a notice message', () => {
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hi' }],
+      },
+    ];
+    const result = chatMessagesReducer(INITIAL_STATE, {
+      type: 'RESTORE',
+      messages: msgs,
+      interrupted: true,
+    });
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].messageId).toBe('m1');
+    // The notice message should be appended
+    const notice = result.messages[1];
+    expect(notice.role).toBe('assistant');
+    expect(notice.blocks[0].content).toContain('interrupted');
+  });
+
+  it('RESTORE without interrupted flag does not append notice', () => {
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hi' }],
+      },
+    ];
+    const result = chatMessagesReducer(INITIAL_STATE, { type: 'RESTORE', messages: msgs });
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('RESTORE does not replace when state has more messages than incoming', () => {
+    const existing: ChatMessagesState = {
+      ...INITIAL_STATE,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'first' }],
+        },
+        {
+          messageId: 'm2',
+          role: 'user',
+          blocks: [{ blockId: 'b2', blockType: 'text', content: 'second' }],
+        },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          blocks: [{ blockId: 'b3', blockType: 'text', content: 'third' }],
+        },
+      ],
+    };
+    // API returns fewer messages — should NOT replace
+    const apiMsgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'first' }],
+      },
+    ];
+    const result = chatMessagesReducer(existing, { type: 'RESTORE', messages: apiMsgs });
+    expect(result.messages).toHaveLength(3); // kept existing
+  });
+
+  it('RESTORE replaces when incoming has more messages than state', () => {
+    const existing: ChatMessagesState = {
+      ...INITIAL_STATE,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'first' }],
+        },
+      ],
+    };
+    const apiMsgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'first' }],
+      },
+      {
+        messageId: 'm2',
+        role: 'user' as const,
+        blocks: [{ blockId: 'b2', blockType: 'text' as const, content: 'second' }],
+      },
+    ];
+    const result = chatMessagesReducer(existing, { type: 'RESTORE', messages: apiMsgs });
+    expect(result.messages).toHaveLength(2); // replaced with API data
+  });
+
   it('RESTORE replaces messages with valid v2 messages', () => {
     const msgs = [
       {
@@ -75,14 +168,74 @@ describe('useChatMessages — reattach_failed handler', () => {
     });
 
     await vi.waitFor(() => {
-      expect(result.current.state.messages).toHaveLength(1);
+      expect(result.current.state.messages.length).toBeGreaterThanOrEqual(1);
+      expect(result.current.state.messages[0].messageId).toBe('r1');
     });
 
-    expect(result.current.state.messages[0].messageId).toBe('r1');
+    // reattach_failed dispatches RESTORE with interrupted: true,
+    // so a notice message is appended after the restored messages.
+    expect(result.current.state.messages).toHaveLength(2);
+    expect(result.current.state.messages[1].blocks[0].content).toContain('interrupted');
     expect(result.current.state.running).toBe(false);
     expect(global.fetch).toHaveBeenCalledWith(
       '/api/sessions/test-session-id/messages',
       expect.objectContaining({ credentials: 'include' }),
     );
+  });
+
+  it('sets restoredViaReattach flag after successful reattach restore', async () => {
+    const apiMessages = [
+      {
+        messageId: 'r1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
+      },
+    ];
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(apiMessages),
+    });
+
+    const { result } = renderHook(() =>
+      useChatMessages('session:test', 'test-session-id', vi.fn(), vi.fn()),
+    );
+
+    expect(result.current.restoredViaReattach).toBe(false);
+
+    act(() => {
+      result.current.handleWsMessage({ type: 'reattach_failed', clientId: 'old-client' });
+    });
+
+    await vi.waitFor(() => {
+      expect(result.current.restoredViaReattach).toBe(true);
+    });
+  });
+
+  it('calls onMessagesRestored callback after reattach restore', async () => {
+    const apiMessages = [
+      {
+        messageId: 'r1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
+      },
+    ];
+
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve(apiMessages),
+    });
+
+    const onMessagesRestored = vi.fn();
+
+    const { result } = renderHook(() =>
+      useChatMessages('session:test', 'test-session-id', vi.fn(), vi.fn(), onMessagesRestored),
+    );
+
+    act(() => {
+      result.current.handleWsMessage({ type: 'reattach_failed', clientId: 'old-client' });
+    });
+
+    await vi.waitFor(() => {
+      expect(onMessagesRestored).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -61,7 +61,7 @@ export type ChatMessagesAction =
   | { type: 'CONNECTION_LOST' }
   | { type: 'PERMISSION_REQUEST'; payload: PermissionRequest }
   | { type: 'PERMISSION_TIMEOUT'; permId: string }
-  | { type: 'RESTORE'; messages: FinishedMessage[] };
+  | { type: 'RESTORE'; messages: FinishedMessage[]; interrupted?: boolean };
 
 const INITIAL_STATE: ChatMessagesState = {
   messages: [],
@@ -274,6 +274,26 @@ export function chatMessagesReducer(
       const valid = action.messages.filter(
         (m) => m && typeof m.messageId === 'string' && Array.isArray(m.blocks),
       );
+      // Don't replace if state already has more messages (e.g. from buffer
+      // drain that added messages the API hasn't persisted yet).
+      if (!action.interrupted && valid.length < state.messages.length) {
+        return state;
+      }
+      if (action.interrupted) {
+        const notice: FinishedMessage = {
+          messageId: `notice-${Date.now()}`,
+          role: 'assistant',
+          blocks: [
+            {
+              blockId: `notice-text-${Date.now()}`,
+              blockType: 'text',
+              content:
+                '**Session interrupted.** Messages above were restored from history — some recent content may be missing.',
+            },
+          ],
+        };
+        return { ...state, messages: [...valid, notice] };
+      }
       return { ...state, messages: valid };
     }
 
@@ -336,6 +356,7 @@ export function useChatMessages(
   currentSessionId: string | undefined,
   onSessionAssigned: (id: string) => void,
   onSessionExpired: (sessionId: string | undefined) => void,
+  onMessagesRestored?: () => void,
 ) {
   const [state, dispatch] = useReducer(chatMessagesReducer, INITIAL_STATE);
   const pendingSend = useRef<Record<string, unknown> | null>(null);
@@ -344,6 +365,7 @@ export function useChatMessages(
   const reattachAbort = useRef<AbortController | null>(null);
   const messagesRef = useRef(state.messages);
   messagesRef.current = state.messages;
+  const restoredViaReattachRef = useRef(false);
 
   useEffect(() => {
     const id = currentSessionIdRef.current;
@@ -398,7 +420,9 @@ export function useChatMessages(
               .then((msgs: FinishedMessage[]) => {
                 if (controller.signal.aborted) return;
                 if (Array.isArray(msgs) && msgs.length > 0) {
-                  dispatch({ type: 'RESTORE', messages: msgs });
+                  dispatch({ type: 'RESTORE', messages: msgs, interrupted: true });
+                  restoredViaReattachRef.current = true;
+                  onMessagesRestored?.();
                 }
               })
               .catch(() => {});
@@ -540,5 +564,11 @@ export function useChatMessages(
     [poolKey, onSessionAssigned, onSessionExpired],
   );
 
-  return { state, dispatch, pendingSend, handleWsMessage };
+  return {
+    state,
+    dispatch,
+    pendingSend,
+    handleWsMessage,
+    restoredViaReattach: restoredViaReattachRef.current,
+  };
 }

--- a/frontend/src/lib/__tests__/ws-pool.test.ts
+++ b/frontend/src/lib/__tests__/ws-pool.test.ts
@@ -53,7 +53,7 @@ Object.defineProperty(globalThis, 'location', {
 });
 
 // Import after mocks are set up
-const { wsSubscribe, wsDrainBuffer } = await import('../ws-pool.js');
+const { wsSubscribe, wsDrainBuffer, wsSetRunning } = await import('../ws-pool.js');
 type WsMsg = import('../ws-pool.js').WsMsg;
 
 describe('ws-pool message buffering', () => {
@@ -166,5 +166,45 @@ describe('ws-pool message buffering', () => {
 
   it('returns empty array for unknown keys', () => {
     expect(wsDrainBuffer('nonexistent')).toEqual([]);
+  });
+});
+
+describe('ws-pool reattach_failed handling', () => {
+  it('broadcasts _open after reattach_failed so component knows connection is live', () => {
+    const received: Array<WsMsg> = [];
+    wsSubscribe('test-reattach-fail-1', (msg) => received.push(msg));
+    const ws1 = lastCreatedWs!;
+    ws1.simulateOpen();
+
+    // Simulate an active session: client_id assigned, marked as running
+    ws1.simulateMessage({ type: 'client_id', clientId: 'old-id' });
+    wsSetRunning('test-reattach-fail-1', true);
+
+    // Clear initial messages
+    received.length = 0;
+
+    // Simulate disconnect + reconnect
+    ws1.simulateClose();
+    const ws2 = lastCreatedWs!;
+    ws2.simulateOpen();
+
+    // Server sends new client_id — pool sees wasRunning=true + prevClientId='old-id'
+    // so it sends reattach and does NOT broadcast _open yet
+    ws2.simulateMessage({ type: 'client_id', clientId: 'new-id' });
+
+    // At this point, _open should NOT have been sent (waiting for reattach result)
+    const typesBeforeReattach = received.filter((m) => m.type === '_open');
+    // _open from ws2.simulateOpen is there (ws.onopen always fires), but the
+    // client_id handler should NOT add another _open
+    const openCountBefore = typesBeforeReattach.length;
+
+    // Server responds with reattach_failed — pool should broadcast _open now
+    ws2.simulateMessage({ type: 'reattach_failed', reason: 'no session' });
+
+    const types = received.map((m) => m.type);
+    expect(types).toContain('reattach_failed');
+    // Must have an _open AFTER the reattach_failed to signal connection is live
+    const openCountAfter = received.filter((m) => m.type === '_open').length;
+    expect(openCountAfter).toBeGreaterThan(openCountBefore);
   });
 });

--- a/frontend/src/lib/ws-pool.ts
+++ b/frontend/src/lib/ws-pool.ts
@@ -107,6 +107,9 @@ function connectEntry(key: string, entry: PoolEntry) {
 
     if (msg.type === 'reattach_failed') {
       entry.wasRunning = false;
+      // Signal that the connection is live even though reattach failed —
+      // without this, the component never learns the WS is open.
+      broadcast(entry, { type: '_open' });
     }
 
     if (msg.type === 'session_end' || msg.type === 'error') {

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -73,11 +73,13 @@ export function ChatView() {
     dispatch,
     pendingSend,
     handleWsMessage,
+    restoredViaReattach,
   } = useChatMessages(
     poolKey,
     sessionState.currentSessionId,
     handleSessionAssigned,
     handleSessionExpired,
+    forceScrollToBottom,
   );
 
   // Auto-scroll during streaming: follow new content if user is near the bottom
@@ -93,13 +95,13 @@ export function ChatView() {
   // Restore messages when sessionId changes. Show cached data instantly,
   // then always reconcile with the API to catch anything the cache missed
   // (e.g. messages that streamed in after the last cache write).
+  // Skip if messages were already restored via reattach to avoid racing.
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId || restoredViaReattach) return;
 
     const controller = new AbortController();
     const cacheKey = `${CHAT_CACHE_KEY_PREFIX}${sessionId}`;
     const cached = localStorage.getItem(cacheKey);
-    let cacheCount = 0;
 
     if (cached) {
       try {
@@ -112,7 +114,6 @@ export function ChatView() {
         if (isV2) {
           dispatch({ type: 'RESTORE', messages: restored });
           setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
-          cacheCount = restored.length;
         } else {
           localStorage.removeItem(cacheKey);
         }
@@ -121,8 +122,9 @@ export function ChatView() {
       }
     }
 
-    // Always fetch from API — if the response has more messages than the
-    // cache (or the cache was empty), replace with the authoritative data.
+    // Always fetch from API for authoritative data. The reducer guards
+    // against replacing state that already has more messages (e.g. from
+    // buffer drain), so we don't need to compare counts here.
     fetch(`/api/sessions/${sessionId}/messages`, {
       credentials: 'include',
       signal: controller.signal,
@@ -131,7 +133,7 @@ export function ChatView() {
       .then((msgs: unknown[]) => {
         if (controller.signal.aborted) return;
         const apiMsgs = msgs as import('../types/chat').FinishedMessage[];
-        if (apiMsgs.length > 0 && apiMsgs.length >= cacheCount) {
+        if (apiMsgs.length > 0) {
           dispatch({ type: 'RESTORE', messages: apiMsgs });
           setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
         }
@@ -139,7 +141,7 @@ export function ChatView() {
       .catch(() => {});
 
     return () => controller.abort();
-  }, [sessionId, dispatch, forceScrollToBottom]);
+  }, [sessionId, restoredViaReattach, dispatch, forceScrollToBottom]);
 
   const { connected } = useChatConnection(poolKey, handleWsMessage);
 


### PR DESCRIPTION
## Summary

Closes #54. Fixes message loss across three scenarios: server restart, chat switching, and screen lock/unlock.

- **Race condition fix**: Added `restoredViaReattach` guard so the reattach restore and ChatView's useEffect don't stomp each other
- **Missing broadcast fix**: `reattach_failed` now broadcasts `_open` so the component knows the WebSocket is live (was stuck showing disconnected)
- **Buffer-aware RESTORE**: Reducer skips replacement when state already has more messages than incoming (prevents buffer drain messages from being overwritten by stale API data)
- **Interrupted notice**: Appends a visible notice when messages are restored after session interruption so the user knows some content may be missing

## Test plan

- [x] 369/369 tests pass (9 new assertions across 2 test files)
- [x] Lint passes (0 errors)
- [ ] Manual: start a session, lock phone, unlock — messages should persist
- [ ] Manual: start a session, switch to another chat, switch back — messages intact
- [ ] Manual: restart server mid-session — messages restored with interruption notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)