### PR TITLE
fix(chat): stop agent prompts leaking as user messages on rejoin

### DIFF
--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -67,6 +67,7 @@ export type ChatMessagesAction =
   | { type: 'PERMISSION_REQUEST'; payload: PermissionRequest }
   | { type: 'PERMISSION_TIMEOUT'; permId: string }
   | { type: 'RESTORE'; messages: FinishedMessage[]; interrupted?: boolean }
+  | { type: 'USER_MESSAGE_RECEIVED'; messageId: string; text: string }
   | { type: 'WORKTREE_OPENED'; repoName: string; path: string }
   | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string };
 
@@ -313,10 +314,17 @@ export function chatMessagesReducer(
       const valid = action.messages.filter(
         (m) => m && typeof m.messageId === 'string' && Array.isArray(m.blocks),
       );
-      // Don't replace if state already has more messages (e.g. from buffer
-      // drain that added messages the API hasn't persisted yet).
-      if (!action.interrupted && valid.length < state.messages.length) {
-        return state;
+      // Don't replace if state already has all the API messages (e.g. from
+      // buffer drain that added messages the API hasn't persisted yet).
+      // Use messageId-based comparison instead of array length — length
+      // comparison silently rejects valid API data when stale pool state
+      // happens to have more entries.
+      if (!action.interrupted) {
+        const existingIds = new Set(state.messages.map((m) => m.messageId));
+        const hasNewMessages = valid.some((m) => !existingIds.has(m.messageId));
+        if (!hasNewMessages && state.messages.length > 0) {
+          return state;
+        }
       }
       if (action.interrupted) {
         const notice: FinishedMessage = {
@@ -334,6 +342,32 @@ export function chatMessagesReducer(
         return { ...state, messages: [...valid, notice] };
       }
       return { ...state, messages: valid };
+    }
+
+    case 'USER_MESSAGE_RECEIVED': {
+      // Server-side user_message event (from reattach replay or live emit).
+      // Deduplicate: USER_SEND already added this message client-side during
+      // the live session, so skip if a message with this ID already exists.
+      if (state.messages.some((m) => m.messageId === action.messageId)) {
+        return state;
+      }
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            messageId: action.messageId,
+            role: 'user',
+            blocks: [
+              {
+                blockId: `user-text-${action.messageId}`,
+                blockType: 'text' as BlockType,
+                content: action.text,
+              },
+            ],
+          },
+        ],
+      };
     }
 
     case 'USER_SEND':
