### PR TITLE
feat(skills): skill registry with scoped discovery and precedence

### DIFF
--- a/server/__tests__/skills-registry.test.ts
+++ b/server/__tests__/skills-registry.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { SkillRegistry, SKILL_SIZE_LIMIT } from '../skills.js';
+import { SkillRegistry, SKILL_SIZE_LIMIT, type PublicSkillMetadata } from '../skills.js';
 
 // --- Helpers ---
 
@@ -283,6 +283,41 @@ describe('SkillRegistry', () => {
 
       registry.invalidate();
       expect(registry.list()).toHaveLength(2);
+    });
+  });
+
+  describe('public metadata', () => {
+    it('listPublic() omits filePath from results', () => {
+      const dir = createTempDir();
+      const skillsDir = join(dir, 'skills');
+      writeSkill(skillsDir, 'deploy', { description: 'Deploy' });
+
+      const registry = new SkillRegistry({ bundledDir: skillsDir });
+      const publicSkills: PublicSkillMetadata[] = registry.listPublic();
+
+      expect(publicSkills).toHaveLength(1);
+      expect(publicSkills[0].name).toBe('deploy');
+      expect(publicSkills[0]).not.toHaveProperty('filePath');
+    });
+  });
+
+  describe('frontmatter validation', () => {
+    it('warns on unknown frontmatter keys (typos)', () => {
+      const dir = createTempDir();
+      const skillsDir = join(dir, 'skills');
+      // 'allowed-tool' is a typo for 'allowed-tools'
+      writeSkill(skillsDir, 'deploy', {
+        description: 'Deploy',
+        'allowed-tool': ['Bash'],
+      });
+
+      const registry = new SkillRegistry({ bundledDir: skillsDir });
+      const skills = registry.list();
+
+      // Skill is still discovered (unknown keys don't block)
+      expect(skills).toHaveLength(1);
+      // But allowedTools is undefined since the typo key is ignored
+      expect(skills[0].allowedTools).toBeUndefined();
     });
   });
 

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -18,6 +18,9 @@ export interface SkillMetadata {
   filePath: string;
 }
 
+/** Safe subset of SkillMetadata for API responses — omits server filesystem paths. */
+export type PublicSkillMetadata = Omit<SkillMetadata, 'filePath'>;
+
 interface SkillRegistryOptions {
   bundledDir?: string;
   userDir?: string;
@@ -87,6 +90,13 @@ function parseFrontmatter(raw: string): { meta: Record<string, unknown>; body: s
   // Flush final list
   if (currentKey && currentList) {
     meta[currentKey] = currentList;
+  }
+
+  const KNOWN_KEYS = new Set(['description', 'allowed-tools']);
+  for (const key of Object.keys(meta)) {
+    if (!KNOWN_KEYS.has(key)) {
+      log.warn(`Unknown frontmatter key "${key}" — check for typos`);
+    }
   }
 
   return { meta, body };
@@ -249,7 +259,14 @@ export class SkillRegistry {
     return this.list().find((s) => s.name === name);
   }
 
-  /** Clear cached data — forces rediscovery on next list() call. */
+  /** Return skill metadata safe for API responses (no filesystem paths). */
+  listPublic(): PublicSkillMetadata[] {
+    return this.list().map(({ filePath: _, ...rest }) => rest);
+  }
+
+  /** Clear cached data — forces rediscovery on next list() call.
+   *  TODO: Add file-watcher for hot-reload so skill changes on disk
+   *  don't require a server restart or explicit invalidate() call. */
   invalidate(): void {
     this.cache = null;
     this.bodyCache.clear();


### PR DESCRIPTION
## Summary
- Introduces `SkillRegistry` class for lazy skill metadata discovery from bundled, user, and repo-local directories
- Deterministic precedence: repo > user > bundled, with collision metadata preserved
- Safe frontmatter parsing (no eval/yaml-load), 10KB size limit, lazy body loading
- 18 tests covering discovery, precedence, collisions, edge cases, and cache invalidation

Step 1 of 6 in the skills v1 build plan (`docs/design/skills-system-v1-plan.md`).

## Test plan
- [x] 18 new tests in `server/__tests__/skills-registry.test.ts` — all pass
- [x] Full suite (435 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)