### PR TITLE
feat(skills): slash-command parsing and prompt rendering

### DIFF
--- a/server/__tests__/skill-rendering.test.ts
+++ b/server/__tests__/skill-rendering.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SkillRegistry } from '../skills.js';
+import { parseSlashCommand, resolveSlashCommand, renderSkillPrompt } from '../slash-commands.js';
+
+// --- Helpers ---
+
+function writeSkill(
+  dir: string,
+  name: string,
+  frontmatter: Record<string, unknown>,
+  body = 'Skill body for $ARGUMENTS',
+): string {
+  const skillDir = join(dir, name);
+  mkdirSync(skillDir, { recursive: true });
+  const yaml = Object.entries(frontmatter)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}:\n${v.map((i) => `  - ${i}`).join('\n')}`;
+      return `${k}: ${JSON.stringify(v)}`;
+    })
+    .join('\n');
+  const content = `---\n${yaml}\n---\n\n${body}`;
+  writeFileSync(join(skillDir, 'SKILL.md'), content);
+  return skillDir;
+}
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'mitzo-slash-test-'));
+}
+
+// --- Tests ---
+
+describe('parseSlashCommand', () => {
+  it('parses /simplify api layer into name and arguments', () => {
+    const result = parseSlashCommand('/simplify api layer');
+    expect(result).toEqual({ name: 'simplify', arguments: 'api layer' });
+  });
+
+  it('parses /skills deploy into name and arguments', () => {
+    const result = parseSlashCommand('/skills deploy');
+    expect(result).toEqual({ name: 'skills', arguments: 'deploy' });
+  });
+
+  it('parses /simplify with no arguments', () => {
+    const result = parseSlashCommand('/simplify');
+    expect(result).toEqual({ name: 'simplify', arguments: '' });
+  });
+
+  it('returns null for plain text', () => {
+    expect(parseSlashCommand('hello world')).toBeNull();
+    expect(parseSlashCommand('fix the bug')).toBeNull();
+    expect(parseSlashCommand('')).toBeNull();
+  });
+
+  it('returns null for messages with slash not at start', () => {
+    expect(parseSlashCommand('use /simplify here')).toBeNull();
+  });
+
+  it('returns null for bare slash', () => {
+    expect(parseSlashCommand('/')).toBeNull();
+    expect(parseSlashCommand('/ ')).toBeNull();
+  });
+});
+
+describe('resolveSlashCommand', () => {
+  let tempDirs: string[];
+
+  beforeEach(() => {
+    tempDirs = [];
+  });
+
+  afterEach(() => {
+    for (const d of tempDirs) {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+
+  function createTempDir(): string {
+    const d = makeTempDir();
+    tempDirs.push(d);
+    return d;
+  }
+
+  it('resolves a known skill to a skill result', () => {
+    const dir = createTempDir();
+    const skillsDir = join(dir, 'skills');
+    writeSkill(skillsDir, 'simplify', { description: 'Simplify code' }, 'Simplify: $ARGUMENTS');
+
+    const registry = new SkillRegistry({ bundledDir: skillsDir });
+    const result = resolveSlashCommand('/simplify api layer', registry, new Set());
+
+    expect(result.type).toBe('skill');
+    if (result.type === 'skill') {
+      expect(result.name).toBe('simplify');
+      expect(result.arguments).toBe('api layer');
+      expect(result.renderedPrompt).toContain('Simplify: api layer');
+    }
+  });
+
+  it('resolves a native command name to a native result', () => {
+    const registry = new SkillRegistry({});
+    const result = resolveSlashCommand('/skills', registry, new Set(['skills']));
+
+    expect(result.type).toBe('native');
+    if (result.type === 'native') {
+      expect(result.name).toBe('skills');
+      expect(result.arguments).toBe('');
+    }
+  });
+
+  it('resolves an unknown slash command to an error with suggestions', () => {
+    const dir = createTempDir();
+    const skillsDir = join(dir, 'skills');
+    writeSkill(skillsDir, 'simplify', { description: 'Simplify code' });
+    writeSkill(skillsDir, 'deploy', { description: 'Deploy' });
+
+    const registry = new SkillRegistry({ bundledDir: skillsDir });
+    const result = resolveSlashCommand('/simpify', registry, new Set());
+
+    expect(result.type).toBe('error');
+    if (result.type === 'error') {
+      expect(result.message).toContain('simpify');
+      expect(result.suggestions).toContain('simplify');
+    }
+  });
+
+  it('returns passthrough for plain text', () => {
+    const registry = new SkillRegistry({});
+    const result = resolveSlashCommand('hello world', registry, new Set());
+
+    expect(result.type).toBe('passthrough');
+  });
+
+  it('includes collision info in skill result', () => {
+    const dir1 = createTempDir();
+    const dir2 = createTempDir();
+
+    writeSkill(join(dir1, 'skills'), 'deploy', { description: 'user deploy' }, 'User deploy');
+    writeSkill(join(dir2, 'skills'), 'deploy', { description: 'bundled deploy' }, 'Bundled deploy');
+
+    const registry = new SkillRegistry({
+      userDir: join(dir1, 'skills'),
+      bundledDir: join(dir2, 'skills'),
+    });
+
+    const result = resolveSlashCommand('/deploy', registry, new Set());
+    expect(result.type).toBe('skill');
+    if (result.type === 'skill') {
+      expect(result.collisions).toBeDefined();
+      expect(result.collisions!.length).toBe(1);
+    }
+  });
+});
+
+describe('renderSkillPrompt', () => {
+  it('substitutes $ARGUMENTS in skill body', () => {
+    const result = renderSkillPrompt('Review the $ARGUMENTS for issues', 'api layer', {
+      name: 'review',
+      scope: 'bundled',
+    });
+    expect(result).toContain('Review the api layer for issues');
+  });
+
+  it('includes skill source metadata in envelope', () => {
+    const result = renderSkillPrompt('Do something', 'args', {
+      name: 'deploy',
+      scope: 'repo',
+    });
+    expect(result).toContain('deploy');
+    expect(result).toContain('repo');
+  });
+
+  it('handles empty arguments', () => {
+    const result = renderSkillPrompt('Scan $ARGUMENTS', '', {
+      name: 'scan',
+      scope: 'user',
+    });
+    expect(result).toContain('Scan ');
+  });
+
+  it('handles body with no $ARGUMENTS token', () => {
+    const result = renderSkillPrompt('Just do the thing', 'extra args', {
+      name: 'simple',
+      scope: 'bundled',
+    });
+    expect(result).toContain('Just do the thing');
+  });
+});

--- a/server/slash-commands.ts
+++ b/server/slash-commands.ts
@@ -1,0 +1,151 @@
+import type { SkillRegistry, SkillScope } from './skills.js';
+
+// --- Parsing ---
+
+export interface ParsedSlash {
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Parse a potential slash command from user input.
+ * Returns null if the input is not a slash command.
+ */
+export function parseSlashCommand(input: string): ParsedSlash | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('/')) return null;
+
+  const spaceIdx = trimmed.indexOf(' ');
+  const name = spaceIdx === -1 ? trimmed.slice(1) : trimmed.slice(1, spaceIdx);
+  const args = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1).trim();
+
+  if (!name) return null;
+
+  return { name, arguments: args };
+}
+
+// --- Resolution ---
+
+export type SlashResolution =
+  | { type: 'passthrough' }
+  | {
+      type: 'native';
+      name: string;
+      arguments: string;
+    }
+  | {
+      type: 'skill';
+      name: string;
+      arguments: string;
+      renderedPrompt: string;
+      allowedTools?: string[];
+      collisions?: Array<{ scope: SkillScope; description: string }>;
+    }
+  | {
+      type: 'error';
+      message: string;
+      suggestions: string[];
+    };
+
+/**
+ * Resolve a user message to a slash command result.
+ * This is the single server-authoritative resolution point.
+ */
+export function resolveSlashCommand(
+  input: string,
+  skillRegistry: SkillRegistry,
+  nativeNames: Set<string>,
+): SlashResolution {
+  const parsed = parseSlashCommand(input);
+  if (!parsed) return { type: 'passthrough' };
+
+  // Native commands take absolute priority
+  if (nativeNames.has(parsed.name)) {
+    return { type: 'native', name: parsed.name, arguments: parsed.arguments };
+  }
+
+  // Look up in skill registry
+  const skill = skillRegistry.get(parsed.name);
+  if (skill) {
+    const body = skillRegistry.getBody(parsed.name);
+    if (!body) {
+      return {
+        type: 'error',
+        message: `Skill "${parsed.name}" has no body content.`,
+        suggestions: [],
+      };
+    }
+
+    const renderedPrompt = renderSkillPrompt(body, parsed.arguments, {
+      name: skill.name,
+      scope: skill.scope,
+    });
+
+    return {
+      type: 'skill',
+      name: skill.name,
+      arguments: parsed.arguments,
+      renderedPrompt,
+      allowedTools: skill.allowedTools,
+      collisions: skill.collisions,
+    };
+  }
+
+  // Unknown — find close matches
+  const allNames = [...skillRegistry.list().map((s) => s.name), ...Array.from(nativeNames)];
+  const suggestions = findSuggestions(parsed.name, allNames);
+
+  const hint = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(', ')}?` : '';
+
+  return {
+    type: 'error',
+    message: `Unknown command "/${parsed.name}".${hint}`,
+    suggestions,
+  };
+}
+
+// --- Prompt rendering ---
+
+/**
+ * Render a skill body with $ARGUMENTS substitution and an envelope.
+ */
+export function renderSkillPrompt(
+  body: string,
+  args: string,
+  meta: { name: string; scope: string },
+): string {
+  const substituted = body.replace(/\$ARGUMENTS/g, args);
+
+  return [`[Skill: /${meta.name} | source: ${meta.scope}]`, '', substituted].join('\n');
+}
+
+// --- Suggestion matching ---
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+
+  return dp[m][n];
+}
+
+function findSuggestions(input: string, candidates: string[], maxDistance = 3): string[] {
+  return candidates
+    .map((c) => ({ name: c, dist: levenshtein(input.toLowerCase(), c.toLowerCase()) }))
+    .filter((c) => c.dist <= maxDistance)
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, 3)
+    .map((c) => c.name);
+}


### PR DESCRIPTION
## Summary
- Adds `parseSlashCommand()` for splitting `/name args` input
- Adds `resolveSlashCommand()` — server-authoritative resolution (native > skill > error)
- Adds `renderSkillPrompt()` with `$ARGUMENTS` substitution and skill envelope
- Levenshtein-based suggestions for unknown commands

Step 2 of 6. Stacked on #87.

## Test plan
- [x] 15 new tests in `server/__tests__/skill-rendering.test.ts` — all pass
- [x] Full suite passes (flaky `socket hang up` in routes is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)