@@ -573,6 +607,14 @@ export function useChatMessages(
 
         case 'skill_invoked':
           // TODO: Implement skill badge rendering on the last user message
+          break;
+
+        case 'user_message':
+          dispatch({
+            type: 'USER_MESSAGE_RECEIVED',
+            messageId: msg.messageId as string,
+            text: msg.text as string,
+          });
           break;
 
         case 'error': {

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -146,6 +146,13 @@ interface SkillInvokedMsg {
   arguments: string;
 }
 
+interface UserMessageMsg {
+  type: 'user_message';
+  v: 2;
+  messageId: string;
+  text: string;
+}
+
 export type ServerMessage =
   | ClientIdMsg
   | ReattachedMsg
@@ -167,4 +174,5 @@ export type ServerMessage =
   | UpdateAvailableMsg
   | WorktreeOpenedMsg
   | NativeCommandResultMsg
-  | SkillInvokedMsg;
+  | SkillInvokedMsg
+  | UserMessageMsg;

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -462,7 +462,10 @@ describe('runQueryLoop', () => {
     expect(ws.sent.some((m) => m.type === 'session_end')).toBe(true);
   });
 
-  it('emits user_message event for user messages with string content', async () => {
+  it('does not emit user_message for SDK user events with string content', async () => {
+    // SDK user events are internal API conversation turns (agent sub-prompts,
+    // multi-turn machinery). Only entry points (startChat, sendToChat,
+    // interruptChat) should persist user_message events.
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-a1' } } },
       {
@@ -479,7 +482,6 @@ describe('runQueryLoop', () => {
       },
       { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
       { type: 'assistant', message: { content: [] }, session_id: 'sess-um' },
-      // User follow-up with string content
       { type: 'user', message: { role: 'user', content: 'Follow-up question' } },
       { type: 'result', session_id: 'sess-um' },
     ];
@@ -487,11 +489,10 @@ describe('runQueryLoop', () => {
     await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
 
     const userMsg = ws.sent.find((m) => m.type === 'user_message');
-    expect(userMsg).toBeDefined();
-    expect(userMsg).toMatchObject({ v: 2, type: 'user_message', text: 'Follow-up question' });
+    expect(userMsg).toBeUndefined();
   });
 
-  it('emits user_message event for user messages with text content blocks', async () => {
+  it('does not emit user_message for SDK user events with text content blocks', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-a2' } } },
       {
@@ -508,7 +509,6 @@ describe('runQueryLoop', () => {
       },
       { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
       { type: 'assistant', message: { content: [] }, session_id: 'sess-um2' },
-      // User message with content blocks array containing text
       {
         type: 'user',
         message: {
@@ -522,11 +522,10 @@ describe('runQueryLoop', () => {
     await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
 
     const userMsg = ws.sent.find((m) => m.type === 'user_message');
-    expect(userMsg).toBeDefined();
-    expect(userMsg).toMatchObject({ v: 2, type: 'user_message', text: 'Another question' });
+    expect(userMsg).toBeUndefined();
   });
 
-  it('emits both user_message and tool_result for mixed content blocks', async () => {
+  it('emits only tool_result (not user_message) for mixed content blocks', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-mix' } } },
       {
@@ -562,16 +561,17 @@ describe('runQueryLoop', () => {
 
     await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
 
+    // Text content from SDK user events must NOT produce user_message
     const userMsg = ws.sent.find((m) => m.type === 'user_message');
-    expect(userMsg).toBeDefined();
-    expect(userMsg).toMatchObject({ text: 'Here is context' });
+    expect(userMsg).toBeUndefined();
 
+    // tool_result extraction should still work
     const toolResult = ws.sent.find((m) => m.type === 'tool_result');
     expect(toolResult).toBeDefined();
     expect(toolResult).toMatchObject({ toolId: 'tool-mix' });
   });
 
-  it('concatenates multiple text blocks into a single user_message event', async () => {
+  it('does not emit user_message for SDK user events with multiple text blocks', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-cat' } } },
       {
@@ -604,8 +604,7 @@ describe('runQueryLoop', () => {
     await runQueryLoop(eventStream(events), clientId, registry, abortController, ws);
 
     const userMsgs = ws.sent.filter((m) => m.type === 'user_message');
-    expect(userMsgs).toHaveLength(1);
-    expect(userMsgs[0]).toMatchObject({ text: 'Part one\n\nPart two' });
+    expect(userMsgs).toHaveLength(0);
   });
 
   it('does not emit user_message for user messages with only tool_result blocks', async () => {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -413,21 +413,16 @@ export async function runQueryLoop(
           tryFlushMessageEnd(currentWs, currentSession);
         }
       } else if (msg.type === 'user') {
+        // Only extract tool_result events from SDK user turns.
+        // Do NOT emit user_message here — human input is persisted at the
+        // entry points (startChat, sendToChat, interruptChat) via PR #100.
+        // Emitting user_message from the SDK stream would capture internal
+        // API conversation turns (agent sub-prompts, tool-result text) and
+        // replay them as user bubbles on session rejoin.
         const content = (msg.message as unknown as Record<string, unknown>)?.content;
-        if (typeof content === 'string' && content) {
-          emit(
-            currentWs,
-            v2('user_message', {
-              messageId: `umsg-${Date.now()}-${userMsgCounter++}`,
-              text: content,
-            }),
-          );
-        } else if (Array.isArray(content)) {
-          const textParts: string[] = [];
+        if (Array.isArray(content)) {
           for (const block of content) {
-            if (block.type === 'text' && block.text) {
-              textParts.push(block.text as string);
-            } else if (block.type === 'tool_result') {
+            if (block.type === 'tool_result') {
               const resultText = extractToolResultText(block.content);
               emit(
                 currentWs,
@@ -439,15 +434,6 @@ export async function runQueryLoop(
                 }),
               );
             }
-          }
-          if (textParts.length > 0) {
-            emit(
-              currentWs,
-              v2('user_message', {
-                messageId: `umsg-${Date.now()}-${userMsgCounter++}`,
-                text: textParts.join('\n\n'),
-              }),
-            );
           }
         }
       }


### PR DESCRIPTION
## Summary

- **Remove** `user_message` emission from the SDK `msg.type === 'user'` handler in `query-loop.ts` — these events capture internal API conversation turns (agent sub-prompts, multi-turn machinery), not human input. This is the root cause of agent prompts appearing as user message bubbles on session rejoin.
- **Keep** tool_result extraction from SDK user events (still needed for live tool pill display)
- **Add** `UserMessageMsg` WS type and frontend handler for `user_message` events during reattach replay
- **Fix** the `RESTORE` guard — replace fragile array-length comparison with messageId-based deduplication

## Context

This is the culmination of a long saga (PRs #47, #53, #54, #56, #57, #58, #66, #79, #98, #99, #100) attempting to fix user messages disappearing on session rejoin. PR #99 added user_message emission from the SDK stream, but that captured ALL API-level user turns — including agent sub-prompts — not just human input. PR #100 correctly persisted at entry points but PR #99's SDK handler was never removed, causing internal prompts to leak into the event store and display as user bubbles.

## Test plan

- [x] All 511 tests pass
- [ ] Start a new chat, send messages, navigate away, navigate back — user messages appear correctly
- [ ] Use Agent tool in a chat, rejoin session — agent prompts do NOT appear as user bubbles
- [ ] Mid-session WS disconnect + reconnect — user messages survive reattach
- [ ] Check event store — only human messages stored as `user_message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)