### PR TITLE
fix(chat): correlation ID dedup + /review-response skill

### DIFF
--- a/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
+++ b/frontend/src/hooks/__tests__/chatMessagesReducer.test.ts
@@ -466,7 +466,11 @@ describe('MESSAGE_SNAPSHOT', () => {
 
 describe('USER_SEND', () => {
   it('adds user message and sets running=true', () => {
-    const state = chatMessagesReducer(INITIAL, { type: 'USER_SEND', text: 'hello' });
+    const state = chatMessagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-1-abc',
+    });
     expect(state.running).toBe(true);
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].role).toBe('user');
@@ -475,7 +479,11 @@ describe('USER_SEND', () => {
 
   it('appends user message when already running', () => {
     const running = { ...INITIAL, running: true };
-    const state = chatMessagesReducer(running, { type: 'USER_SEND', text: 'follow-up' });
+    const state = chatMessagesReducer(running, {
+      type: 'USER_SEND',
+      text: 'follow-up',
+      clientMsgId: 'user-2-def',
+    });
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].role).toBe('user');
     expect(state.messages[0].blocks[0].content).toBe('follow-up');
@@ -486,6 +494,7 @@ describe('USER_SEND', () => {
     const state = chatMessagesReducer(INITIAL, {
       type: 'USER_SEND',
       text: 'look',
+      clientMsgId: 'user-3-ghi',
       images: ['data:image/png;base64,...'],
     });
     expect(state.messages[0].images).toEqual(['data:image/png;base64,...']);
@@ -539,7 +548,11 @@ describe('full turn sequence', () => {
     let state = INITIAL;
 
     // User sends
-    state = chatMessagesReducer(state, { type: 'USER_SEND', text: 'list files' });
+    state = chatMessagesReducer(state, {
+      type: 'USER_SEND',
+      text: 'list files',
+      clientMsgId: 'user-4-jkl',
+    });
 
     // Assistant turn starts
     state = chatMessagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-a' });

--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -376,7 +376,7 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
     expect(result).toBe(stateWithAssistant);
   });
 
-  it('adds message with different ID when no optimistic match exists', () => {
+  it('adds message with different ID even if text is identical', () => {
     const stateWithMsg: ChatMessagesState = {
       ...INITIAL_STATE,
       messages: [
@@ -387,7 +387,6 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
         },
       ],
     };
-    // umsg-100 is a server ID (not optimistic user-*), so same text should still add
     const result = chatMessagesReducer(stateWithMsg, {
       type: 'USER_MESSAGE_RECEIVED',
       messageId: 'umsg-200',
@@ -397,52 +396,65 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
     expect(result.messages[1].messageId).toBe('umsg-200');
   });
 
-  it('deduplicates optimistic USER_SEND when server echo arrives with different ID', () => {
-    // Simulate: user sends message (optimistic), then server echoes it back
+  it('deduplicates when server echoes back the same clientMsgId', () => {
+    // Client sends with a clientMsgId — both USER_SEND and server echo use it
+    const clientMsgId = 'user-1234-abc';
     const afterSend = chatMessagesReducer(INITIAL_STATE, {
       type: 'USER_SEND',
       text: "Yep. Let's go",
+      clientMsgId,
     });
     expect(afterSend.messages).toHaveLength(1);
-    expect(afterSend.messages[0].messageId).toMatch(/^user-/);
+    expect(afterSend.messages[0].messageId).toBe(clientMsgId);
 
-    // Server echoes back with a different ID
+    // Server echoes back the same ID
     const afterEcho = chatMessagesReducer(afterSend, {
       type: 'USER_MESSAGE_RECEIVED',
-      messageId: 'umsg-999-send',
+      messageId: clientMsgId,
       text: "Yep. Let's go",
     });
-    // Should NOT duplicate — should upgrade the ID instead
+    // Exact ID match — no duplicate
     expect(afterEcho.messages).toHaveLength(1);
-    expect(afterEcho.messages[0].messageId).toBe('umsg-999-send');
-    expect(afterEcho.messages[0].blocks[0].content).toBe("Yep. Let's go");
+    expect(afterEcho).toBe(afterSend); // reference equality — no state change
   });
 
-  it('adds server echo when no optimistic message matches the text', () => {
-    // User sent "hello" optimistically, but server echoes "different text"
-    const afterSend = chatMessagesReducer(INITIAL_STATE, {
+  it('handles duplicate text sent twice with different clientMsgIds', () => {
+    const afterSend1 = chatMessagesReducer(INITIAL_STATE, {
       type: 'USER_SEND',
       text: 'hello',
+      clientMsgId: 'user-1-aaa',
     });
-    const result = chatMessagesReducer(afterSend, {
+    const afterSend2 = chatMessagesReducer(afterSend1, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-2-bbb',
+    });
+    expect(afterSend2.messages).toHaveLength(2);
+
+    // Server echoes both — each deduplicates against its own optimistic copy
+    const afterEcho1 = chatMessagesReducer(afterSend2, {
       type: 'USER_MESSAGE_RECEIVED',
-      messageId: 'umsg-999-send',
-      text: 'different text',
+      messageId: 'user-1-aaa',
+      text: 'hello',
     });
-    // Different text — should add as a new message
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[1].messageId).toBe('umsg-999-send');
+    expect(afterEcho1.messages).toHaveLength(2);
+    const afterEcho2 = chatMessagesReducer(afterEcho1, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'user-2-bbb',
+      text: 'hello',
+    });
+    expect(afterEcho2.messages).toHaveLength(2);
   });
 
-  it('adds server message when no optimistic user-* message exists (reconnect)', () => {
+  it('adds server message when no optimistic message exists (reconnect)', () => {
     // Reconnect scenario: no optimistic message in state, server replays
     const result = chatMessagesReducer(INITIAL_STATE, {
       type: 'USER_MESSAGE_RECEIVED',
-      messageId: 'umsg-500-send',
+      messageId: 'user-500-xyz',
       text: 'reconnected message',
     });
     expect(result.messages).toHaveLength(1);
-    expect(result.messages[0].messageId).toBe('umsg-500-send');
+    expect(result.messages[0].messageId).toBe('user-500-xyz');
   });
 
   it('deduplicates after RESTORE with interrupted flow', () => {

--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -376,7 +376,7 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
     expect(result).toBe(stateWithAssistant);
   });
 
-  it('adds message with different ID even if text is identical', () => {
+  it('adds message with different ID when no optimistic match exists', () => {
     const stateWithMsg: ChatMessagesState = {
       ...INITIAL_STATE,
       messages: [
@@ -387,6 +387,7 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
         },
       ],
     };
+    // umsg-100 is a server ID (not optimistic user-*), so same text should still add
     const result = chatMessagesReducer(stateWithMsg, {
       type: 'USER_MESSAGE_RECEIVED',
       messageId: 'umsg-200',
@@ -394,6 +395,54 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
     });
     expect(result.messages).toHaveLength(2);
     expect(result.messages[1].messageId).toBe('umsg-200');
+  });
+
+  it('deduplicates optimistic USER_SEND when server echo arrives with different ID', () => {
+    // Simulate: user sends message (optimistic), then server echoes it back
+    const afterSend = chatMessagesReducer(INITIAL_STATE, {
+      type: 'USER_SEND',
+      text: "Yep. Let's go",
+    });
+    expect(afterSend.messages).toHaveLength(1);
+    expect(afterSend.messages[0].messageId).toMatch(/^user-/);
+
+    // Server echoes back with a different ID
+    const afterEcho = chatMessagesReducer(afterSend, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-999-send',
+      text: "Yep. Let's go",
+    });
+    // Should NOT duplicate — should upgrade the ID instead
+    expect(afterEcho.messages).toHaveLength(1);
+    expect(afterEcho.messages[0].messageId).toBe('umsg-999-send');
+    expect(afterEcho.messages[0].blocks[0].content).toBe("Yep. Let's go");
+  });
+
+  it('adds server echo when no optimistic message matches the text', () => {
+    // User sent "hello" optimistically, but server echoes "different text"
+    const afterSend = chatMessagesReducer(INITIAL_STATE, {
+      type: 'USER_SEND',
+      text: 'hello',
+    });
+    const result = chatMessagesReducer(afterSend, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-999-send',
+      text: 'different text',
+    });
+    // Different text — should add as a new message
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1].messageId).toBe('umsg-999-send');
+  });
+
+  it('adds server message when no optimistic user-* message exists (reconnect)', () => {
+    // Reconnect scenario: no optimistic message in state, server replays
+    const result = chatMessagesReducer(INITIAL_STATE, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-500-send',
+      text: 'reconnected message',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].messageId).toBe('umsg-500-send');
   });
 
   it('deduplicates after RESTORE with interrupted flow', () => {

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -377,11 +377,25 @@ export function chatMessagesReducer(
 
     case 'USER_MESSAGE_RECEIVED': {
       // Server-side user_message event (from reattach replay or live emit).
-      // Deduplicate: USER_SEND already added this message client-side during
-      // the live session, so skip if a message with this ID already exists.
+      // Exact ID match — already have this message (reattach replay).
       if (state.messages.some((m) => m.messageId === action.messageId)) {
         return state;
       }
+      // Content match — optimistic USER_SEND already rendered this message.
+      // Upgrade the ID to the server's canonical one so reconnect/restore
+      // can find it by the persisted ID.
+      const optimisticIdx = state.messages.findIndex(
+        (m) =>
+          m.role === 'user' &&
+          m.messageId.startsWith('user-') &&
+          m.blocks[0]?.content === action.text,
+      );
+      if (optimisticIdx !== -1) {
+        const updated = [...state.messages];
+        updated[optimisticIdx] = { ...updated[optimisticIdx], messageId: action.messageId };
+        return { ...state, messages: updated };
+      }
+      // No match — add as new (reconnect/reattach scenario).
       return {
         ...state,
         messages: [

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -61,7 +61,13 @@ export type ChatMessagesAction =
   // Session / UI lifecycle
   | { type: 'ERROR'; error: string }
   | { type: 'SESSION_INFO'; branch: string; isWorktree: boolean }
-  | { type: 'USER_SEND'; text: string; images?: string[]; contextBlocks?: string[] }
+  | {
+      type: 'USER_SEND';
+      text: string;
+      clientMsgId: string;
+      images?: string[];
+      contextBlocks?: string[];
+    }
   | { type: 'SET_RUNNING'; running: boolean }
   | { type: 'CONNECTION_LOST' }
   | { type: 'PERMISSION_REQUEST'; payload: PermissionRequest }
@@ -376,26 +382,13 @@ export function chatMessagesReducer(
     }
 
     case 'USER_MESSAGE_RECEIVED': {
-      // Server-side user_message event (from reattach replay or live emit).
-      // Exact ID match — already have this message (reattach replay).
+      // Server echo of a user message (live confirmation or reattach replay).
+      // The client's USER_SEND uses the same clientMsgId that the server
+      // echoes back, so exact ID match deduplicates correctly.
       if (state.messages.some((m) => m.messageId === action.messageId)) {
         return state;
       }
-      // Content match — optimistic USER_SEND already rendered this message.
-      // Upgrade the ID to the server's canonical one so reconnect/restore
-      // can find it by the persisted ID.
-      const optimisticIdx = state.messages.findIndex(
-        (m) =>
-          m.role === 'user' &&
-          m.messageId.startsWith('user-') &&
-          m.blocks[0]?.content === action.text,
-      );
-      if (optimisticIdx !== -1) {
-        const updated = [...state.messages];
-        updated[optimisticIdx] = { ...updated[optimisticIdx], messageId: action.messageId };
-        return { ...state, messages: updated };
-      }
-      // No match — add as new (reconnect/reattach scenario).
+      // No match — add as new (reconnect where no optimistic message exists).
       return {
         ...state,
         messages: [
@@ -421,7 +414,7 @@ export function chatMessagesReducer(
         messages: [
           ...state.messages,
           {
-            messageId: `user-${Date.now()}`,
+            messageId: action.clientMsgId,
             role: 'user',
             blocks: [],
             images: action.images,
@@ -431,7 +424,7 @@ export function chatMessagesReducer(
               ? {
                   blocks: [
                     {
-                      blockId: `user-text-${Date.now()}`,
+                      blockId: `user-text-${action.clientMsgId}`,
                       blockType: 'text' as BlockType,
                       content: action.text,
                     },

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -19,6 +19,10 @@ import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
 import type { FinishedBlock, ImageAttachment } from '../types/chat';
 
+function generateClientMsgId(): string {
+  return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 export function ChatView() {
   const { sessionId } = useParams<{ sessionId?: string }>();
   const [searchParams] = useSearchParams();
@@ -134,10 +138,6 @@ export function ChatView() {
   });
 
   const hasStarted = msgState.messages.some((m) => m.role === 'user');
-
-  function generateClientMsgId(): string {
-    return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  }
 
   function buildSendPayload(
     text: string,

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -135,10 +135,19 @@ export function ChatView() {
 
   const hasStarted = msgState.messages.some((m) => m.role === 'user');
 
-  function buildSendPayload(text: string, images?: ImageAttachment[]): Record<string, unknown> {
+  function generateClientMsgId(): string {
+    return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function buildSendPayload(
+    text: string,
+    clientMsgId: string,
+    images?: ImageAttachment[],
+  ): Record<string, unknown> {
     const payload: Record<string, unknown> = {
       type: 'send',
       prompt: text,
+      clientMsgId,
       model: sessionState.model,
       mode: sessionState.mode,
     };
@@ -167,19 +176,20 @@ export function ChatView() {
     // Stop TTS playback when user sends a new message
     voice.stopSpeaking();
 
-    const payload = buildSendPayload(text, images);
+    const clientMsgId = generateClientMsgId();
+    const payload = buildSendPayload(text, clientMsgId, images);
     if (contextBlocks?.length) payload.contextBlocks = contextBlocks;
     const previews = images?.map((img) => img.preview);
 
     if (msgState.running) {
       // Server queues it natively — no client-side stop+re-send needed.
       wsSend(poolKey, payload);
-      dispatch({ type: 'USER_SEND', text, images: previews, contextBlocks });
+      dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
       forceScrollToBottom();
     } else {
       wsSetRunning(poolKey, true);
       wsSend(poolKey, payload);
-      dispatch({ type: 'USER_SEND', text, images: previews, contextBlocks });
+      dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
       forceScrollToBottom();
     }
 
@@ -192,15 +202,17 @@ export function ChatView() {
     contextBlocks?: string[],
   ): void {
     if (!wsIsOpen(poolKey) || !msgState.running) return;
+    const clientMsgId = generateClientMsgId();
     const imagePayload = images?.map((img) => ({ data: img.data, mediaType: img.mediaType }));
     const previews = images?.map((img) => img.preview);
     wsSend(poolKey, {
       type: 'interrupt',
       prompt: text,
+      clientMsgId,
       images: imagePayload,
       ...(contextBlocks?.length ? { contextBlocks } : {}),
     });
-    dispatch({ type: 'USER_SEND', text, images: previews, contextBlocks });
+    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
     forceScrollToBottom();
   }
 

--- a/server/__tests__/bundled-skills.test.ts
+++ b/server/__tests__/bundled-skills.test.ts
@@ -101,15 +101,6 @@ describe('bundled skills', () => {
     expect(prReview!.allowedTools).not.toContain('Edit');
   });
 
-  it('/review-response includes Bash for gh CLI access', () => {
-    const reviewResponse = skills.find((s) => s.name === 'review-response');
-    expect(reviewResponse).toBeDefined();
-    expect(reviewResponse!.allowedTools).toBeDefined();
-    expect(reviewResponse!.allowedTools).toContain('Bash');
-    expect(reviewResponse!.allowedTools).not.toContain('Write');
-    expect(reviewResponse!.allowedTools).not.toContain('Edit');
-  });
-
   it('all bundled skills are scoped as bundled', () => {
     for (const skill of skills) {
       expect(skill.scope).toBe('bundled');

--- a/server/__tests__/bundled-skills.test.ts
+++ b/server/__tests__/bundled-skills.test.ts
@@ -12,9 +12,9 @@ describe('bundled skills', () => {
   const registry = new SkillRegistry({ bundledDir: SKILLS_DIR });
   const skills = registry.list();
 
-  it('discovers all three bundled skills', () => {
+  it('discovers all four bundled skills', () => {
     const names = skills.map((s) => s.name).sort();
-    expect(names).toEqual(['pr-review', 'risk-scan', 'simplify']);
+    expect(names).toEqual(['pr-review', 'review-response', 'risk-scan', 'simplify']);
   });
 
   it('has unique names', () => {
@@ -82,6 +82,15 @@ describe('bundled skills', () => {
     expect(riskScan!.allowedTools).not.toContain('Edit');
   });
 
+  it('/review-response includes Bash for gh CLI access', () => {
+    const reviewResponse = skills.find((s) => s.name === 'review-response');
+    expect(reviewResponse).toBeDefined();
+    expect(reviewResponse!.allowedTools).toBeDefined();
+    expect(reviewResponse!.allowedTools).toContain('Bash');
+    expect(reviewResponse!.allowedTools).not.toContain('Write');
+    expect(reviewResponse!.allowedTools).not.toContain('Edit');
+  });
+
   it('/pr-review includes Bash for git diff access', () => {
     const prReview = skills.find((s) => s.name === 'pr-review');
     expect(prReview).toBeDefined();
@@ -90,6 +99,15 @@ describe('bundled skills', () => {
     // But not Write/Edit — analysis first
     expect(prReview!.allowedTools).not.toContain('Write');
     expect(prReview!.allowedTools).not.toContain('Edit');
+  });
+
+  it('/review-response includes Bash for gh CLI access', () => {
+    const reviewResponse = skills.find((s) => s.name === 'review-response');
+    expect(reviewResponse).toBeDefined();
+    expect(reviewResponse!.allowedTools).toBeDefined();
+    expect(reviewResponse!.allowedTools).toContain('Bash');
+    expect(reviewResponse!.allowedTools).not.toContain('Write');
+    expect(reviewResponse!.allowedTools).not.toContain('Edit');
   });
 
   it('all bundled skills are scoped as bundled', () => {

--- a/server/__tests__/send-to-chat.test.ts
+++ b/server/__tests__/send-to-chat.test.ts
@@ -48,7 +48,33 @@ describe('sendToChat emits user_message via WebSocket', () => {
       type: 'user_message',
       text: 'Hello from user',
     });
+    // Falls back to server-generated umsg-* when no clientMsgId provided
     expect(userMsgEvents[0].messageId).toMatch(/^umsg-/);
+  });
+
+  it('uses clientMsgId as messageId when provided', () => {
+    const ws = mockWs();
+    const pushSpy = vi.fn();
+
+    registry.register(CLIENT_ID, {
+      ws,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+    });
+
+    const session = registry.get(CLIENT_ID)!;
+    session.sessionId = 'sess-client-id';
+    session.inputQueue = { push: pushSpy, close: vi.fn() };
+
+    const result = sendToChat(CLIENT_ID, 'Hello', undefined, undefined, 'user-1234-abc');
+    expect(result).toBe(true);
+
+    const userMsgEvents = ws._sent.filter(
+      (m: Record<string, unknown>) => m.type === 'user_message',
+    );
+    expect(userMsgEvents).toHaveLength(1);
+    expect(userMsgEvents[0].messageId).toBe('user-1234-abc');
   });
 
   it('does not crash when ws is not OPEN', () => {
@@ -127,5 +153,31 @@ describe('interruptChat emits user_message via WebSocket', () => {
       type: 'user_message',
       text: 'Urgent message',
     });
+  });
+
+  it('uses clientMsgId as messageId when provided', async () => {
+    const ws = mockWs();
+    const pushSpy = vi.fn();
+
+    registry.register(CLIENT_ID, {
+      ws,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+    });
+
+    const session = registry.get(CLIENT_ID)!;
+    session.sessionId = 'sess-int-2';
+    session.inputQueue = { push: pushSpy, close: vi.fn() };
+    session.queryInstance = { interrupt: vi.fn().mockResolvedValue(undefined), close: vi.fn() };
+
+    const result = await interruptChat(CLIENT_ID, 'Urgent', undefined, undefined, 'user-5678-def');
+    expect(result).toBe(true);
+
+    const userMsgEvents = ws._sent.filter(
+      (m: Record<string, unknown>) => m.type === 'user_message',
+    );
+    expect(userMsgEvents).toHaveLength(1);
+    expect(userMsgEvents[0].messageId).toBe('user-5678-def');
   });
 });

--- a/server/__tests__/ws-schemas.test.ts
+++ b/server/__tests__/ws-schemas.test.ts
@@ -56,6 +56,14 @@ describe('WS message schemas', () => {
     expect(result.success).toBe(true);
   });
 
+  it('rejects interrupt without clientMsgId', () => {
+    const result = IncomingWsMessage.safeParse({
+      type: 'interrupt',
+      prompt: 'wait',
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('accepts permission_response', () => {
     const result = IncomingWsMessage.safeParse({
       type: 'permission_response',

--- a/server/__tests__/ws-schemas.test.ts
+++ b/server/__tests__/ws-schemas.test.ts
@@ -6,11 +6,20 @@ describe('WS message schemas', () => {
     const result = IncomingWsMessage.safeParse({
       type: 'send',
       prompt: 'hello',
+      clientMsgId: 'user-1-abc',
       model: 'claude-sonnet-4-6',
       mode: 'agent',
     });
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.type).toBe('send');
+  });
+
+  it('rejects send without clientMsgId', () => {
+    const result = IncomingWsMessage.safeParse({
+      type: 'send',
+      prompt: 'hello',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects send with empty prompt', () => {
@@ -39,7 +48,11 @@ describe('WS message schemas', () => {
   });
 
   it('accepts interrupt message', () => {
-    const result = IncomingWsMessage.safeParse({ type: 'interrupt', prompt: 'wait' });
+    const result = IncomingWsMessage.safeParse({
+      type: 'interrupt',
+      prompt: 'wait',
+      clientMsgId: 'user-2-def',
+    });
     expect(result.success).toBe(true);
   });
 
@@ -71,6 +84,7 @@ describe('WS message schemas', () => {
     const result = IncomingWsMessage.safeParse({
       type: 'send',
       prompt: 'look at this',
+      clientMsgId: 'user-3-ghi',
       images: [{ data: 'base64data', mediaType: 'image/png' }],
     });
     expect(result.success).toBe(true);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -458,7 +458,7 @@ export function sendToChat(
   const session = registry.get(clientId);
   if (!session?.inputQueue) return false;
   const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = clientMsgId ?? `umsg-${Date.now()}-send`;
+  const messageId = clientMsgId || `umsg-${Date.now()}-send`;
   if (session.sessionId) {
     eventStore.append(session.sessionId, 'user_message', {
       v: 2,
@@ -488,7 +488,7 @@ export async function interruptChat(
   const session = registry.get(clientId);
   if (!session?.queryInstance || !session?.inputQueue) return false;
   const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = clientMsgId ?? `umsg-${Date.now()}-interrupt`;
+  const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
   if (session.sessionId) {
     eventStore.append(session.sessionId, 'user_message', {
       v: 2,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -306,6 +306,7 @@ export async function startChat(
     worktree?: boolean;
     images?: Array<{ data: string; mediaType: string }>;
     contextBlocks?: string[];
+    clientMsgId?: string;
   },
 ) {
   const abortController = new AbortController();
@@ -452,11 +453,12 @@ export function sendToChat(
   prompt: string,
   images?: Array<{ data: string; mediaType: string }>,
   contextBlocks?: string[],
+  clientMsgId?: string,
 ): boolean {
   const session = registry.get(clientId);
   if (!session?.inputQueue) return false;
   const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = `umsg-${Date.now()}-send`;
+  const messageId = clientMsgId ?? `umsg-${Date.now()}-send`;
   if (session.sessionId) {
     eventStore.append(session.sessionId, 'user_message', {
       v: 2,
@@ -481,11 +483,12 @@ export async function interruptChat(
   prompt: string,
   images?: Array<{ data: string; mediaType: string }>,
   contextBlocks?: string[],
+  clientMsgId?: string,
 ): Promise<boolean> {
   const session = registry.get(clientId);
   if (!session?.queryInstance || !session?.inputQueue) return false;
   const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = `umsg-${Date.now()}-interrupt`;
+  const messageId = clientMsgId ?? `umsg-${Date.now()}-interrupt`;
   if (session.sessionId) {
     eventStore.append(session.sessionId, 'user_message', {
       v: 2,

--- a/server/index.ts
+++ b/server/index.ts
@@ -225,7 +225,13 @@ function handleChatWs(ws: WebSocket, initialClientId: string) {
 
           // Pass rendered prompt through to normal chat flow
           if (isActive(clientId)) {
-            sendToChat(clientId, resolution.renderedPrompt, msg.images, msg.contextBlocks);
+            sendToChat(
+              clientId,
+              resolution.renderedPrompt,
+              msg.images,
+              msg.contextBlocks,
+              msg.clientMsgId,
+            );
           } else {
             startChat(ws, clientId, resolution.renderedPrompt, {
               resume: msg.resume,
@@ -236,13 +242,14 @@ function handleChatWs(ws: WebSocket, initialClientId: string) {
               worktree: msg.worktree,
               images: msg.images,
               contextBlocks: msg.contextBlocks,
+              clientMsgId: msg.clientMsgId,
             });
           }
         } else {
           // Passthrough — plain text, no slash command
           clearSkillPolicy(registry, clientId);
           if (isActive(clientId)) {
-            sendToChat(clientId, msg.prompt, msg.images, msg.contextBlocks);
+            sendToChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
           } else {
             startChat(ws, clientId, msg.prompt, {
               resume: msg.resume,
@@ -253,11 +260,12 @@ function handleChatWs(ws: WebSocket, initialClientId: string) {
               worktree: msg.worktree,
               images: msg.images,
               contextBlocks: msg.contextBlocks,
+              clientMsgId: msg.clientMsgId,
             });
           }
         }
       } else if (msg.type === 'interrupt') {
-        interruptChat(clientId, msg.prompt, msg.images, msg.contextBlocks);
+        interruptChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
       } else if (msg.type === 'stop') {
         stopChat(clientId);
       }

--- a/server/ws-schemas.ts
+++ b/server/ws-schemas.ts
@@ -14,6 +14,7 @@ export const ReattachMessage = z.object({
 export const SendMessage = z.object({
   type: z.literal('send'),
   prompt: z.string().min(1),
+  clientMsgId: z.string().min(1),
   model: z.string().optional(),
   mode: z.enum(['ask', 'agent', 'auto']).optional(),
   resume: z.string().optional(),
@@ -27,6 +28,7 @@ export const SendMessage = z.object({
 export const InterruptMessage = z.object({
   type: z.literal('interrupt'),
   prompt: z.string().min(1),
+  clientMsgId: z.string().min(1),
   images: z.array(ImageSchema).optional(),
   contextBlocks: z.array(z.string()).optional(),
 });

--- a/skills/review-response/SKILL.md
+++ b/skills/review-response/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools:
 
 Triage all review comments on $ARGUMENTS.
 
-If `$ARGUMENTS` is a PR number, fetch comments with `gh api repos/{owner}/{repo}/pulls/{number}/reviews` and `gh api repos/{owner}/{repo}/pulls/{number}/comments`. If no number is given, detect the current branch's open PR with `gh pr view --json number,url`.
+If `$ARGUMENTS` is a PR number, fetch review comments with `gh pr view {number} --json reviews,comments` and `gh api repos/:owner/:repo/pulls/{number}/comments` (`:owner/:repo` is resolved automatically by `gh`). If no number is given, detect the current branch's open PR with `gh pr view --json number,url`.
 
 For **every** finding:
 

--- a/skills/review-response/SKILL.md
+++ b/skills/review-response/SKILL.md
@@ -1,0 +1,35 @@
+---
+description: Triage PR review comments, investigate each finding, and fix properly
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+Triage all review comments on $ARGUMENTS.
+
+If `$ARGUMENTS` is a PR number, fetch comments with `gh api repos/{owner}/{repo}/pulls/{number}/reviews` and `gh api repos/{owner}/{repo}/pulls/{number}/comments`. If no number is given, detect the current branch's open PR with `gh pr view --json number,url`.
+
+For **every** finding:
+
+1. **Investigate** — read the referenced code, search for related patterns, understand the full context. Do not dismiss findings without evidence.
+2. **Classify** severity:
+   - **Critical** — bugs, data loss, security issues, correctness failures
+   - **Valid** — real improvements to maintainability, robustness, or clarity
+   - **Cosmetic** — style-only changes with no functional impact
+3. **Decide** — the default is to **fix**. Only reject a finding if investigation proves it is factually wrong (not just unlikely). "It can't happen today" is not a reason to skip — if the code allows it structurally, fix it. Boy Scout rule: leave the code better than you found it.
+
+Present all findings in a compact table before making changes:
+
+| #   | File | Finding | Severity | Action | Reason |
+| --- | ---- | ------- | -------- | ------ | ------ |
+
+After presenting, wait for approval. Then fix everything marked for action.
+
+**Principles:**
+
+- Every valid finding gets fixed. No deferring to "future PRs" or "out of scope."
+- If a finding reveals a deeper issue than what the reviewer described, fix the deeper issue.
+- If multiple findings point to the same root cause, fix the root cause once rather than patching each symptom.
+- If a reviewer suggests an approach and a better one exists, use the better one — but acknowledge the reviewer's insight.


### PR DESCRIPTION
## Summary

- Fix duplicate user message bubble caused by mismatched optimistic/server IDs
- **Proper fix**: client generates a `clientMsgId` nonce, sends it with the WS message, server echoes it back — exact ID match deduplication works perfectly
- Replaces the fragile content-based matching from the initial commit
- Add `/review-response` bundled skill for triaging PR review comments

## Commits

1. `fix(chat): deduplicate optimistic user message against server echo` — initial content-based fix
2. `refactor(chat): replace content-based dedup with correlation ID` — proper long-term fix
3. `feat(skills): add /review-response bundled skill` — new skill for review triage

## Test plan

- [x] Correlation ID dedup: USER_SEND + server echo with same clientMsgId → single message (717 tests pass)
- [x] Duplicate text with different clientMsgIds → both preserved correctly
- [x] Reconnect scenario (no optimistic message) → server message added normally
- [x] /review-response skill discovered, has Bash in allowed-tools, passes approval gate check
- [ ] Manual: send follow-up message in live session — appears once
- [ ] Manual: disconnect and reconnect — user messages survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)