### PR TITLE
refactor(chat): stack input action buttons vertically

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -178,34 +178,36 @@ export function ChatInput({ onSend, onStop, onInterrupt, running, initialText, c
         </div>
       )}
       <div className="chat-input-row">
-        <button
-          className="chat-input-btn chat-input-btn--skills"
-          onClick={() => {
-            if (!text.startsWith('/')) setText('/');
-            setShowSlashPicker(true);
-            textareaRef.current?.focus();
-          }}
-          title="Skills"
-        >
-          /
-        </button>
-        <button
-          className="chat-input-btn chat-input-btn--attach"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={images.length >= MAX_IMAGE_ATTACHMENTS}
-          title="Attach image"
-        >
-          +
-        </button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/gif,image/webp"
-          multiple
-          capture="environment"
-          onChange={handleFileChange}
-          className="sr-only"
-        />
+        <div className="chat-input-actions">
+          <button
+            className="chat-input-btn chat-input-btn--skills"
+            onClick={() => {
+              if (!text.startsWith('/')) setText('/');
+              setShowSlashPicker(true);
+              textareaRef.current?.focus();
+            }}
+            title="Skills"
+          >
+            /
+          </button>
+          <button
+            className="chat-input-btn chat-input-btn--attach"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={images.length >= MAX_IMAGE_ATTACHMENTS}
+            title="Attach image"
+          >
+            +
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            multiple
+            capture="environment"
+            onChange={handleFileChange}
+            className="sr-only"
+          />
+        </div>
         <textarea
           ref={textareaRef}
           className="chat-input-field"

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1667,7 +1667,15 @@ textarea:focus {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 22px;
-  padding: 0.35rem 0.35rem 0.35rem 0.5rem;
+  padding: 0.35rem 0.35rem 0.35rem 0.35rem;
+}
+
+.chat-input-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  align-self: flex-end;
+  flex-shrink: 0;
 }
 
 .chat-input-field {
@@ -1751,11 +1759,11 @@ textarea:focus {
 }
 
 .chat-input-btn--attach {
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 1.7rem;
+  height: 1.7rem;
   border-radius: 50%;
   padding: 0;
-  font-size: 1.2rem;
+  font-size: 1rem;
   font-weight: 600;
   background: transparent;
   color: var(--text-dim);
@@ -1763,7 +1771,6 @@ textarea:focus {
   align-items: center;
   justify-content: center;
   line-height: 1;
-  align-self: flex-end;
 }
 
 .chat-input-btn--attach:hover:not(:disabled) {
@@ -1779,11 +1786,11 @@ textarea:focus {
 }
 
 .chat-input-btn--skills {
-  width: 2.2rem;
-  height: 2.2rem;
+  width: 1.7rem;
+  height: 1.7rem;
   border-radius: 50%;
   padding: 0;
-  font-size: 1rem;
+  font-size: 0.85rem;
   font-weight: 700;
   background: transparent;
   color: var(--text-dim);
@@ -1791,7 +1798,6 @@ textarea:focus {
   align-items: center;
   justify-content: center;
   line-height: 1;
-  align-self: flex-end;
   font-family: monospace;
 }
 


### PR DESCRIPTION
## Summary
- Wraps the `/` (slash command) and `+` (attach) buttons in a vertical flex column instead of side-by-side
- Shrinks buttons from 2.2rem to 1.7rem to keep the stack compact
- Reclaims horizontal space for the text input on mobile screens

## Test plan
- [ ] Verify buttons stack vertically on mobile viewport
- [ ] Tap `/` — slash picker opens correctly
- [ ] Tap `+` — file picker opens correctly
- [ ] Text input has more horizontal space than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)