### PR TITLE
fix: address review findings for PR #154

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -215,7 +215,7 @@ function handleChatWs(ws: WebSocket, initialClientId: string) {
           ws.send(
             JSON.stringify({
               type: 'skill_invoked',
-              v: 2,
+v: 2,
               name: resolution.name,
               source: skillRegistry.get(resolution.name)?.scope || 'bundled',
               arguments: resolution.arguments,
@@ -316,7 +316,7 @@ checkPort(PORT).then((inUse) => {
     const protocol = USE_TLS ? 'https' : 'http';
     log.info(`Chat Agent running on ${protocol}://localhost:${PORT}${USE_TLS ? ' (TLS)' : ''}`);
     // Clean up stale worktrees across all repos
-    let repoEntries: [string, string][] = [['primary', BASE_REPO]];
+    const repoEntries: [string, string][] = [['primary', BASE_REPO]];
     try {
       const config = getRepoConfig();
       repoEntries.push(...Object.entries(config.repos));


### PR DESCRIPTION
## Centaur Auto-Fix

Fixes for review findings on PR #154 (`refactor(server): load repo config dynamically`).

### Changes
- Changed `let repoEntries` to `const repoEntries` on L319 since the binding is never reassigned (only mutated via `.push()`)

---
*Generated by Centaur*