### PR TITLE
fix: address review findings for PR #158

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@anthropic-ai/vertex-sdk": "^0.15.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.8.0",
-    "contexgin": "file:../../projects/contexgin",
+    "contexgin": "github:dimakis/contexgin",
     "cookie-parser": "^1.4.7",
     "dotenv": "^17.2.4",
     "express": "^4.21.0",
@@ -60,6 +60,6 @@
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.58.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.2"
   }
 }

--- a/server/__tests__/contexgin-smoke.test.ts
+++ b/server/__tests__/contexgin-smoke.test.ts
@@ -2,23 +2,31 @@
  * Smoke test: verify contexgin is importable and exports the expected API.
  * This test exists to catch broken links or missing builds early.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 
 describe('contexgin dependency', () => {
-  it('exports compile and discoverSources', async () => {
-    const contexgin = await import('contexgin');
+  let contexgin: typeof import('contexgin') extends Promise<infer T> ? T : never;
+
+  beforeAll(async () => {
+    contexgin = await import('contexgin');
+  });
+
+  it('exports compile and discoverSources', () => {
     expect(typeof contexgin.compile).toBe('function');
     expect(typeof contexgin.discoverSources).toBe('function');
   });
 
-  it('exports integrity functions', async () => {
-    const contexgin = await import('contexgin');
+  it('compile runs without throwing on trivial input', async () => {
+    const result = await contexgin.compile({ sources: [] });
+    expect(result).toBeDefined();
+  });
+
+  it('exports integrity functions', () => {
     expect(typeof contexgin.extractClaims).toBe('function');
     expect(typeof contexgin.validateAll).toBe('function');
   });
 
-  it('exports navigation functions', async () => {
-    const contexgin = await import('contexgin');
+  it('exports navigation functions', () => {
     expect(typeof contexgin.indexConstitutions).toBe('function');
     expect(typeof contexgin.generateReadingList).toBe('function');
   });


### PR DESCRIPTION
## Centaur Auto-Fix

Fixes for review findings on PR #158 (`feat(context): add contexgin dependency`).

### Changes
- Replaced `file:../../projects/contexgin` with `github:dimakis/contexgin` to remove the machine-specific hardcoded path and make the dependency portable for any contributor
- Reverted vitest from ^4.1.4 back to ^4.1.2 to keep the unrelated dependency bump out of this feature PR
- Moved the dynamic import into a single beforeAll block to avoid redundant module resolution across test cases
- Added a test that actually invokes compile with trivial input to catch runtime errors beyond typeof checks

---
*Generated by Centaur*