### PR TITLE
fix: increase tool result display limit to 50k chars

### DIFF
--- a/server/__tests__/content-blocks.test.ts
+++ b/server/__tests__/content-blocks.test.ts
@@ -57,10 +57,10 @@ describe('parseContentBlocks', () => {
     expect(result.toolResults[0].result).toBe('file contents here');
   });
 
-  it('truncates tool results to 10000 chars', () => {
-    const blocks = [{ type: 'tool_result', tool_use_id: 'tc-1', content: 'x'.repeat(12000) }];
+  it('truncates tool results to 50000 chars', () => {
+    const blocks = [{ type: 'tool_result', tool_use_id: 'tc-1', content: 'x'.repeat(60000) }];
     const result = parseContentBlocks(blocks);
-    expect(result.toolResults[0].result.length).toBe(10_000);
+    expect(result.toolResults[0].result.length).toBe(50_000);
   });
 
   it('handles mixed blocks', () => {

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -6,7 +6,7 @@ export const PERMISSION_TIMEOUT_MS = 120_000; // 2 minutes
 export const NTFY_NOTIFICATION_DELAY_MS = 10_000; // 10 seconds
 
 // --- Tool display ---
-export const TOOL_RESULT_MAX_CHARS = 10_000;
+export const TOOL_RESULT_MAX_CHARS = 50_000;
 export const NOTIFY_INPUT_MAX_CHARS = 100;
 export const TOOL_SUMMARY_MAX_CHARS = 200;
 export const RAW_INPUT_MAX_CHARS = 50_000;


### PR DESCRIPTION
## Summary
- Bumped `TOOL_RESULT_MAX_CHARS` from 10k to 50k in `server/constants.ts`
- Morning briefings and other long tool outputs were silently truncated, making results invisible on mobile

## Test plan
- [x] Updated truncation test to match new limit
- [x] All 381 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)