### PR TITLE
fix(frontend): prevent table column crushing on mobile

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -31,7 +31,18 @@ export function TextBubble({ content, streaming = false }: TextBubbleProps) {
   return (
     <div className={`msg-bubble msg-bubble--assistant${streaming ? ' msg-bubble--streaming' : ''}`}>
       <div className="msg-bubble-markdown">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            table: ({ children, ...props }) => (
+              <div className="table-scroll-wrapper">
+                <table {...props}>{children}</table>
+              </div>
+            ),
+          }}
+        >
+          {content}
+        </ReactMarkdown>
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -1,14 +1,25 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Mock react-markdown and remark-gfm before importing the component
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let capturedComponents: Record<string, any> | undefined;
 vi.mock('react-markdown', () => ({
-  default: ({ children }: { children: string }) => children,
+  default: ({
+    children,
+    components,
+  }: {
+    children: string;
+    components?: Record<string, unknown>;
+  }) => {
+    capturedComponents = components;
+    return children;
+  },
 }));
 vi.mock('remark-gfm', () => ({ default: () => {} }));
 
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { MessageBubble } from '../MessageBubble';
+import { MessageBubble, TextBubble } from '../MessageBubble';
 import type { FinishedMessage } from '../../types/chat';
 
 function userMessage(text: string): FinishedMessage {
@@ -26,6 +37,19 @@ describe('MessageBubble', () => {
     );
     expect(html).toContain('msg-bubble-content');
     expect(html).toContain('hello\nworld');
+  });
+
+  it('passes table scroll wrapper component to ReactMarkdown', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    expect(capturedComponents).toBeDefined();
+    expect(capturedComponents!.table).toBeDefined();
+
+    // Render the custom table component and verify wrapper
+    const tableHtml = renderToStaticMarkup(
+      capturedComponents!.table({ children: createElement('tr', null, 'row') }),
+    );
+    expect(tableHtml).toContain('table-scroll-wrapper');
+    expect(tableHtml).toContain('<table');
   });
 
   it('preserves newlines in user message text', () => {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1154,10 +1154,16 @@ textarea:focus {
   margin: 0.75em 0;
 }
 
+.msg-bubble--assistant .table-scroll-wrapper {
+  overflow-x: auto;
+  margin: 0.5em 0;
+  -webkit-overflow-scrolling: touch;
+}
+
 .msg-bubble--assistant table {
   border-collapse: collapse;
-  width: 100%;
-  margin: 0.5em 0;
+  width: max-content;
+  min-width: 100%;
   font-size: 0.85em;
 }
 
@@ -1166,6 +1172,7 @@ textarea:focus {
   border: 1px solid var(--border);
   padding: 0.35em 0.6em;
   text-align: left;
+  white-space: nowrap;
 }
 
 .msg-bubble--assistant th {


### PR DESCRIPTION
## Summary
- Wraps markdown tables in a horizontally-scrollable `div` so wide tables don't crush narrow columns on mobile
- Adds `white-space: nowrap` on `td`/`th` to prevent character-by-character wrapping (e.g. "10:00" rendering vertically)
- Uses `width: max-content; min-width: 100%` so tables expand naturally but still fill available space

## Test plan
- [x] Existing tests pass (381/381)
- [x] New test verifies `table-scroll-wrapper` is rendered
- [ ] Visual check: tables with short columns (times, status) no longer crush on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)