### PR TITLE
feat(frontend): desktop three-panel layout with persistent context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import { useState, useEffect } from 'react';
 import { Login } from './pages/Login';
 import { SessionList } from './pages/SessionList';
 import { ChatView } from './pages/ChatView';
+import { DesktopChatView } from './pages/DesktopChatView';
 import { FileViewer } from './pages/FileViewer';
 import { InboxView } from './pages/InboxView';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { useIsDesktop } from './hooks/useMediaQuery';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const [auth, setAuth] = useState<'loading' | 'ok' | 'denied'>('loading');
@@ -21,6 +23,16 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+function HomeRoute() {
+  const isDesktop = useIsDesktop();
+  return isDesktop ? <DesktopChatView /> : <SessionList />;
+}
+
+function ChatRoute() {
+  const isDesktop = useIsDesktop();
+  return isDesktop ? <DesktopChatView /> : <ChatView />;
+}
+
 export function App() {
   return (
     <ErrorBoundary>
@@ -31,7 +43,9 @@ export function App() {
             path="/"
             element={
               <ProtectedRoute>
-                <SessionList />
+                <ErrorBoundary>
+                  <HomeRoute />
+                </ErrorBoundary>
               </ProtectedRoute>
             }
           />
@@ -40,7 +54,7 @@ export function App() {
             element={
               <ProtectedRoute>
                 <ErrorBoundary>
-                  <ChatView />
+                  <ChatRoute />
                 </ErrorBoundary>
               </ProtectedRoute>
             }
@@ -50,7 +64,7 @@ export function App() {
             element={
               <ProtectedRoute>
                 <ErrorBoundary>
-                  <ChatView />
+                  <ChatRoute />
                 </ErrorBoundary>
               </ProtectedRoute>
             }

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { UserBubble, TextBubble } from './MessageBubble';
+import { ThinkingBlock } from './ThinkingBlock';
+import { ToolPill } from './ToolPill';
+import { ToolGroup } from './ToolGroup';
+import { PermissionBanner } from './PermissionBanner';
+import { groupBlocks } from '../lib/groupMessages';
+import { SCROLL_NEAR_BOTTOM_PX } from '../lib/constants';
+import type {
+  FinishedMessage,
+  FinishedBlock,
+  StreamingMessage,
+  PermissionRequest,
+} from '../types/chat';
+
+export interface ChatAreaProps {
+  messages: FinishedMessage[];
+  current: StreamingMessage | null;
+  running: boolean;
+  permission: PermissionRequest | null;
+  onPermissionRespond: (
+    permId: string,
+    decision: 'once' | 'always' | 'deny',
+    toolName: string,
+  ) => void;
+  /** External ref for scroll container — caller can use for forceScrollToBottom */
+  scrollRef?: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ChatArea({
+  messages,
+  current,
+  running,
+  permission,
+  onPermissionRespond,
+  scrollRef: externalScrollRef,
+}: ChatAreaProps) {
+  const internalScrollRef = useRef<HTMLDivElement>(null);
+  const scrollRef = externalScrollRef ?? internalScrollRef;
+
+  // Auto-scroll during streaming: follow new content if user is near the bottom
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distFromBottom <= SCROLL_NEAR_BOTTOM_PX) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages, current, scrollRef]);
+
+  // Group blocks per finished assistant turn for tool collapsing.
+  const groupedMessages = useMemo(
+    () =>
+      messages.map((msg) => ({
+        msg,
+        grouped: msg.role === 'assistant' ? groupBlocks(msg.blocks) : null,
+      })),
+    [messages],
+  );
+
+  return (
+    <>
+      <div className="chat-messages" ref={scrollRef}>
+        {messages.length === 0 && !current && !running && (
+          <p className="chat-empty">Send a message to start</p>
+        )}
+
+        {/* Finished turns */}
+        {groupedMessages.map(({ msg, grouped }) => {
+          if (msg.role === 'user') {
+            const textBlock = msg.blocks.find((b) => b.blockType === 'text');
+            return (
+              <UserBubble
+                key={msg.messageId}
+                text={textBlock?.content}
+                images={msg.images}
+                contextBlocks={msg.contextBlocks}
+              />
+            );
+          }
+
+          // Assistant turn — render grouped blocks
+          return (
+            <div key={msg.messageId} className="msg-turn">
+              {(grouped ?? []).map((item, i) => {
+                if (item.type === 'tool-group') {
+                  return <ToolGroup key={item.key} tools={item.tools} />;
+                }
+                const block: FinishedBlock = item.block;
+                if (block.blockType === 'thinking' || block.blockType === 'redacted_thinking') {
+                  return <ThinkingBlock key={block.blockId} block={block} />;
+                }
+                if (block.blockType === 'tool_use') {
+                  return <ToolPill key={block.blockId} block={block} />;
+                }
+                return (
+                  <TextBubble key={block.blockId || `text-${i}`} content={block.content ?? ''} />
+                );
+              })}
+            </div>
+          );
+        })}
+
+        {/* In-flight streaming turn — rendered inline, no grouping */}
+        {current && (
+          <div className="msg-turn msg-turn--streaming">
+            {current.blockOrder.map((blockId) => {
+              const block = current.blocks.get(blockId)!;
+              if (block.blockType === 'thinking' || block.blockType === 'redacted_thinking') {
+                return <ThinkingBlock key={block.blockId} block={block} streaming />;
+              }
+              if (block.blockType === 'tool_use') {
+                return <ToolPill key={block.blockId} block={block} />;
+              }
+              return <TextBubble key={block.blockId} content={block.content ?? ''} streaming />;
+            })}
+          </div>
+        )}
+      </div>
+
+      {permission && (
+        <PermissionBanner
+          permId={permission.permId}
+          toolName={permission.toolName}
+          toolInput={permission.toolInput}
+          title={permission.title}
+          description={permission.description}
+          displayName={permission.displayName}
+          tier={permission.tier}
+          onRespond={onPermissionRespond}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -28,6 +28,8 @@ interface Props {
   sandbox?: boolean;
   onSandboxToggle?: () => void;
   sandboxDisabled?: boolean;
+  /** When provided, uses these context blocks instead of internal state. Hides @ picker. */
+  externalContextBlocks?: string[];
 }
 
 export function ChatInput({
@@ -43,12 +45,15 @@ export function ChatInput({
   sandbox,
   onSandboxToggle,
   sandboxDisabled,
+  externalContextBlocks,
 }: Props) {
   const [text, setText] = useState(initialText || '');
   const [images, setImages] = useState<ImageAttachment[]>([]);
   const [showSlashPicker, setShowSlashPicker] = useState(false);
   const [showContextPicker, setShowContextPicker] = useState(false);
   const [contextBlocks, setContextBlocks] = useState<string[]>([]);
+  const useExternal = externalContextBlocks !== undefined;
+  const activeContextBlocks = useExternal ? externalContextBlocks : contextBlocks;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const initialApplied = useRef(false);
@@ -102,12 +107,12 @@ export function ChatInput({
     const sent = onSend(
       trimmed || 'What do you see in this image?',
       images.length > 0 ? images : undefined,
-      contextBlocks.length > 0 ? contextBlocks : undefined,
+      activeContextBlocks.length > 0 ? activeContextBlocks : undefined,
     );
     if (sent) {
       setText('');
       setImages([]);
-      setContextBlocks([]);
+      if (!useExternal) setContextBlocks([]);
       requestAnimationFrame(() => {
         autoResize();
         textareaRef.current?.focus();
@@ -190,11 +195,11 @@ export function ChatInput({
     onInterrupt(
       trimmed || 'What do you see in this image?',
       images.length > 0 ? images : undefined,
-      contextBlocks.length > 0 ? contextBlocks : undefined,
+      activeContextBlocks.length > 0 ? activeContextBlocks : undefined,
     );
     setText('');
     setImages([]);
-    setContextBlocks([]);
+    if (!useExternal) setContextBlocks([]);
     requestAnimationFrame(() => {
       autoResize();
       textareaRef.current?.focus();
@@ -211,7 +216,7 @@ export function ChatInput({
           cwd={cwd}
         />
       )}
-      {showContextPicker && (
+      {!useExternal && showContextPicker && (
         <ContextPicker
           selected={contextBlocks}
           onToggle={(name) =>
@@ -234,7 +239,7 @@ export function ChatInput({
           ))}
         </div>
       )}
-      {contextBlocks.length > 0 && (
+      {!useExternal && contextBlocks.length > 0 && (
         <div className="chat-input-context-pills">
           {contextBlocks.map((name) => (
             <span key={name} className="chat-input-context-pill">
@@ -272,13 +277,15 @@ export function ChatInput({
         >
           +
         </button>
-        <button
-          className={`chat-input-btn chat-input-btn--context${contextBlocks.length > 0 ? ' chat-input-btn--active' : ''}`}
-          onClick={() => setShowContextPicker((v) => !v)}
-          title="Attach context"
-        >
-          @
-        </button>
+        {!useExternal && (
+          <button
+            className={`chat-input-btn chat-input-btn--context${contextBlocks.length > 0 ? ' chat-input-btn--active' : ''}`}
+            onClick={() => setShowContextPicker((v) => !v)}
+            title="Attach context"
+          >
+            @
+          </button>
+        )}
         <input
           ref={fileInputRef}
           type="file"

--- a/frontend/src/components/ContextPanel.tsx
+++ b/frontend/src/components/ContextPanel.tsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react';
+import type { ContextBlockEntry } from './ContextPicker';
+
+export interface ContextPanelProps {
+  selected: string[];
+  onToggle: (name: string) => void;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+
+export function ContextPanel({ selected, onToggle }: ContextPanelProps) {
+  const [blocks, setBlocks] = useState<ContextBlockEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/config', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data: { contextBlocks?: Record<string, { path: string; sizeBytes: number }> }) => {
+        const entries: ContextBlockEntry[] = [];
+        if (data.contextBlocks) {
+          for (const [name, info] of Object.entries(data.contextBlocks)) {
+            entries.push({ name, path: info.path, sizeBytes: info.sizeBytes });
+          }
+        }
+        setBlocks(entries);
+        setLoaded(true);
+      })
+      .catch(() => {
+        setLoaded(true);
+      });
+  }, []);
+
+  if (!loaded) return null;
+
+  return (
+    <div className="context-panel">
+      <div className="context-panel-header">Context</div>
+      {blocks.length === 0 ? (
+        <p className="context-panel-empty">No context blocks</p>
+      ) : (
+        <div className="context-panel-list">
+          {blocks.map((block) => {
+            const isSelected = selected.includes(block.name);
+            return (
+              <button
+                key={block.name}
+                className={`context-panel-item${isSelected ? ' context-panel-item--selected' : ''}`}
+                onClick={() => onToggle(block.name)}
+              >
+                <span className="context-panel-check">{isSelected ? '✓' : ''}</span>
+                <span className="context-panel-name">{block.name}</span>
+                <span className="context-panel-size">{formatSize(block.sizeBytes)}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ContextPanel.tsx
+++ b/frontend/src/components/ContextPanel.tsx
@@ -4,6 +4,8 @@ import type { ContextBlockEntry } from './ContextPicker';
 export interface ContextPanelProps {
   selected: string[];
   onToggle: (name: string) => void;
+  blocks?: ContextBlockEntry[];
+  loaded?: boolean;
 }
 
 function formatSize(bytes: number): string {
@@ -14,11 +16,18 @@ function formatSize(bytes: number): string {
   return `${(kb / 1024).toFixed(1)} MB`;
 }
 
-export function ContextPanel({ selected, onToggle }: ContextPanelProps) {
-  const [blocks, setBlocks] = useState<ContextBlockEntry[]>([]);
-  const [loaded, setLoaded] = useState(false);
+export function ContextPanel({
+  selected,
+  onToggle,
+  blocks: externalBlocks,
+  loaded: externalLoaded,
+}: ContextPanelProps) {
+  const [selfBlocks, setSelfBlocks] = useState<ContextBlockEntry[]>([]);
+  const [selfLoaded, setSelfLoaded] = useState(false);
 
+  // Self-fetch config only when not provided via props (standalone usage)
   useEffect(() => {
+    if (externalBlocks !== undefined) return;
     fetch('/api/config', { credentials: 'include' })
       .then((r) => r.json())
       .then((data: { contextBlocks?: Record<string, { path: string; sizeBytes: number }> }) => {
@@ -28,13 +37,14 @@ export function ContextPanel({ selected, onToggle }: ContextPanelProps) {
             entries.push({ name, path: info.path, sizeBytes: info.sizeBytes });
           }
         }
-        setBlocks(entries);
-        setLoaded(true);
+        setSelfBlocks(entries);
+        setSelfLoaded(true);
       })
-      .catch(() => {
-        setLoaded(true);
-      });
-  }, []);
+      .catch(() => setSelfLoaded(true));
+  }, [externalBlocks]);
+
+  const blocks = externalBlocks ?? selfBlocks;
+  const loaded = externalLoaded ?? selfLoaded;
 
   if (!loaded) return null;
 

--- a/frontend/src/components/DesktopShell.tsx
+++ b/frontend/src/components/DesktopShell.tsx
@@ -1,0 +1,81 @@
+import { useState, useCallback, type ReactNode } from 'react';
+
+export interface DesktopShellProps {
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+  statusBar?: ReactNode;
+}
+
+const STORAGE_KEY_LEFT = 'mitzo-sidebar-left-collapsed';
+const STORAGE_KEY_RIGHT = 'mitzo-sidebar-right-collapsed';
+
+function readCollapsed(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function DesktopShell({ left, center, right, statusBar }: DesktopShellProps) {
+  const [leftCollapsed, setLeftCollapsed] = useState(() => readCollapsed(STORAGE_KEY_LEFT));
+  const [rightCollapsed, setRightCollapsed] = useState(() => readCollapsed(STORAGE_KEY_RIGHT));
+
+  const toggleLeft = useCallback(() => {
+    setLeftCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY_LEFT, next ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleRight = useCallback(() => {
+    setRightCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY_RIGHT, next ? '1' : '0');
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="desktop-shell">
+      <div className="desktop-body">
+        <div
+          className={`desktop-sidebar-left${leftCollapsed ? ' desktop-sidebar--collapsed' : ''}`}
+        >
+          <button
+            className="desktop-collapse-btn"
+            onClick={toggleLeft}
+            title={leftCollapsed ? 'Show sessions' : 'Hide sessions'}
+          >
+            {leftCollapsed ? '\u25B6' : '\u25C0'}
+          </button>
+          {!leftCollapsed && left}
+        </div>
+        <div className="desktop-center">{center}</div>
+        <div
+          className={`desktop-sidebar-right${rightCollapsed ? ' desktop-sidebar--collapsed' : ''}`}
+        >
+          <button
+            className="desktop-collapse-btn"
+            onClick={toggleRight}
+            title={rightCollapsed ? 'Show context' : 'Hide context'}
+          >
+            {rightCollapsed ? '\u25C0' : '\u25B6'}
+          </button>
+          {!rightCollapsed && right}
+        </div>
+      </div>
+      {statusBar && <div className="desktop-status-row">{statusBar}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/FileBrowserPanel.tsx
+++ b/frontend/src/components/FileBrowserPanel.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface DirEntry {
+  name: string;
+  isDir: boolean;
+}
+
+interface FileRoot {
+  label: string;
+  path: string;
+}
+
+export function FileBrowserPanel() {
+  const [roots, setRoots] = useState<FileRoot[]>([]);
+  const [activeRoot, setActiveRoot] = useState('');
+  const [currentDir, setCurrentDir] = useState('');
+  const [entries, setEntries] = useState<DirEntry[]>([]);
+  const [preview, setPreview] = useState<{ name: string; content: string } | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Fetch roots from config
+  useEffect(() => {
+    fetch('/api/config', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data: { fileViewerRoots?: FileRoot[] }) => {
+        const r = data.fileViewerRoots ?? [];
+        setRoots(r);
+        if (r.length > 0) {
+          setActiveRoot(r[0].path);
+        }
+        setLoaded(true);
+      })
+      .catch(() => setLoaded(true));
+  }, []);
+
+  // Fetch directory listing when root or dir changes
+  useEffect(() => {
+    if (!activeRoot) return;
+    const params = new URLSearchParams();
+    if (currentDir) params.set('dir', currentDir);
+    else params.set('dir', activeRoot);
+
+    fetch(`/api/files/list?${params}`, { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data: { entries: DirEntry[]; currentDir: string }) => {
+        setEntries(data.entries ?? []);
+        setCurrentDir(data.currentDir);
+      })
+      .catch(() => setEntries([]));
+  }, [activeRoot, currentDir]);
+
+  const navigateToDir = useCallback(
+    (dirName: string) => {
+      setPreview(null);
+      if (dirName === '..') {
+        const parent = currentDir.split('/').slice(0, -1).join('/');
+        setCurrentDir(parent || activeRoot);
+      } else {
+        setCurrentDir(`${currentDir}/${dirName}`);
+      }
+    },
+    [currentDir, activeRoot],
+  );
+
+  const openFile = useCallback(
+    (fileName: string) => {
+      const filePath = `${currentDir}/${fileName}`;
+      fetch(`/api/files/read?path=${encodeURIComponent(filePath)}`, { credentials: 'include' })
+        .then((r) => r.json())
+        .then((data: { content: string }) => {
+          setPreview({ name: fileName, content: data.content });
+        })
+        .catch(() => {});
+    },
+    [currentDir],
+  );
+
+  const handleRootChange = useCallback((rootPath: string) => {
+    setActiveRoot(rootPath);
+    setCurrentDir(rootPath);
+    setPreview(null);
+  }, []);
+
+  const isSubdir = currentDir !== activeRoot && currentDir !== '';
+
+  if (!loaded) return null;
+
+  return (
+    <div className="file-browser-panel">
+      <div className="file-browser-header">Files</div>
+
+      {roots.length > 1 && (
+        <div className="file-browser-roots">
+          {roots.map((r) => (
+            <button
+              key={r.path}
+              className={`file-browser-root${r.path === activeRoot ? ' file-browser-root--active' : ''}`}
+              onClick={() => handleRootChange(r.path)}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {preview ? (
+        <div className="file-browser-preview">
+          <button className="file-browser-back" onClick={() => setPreview(null)}>
+            &larr; {preview.name}
+          </button>
+          <pre className="file-browser-preview-content">{preview.content}</pre>
+        </div>
+      ) : (
+        <div className="file-browser-listing">
+          {isSubdir && (
+            <button
+              className="file-browser-entry file-browser-entry--dir"
+              onClick={() => navigateToDir('..')}
+            >
+              ..
+            </button>
+          )}
+          {entries.length === 0 && !isSubdir && (
+            <p className="file-browser-empty">Empty directory</p>
+          )}
+          {entries.map((entry) => (
+            <button
+              key={entry.name}
+              className={`file-browser-entry${entry.isDir ? ' file-browser-entry--dir' : ''}`}
+              onClick={() => (entry.isDir ? navigateToDir(entry.name) : openFile(entry.name))}
+            >
+              {entry.isDir ? `${entry.name}/` : entry.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/FileBrowserPanel.tsx
+++ b/frontend/src/components/FileBrowserPanel.tsx
@@ -5,59 +5,77 @@ interface DirEntry {
   isDir: boolean;
 }
 
-interface FileRoot {
+export interface FileRoot {
   label: string;
   path: string;
 }
 
-export function FileBrowserPanel() {
-  const [roots, setRoots] = useState<FileRoot[]>([]);
+export interface FileBrowserPanelProps {
+  roots?: FileRoot[];
+  loaded?: boolean;
+}
+
+export function FileBrowserPanel({ roots: externalRoots, loaded: externalLoaded }: FileBrowserPanelProps) {
+  const [selfRoots, setSelfRoots] = useState<FileRoot[]>([]);
+  const [selfLoaded, setSelfLoaded] = useState(false);
+
+  // Self-fetch config only when not provided via props (standalone usage)
+  useEffect(() => {
+    if (externalRoots !== undefined) return;
+    fetch('/api/config', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data: { fileViewerRoots?: FileRoot[] }) => {
+        setSelfRoots(data.fileViewerRoots ?? []);
+        setSelfLoaded(true);
+      })
+      .catch(() => setSelfLoaded(true));
+  }, [externalRoots]);
+
+  const roots = externalRoots ?? selfRoots;
+  const loaded = externalLoaded ?? selfLoaded;
+
   const [activeRoot, setActiveRoot] = useState('');
   const [currentDir, setCurrentDir] = useState('');
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [preview, setPreview] = useState<{ name: string; content: string } | null>(null);
-  const [loaded, setLoaded] = useState(false);
 
-  // Fetch roots from config
+  // Set initial root when roots become available
   useEffect(() => {
-    fetch('/api/config', { credentials: 'include' })
-      .then((r) => r.json())
-      .then((data: { fileViewerRoots?: FileRoot[] }) => {
-        const r = data.fileViewerRoots ?? [];
-        setRoots(r);
-        if (r.length > 0) {
-          setActiveRoot(r[0].path);
-        }
-        setLoaded(true);
-      })
-      .catch(() => setLoaded(true));
-  }, []);
+    if (roots.length > 0 && !activeRoot) {
+      setActiveRoot(roots[0].path);
+      setCurrentDir(roots[0].path);
+    }
+  }, [roots, activeRoot]);
 
-  // Fetch directory listing when root or dir changes
+  // Fetch directory listing when root changes or navigating
+  const [fetchDir, setFetchDir] = useState('');
+
   useEffect(() => {
     if (!activeRoot) return;
-    const params = new URLSearchParams();
-    if (currentDir) params.set('dir', currentDir);
-    else params.set('dir', activeRoot);
-
+    const dir = fetchDir || activeRoot;
+    const params = new URLSearchParams({ dir });
     fetch(`/api/files/list?${params}`, { credentials: 'include' })
       .then((r) => r.json())
       .then((data: { entries: DirEntry[]; currentDir: string }) => {
         setEntries(data.entries ?? []);
+        // Don't feed server response back into dependencies — trust client state
         setCurrentDir(data.currentDir);
       })
       .catch(() => setEntries([]));
-  }, [activeRoot, currentDir]);
+  }, [activeRoot, fetchDir]);
 
   const navigateToDir = useCallback(
     (dirName: string) => {
       setPreview(null);
+      let target: string;
       if (dirName === '..') {
         const parent = currentDir.split('/').slice(0, -1).join('/');
-        setCurrentDir(parent || activeRoot);
+        target = parent || activeRoot;
       } else {
-        setCurrentDir(`${currentDir}/${dirName}`);
+        target = `${currentDir}/${dirName}`;
       }
+      setCurrentDir(target);
+      setFetchDir(target);
     },
     [currentDir, activeRoot],
   );
@@ -78,6 +96,7 @@ export function FileBrowserPanel() {
   const handleRootChange = useCallback((rootPath: string) => {
     setActiveRoot(rootPath);
     setCurrentDir(rootPath);
+    setFetchDir(rootPath);
     setPreview(null);
   }, []);
 

--- a/frontend/src/components/FileBrowserPanel.tsx
+++ b/frontend/src/components/FileBrowserPanel.tsx
@@ -100,7 +100,10 @@ export function FileBrowserPanel({ roots: externalRoots, loaded: externalLoaded 
     setPreview(null);
   }, []);
 
-  const isSubdir = currentDir !== activeRoot && currentDir !== '';
+  // Normalize trailing slashes for comparison to avoid false isSubdir
+  const normDir = currentDir.replace(/\/+$/, '');
+  const normRoot = activeRoot.replace(/\/+$/, '');
+  const isSubdir = normDir !== normRoot && normDir !== '';
 
   if (!loaded) return null;
 

--- a/frontend/src/components/FileBrowserPanel.tsx
+++ b/frontend/src/components/FileBrowserPanel.tsx
@@ -15,7 +15,10 @@ export interface FileBrowserPanelProps {
   loaded?: boolean;
 }
 
-export function FileBrowserPanel({ roots: externalRoots, loaded: externalLoaded }: FileBrowserPanelProps) {
+export function FileBrowserPanel({
+  roots: externalRoots,
+  loaded: externalLoaded,
+}: FileBrowserPanelProps) {
   const [selfRoots, setSelfRoots] = useState<FileRoot[]>([]);
   const [selfLoaded, setSelfLoaded] = useState(false);
 

--- a/frontend/src/components/SessionPanel.tsx
+++ b/frontend/src/components/SessionPanel.tsx
@@ -1,0 +1,56 @@
+import { useSessionList } from '../hooks/useSessionList';
+import { formatRelativeTime } from '../lib/formatTime';
+
+export interface SessionPanelProps {
+  activeSessionId: string | undefined;
+  onSelectSession: (id: string) => void;
+  onNewChat: () => void;
+}
+
+export function SessionPanel({ activeSessionId, onSelectSession, onNewChat }: SessionPanelProps) {
+  const { sessions, loading, dismissSession } = useSessionList();
+
+  return (
+    <div className="session-panel">
+      <button className="session-panel-new" onClick={onNewChat}>
+        New Chat
+      </button>
+
+      {loading && <p className="session-panel-empty">Loading...</p>}
+
+      {!loading && sessions.length === 0 && <p className="session-panel-empty">No sessions</p>}
+
+      {!loading && sessions.length > 0 && (
+        <div className="session-panel-list">
+          {sessions.map((s) => (
+            <div
+              key={s.id}
+              className={`session-panel-item${s.id === activeSessionId ? ' session-panel-item--active' : ''}`}
+              onClick={() => onSelectSession(s.id)}
+            >
+              <div className="session-panel-item-text">
+                <div className="session-panel-item-summary">{s.summary || 'Untitled session'}</div>
+                <div className="session-panel-item-meta">
+                  <span className="session-panel-item-time">
+                    {formatRelativeTime(s.lastModified)}
+                  </span>
+                  {s.branch && <span className="session-panel-item-branch">{s.branch}</span>}
+                </div>
+              </div>
+              <button
+                className="session-panel-delete"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dismissSession(s.id);
+                }}
+                title="Delete session"
+              >
+                &times;
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,0 +1,26 @@
+export interface StatusBarProps {
+  connected: boolean;
+  sessionId?: string;
+  branch?: string;
+  isWorktree?: boolean;
+}
+
+export function StatusBar({ connected, sessionId, branch, isWorktree }: StatusBarProps) {
+  return (
+    <div className="desktop-status-bar">
+      <span className={`status-dot ${connected ? 'status-dot--on' : 'status-dot--off'}`} />
+      <span className="status-label">{connected ? 'Connected' : 'Disconnected'}</span>
+      {sessionId && (
+        <span className="status-session" title={sessionId}>
+          {sessionId.slice(0, 12)}
+        </span>
+      )}
+      {branch && (
+        <span className="status-branch">
+          {isWorktree && <span className="status-wt-badge">WT</span>}
+          {branch}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ChatArea.test.tsx
+++ b/frontend/src/components/__tests__/ChatArea.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ChatArea } from '../ChatArea';
+import type { FinishedMessage, StreamingBlock } from '../../types/chat';
+
+// Mock child components to isolate ChatArea tests
+vi.mock('../MessageBubble', () => ({
+  UserBubble: ({ text }: { text?: string }) => <div data-testid="user-bubble">{text}</div>,
+  TextBubble: ({ content }: { content: string }) => <div data-testid="text-bubble">{content}</div>,
+}));
+
+vi.mock('../ThinkingBlock', () => ({
+  ThinkingBlock: ({ block }: { block: { blockId: string } }) => (
+    <div data-testid="thinking-block">{block.blockId}</div>
+  ),
+}));
+
+vi.mock('../ToolPill', () => ({
+  ToolPill: ({ block }: { block: { blockId: string } }) => (
+    <div data-testid="tool-pill">{block.blockId}</div>
+  ),
+}));
+
+vi.mock('../ToolGroup', () => ({
+  ToolGroup: () => <div data-testid="tool-group" />,
+}));
+
+vi.mock('../PermissionBanner', () => ({
+  PermissionBanner: ({ permId }: { permId: string }) => (
+    <div data-testid="permission-banner">{permId}</div>
+  ),
+}));
+
+afterEach(() => cleanup());
+
+describe('ChatArea', () => {
+  const defaultProps = {
+    messages: [] as FinishedMessage[],
+    current: null,
+    running: false,
+    permission: null,
+    onPermissionRespond: vi.fn(),
+  };
+
+  it('renders empty state when no messages', () => {
+    render(<ChatArea {...defaultProps} />);
+    expect(screen.getByText('Send a message to start')).toBeTruthy();
+  });
+
+  it('does not render empty state when running', () => {
+    render(<ChatArea {...defaultProps} running={true} />);
+    expect(screen.queryByText('Send a message to start')).toBeNull();
+  });
+
+  it('renders user messages', () => {
+    const messages: FinishedMessage[] = [
+      {
+        messageId: 'u1',
+        role: 'user',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hello', done: true }],
+      },
+    ];
+    render(<ChatArea {...defaultProps} messages={messages} />);
+    expect(screen.getByTestId('user-bubble')).toBeTruthy();
+    expect(screen.getByText('Hello')).toBeTruthy();
+  });
+
+  it('renders assistant text blocks', () => {
+    const messages: FinishedMessage[] = [
+      {
+        messageId: 'a1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hi there', done: true }],
+      },
+    ];
+    render(<ChatArea {...defaultProps} messages={messages} />);
+    expect(screen.getByTestId('text-bubble')).toBeTruthy();
+    expect(screen.getByText('Hi there')).toBeTruthy();
+  });
+
+  it('renders streaming turn when current is provided', () => {
+    const blocks = new Map<string, StreamingBlock>();
+    blocks.set('sb1', {
+      blockId: 'sb1',
+      blockType: 'text',
+      content: 'Streaming...',
+      done: false,
+    });
+    const current = {
+      messageId: 'stream-1',
+      blocks,
+      blockOrder: ['sb1'],
+    };
+    render(<ChatArea {...defaultProps} current={current} />);
+    expect(screen.getByText('Streaming...')).toBeTruthy();
+  });
+
+  it('renders PermissionBanner when permission is present', () => {
+    const permission = {
+      permId: 'perm-1',
+      toolName: 'Bash',
+      toolInput: 'ls',
+      title: 'Allow Bash?',
+      description: 'Execute shell command',
+      displayName: 'Bash',
+      tier: 'elevated' as const,
+    };
+    render(<ChatArea {...defaultProps} permission={permission} />);
+    expect(screen.getByTestId('permission-banner')).toBeTruthy();
+    expect(screen.getByText('perm-1')).toBeTruthy();
+  });
+
+  it('does not render PermissionBanner when no permission', () => {
+    render(<ChatArea {...defaultProps} />);
+    expect(screen.queryByTestId('permission-banner')).toBeNull();
+  });
+
+  it('renders thinking blocks', () => {
+    const messages: FinishedMessage[] = [
+      {
+        messageId: 'a1',
+        role: 'assistant',
+        blocks: [{ blockId: 'tb1', blockType: 'thinking', content: 'thinking...', done: true }],
+      },
+    ];
+    render(<ChatArea {...defaultProps} messages={messages} />);
+    expect(screen.getByTestId('thinking-block')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/__tests__/ChatArea.test.tsx
+++ b/frontend/src/components/__tests__/ChatArea.test.tsx
@@ -58,7 +58,7 @@ describe('ChatArea', () => {
       {
         messageId: 'u1',
         role: 'user',
-        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hello', done: true }],
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hello' }],
       },
     ];
     render(<ChatArea {...defaultProps} messages={messages} />);
@@ -71,7 +71,7 @@ describe('ChatArea', () => {
       {
         messageId: 'a1',
         role: 'assistant',
-        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hi there', done: true }],
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hi there' }],
       },
     ];
     render(<ChatArea {...defaultProps} messages={messages} />);
@@ -121,7 +121,7 @@ describe('ChatArea', () => {
       {
         messageId: 'a1',
         role: 'assistant',
-        blocks: [{ blockId: 'tb1', blockType: 'thinking', content: 'thinking...', done: true }],
+        blocks: [{ blockId: 'tb1', blockType: 'thinking', content: 'thinking...' }],
       },
     ];
     render(<ChatArea {...defaultProps} messages={messages} />);

--- a/frontend/src/components/__tests__/ChatInputContextBlocks.test.tsx
+++ b/frontend/src/components/__tests__/ChatInputContextBlocks.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ChatInput } from '../ChatInput';
+
+// Mock child components that fetch data
+vi.mock('../SlashPicker', () => ({
+  SlashPicker: () => null,
+}));
+vi.mock('../ContextPicker', () => ({
+  ContextPicker: ({ selected }: { selected: string[] }) => (
+    <div data-testid="context-picker">{selected.join(',')}</div>
+  ),
+}));
+vi.mock('../MicButton', () => ({
+  MicButton: () => null,
+}));
+
+afterEach(() => cleanup());
+
+describe('ChatInput with externalContextBlocks', () => {
+  const baseProps = {
+    onSend: vi.fn().mockReturnValue(true),
+    onStop: vi.fn(),
+    running: false,
+  };
+
+  it('hides @ button when externalContextBlocks provided', () => {
+    const { container } = render(
+      <ChatInput {...baseProps} externalContextBlocks={['boot-context']} />,
+    );
+    expect(container.querySelector('.chat-input-btn--context')).toBeNull();
+  });
+
+  it('shows @ button when externalContextBlocks not provided', () => {
+    const { container } = render(<ChatInput {...baseProps} />);
+    expect(container.querySelector('.chat-input-btn--context')).toBeTruthy();
+  });
+
+  it('does not show inline context pills when external blocks provided', () => {
+    const { container } = render(
+      <ChatInput {...baseProps} externalContextBlocks={['boot-context']} />,
+    );
+    // External blocks are managed by parent, not shown as pills in ChatInput
+    expect(container.querySelector('.chat-input-context-pills')).toBeNull();
+  });
+
+  it('passes external context blocks to onSend', () => {
+    const onSend = vi.fn().mockReturnValue(true);
+    render(
+      <ChatInput
+        {...baseProps}
+        onSend={onSend}
+        externalContextBlocks={['boot-context', 'constitution']}
+      />,
+    );
+
+    const textarea = screen.getByPlaceholderText('Message Mitzo...');
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(onSend).toHaveBeenCalledWith('hello', undefined, ['boot-context', 'constitution']);
+  });
+
+  it('does NOT clear external context blocks on send', () => {
+    const onSend = vi.fn().mockReturnValue(true);
+    const blocks = ['boot-context'];
+    const { rerender } = render(
+      <ChatInput {...baseProps} onSend={onSend} externalContextBlocks={blocks} />,
+    );
+
+    const textarea = screen.getByPlaceholderText('Message Mitzo...');
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    // Re-render with same blocks (parent controls them, they persist)
+    rerender(<ChatInput {...baseProps} onSend={onSend} externalContextBlocks={blocks} />);
+
+    // Send again
+    fireEvent.change(screen.getByPlaceholderText('Message Mitzo...'), {
+      target: { value: 'second message' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText('Message Mitzo...'), { key: 'Enter' });
+
+    // Both sends should include the external blocks
+    expect(onSend).toHaveBeenCalledTimes(2);
+    expect(onSend).toHaveBeenNthCalledWith(2, 'second message', undefined, ['boot-context']);
+  });
+});

--- a/frontend/src/components/__tests__/ContextPanel.test.tsx
+++ b/frontend/src/components/__tests__/ContextPanel.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { ContextPanel } from '../ContextPanel';
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function mockConfigResponse(contextBlocks: Record<string, { path: string; sizeBytes: number }>) {
+  (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    json: () => Promise.resolve({ contextBlocks }),
+  });
+}
+
+describe('ContextPanel', () => {
+  it('fetches and renders context blocks', async () => {
+    mockConfigResponse({
+      'boot-context': { path: '/ctx/boot.md', sizeBytes: 2048 },
+      constitution: { path: '/ctx/const.md', sizeBytes: 512 },
+    });
+    render(<ContextPanel selected={[]} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('boot-context')).toBeTruthy();
+      expect(screen.getByText('constitution')).toBeTruthy();
+    });
+  });
+
+  it('shows selected state for active blocks', async () => {
+    mockConfigResponse({
+      'boot-context': { path: '/ctx/boot.md', sizeBytes: 2048 },
+    });
+    const { container } = render(<ContextPanel selected={['boot-context']} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(container.querySelector('.context-panel-item--selected')).toBeTruthy();
+    });
+  });
+
+  it('calls onToggle when block clicked', async () => {
+    mockConfigResponse({
+      'boot-context': { path: '/ctx/boot.md', sizeBytes: 2048 },
+    });
+    const onToggle = vi.fn();
+    render(<ContextPanel selected={[]} onToggle={onToggle} />);
+    await waitFor(() => screen.getByText('boot-context'));
+    fireEvent.click(screen.getByText('boot-context'));
+    expect(onToggle).toHaveBeenCalledWith('boot-context');
+  });
+
+  it('shows file size', async () => {
+    mockConfigResponse({
+      'boot-context': { path: '/ctx/boot.md', sizeBytes: 2048 },
+    });
+    render(<ContextPanel selected={[]} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('2.0 KB')).toBeTruthy();
+    });
+  });
+
+  it('shows empty state when no blocks configured', async () => {
+    mockConfigResponse({});
+    render(<ContextPanel selected={[]} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('No context blocks')).toBeTruthy();
+    });
+  });
+
+  it('handles fetch error gracefully', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('fail'));
+    render(<ContextPanel selected={[]} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('No context blocks')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/components/__tests__/DesktopShell.test.tsx
+++ b/frontend/src/components/__tests__/DesktopShell.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { DesktopShell } from '../DesktopShell';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => cleanup());
+
+describe('DesktopShell', () => {
+  it('renders all three panels', () => {
+    render(
+      <DesktopShell
+        left={<div>Left Panel</div>}
+        center={<div>Center Panel</div>}
+        right={<div>Right Panel</div>}
+      />,
+    );
+    expect(screen.getByText('Left Panel')).toBeTruthy();
+    expect(screen.getByText('Center Panel')).toBeTruthy();
+    expect(screen.getByText('Right Panel')).toBeTruthy();
+  });
+
+  it('collapses left sidebar and hides content', () => {
+    render(
+      <DesktopShell
+        left={<div>Left Panel</div>}
+        center={<div>Center</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    const toggleBtn = screen.getByTitle('Hide sessions');
+    fireEvent.click(toggleBtn);
+    expect(screen.queryByText('Left Panel')).toBeNull();
+    expect(localStorage.getItem('mitzo-sidebar-left-collapsed')).toBe('1');
+  });
+
+  it('collapses right sidebar and hides content', () => {
+    render(
+      <DesktopShell
+        left={<div>Left</div>}
+        center={<div>Center</div>}
+        right={<div>Right Panel</div>}
+      />,
+    );
+    const toggleBtn = screen.getByTitle('Hide context');
+    fireEvent.click(toggleBtn);
+    expect(screen.queryByText('Right Panel')).toBeNull();
+    expect(localStorage.getItem('mitzo-sidebar-right-collapsed')).toBe('1');
+  });
+
+  it('restores collapsed state from localStorage', () => {
+    localStorage.setItem('mitzo-sidebar-left-collapsed', '1');
+    render(
+      <DesktopShell
+        left={<div>Left Panel</div>}
+        center={<div>Center</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    expect(screen.queryByText('Left Panel')).toBeNull();
+    expect(screen.getByTitle('Show sessions')).toBeTruthy();
+  });
+
+  it('expands collapsed sidebar on toggle', () => {
+    localStorage.setItem('mitzo-sidebar-left-collapsed', '1');
+    render(
+      <DesktopShell
+        left={<div>Left Panel</div>}
+        center={<div>Center</div>}
+        right={<div>Right</div>}
+      />,
+    );
+    fireEvent.click(screen.getByTitle('Show sessions'));
+    expect(screen.getByText('Left Panel')).toBeTruthy();
+    expect(localStorage.getItem('mitzo-sidebar-left-collapsed')).toBe('0');
+  });
+
+  it('renders status bar when provided', () => {
+    render(
+      <DesktopShell
+        left={<div>L</div>}
+        center={<div>C</div>}
+        right={<div>R</div>}
+        statusBar={<div>Status Info</div>}
+      />,
+    );
+    expect(screen.getByText('Status Info')).toBeTruthy();
+  });
+
+  it('does not render status row when statusBar is absent', () => {
+    const { container } = render(
+      <DesktopShell left={<div>L</div>} center={<div>C</div>} right={<div>R</div>} />,
+    );
+    expect(container.querySelector('.desktop-status-row')).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/FileBrowserPanel.test.tsx
+++ b/frontend/src/components/__tests__/FileBrowserPanel.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { FileBrowserPanel } from '../FileBrowserPanel';
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function mockFetch(responses: Record<string, unknown>) {
+  (fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    for (const [pattern, data] of Object.entries(responses)) {
+      if (url.includes(pattern)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+      }
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+describe('FileBrowserPanel', () => {
+  it('fetches and renders roots from config', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [
+          { label: 'Project', path: '/home/user/project' },
+          { label: 'Docs', path: '/home/user/docs' },
+        ],
+      },
+      '/api/files/list': { entries: [], currentDir: '/home/user/project' },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('Project')).toBeTruthy();
+      expect(screen.getByText('Docs')).toBeTruthy();
+    });
+  });
+
+  it('renders directory entries', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/home/user/project' }],
+      },
+      '/api/files/list': {
+        entries: [
+          { name: 'src', isDir: true },
+          { name: 'README.md', isDir: false },
+        ],
+        currentDir: '/home/user/project',
+      },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('src/')).toBeTruthy();
+      expect(screen.getByText('README.md')).toBeTruthy();
+    });
+  });
+
+  it('navigates into directory on click', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': {
+        entries: [{ name: 'src', isDir: true }],
+        currentDir: '/p',
+      },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => screen.getByText('src/'));
+
+    // Update mock for subdirectory
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': {
+        entries: [{ name: 'index.ts', isDir: false }],
+        currentDir: '/p/src',
+      },
+    });
+
+    fireEvent.click(screen.getByText('src/'));
+    await waitFor(() => {
+      expect(screen.getByText('index.ts')).toBeTruthy();
+    });
+  });
+
+  it('shows back button when in subdirectory', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': {
+        entries: [{ name: 'src', isDir: true }],
+        currentDir: '/p',
+      },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => screen.getByText('src/'));
+
+    // Navigate into src
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': {
+        entries: [{ name: 'index.ts', isDir: false }],
+        currentDir: '/p/src',
+      },
+    });
+    fireEvent.click(screen.getByText('src/'));
+    await waitFor(() => {
+      expect(screen.getByText('..')).toBeTruthy();
+    });
+  });
+
+  it('shows file preview when file clicked', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': {
+        entries: [{ name: 'hello.txt', isDir: false }],
+        currentDir: '/p',
+      },
+      '/api/files/read': { content: 'Hello world!', ext: '.txt' },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => screen.getByText('hello.txt'));
+    fireEvent.click(screen.getByText('hello.txt'));
+    await waitFor(() => {
+      expect(screen.getByText('Hello world!')).toBeTruthy();
+    });
+  });
+
+  it('handles empty directory', async () => {
+    mockFetch({
+      '/api/config': {
+        fileViewerRoots: [{ label: 'Project', path: '/p' }],
+      },
+      '/api/files/list': { entries: [], currentDir: '/p' },
+    });
+    render(<FileBrowserPanel />);
+    await waitFor(() => {
+      expect(screen.getByText('Empty directory')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/components/__tests__/SessionPanel.test.tsx
+++ b/frontend/src/components/__tests__/SessionPanel.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+// Mock useSessionList before importing SessionPanel
+vi.mock('../../hooks/useSessionList', () => ({
+  useSessionList: vi.fn(),
+}));
+
+import { SessionPanel } from '../SessionPanel';
+import { useSessionList } from '../../hooks/useSessionList';
+
+const mockUseSessionList = vi.mocked(useSessionList);
+
+function makeDefaultReturn(overrides = {}) {
+  return {
+    sessions: [],
+    quickActions: [],
+    loading: false,
+    inboxCount: 0,
+    updateAvailable: false,
+    checking: false,
+    dismissSession: vi.fn(),
+    clearAll: vi.fn(),
+    handleRename: vi.fn(),
+    checkForUpdates: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockUseSessionList.mockReturnValue(makeDefaultReturn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('SessionPanel', () => {
+  it('renders new chat button', () => {
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    expect(screen.getByText('New Chat')).toBeTruthy();
+  });
+
+  it('calls onNewChat when button clicked', () => {
+    const onNewChat = vi.fn();
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={onNewChat} />,
+    );
+    fireEvent.click(screen.getByText('New Chat'));
+    expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
+  it('renders session list', () => {
+    mockUseSessionList.mockReturnValue(
+      makeDefaultReturn({
+        sessions: [
+          { id: 's1', summary: 'First session', lastModified: Date.now() },
+          { id: 's2', summary: 'Second session', lastModified: Date.now() },
+        ],
+      }),
+    );
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    expect(screen.getByText('First session')).toBeTruthy();
+    expect(screen.getByText('Second session')).toBeTruthy();
+  });
+
+  it('highlights active session', () => {
+    mockUseSessionList.mockReturnValue(
+      makeDefaultReturn({
+        sessions: [{ id: 's1', summary: 'Active one', lastModified: Date.now() }],
+      }),
+    );
+    const { container } = render(
+      <SessionPanel activeSessionId="s1" onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    const activeItem = container.querySelector('.session-panel-item--active');
+    expect(activeItem).toBeTruthy();
+  });
+
+  it('calls onSelectSession when session clicked', () => {
+    mockUseSessionList.mockReturnValue(
+      makeDefaultReturn({
+        sessions: [{ id: 's1', summary: 'Click me', lastModified: Date.now() }],
+      }),
+    );
+    const onSelect = vi.fn();
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={onSelect} onNewChat={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByText('Click me'));
+    expect(onSelect).toHaveBeenCalledWith('s1');
+  });
+
+  it('shows loading state', () => {
+    mockUseSessionList.mockReturnValue(makeDefaultReturn({ loading: true }));
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+
+  it('shows empty state when no sessions', () => {
+    render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    expect(screen.getByText('No sessions')).toBeTruthy();
+  });
+
+  it('shows delete button on hover (via class)', () => {
+    mockUseSessionList.mockReturnValue(
+      makeDefaultReturn({
+        sessions: [{ id: 's1', summary: 'Hoverable', lastModified: Date.now() }],
+      }),
+    );
+    const { container } = render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    // Delete button exists in DOM but shown via CSS :hover
+    const deleteBtn = container.querySelector('.session-panel-delete');
+    expect(deleteBtn).toBeTruthy();
+  });
+
+  it('calls dismissSession when delete clicked', () => {
+    const dismiss = vi.fn();
+    mockUseSessionList.mockReturnValue(
+      makeDefaultReturn({
+        sessions: [{ id: 's1', summary: 'Delete me', lastModified: Date.now() }],
+        dismissSession: dismiss,
+      }),
+    );
+    const { container } = render(
+      <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+    );
+    const deleteBtn = container.querySelector('.session-panel-delete')!;
+    fireEvent.click(deleteBtn);
+    expect(dismiss).toHaveBeenCalledWith('s1');
+  });
+});

--- a/frontend/src/components/__tests__/StatusBar.test.tsx
+++ b/frontend/src/components/__tests__/StatusBar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StatusBar } from '../StatusBar';
+
+afterEach(() => cleanup());
+
+describe('StatusBar', () => {
+  it('renders connected state', () => {
+    const { container } = render(<StatusBar connected={true} />);
+    expect(screen.getByText('Connected')).toBeTruthy();
+    expect(container.querySelector('.status-dot--on')).toBeTruthy();
+  });
+
+  it('renders disconnected state', () => {
+    const { container } = render(<StatusBar connected={false} />);
+    expect(screen.getByText('Disconnected')).toBeTruthy();
+    expect(container.querySelector('.status-dot--off')).toBeTruthy();
+  });
+
+  it('renders session ID truncated', () => {
+    render(<StatusBar connected={true} sessionId="abcdef1234567890" />);
+    expect(screen.getByText('abcdef123456')).toBeTruthy();
+  });
+
+  it('does not render session ID when absent', () => {
+    const { container } = render(<StatusBar connected={true} />);
+    expect(container.querySelector('.status-session')).toBeNull();
+  });
+
+  it('renders branch name', () => {
+    render(<StatusBar connected={true} branch="feat/desktop-ui" />);
+    expect(screen.getByText('feat/desktop-ui')).toBeTruthy();
+  });
+
+  it('renders worktree badge when isWorktree', () => {
+    render(<StatusBar connected={true} branch="wt-branch" isWorktree={true} />);
+    expect(screen.getByText('WT')).toBeTruthy();
+  });
+
+  it('does not render worktree badge when not worktree', () => {
+    render(<StatusBar connected={true} branch="main" isWorktree={false} />);
+    expect(screen.queryByText('WT')).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useChatActions.test.ts
+++ b/frontend/src/hooks/__tests__/useChatActions.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useChatActions } from '../useChatActions';
+
+vi.mock('../../lib/ws-pool', () => ({
+  wsIsOpen: vi.fn(),
+  wsSend: vi.fn(),
+  wsSetRunning: vi.fn(),
+}));
+
+import { wsIsOpen, wsSend, wsSetRunning } from '../../lib/ws-pool';
+
+function makeDeps(overrides: Partial<Parameters<typeof useChatActions>[0]> = {}) {
+  return {
+    poolKey: 'session:test-123',
+    sessionState: {
+      model: 'claude-sonnet-4-6',
+      mode: 'agent' as const,
+      currentSessionId: 'test-123',
+      sandbox: false,
+    },
+    searchParams: new URLSearchParams(),
+    dispatch: vi.fn(),
+    pendingSend: { current: null },
+    forceScrollToBottom: vi.fn(),
+    voice: { stopSpeaking: vi.fn() },
+    running: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (wsIsOpen as ReturnType<typeof vi.fn>).mockReturnValue(true);
+});
+
+describe('useChatActions', () => {
+  it('dispatches CONNECTION_LOST when WS is closed', () => {
+    (wsIsOpen as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    const deps = makeDeps();
+    const { result } = renderHook(() => useChatActions(deps));
+
+    const sent = result.current.sendMessage('hello');
+
+    expect(sent).toBe(false);
+    expect(deps.dispatch).toHaveBeenCalledWith({ type: 'CONNECTION_LOST' });
+    expect(wsSend).not.toHaveBeenCalled();
+  });
+
+  it('sends message and dispatches USER_SEND', () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useChatActions(deps));
+
+    const sent = result.current.sendMessage('hello');
+
+    expect(sent).toBe(true);
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ type: 'send', prompt: 'hello', model: 'claude-sonnet-4-6' }),
+    );
+    expect(deps.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'USER_SEND', text: 'hello' }),
+    );
+    expect(deps.forceScrollToBottom).toHaveBeenCalled();
+    expect(deps.voice.stopSpeaking).toHaveBeenCalled();
+  });
+
+  it('calls wsSetRunning only when not already running', () => {
+    const deps = makeDeps({ running: false });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello');
+    expect(wsSetRunning).toHaveBeenCalledWith('session:test-123', true);
+  });
+
+  it('does not call wsSetRunning when already running', () => {
+    const deps = makeDeps({ running: true });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello');
+    expect(wsSetRunning).not.toHaveBeenCalled();
+  });
+
+  it('forwards contextBlocks in payload', () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello', undefined, ['boot-context']);
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ contextBlocks: ['boot-context'] }),
+    );
+  });
+
+  it('includes resume when currentSessionId exists', () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello');
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ resume: 'test-123' }),
+    );
+  });
+
+  it('interruptMessage is guarded by running state', () => {
+    const deps = makeDeps({ running: false });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.interruptMessage('stop that');
+
+    expect(wsSend).not.toHaveBeenCalled();
+    expect(deps.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('interruptMessage sends when running', () => {
+    const deps = makeDeps({ running: true });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.interruptMessage('stop that');
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ type: 'interrupt', prompt: 'stop that' }),
+    );
+    expect(deps.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'USER_SEND', text: 'stop that' }),
+    );
+  });
+
+  it('handleStop sends stop and resets running', () => {
+    const deps = makeDeps({ running: true });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    act(() => result.current.handleStop());
+
+    expect(wsSend).toHaveBeenCalledWith('session:test-123', { type: 'stop' });
+    expect(wsSetRunning).toHaveBeenCalledWith('session:test-123', false);
+    expect(deps.dispatch).toHaveBeenCalledWith({ type: 'SET_RUNNING', running: false });
+  });
+
+  it('includes worktree flag for sandbox new sessions', () => {
+    const deps = makeDeps({
+      sessionState: {
+        model: 'claude-sonnet-4-6',
+        mode: 'agent',
+        currentSessionId: undefined,
+        sandbox: true,
+      },
+    });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello');
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ worktree: true }),
+    );
+  });
+
+  it('forwards cwd and extraTools from searchParams', () => {
+    const params = new URLSearchParams({ cwd: '/my/dir', extraTools: 'Bash' });
+    const deps = makeDeps({ searchParams: params });
+    const { result } = renderHook(() => useChatActions(deps));
+
+    result.current.sendMessage('hello');
+
+    expect(wsSend).toHaveBeenCalledWith(
+      'session:test-123',
+      expect.objectContaining({ cwd: '/my/dir', extraTools: 'Bash' }),
+    );
+  });
+});

--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -59,6 +59,26 @@ describe('chatMessagesReducer', () => {
     expect(result.messages).toHaveLength(1);
   });
 
+  it('CLEAR resets state to initial', () => {
+    const populated: ChatMessagesState = {
+      ...INITIAL_STATE,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'hello' }],
+        },
+      ],
+      running: true,
+      branch: 'main',
+    };
+    const result = chatMessagesReducer(populated, { type: 'CLEAR' });
+    expect(result.messages).toHaveLength(0);
+    expect(result.current).toBeNull();
+    expect(result.running).toBe(false);
+    expect(result.branch).toBeNull();
+  });
+
   it('RESTORE does not replace when state has more messages than incoming', () => {
     const existing: ChatMessagesState = {
       ...INITIAL_STATE,

--- a/frontend/src/hooks/__tests__/useMediaQuery.test.ts
+++ b/frontend/src/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+let changeHandler: ((e: { matches: boolean }) => void) | null = null;
+let currentMatches = false;
+
+beforeEach(() => {
+  changeHandler = null;
+  currentMatches = false;
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: currentMatches,
+      media: query,
+      addEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+        changeHandler = handler;
+      },
+      removeEventListener: vi.fn(),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Import after mocks are set up
+const load = async () => import('../useMediaQuery');
+
+describe('useMediaQuery', () => {
+  it('returns false when query does not match', async () => {
+    currentMatches = false;
+    const { useMediaQuery } = await load();
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when query matches', async () => {
+    currentMatches = true;
+    const { useMediaQuery } = await load();
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when media query changes', async () => {
+    currentMatches = false;
+    const { useMediaQuery } = await load();
+    const { result } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      changeHandler?.({ matches: true });
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      changeHandler?.({ matches: false });
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('cleans up listener on unmount', async () => {
+    const removeListener = vi.fn();
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+          changeHandler = handler;
+        },
+        removeEventListener: removeListener,
+      })),
+    );
+
+    const { useMediaQuery } = await load();
+    const { unmount } = renderHook(() => useMediaQuery('(min-width: 768px)'));
+    unmount();
+    expect(removeListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});
+
+describe('useIsDesktop', () => {
+  it('returns result of min-width 768px query', async () => {
+    currentMatches = true;
+    const { useIsDesktop } = await load();
+    const { result } = renderHook(() => useIsDesktop());
+    expect(result.current).toBe(true);
+  });
+});

--- a/frontend/src/hooks/__tests__/useSessionList.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionList.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const mockWsSubscribe = vi.fn().mockReturnValue(vi.fn());
+
+vi.mock('../../lib/ws-pool', () => ({
+  wsSubscribe: (...args: unknown[]) => mockWsSubscribe(...args),
+}));
+
+vi.mock('../../lib/rename-session', () => ({
+  renameSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { useSessionList } from '../useSessionList';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockWsSubscribe.mockClear().mockReturnValue(vi.fn());
+  mockFetch.mockReset();
+  vi.stubGlobal('fetch', mockFetch);
+
+  // Default: all fetches succeed with empty data
+  mockFetch.mockImplementation((url: string) => {
+    if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
+    if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
+    if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+    if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+    return Promise.resolve({ json: () => Promise.resolve({}) });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSessionList', () => {
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useSessionList());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('fetches sessions on mount', async () => {
+    const sessions = [{ id: 'abc', summary: 'Test', lastModified: Date.now() }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/sessions')
+        return Promise.resolve({ json: () => Promise.resolve(sessions) });
+      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { result } = renderHook(() => useSessionList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.sessions).toEqual(sessions);
+  });
+
+  it('dismissSession removes from list and calls DELETE', async () => {
+    const sessions = [
+      { id: 'a', summary: 'A', lastModified: Date.now() },
+      { id: 'b', summary: 'B', lastModified: Date.now() },
+    ];
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/sessions')
+        return Promise.resolve({ json: () => Promise.resolve(sessions) });
+      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { result } = renderHook(() => useSessionList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.dismissSession('a');
+    });
+
+    expect(result.current.sessions).toHaveLength(1);
+    expect(result.current.sessions[0].id).toBe('b');
+    expect(mockFetch).toHaveBeenCalledWith('/api/sessions/a', { method: 'DELETE' });
+  });
+
+  it('clearAll empties sessions and calls DELETE', async () => {
+    const sessions = [{ id: 'a', summary: 'A', lastModified: Date.now() }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/sessions')
+        return Promise.resolve({ json: () => Promise.resolve(sessions) });
+      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { result } = renderHook(() => useSessionList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.sessions).toHaveLength(0);
+    expect(mockFetch).toHaveBeenCalledWith('/api/sessions', { method: 'DELETE' });
+  });
+
+  it('handleRename does optimistic update', async () => {
+    const sessions = [{ id: 'a', summary: 'Old', lastModified: Date.now() }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/sessions')
+        return Promise.resolve({ json: () => Promise.resolve(sessions) });
+      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { result } = renderHook(() => useSessionList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleRename('a', 'New Name');
+    });
+
+    expect(result.current.sessions[0].summary).toBe('New Name');
+  });
+
+  it('subscribes to WS for inbox updates', () => {
+    renderHook(() => useSessionList());
+    expect(mockWsSubscribe).toHaveBeenCalledWith('global:system', expect.any(Function));
+  });
+
+  it('builds quick actions from config', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
+      if (url === '/api/config')
+        return Promise.resolve({
+          json: () => Promise.resolve({ quickActions: [{ label: 'Test', desc: 'Test action' }] }),
+        });
+      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
+      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    });
+
+    const { result } = renderHook(() => useSessionList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.quickActions).toHaveLength(3); // Chat + server action + Files
+    expect(result.current.quickActions[1].label).toBe('Test');
+  });
+});

--- a/frontend/src/hooks/useChatActions.ts
+++ b/frontend/src/hooks/useChatActions.ts
@@ -1,0 +1,100 @@
+import { useCallback } from 'react';
+import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
+import type { ImageAttachment } from '../types/chat';
+
+function generateClientMsgId(): string {
+  return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+interface ChatActionsDeps {
+  poolKey: string;
+  sessionState: {
+    model: string;
+    mode: string;
+    currentSessionId: string | undefined;
+    sandbox: boolean;
+  };
+  searchParams: URLSearchParams;
+  dispatch: (action: { type: string; [key: string]: unknown }) => void;
+  pendingSend: React.RefObject<unknown | null>;
+  forceScrollToBottom: () => void;
+  voice: { stopSpeaking: () => void };
+  running: boolean;
+}
+
+export function useChatActions({
+  poolKey,
+  sessionState,
+  searchParams,
+  dispatch,
+  pendingSend,
+  forceScrollToBottom,
+  voice,
+  running,
+}: ChatActionsDeps) {
+  function buildSendPayload(
+    text: string,
+    clientMsgId: string,
+    images?: ImageAttachment[],
+  ): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      type: 'send',
+      prompt: text,
+      clientMsgId,
+      model: sessionState.model,
+      mode: sessionState.mode,
+    };
+    if (sessionState.currentSessionId) payload.resume = sessionState.currentSessionId;
+    if (images?.length) {
+      payload.images = images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
+    }
+    if (sessionState.sandbox && !sessionState.currentSessionId) payload.worktree = true;
+    const cwd = searchParams.get('cwd');
+    if (cwd) payload.cwd = cwd;
+    const extraTools = searchParams.get('extraTools');
+    if (extraTools) payload.extraTools = extraTools;
+    return payload;
+  }
+
+  function sendMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): boolean {
+    if (!wsIsOpen(poolKey)) {
+      dispatch({ type: 'CONNECTION_LOST' });
+      return false;
+    }
+    voice.stopSpeaking();
+    const clientMsgId = generateClientMsgId();
+    const payload = buildSendPayload(text, clientMsgId, images);
+    if (ctxBlocks?.length) payload.contextBlocks = ctxBlocks;
+    const previews = images?.map((img) => img.preview);
+    if (!running) wsSetRunning(poolKey, true);
+    wsSend(poolKey, payload);
+    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks: ctxBlocks });
+    forceScrollToBottom();
+    return true;
+  }
+
+  function interruptMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): void {
+    if (!wsIsOpen(poolKey) || !running) return;
+    const clientMsgId = generateClientMsgId();
+    const imagePayload = images?.map((img) => ({ data: img.data, mediaType: img.mediaType }));
+    const previews = images?.map((img) => img.preview);
+    wsSend(poolKey, {
+      type: 'interrupt',
+      prompt: text,
+      clientMsgId,
+      images: imagePayload,
+      ...(ctxBlocks?.length ? { contextBlocks: ctxBlocks } : {}),
+    });
+    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks: ctxBlocks });
+    forceScrollToBottom();
+  }
+
+  const handleStop = useCallback(() => {
+    pendingSend.current = null;
+    wsSend(poolKey, { type: 'stop' });
+    wsSetRunning(poolKey, false);
+    dispatch({ type: 'SET_RUNNING', running: false });
+  }, [poolKey, dispatch, pendingSend]);
+
+  return { sendMessage, interruptMessage, handleStop };
+}

--- a/frontend/src/hooks/useChatActions.ts
+++ b/frontend/src/hooks/useChatActions.ts
@@ -9,12 +9,10 @@ function generateClientMsgId(): string {
 
 interface ChatActionsDeps {
   poolKey: string;
-  sessionState: {
-    model: string;
-    mode: string;
-    currentSessionId: string | undefined;
-    sandbox: boolean;
-  };
+  sessionState: Pick<
+    import('./useChatSession').ChatSessionState,
+    'model' | 'mode' | 'currentSessionId' | 'sandbox'
+  >;
   searchParams: URLSearchParams;
   dispatch: (action: ChatMessagesAction) => void;
   pendingSend: React.RefObject<unknown | null>;

--- a/frontend/src/hooks/useChatActions.ts
+++ b/frontend/src/hooks/useChatActions.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
 import type { ImageAttachment } from '../types/chat';
+import type { ChatMessagesAction } from './useChatMessages';
 
 function generateClientMsgId(): string {
   return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -15,7 +16,7 @@ interface ChatActionsDeps {
     sandbox: boolean;
   };
   searchParams: URLSearchParams;
-  dispatch: (action: { type: string; [key: string]: unknown }) => void;
+  dispatch: (action: ChatMessagesAction) => void;
   pendingSend: React.RefObject<unknown | null>;
   forceScrollToBottom: () => void;
   voice: { stopSpeaking: () => void };

--- a/frontend/src/hooks/useChatMessages.ts
+++ b/frontend/src/hooks/useChatMessages.ts
@@ -75,7 +75,8 @@ export type ChatMessagesAction =
   | { type: 'RESTORE'; messages: FinishedMessage[]; interrupted?: boolean }
   | { type: 'USER_MESSAGE_RECEIVED'; messageId: string; text: string }
   | { type: 'WORKTREE_OPENED'; repoName: string; path: string }
-  | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string };
+  | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string }
+  | { type: 'CLEAR' };
 
 const INITIAL_STATE: ChatMessagesState = {
   messages: [],
@@ -315,6 +316,9 @@ export function chatMessagesReducer(
         messages: [...state.messages, cmdMsg],
       };
     }
+
+    case 'CLEAR':
+      return { ...INITIAL_STATE };
 
     case 'RESTORE': {
       const valid = action.messages.filter(

--- a/frontend/src/hooks/useChatSession.ts
+++ b/frontend/src/hooks/useChatSession.ts
@@ -30,6 +30,12 @@ export function useChatSession(
     setPreferredModel(id);
   }, []);
 
+  // Sync currentSessionId when route param changes (critical for DesktopChatView
+  // which stays mounted across session switches, unlike ChatView which remounts).
+  useEffect(() => {
+    setCurrentSessionId(sessionId);
+  }, [sessionId]);
+
   const newSessionUid = useRef(`new:${Math.random().toString(36).slice(2)}`);
   const poolKey = sessionId ? `session:${sessionId}` : newSessionUid.current;
 

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handler = (e: MediaQueryListEvent | { matches: boolean }) => {
+      setMatches(e.matches);
+    };
+
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}
+
+export function useIsDesktop(): boolean {
+  return useMediaQuery('(min-width: 768px)');
+}

--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Session } from '../types/chat';
+import { renameSession as renameSessionApi } from '../lib/rename-session';
+import { wsSubscribe } from '../lib/ws-pool';
+
+export interface QuickAction {
+  label: string;
+  desc: string;
+  path?: string;
+  prompt?: string;
+  cwd?: string;
+  extraTools?: string;
+}
+
+const DEFAULT_ACTIONS: QuickAction[] = [
+  { label: 'Chat Session', desc: 'Interactive chat', path: '/chat' },
+  { label: 'Files', desc: 'Browse repo files', path: '/files' },
+];
+
+function buildQuickActions(serverActions: QuickAction[] | undefined): QuickAction[] {
+  if (!serverActions || serverActions.length === 0) return DEFAULT_ACTIONS;
+  return [
+    { label: 'Chat Session', desc: 'Interactive chat', path: '/chat' },
+    ...serverActions,
+    { label: 'Files', desc: 'Browse repo files', path: '/files' },
+  ];
+}
+
+export interface UseSessionListReturn {
+  sessions: Session[];
+  quickActions: QuickAction[];
+  loading: boolean;
+  inboxCount: number;
+  updateAvailable: boolean;
+  checking: boolean;
+  dismissSession: (id: string) => void;
+  clearAll: () => void;
+  handleRename: (id: string, title: string) => void;
+  checkForUpdates: () => Promise<void>;
+}
+
+export function useSessionList(): UseSessionListReturn {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [quickActions, setQuickActions] = useState<QuickAction[]>(DEFAULT_ACTIONS);
+  const [loading, setLoading] = useState(true);
+  const [inboxCount, setInboxCount] = useState(0);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [checking, setChecking] = useState(false);
+
+  useEffect(() => {
+    const loadAll = () =>
+      Promise.all([
+        fetch('/api/sessions')
+          .then((r) => r.json())
+          .catch(() => []),
+        fetch('/api/config')
+          .then((r) => r.json())
+          .catch(() => ({})),
+        fetch('/api/version')
+          .then((r) => r.json())
+          .catch(() => ({})),
+        fetch('/api/inbox')
+          .then((r) => r.json())
+          .catch(() => []),
+      ]).then(([sessData, config, version, inboxData]) => {
+        setSessions(sessData);
+        setQuickActions(buildQuickActions(config.quickActions));
+        if (version?.updateAvailable) setUpdateAvailable(true);
+        if (Array.isArray(inboxData)) setInboxCount(inboxData.length);
+      });
+
+    loadAll().finally(() => setLoading(false));
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') loadAll();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
+    let inboxFetchTimer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = wsSubscribe('global:system', (msg) => {
+      if (msg.type === 'inbox_updated') {
+        if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
+        inboxFetchTimer = setTimeout(() => {
+          fetch('/api/inbox')
+            .then((r) => r.json())
+            .then((data) => {
+              if (Array.isArray(data)) setInboxCount(data.length);
+            })
+            .catch(() => {});
+        }, 300);
+      }
+    });
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
+      unsub();
+    };
+  }, []);
+
+  const dismissSession = useCallback((id: string) => {
+    setSessions((prev) => prev.filter((s) => s.id !== id));
+    fetch(`/api/sessions/${id}`, { method: 'DELETE' }).catch(() => {});
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setSessions([]);
+    fetch('/api/sessions', { method: 'DELETE' }).catch(() => {});
+  }, []);
+
+  const handleRename = useCallback((id: string, title: string) => {
+    setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, summary: title } : s)));
+    renameSessionApi(id, title).catch(() => {
+      fetch('/api/sessions')
+        .then((r) => r.json())
+        .then(setSessions)
+        .catch(() => {});
+    });
+  }, []);
+
+  const checkForUpdates = useCallback(async () => {
+    setChecking(true);
+    try {
+      const res = await fetch('/api/version/check', { method: 'POST' });
+      const data = await res.json();
+      setUpdateAvailable(data.updateAvailable);
+    } catch {
+      // Network error — ignore
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
+  return {
+    sessions,
+    quickActions,
+    loading,
+    inboxCount,
+    updateAvailable,
+    checking,
+    dismissSession,
+    clearAll,
+    handleRename,
+    checkForUpdates,
+  };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import './styles/global.css';
+import './styles/desktop.css';
 
 // Unregister any previously installed service workers — the SW was causing
 // WS disconnects (code 1001) via clients.claim() on activate. For a tool

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -1,23 +1,18 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
-import { UserBubble, TextBubble } from '../components/MessageBubble';
-import { ThinkingBlock } from '../components/ThinkingBlock';
-import { ToolPill } from '../components/ToolPill';
-import { ToolGroup } from '../components/ToolGroup';
-import { PermissionBanner } from '../components/PermissionBanner';
+import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
 import { VoiceSettings } from '../components/VoiceSettings';
 import { MitzoLogo } from '../components/MitzoLogo';
-import { groupBlocks } from '../lib/groupMessages';
 import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
-import { SCROLL_NEAR_BOTTOM_PX, SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
+import { SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
 import { useChatSession } from '../hooks/useChatSession';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { useChatConnection } from '../hooks/useChatConnection';
 import { usePermission } from '../hooks/usePermission';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
-import type { FinishedBlock, ImageAttachment } from '../types/chat';
+import type { ImageAttachment } from '../types/chat';
 
 function generateClientMsgId(): string {
   return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -87,16 +82,6 @@ export function ChatView() {
     forceScrollToBottom,
     handleSessionRenamed,
   );
-
-  // Auto-scroll during streaming: follow new content if user is near the bottom
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    if (distFromBottom <= SCROLL_NEAR_BOTTOM_PX) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [msgState.messages, msgState.current]);
 
   // Restore messages when navigating to an existing session.
   // Fetch from the API (single source of truth — no localStorage cache).
@@ -230,16 +215,6 @@ export function ChatView() {
     }
   }
 
-  // Group blocks per finished assistant turn for tool collapsing.
-  const groupedMessages = useMemo(
-    () =>
-      msgState.messages.map((msg) => ({
-        msg,
-        grouped: msg.role === 'assistant' ? groupBlocks(msg.blocks) : null,
-      })),
-    [msgState.messages],
-  );
-
   const initialPrompt = searchParams.get('prompt') || undefined;
 
   return (
@@ -286,76 +261,14 @@ export function ChatView() {
         />
       </header>
 
-      <div className="chat-messages" ref={scrollRef}>
-        {msgState.messages.length === 0 && !msgState.current && !msgState.running && (
-          <p className="chat-empty">Send a message to start</p>
-        )}
-
-        {/* Finished turns */}
-        {groupedMessages.map(({ msg, grouped }) => {
-          if (msg.role === 'user') {
-            const textBlock = msg.blocks.find((b) => b.blockType === 'text');
-            return (
-              <UserBubble
-                key={msg.messageId}
-                text={textBlock?.content}
-                images={msg.images}
-                contextBlocks={msg.contextBlocks}
-              />
-            );
-          }
-
-          // Assistant turn — render grouped blocks
-          return (
-            <div key={msg.messageId} className="msg-turn">
-              {(grouped ?? []).map((item, i) => {
-                if (item.type === 'tool-group') {
-                  return <ToolGroup key={item.key} tools={item.tools} />;
-                }
-                const block: FinishedBlock = item.block;
-                if (block.blockType === 'thinking' || block.blockType === 'redacted_thinking') {
-                  return <ThinkingBlock key={block.blockId} block={block} />;
-                }
-                if (block.blockType === 'tool_use') {
-                  return <ToolPill key={block.blockId} block={block} />;
-                }
-                return (
-                  <TextBubble key={block.blockId || `text-${i}`} content={block.content ?? ''} />
-                );
-              })}
-            </div>
-          );
-        })}
-
-        {/* In-flight streaming turn — rendered inline, no grouping */}
-        {msgState.current && (
-          <div className="msg-turn msg-turn--streaming">
-            {msgState.current.blockOrder.map((blockId) => {
-              const block = msgState.current!.blocks.get(blockId)!;
-              if (block.blockType === 'thinking' || block.blockType === 'redacted_thinking') {
-                return <ThinkingBlock key={block.blockId} block={block} streaming />;
-              }
-              if (block.blockType === 'tool_use') {
-                return <ToolPill key={block.blockId} block={block} />;
-              }
-              return <TextBubble key={block.blockId} content={block.content ?? ''} streaming />;
-            })}
-          </div>
-        )}
-      </div>
-
-      {msgState.permission && (
-        <PermissionBanner
-          permId={msgState.permission.permId}
-          toolName={msgState.permission.toolName}
-          toolInput={msgState.permission.toolInput}
-          title={msgState.permission.title}
-          description={msgState.permission.description}
-          displayName={msgState.permission.displayName}
-          tier={msgState.permission.tier}
-          onRespond={handlePermission}
-        />
-      )}
+      <ChatArea
+        messages={msgState.messages}
+        current={msgState.current}
+        running={msgState.running}
+        permission={msgState.permission}
+        onPermissionRespond={handlePermission}
+        scrollRef={scrollRef}
+      />
 
       <ChatInput
         onSend={sendMessage}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -4,19 +4,15 @@ import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
 import { VoiceSettings } from '../components/VoiceSettings';
 import { MitzoLogo } from '../components/MitzoLogo';
-import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
+import { wsSend } from '../lib/ws-pool';
 import { SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
 import { useChatSession } from '../hooks/useChatSession';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { useChatConnection } from '../hooks/useChatConnection';
+import { useChatActions } from '../hooks/useChatActions';
 import { usePermission } from '../hooks/usePermission';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
-import type { ImageAttachment } from '../types/chat';
-
-function generateClientMsgId(): string {
-  return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
 
 export function ChatView() {
   const { sessionId } = useParams<{ sessionId?: string }>();
@@ -124,89 +120,16 @@ export function ChatView() {
 
   const hasStarted = msgState.messages.some((m) => m.role === 'user');
 
-  function buildSendPayload(
-    text: string,
-    clientMsgId: string,
-    images?: ImageAttachment[],
-  ): Record<string, unknown> {
-    const payload: Record<string, unknown> = {
-      type: 'send',
-      prompt: text,
-      clientMsgId,
-      model: sessionState.model,
-      mode: sessionState.mode,
-    };
-    if (sessionState.currentSessionId) payload.resume = sessionState.currentSessionId;
-    if (images?.length) {
-      payload.images = images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
-    }
-    if (sessionState.sandbox && !sessionState.currentSessionId) payload.worktree = true;
-    const cwd = searchParams.get('cwd');
-    if (cwd) payload.cwd = cwd;
-    const extraTools = searchParams.get('extraTools');
-    if (extraTools) payload.extraTools = extraTools;
-    return payload;
-  }
-
-  function sendMessage(
-    text: string,
-    images?: ImageAttachment[],
-    contextBlocks?: string[],
-  ): boolean {
-    if (!wsIsOpen(poolKey)) {
-      dispatch({ type: 'CONNECTION_LOST' });
-      return false;
-    }
-
-    // Stop TTS playback when user sends a new message
-    voice.stopSpeaking();
-
-    const clientMsgId = generateClientMsgId();
-    const payload = buildSendPayload(text, clientMsgId, images);
-    if (contextBlocks?.length) payload.contextBlocks = contextBlocks;
-    const previews = images?.map((img) => img.preview);
-
-    if (msgState.running) {
-      // Server queues it natively — no client-side stop+re-send needed.
-      wsSend(poolKey, payload);
-      dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
-      forceScrollToBottom();
-    } else {
-      wsSetRunning(poolKey, true);
-      wsSend(poolKey, payload);
-      dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
-      forceScrollToBottom();
-    }
-
-    return true;
-  }
-
-  function interruptMessage(
-    text: string,
-    images?: ImageAttachment[],
-    contextBlocks?: string[],
-  ): void {
-    if (!wsIsOpen(poolKey) || !msgState.running) return;
-    const clientMsgId = generateClientMsgId();
-    const imagePayload = images?.map((img) => ({ data: img.data, mediaType: img.mediaType }));
-    const previews = images?.map((img) => img.preview);
-    wsSend(poolKey, {
-      type: 'interrupt',
-      prompt: text,
-      clientMsgId,
-      images: imagePayload,
-      ...(contextBlocks?.length ? { contextBlocks } : {}),
-    });
-    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks });
-    forceScrollToBottom();
-  }
-
-  const handleStop = useCallback(() => {
-    pendingSend.current = null;
-    wsSend(poolKey, { type: 'stop' });
-    wsSetRunning(poolKey, false);
-    dispatch({ type: 'SET_RUNNING', running: false });
-  }, [poolKey, dispatch, pendingSend]);
+  const { sendMessage, interruptMessage, handleStop } = useChatActions({
+    poolKey,
+    sessionState,
+    searchParams,
+    dispatch,
+    pendingSend,
+    forceScrollToBottom,
+    voice,
+    running: msgState.running,
+  });
 
   function handleModeChange(newMode: 'ask' | 'agent' | 'auto') {
     sessionActions.setMode(newMode);

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -1,0 +1,258 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { DesktopShell } from '../components/DesktopShell';
+import { SessionPanel } from '../components/SessionPanel';
+import { ContextPanel } from '../components/ContextPanel';
+import { FileBrowserPanel } from '../components/FileBrowserPanel';
+import { ChatArea } from '../components/ChatArea';
+import { ChatInput } from '../components/ChatInput';
+import { StatusBar } from '../components/StatusBar';
+import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
+import { SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
+import { useChatSession } from '../hooks/useChatSession';
+import { useChatMessages } from '../hooks/useChatMessages';
+import { useChatConnection } from '../hooks/useChatConnection';
+import { usePermission } from '../hooks/usePermission';
+import { useVoice } from '../hooks/useVoice';
+import { useAutoSpeak } from '../hooks/useAutoSpeak';
+import type { ImageAttachment } from '../types/chat';
+
+function generateClientMsgId(): string {
+  return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function DesktopChatView() {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const [contextBlocks, setContextBlocks] = useState<string[]>([]);
+
+  const [sessionState, sessionActions, poolKey] = useChatSession(
+    sessionId,
+    searchParams.get('extraTools') ? 'auto' : 'agent',
+  );
+
+  const voice = useVoice();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const forceScrollToBottom = useCallback(() => {
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+    });
+  }, []);
+
+  const handleSessionExpired = useCallback(
+    (staleId: string | undefined) => {
+      sessionActions.setCurrentSessionId(undefined);
+      if (staleId) localStorage.removeItem(LAST_SESSION_KEY);
+      if (sessionId) navigate('/chat', { replace: true });
+    },
+    [sessionId, navigate, sessionActions],
+  );
+
+  const handleSessionAssigned = useCallback(
+    (id: string) => {
+      sessionActions.setCurrentSessionId(id);
+      if (!sessionId && window.location.pathname === '/chat') {
+        window.history.replaceState(null, '', `/chat/${id}`);
+      }
+    },
+    [sessionId, sessionActions],
+  );
+
+  const handleSessionRenamed = useCallback((name: string) => {
+    document.title = `${name} — Mitzo`;
+  }, []);
+
+  const {
+    state: msgState,
+    dispatch,
+    pendingSend,
+    handleWsMessage,
+  } = useChatMessages(
+    poolKey,
+    sessionState.currentSessionId,
+    handleSessionAssigned,
+    handleSessionExpired,
+    forceScrollToBottom,
+    handleSessionRenamed,
+  );
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const controller = new AbortController();
+    fetch(`/api/sessions/${sessionId}/messages`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((msgs: unknown[]) => {
+        if (controller.signal.aborted) return;
+        const apiMsgs = msgs as import('../types/chat').FinishedMessage[];
+        if (apiMsgs.length > 0) {
+          dispatch({ type: 'RESTORE', messages: apiMsgs });
+          setTimeout(forceScrollToBottom, SCROLL_RESTORE_DELAY_MS);
+        }
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [sessionId, dispatch, forceScrollToBottom]);
+
+  const { connected } = useChatConnection(poolKey, handleWsMessage);
+
+  const { handlePermission } = usePermission(poolKey, () => {
+    dispatch({ type: 'PERMISSION_TIMEOUT', permId: msgState.permission?.permId ?? '' });
+  });
+
+  useAutoSpeak({
+    messages: msgState.messages,
+    running: msgState.running,
+    ttsEnabled: voice.ttsEnabled,
+    ttsAvailable: voice.ttsAvailable,
+    speak: voice.speak,
+  });
+
+  function buildSendPayload(
+    text: string,
+    clientMsgId: string,
+    images?: ImageAttachment[],
+  ): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      type: 'send',
+      prompt: text,
+      clientMsgId,
+      model: sessionState.model,
+      mode: sessionState.mode,
+    };
+    if (sessionState.currentSessionId) payload.resume = sessionState.currentSessionId;
+    if (images?.length) {
+      payload.images = images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
+    }
+    if (sessionState.sandbox && !sessionState.currentSessionId) payload.worktree = true;
+    const cwd = searchParams.get('cwd');
+    if (cwd) payload.cwd = cwd;
+    const extraTools = searchParams.get('extraTools');
+    if (extraTools) payload.extraTools = extraTools;
+    return payload;
+  }
+
+  function sendMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): boolean {
+    if (!wsIsOpen(poolKey)) {
+      dispatch({ type: 'CONNECTION_LOST' });
+      return false;
+    }
+    voice.stopSpeaking();
+    const clientMsgId = generateClientMsgId();
+    const payload = buildSendPayload(text, clientMsgId, images);
+    if (ctxBlocks?.length) payload.contextBlocks = ctxBlocks;
+    const previews = images?.map((img) => img.preview);
+    if (msgState.running) {
+      wsSend(poolKey, payload);
+      dispatch({
+        type: 'USER_SEND',
+        text,
+        clientMsgId,
+        images: previews,
+        contextBlocks: ctxBlocks,
+      });
+    } else {
+      wsSetRunning(poolKey, true);
+      wsSend(poolKey, payload);
+      dispatch({
+        type: 'USER_SEND',
+        text,
+        clientMsgId,
+        images: previews,
+        contextBlocks: ctxBlocks,
+      });
+    }
+    forceScrollToBottom();
+    return true;
+  }
+
+  function interruptMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): void {
+    if (!wsIsOpen(poolKey) || !msgState.running) return;
+    const clientMsgId = generateClientMsgId();
+    const imagePayload = images?.map((img) => ({ data: img.data, mediaType: img.mediaType }));
+    const previews = images?.map((img) => img.preview);
+    wsSend(poolKey, {
+      type: 'interrupt',
+      prompt: text,
+      clientMsgId,
+      images: imagePayload,
+      ...(ctxBlocks?.length ? { contextBlocks: ctxBlocks } : {}),
+    });
+    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks: ctxBlocks });
+    forceScrollToBottom();
+  }
+
+  const handleStop = useCallback(() => {
+    pendingSend.current = null;
+    wsSend(poolKey, { type: 'stop' });
+    wsSetRunning(poolKey, false);
+    dispatch({ type: 'SET_RUNNING', running: false });
+  }, [poolKey, dispatch, pendingSend]);
+
+  const handleToggleContext = useCallback((name: string) => {
+    setContextBlocks((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
+    );
+  }, []);
+
+  const handleSelectSession = useCallback((id: string) => navigate(`/chat/${id}`), [navigate]);
+
+  const handleNewChat = useCallback(() => navigate('/chat'), [navigate]);
+
+  return (
+    <DesktopShell
+      left={
+        <SessionPanel
+          activeSessionId={sessionState.currentSessionId}
+          onSelectSession={handleSelectSession}
+          onNewChat={handleNewChat}
+        />
+      }
+      center={
+        <div className="desktop-chat-center">
+          <ChatArea
+            messages={msgState.messages}
+            current={msgState.current}
+            running={msgState.running}
+            permission={msgState.permission}
+            onPermissionRespond={handlePermission}
+            scrollRef={scrollRef}
+          />
+          <ChatInput
+            onSend={sendMessage}
+            onStop={handleStop}
+            onInterrupt={interruptMessage}
+            running={msgState.running}
+            initialText={searchParams.get('prompt') || undefined}
+            voice={voice}
+            branch={msgState.branch || undefined}
+            isWorktree={msgState.isWorktree}
+            sandbox={sessionState.sandbox}
+            onSandboxToggle={() => sessionActions.setSandbox(!sessionState.sandbox)}
+            sandboxDisabled={msgState.messages.some((m) => m.role === 'user')}
+            externalContextBlocks={contextBlocks}
+          />
+        </div>
+      }
+      right={
+        <div className="desktop-right-panels">
+          <ContextPanel selected={contextBlocks} onToggle={handleToggleContext} />
+          <FileBrowserPanel />
+        </div>
+      }
+      statusBar={
+        <StatusBar
+          connected={connected}
+          sessionId={sessionState.currentSessionId}
+          branch={msgState.branch || undefined}
+          isWorktree={msgState.isWorktree}
+        />
+      }
+    />
+  );
+}

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -80,6 +80,10 @@ export function DesktopChatView() {
   );
 
   useEffect(() => {
+    dispatch({ type: 'CLEAR' });
+  }, [sessionId, dispatch]);
+
+  useEffect(() => {
     if (!sessionId) return;
     const controller = new AbortController();
     fetch(`/api/sessions/${sessionId}/messages`, {

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -7,6 +7,8 @@ import { FileBrowserPanel } from '../components/FileBrowserPanel';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
 import { StatusBar } from '../components/StatusBar';
+import { VoiceSettings } from '../components/VoiceSettings';
+import { wsSend } from '../lib/ws-pool';
 import { SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
 import { useChatSession } from '../hooks/useChatSession';
 import { useChatMessages } from '../hooks/useChatMessages';
@@ -149,6 +151,13 @@ export function DesktopChatView() {
     running: msgState.running,
   });
 
+  function handleModeChange(newMode: 'ask' | 'agent' | 'auto') {
+    sessionActions.setMode(newMode);
+    if (msgState.running) {
+      wsSend(poolKey, { type: 'set_mode', mode: newMode });
+    }
+  }
+
   const handleToggleContext = useCallback((name: string) => {
     setContextBlocks((prev) =>
       prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
@@ -170,6 +179,46 @@ export function DesktopChatView() {
       }
       center={
         <div className="desktop-chat-center">
+          <header className="desktop-chat-header">
+            {!connected && (
+              <span
+                className="chat-header-offline"
+                title={msgState.running ? 'Reconnecting — session still active' : 'Reconnecting...'}
+              >
+                !
+              </span>
+            )}
+            <select
+              className="chat-model-select"
+              value={sessionState.model}
+              onChange={(e) => sessionActions.setModel(e.target.value)}
+              disabled={msgState.running}
+            >
+              <option value="claude-sonnet-4-6">Sonnet</option>
+              <option value="claude-opus-4-6">Opus</option>
+              <option value="claude-haiku-4-5">Haiku</option>
+            </select>
+            <div className="mode-pills">
+              {(['ask', 'agent', 'auto'] as const).map((m) => (
+                <button
+                  key={m}
+                  className={`mode-pill${sessionState.mode === m ? ' mode-pill--active' : ''}`}
+                  onClick={() => handleModeChange(m)}
+                >
+                  {m.charAt(0).toUpperCase() + m.slice(1)}
+                </button>
+              ))}
+            </div>
+            <VoiceSettings
+              ttsAvailable={voice.ttsAvailable}
+              ttsEnabled={voice.ttsEnabled}
+              speaking={voice.speaking}
+              voices={voice.voices}
+              selectedVoice={voice.selectedVoice}
+              onToggle={() => voice.setTtsEnabled(!voice.ttsEnabled)}
+              onVoiceChange={voice.setVoice}
+            />
+          </header>
           <ChatArea
             messages={msgState.messages}
             current={msgState.current}

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -7,19 +7,16 @@ import { FileBrowserPanel } from '../components/FileBrowserPanel';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
 import { StatusBar } from '../components/StatusBar';
-import { wsIsOpen, wsSend, wsSetRunning } from '../lib/ws-pool';
 import { SCROLL_RESTORE_DELAY_MS, LAST_SESSION_KEY } from '../lib/constants';
 import { useChatSession } from '../hooks/useChatSession';
 import { useChatMessages } from '../hooks/useChatMessages';
 import { useChatConnection } from '../hooks/useChatConnection';
+import { useChatActions } from '../hooks/useChatActions';
 import { usePermission } from '../hooks/usePermission';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
-import type { ImageAttachment } from '../types/chat';
-
-function generateClientMsgId(): string {
-  return `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-}
+import type { FileRoot } from '../components/FileBrowserPanel';
+import type { ContextBlockEntry } from '../components/ContextPicker';
 
 export function DesktopChatView() {
   const { sessionId } = useParams<{ sessionId?: string }>();
@@ -27,6 +24,32 @@ export function DesktopChatView() {
   const navigate = useNavigate();
 
   const [contextBlocks, setContextBlocks] = useState<string[]>([]);
+
+  // Shared config fetch for right-panel children
+  const [configBlocks, setConfigBlocks] = useState<ContextBlockEntry[]>([]);
+  const [fileRoots, setFileRoots] = useState<FileRoot[]>([]);
+  const [configLoaded, setConfigLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/config', { credentials: 'include' })
+      .then((r) => r.json())
+      .then((data) => {
+        // Context blocks
+        const entries: ContextBlockEntry[] = [];
+        if (data.contextBlocks) {
+          for (const [name, info] of Object.entries(
+            data.contextBlocks as Record<string, { path: string; sizeBytes: number }>,
+          )) {
+            entries.push({ name, path: info.path, sizeBytes: info.sizeBytes });
+          }
+        }
+        setConfigBlocks(entries);
+        // File roots
+        setFileRoots(data.fileViewerRoots ?? []);
+        setConfigLoaded(true);
+      })
+      .catch(() => setConfigLoaded(true));
+  }, []);
 
   const [sessionState, sessionActions, poolKey] = useChatSession(
     sessionId,
@@ -79,11 +102,9 @@ export function DesktopChatView() {
     handleSessionRenamed,
   );
 
+  // Clear + restore on session switch — abort previous fetch to prevent race condition
   useEffect(() => {
     dispatch({ type: 'CLEAR' });
-  }, [sessionId, dispatch]);
-
-  useEffect(() => {
     if (!sessionId) return;
     const controller = new AbortController();
     fetch(`/api/sessions/${sessionId}/messages`, {
@@ -117,86 +138,16 @@ export function DesktopChatView() {
     speak: voice.speak,
   });
 
-  function buildSendPayload(
-    text: string,
-    clientMsgId: string,
-    images?: ImageAttachment[],
-  ): Record<string, unknown> {
-    const payload: Record<string, unknown> = {
-      type: 'send',
-      prompt: text,
-      clientMsgId,
-      model: sessionState.model,
-      mode: sessionState.mode,
-    };
-    if (sessionState.currentSessionId) payload.resume = sessionState.currentSessionId;
-    if (images?.length) {
-      payload.images = images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
-    }
-    if (sessionState.sandbox && !sessionState.currentSessionId) payload.worktree = true;
-    const cwd = searchParams.get('cwd');
-    if (cwd) payload.cwd = cwd;
-    const extraTools = searchParams.get('extraTools');
-    if (extraTools) payload.extraTools = extraTools;
-    return payload;
-  }
-
-  function sendMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): boolean {
-    if (!wsIsOpen(poolKey)) {
-      dispatch({ type: 'CONNECTION_LOST' });
-      return false;
-    }
-    voice.stopSpeaking();
-    const clientMsgId = generateClientMsgId();
-    const payload = buildSendPayload(text, clientMsgId, images);
-    if (ctxBlocks?.length) payload.contextBlocks = ctxBlocks;
-    const previews = images?.map((img) => img.preview);
-    if (msgState.running) {
-      wsSend(poolKey, payload);
-      dispatch({
-        type: 'USER_SEND',
-        text,
-        clientMsgId,
-        images: previews,
-        contextBlocks: ctxBlocks,
-      });
-    } else {
-      wsSetRunning(poolKey, true);
-      wsSend(poolKey, payload);
-      dispatch({
-        type: 'USER_SEND',
-        text,
-        clientMsgId,
-        images: previews,
-        contextBlocks: ctxBlocks,
-      });
-    }
-    forceScrollToBottom();
-    return true;
-  }
-
-  function interruptMessage(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): void {
-    if (!wsIsOpen(poolKey) || !msgState.running) return;
-    const clientMsgId = generateClientMsgId();
-    const imagePayload = images?.map((img) => ({ data: img.data, mediaType: img.mediaType }));
-    const previews = images?.map((img) => img.preview);
-    wsSend(poolKey, {
-      type: 'interrupt',
-      prompt: text,
-      clientMsgId,
-      images: imagePayload,
-      ...(ctxBlocks?.length ? { contextBlocks: ctxBlocks } : {}),
-    });
-    dispatch({ type: 'USER_SEND', text, clientMsgId, images: previews, contextBlocks: ctxBlocks });
-    forceScrollToBottom();
-  }
-
-  const handleStop = useCallback(() => {
-    pendingSend.current = null;
-    wsSend(poolKey, { type: 'stop' });
-    wsSetRunning(poolKey, false);
-    dispatch({ type: 'SET_RUNNING', running: false });
-  }, [poolKey, dispatch, pendingSend]);
+  const { sendMessage, interruptMessage, handleStop } = useChatActions({
+    poolKey,
+    sessionState,
+    searchParams,
+    dispatch,
+    pendingSend,
+    forceScrollToBottom,
+    voice,
+    running: msgState.running,
+  });
 
   const handleToggleContext = useCallback((name: string) => {
     setContextBlocks((prev) =>
@@ -245,8 +196,13 @@ export function DesktopChatView() {
       }
       right={
         <div className="desktop-right-panels">
-          <ContextPanel selected={contextBlocks} onToggle={handleToggleContext} />
-          <FileBrowserPanel />
+          <ContextPanel
+            selected={contextBlocks}
+            onToggle={handleToggleContext}
+            blocks={configBlocks}
+            loaded={configLoaded}
+          />
+          <FileBrowserPanel roots={fileRoots} loaded={configLoaded} />
         </div>
       }
       statusBar={

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -2,34 +2,10 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { Session } from '../types/chat';
 import { formatRelativeTime } from '../lib/formatTime';
-import { renameSession } from '../lib/rename-session';
 import { useLongPress } from '../hooks/useLongPress';
 import { computeSwipeState, REVEAL_WIDTH } from '../lib/swipe-reveal';
-import { wsSubscribe } from '../lib/ws-pool';
-
-interface QuickAction {
-  label: string;
-  desc: string;
-  path?: string;
-  prompt?: string;
-  cwd?: string;
-  extraTools?: string;
-}
-
-const DEFAULT_ACTIONS: QuickAction[] = [
-  { label: 'Chat Session', desc: 'Interactive chat', path: '/chat' },
-  { label: 'Files', desc: 'Browse repo files', path: '/files' },
-];
-
-function buildQuickActions(serverActions: QuickAction[] | undefined): QuickAction[] {
-  if (!serverActions || serverActions.length === 0) return DEFAULT_ACTIONS;
-  const actions: QuickAction[] = [
-    { label: 'Chat Session', desc: 'Interactive chat', path: '/chat' },
-    ...serverActions,
-    { label: 'Files', desc: 'Browse repo files', path: '/files' },
-  ];
-  return actions;
-}
+import { useSessionList } from '../hooks/useSessionList';
+import type { QuickAction } from '../hooks/useSessionList';
 
 function SwipeableSession({
   session,
@@ -211,107 +187,22 @@ async function refreshUI() {
 
 export function SessionList() {
   const navigate = useNavigate();
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [quickActions, setQuickActions] = useState<QuickAction[]>(DEFAULT_ACTIONS);
-  const [loading, setLoading] = useState(true);
-  const [inboxCount, setInboxCount] = useState(0);
-  const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [checking, setChecking] = useState(false);
-
-  useEffect(() => {
-    const loadAll = () =>
-      Promise.all([
-        fetch('/api/sessions')
-          .then((r) => r.json())
-          .catch(() => []),
-        fetch('/api/config')
-          .then((r) => r.json())
-          .catch(() => ({})),
-        fetch('/api/version')
-          .then((r) => r.json())
-          .catch(() => ({})),
-        fetch('/api/inbox')
-          .then((r) => r.json())
-          .catch(() => []),
-      ]).then(([sessData, config, version, inboxData]) => {
-        setSessions(sessData);
-        setQuickActions(buildQuickActions(config.quickActions));
-        if (version?.updateAvailable) setUpdateAvailable(true);
-        if (Array.isArray(inboxData)) setInboxCount(inboxData.length);
-      });
-
-    loadAll().finally(() => setLoading(false));
-
-    const onVisible = () => {
-      if (document.visibilityState === 'visible') loadAll();
-    };
-    document.addEventListener('visibilitychange', onVisible);
-
-    // Subscribe to WS for real-time inbox count updates
-    let inboxFetchTimer: ReturnType<typeof setTimeout> | null = null;
-    const unsub = wsSubscribe('global:system', (msg) => {
-      if (msg.type === 'inbox_updated') {
-        if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
-        inboxFetchTimer = setTimeout(() => {
-          fetch('/api/inbox')
-            .then((r) => r.json())
-            .then((data) => {
-              if (Array.isArray(data)) setInboxCount(data.length);
-            })
-            .catch(() => {});
-        }, 300);
-      }
-    });
-
-    return () => {
-      document.removeEventListener('visibilitychange', onVisible);
-      if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
-      unsub();
-    };
-  }, []);
-
-  async function checkForUpdates() {
-    setChecking(true);
-    try {
-      const res = await fetch('/api/version/check', { method: 'POST' });
-      const data = await res.json();
-      setUpdateAvailable(data.updateAvailable);
-    } catch {
-      // Network error — ignore
-    } finally {
-      setChecking(false);
-    }
-  }
+  const {
+    sessions,
+    quickActions,
+    loading,
+    inboxCount,
+    updateAvailable,
+    checking,
+    dismissSession,
+    clearAll,
+    handleRename,
+    checkForUpdates,
+  } = useSessionList();
 
   function handleDeployAction() {
     const deploy = quickActions.find((a) => a.label === 'Deploy Mitzo');
     if (deploy) handleQuickAction(deploy);
-  }
-
-  function dismissSession(id: string) {
-    setSessions((prev) => prev.filter((s) => s.id !== id));
-    fetch(`/api/sessions/${id}`, { method: 'DELETE' }).catch(() => {
-      // Best-effort server-side dismiss — UI already updated
-    });
-  }
-
-  function clearAll() {
-    setSessions([]);
-    fetch('/api/sessions', { method: 'DELETE' }).catch(() => {
-      // Best-effort server-side clear — UI already updated
-    });
-  }
-
-  function handleRename(id: string, title: string) {
-    // Optimistic update
-    setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, summary: title } : s)));
-    renameSession(id, title).catch(() => {
-      // Revert on failure — reload from server
-      fetch('/api/sessions')
-        .then((r) => r.json())
-        .then(setSessions)
-        .catch(() => {});
-    });
   }
 
   function handleQuickAction(action: QuickAction) {

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -106,6 +106,14 @@ vi.mock('../../hooks/useVoice', () => ({
   }),
 }));
 
+vi.mock('../../hooks/useChatActions', () => ({
+  useChatActions: () => ({
+    sendMessage: vi.fn(),
+    interruptMessage: vi.fn(),
+    handleStop: vi.fn(),
+  }),
+}));
+
 vi.mock('../../hooks/useAutoSpeak', () => ({
   useAutoSpeak: vi.fn(),
 }));
@@ -120,6 +128,13 @@ import { DesktopChatView } from '../DesktopChatView';
 
 beforeEach(() => {
   localStorage.clear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ contextBlocks: {}, fileViewerRoots: [] }),
+    }),
+  );
 });
 
 afterEach(() => {

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Mock all heavy sub-components to isolate DesktopChatView wiring
+vi.mock('../../components/DesktopShell', () => ({
+  DesktopShell: ({ left, center, right, statusBar }: Record<string, React.ReactNode>) => (
+    <div>
+      <div data-testid="left">{left}</div>
+      <div data-testid="center">{center}</div>
+      <div data-testid="right">{right}</div>
+      {statusBar && <div data-testid="status">{statusBar}</div>}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/SessionPanel', () => ({
+  SessionPanel: () => <div data-testid="session-panel">SessionPanel</div>,
+}));
+
+vi.mock('../../components/ContextPanel', () => ({
+  ContextPanel: ({ selected }: { selected: string[] }) => (
+    <div data-testid="context-panel">selected: {selected.length}</div>
+  ),
+}));
+
+vi.mock('../../components/FileBrowserPanel', () => ({
+  FileBrowserPanel: () => <div data-testid="file-browser">FileBrowser</div>,
+}));
+
+vi.mock('../../components/ChatArea', () => ({
+  ChatArea: () => <div data-testid="chat-area">ChatArea</div>,
+}));
+
+vi.mock('../../components/ChatInput', () => ({
+  ChatInput: ({ externalContextBlocks }: { externalContextBlocks?: string[] }) => (
+    <div data-testid="chat-input">
+      external: {externalContextBlocks ? externalContextBlocks.length : 'none'}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/StatusBar', () => ({
+  StatusBar: ({ connected }: { connected: boolean }) => (
+    <div data-testid="status-bar">connected: {String(connected)}</div>
+  ),
+}));
+
+vi.mock('../../hooks/useChatSession', () => ({
+  useChatSession: () => [
+    { currentSessionId: undefined, model: 'claude-sonnet-4-6', mode: 'agent', sandbox: false },
+    {
+      setCurrentSessionId: vi.fn(),
+      setModel: vi.fn(),
+      setMode: vi.fn(),
+      setSandbox: vi.fn(),
+    },
+    'pool-key',
+  ],
+}));
+
+vi.mock('../../hooks/useChatMessages', () => ({
+  useChatMessages: () => ({
+    state: {
+      messages: [],
+      current: null,
+      running: false,
+      permission: null,
+      branch: 'main',
+      isWorktree: false,
+    },
+    dispatch: vi.fn(),
+    pendingSend: { current: null },
+    handleWsMessage: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useChatConnection', () => ({
+  useChatConnection: () => ({ connected: true }),
+}));
+
+vi.mock('../../hooks/usePermission', () => ({
+  usePermission: () => ({ handlePermission: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useVoice', () => ({
+  useVoice: () => ({
+    available: false,
+    recording: false,
+    transcribing: false,
+    micBlocked: false,
+    ttsEnabled: false,
+    ttsAvailable: false,
+    speaking: false,
+    voices: [],
+    selectedVoice: '',
+    speak: vi.fn(),
+    stopSpeaking: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    cancelRecording: vi.fn(),
+    setTtsEnabled: vi.fn(),
+    setVoice: vi.fn(),
+    partialTranscript: '',
+  }),
+}));
+
+vi.mock('../../hooks/useAutoSpeak', () => ({
+  useAutoSpeak: vi.fn(),
+}));
+
+vi.mock('../../lib/ws-pool', () => ({
+  wsIsOpen: () => true,
+  wsSend: vi.fn(),
+  wsSetRunning: vi.fn(),
+}));
+
+import { DesktopChatView } from '../DesktopChatView';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderWithRouter(sessionId?: string) {
+  const path = sessionId ? `/chat/${sessionId}` : '/chat';
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <DesktopChatView />
+    </MemoryRouter>,
+  );
+}
+
+describe('DesktopChatView', () => {
+  it('renders three-panel layout', () => {
+    renderWithRouter();
+    expect(screen.getByTestId('session-panel')).toBeTruthy();
+    expect(screen.getByTestId('chat-area')).toBeTruthy();
+    expect(screen.getByTestId('context-panel')).toBeTruthy();
+    expect(screen.getByTestId('file-browser')).toBeTruthy();
+  });
+
+  it('renders session panel in left slot', () => {
+    renderWithRouter();
+    const left = screen.getByTestId('left');
+    expect(left.querySelector('[data-testid="session-panel"]')).toBeTruthy();
+  });
+
+  it('renders chat area and input in center slot', () => {
+    renderWithRouter();
+    const center = screen.getByTestId('center');
+    expect(center.querySelector('[data-testid="chat-area"]')).toBeTruthy();
+    expect(center.querySelector('[data-testid="chat-input"]')).toBeTruthy();
+  });
+
+  it('renders context panel and file browser in right slot', () => {
+    renderWithRouter();
+    const right = screen.getByTestId('right');
+    expect(right.querySelector('[data-testid="context-panel"]')).toBeTruthy();
+    expect(right.querySelector('[data-testid="file-browser"]')).toBeTruthy();
+  });
+
+  it('renders status bar', () => {
+    renderWithRouter();
+    expect(screen.getByTestId('status-bar')).toBeTruthy();
+  });
+
+  it('passes externalContextBlocks to ChatInput', () => {
+    renderWithRouter();
+    // Initial state: 0 external blocks
+    expect(screen.getByTestId('chat-input').textContent).toContain('external: 0');
+  });
+});

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -33,6 +33,10 @@ vi.mock('../../components/ChatArea', () => ({
   ChatArea: () => <div data-testid="chat-area">ChatArea</div>,
 }));
 
+vi.mock('../../components/VoiceSettings', () => ({
+  VoiceSettings: () => <div data-testid="voice-settings">Voice</div>,
+}));
+
 vi.mock('../../components/ChatInput', () => ({
   ChatInput: ({ externalContextBlocks }: { externalContextBlocks?: string[] }) => (
     <div data-testid="chat-input">
@@ -189,5 +193,17 @@ describe('DesktopChatView', () => {
     renderWithRouter();
     // Initial state: 0 external blocks
     expect(screen.getByTestId('chat-input').textContent).toContain('external: 0');
+  });
+
+  it('renders model selector and mode pills in center header', () => {
+    renderWithRouter();
+    const center = screen.getByTestId('center');
+    expect(center.querySelector('.chat-model-select')).toBeTruthy();
+    expect(center.querySelector('.mode-pills')).toBeTruthy();
+  });
+
+  it('renders voice settings in center header', () => {
+    renderWithRouter();
+    expect(screen.getByTestId('voice-settings')).toBeTruthy();
   });
 });

--- a/frontend/src/styles/desktop.css
+++ b/frontend/src/styles/desktop.css
@@ -81,6 +81,25 @@
     height: 100%;
   }
 
+  /* === Desktop Chat Header (model/mode/voice) === */
+  .desktop-chat-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    flex-shrink: 0;
+  }
+
+  .desktop-chat-header .chat-model-select {
+    font-size: 0.8125rem;
+  }
+
+  .desktop-chat-header .mode-pills {
+    margin-left: 0;
+  }
+
   .desktop-chat-center .chat-messages {
     flex: 1;
     min-height: 0;

--- a/frontend/src/styles/desktop.css
+++ b/frontend/src/styles/desktop.css
@@ -1,0 +1,444 @@
+/* Desktop layout — all rules scoped to min-width: 768px */
+@media (min-width: 768px) {
+  /* === Shell Grid === */
+  .desktop-shell {
+    display: grid;
+    grid-template-rows: 1fr auto;
+    height: 100dvh;
+    background: var(--bg);
+  }
+
+  .desktop-body {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  /* === Sidebars === */
+  .desktop-sidebar-left,
+  .desktop-sidebar-right {
+    display: flex;
+    flex-direction: column;
+    width: 280px;
+    background: var(--surface);
+    border-color: var(--border);
+    overflow-y: auto;
+    transition: width 0.2s ease;
+  }
+
+  .desktop-sidebar-left {
+    border-right: 1px solid var(--border);
+  }
+
+  .desktop-sidebar-right {
+    border-left: 1px solid var(--border);
+  }
+
+  .desktop-sidebar--collapsed {
+    width: 36px;
+    min-width: 36px;
+    overflow: hidden;
+  }
+
+  .desktop-collapse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 32px;
+    padding: 0;
+    font-size: 0.625rem;
+    color: var(--text-dim);
+    background: transparent;
+    border-radius: 0;
+    flex-shrink: 0;
+  }
+
+  .desktop-collapse-btn:hover {
+    background: var(--border);
+    color: var(--text);
+  }
+
+  /* === Center Panel === */
+  .desktop-center {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .desktop-chat-center {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  /* Override chat-page fixed positioning when inside desktop shell */
+  .desktop-shell .chat-page {
+    position: static;
+    height: 100%;
+  }
+
+  .desktop-chat-center .chat-messages {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  .desktop-chat-center .chat-input {
+    flex-shrink: 0;
+  }
+
+  /* === Status Bar === */
+  .desktop-status-row {
+    border-top: 1px solid var(--border);
+    background: var(--surface);
+  }
+
+  .desktop-status-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    color: var(--text-dim);
+  }
+
+  .status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot--on {
+    background: var(--success);
+  }
+
+  .status-dot--off {
+    background: var(--danger);
+  }
+
+  .status-label {
+    margin-right: 0.5rem;
+  }
+
+  .status-session {
+    font-family: var(--code-font);
+    font-size: 0.6875rem;
+    opacity: 0.7;
+  }
+
+  .status-branch {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: auto;
+    font-family: var(--code-font);
+    font-size: 0.6875rem;
+  }
+
+  .status-wt-badge {
+    background: var(--accent);
+    color: #fff;
+    font-size: 0.5625rem;
+    padding: 0 0.25rem;
+    border-radius: 3px;
+    font-weight: 600;
+  }
+
+  /* === Session Panel === */
+  .session-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .session-panel-new {
+    background: var(--accent);
+    color: #fff;
+    padding: 0.5rem;
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    width: 100%;
+  }
+
+  .session-panel-new:hover {
+    background: var(--accent-hover);
+  }
+
+  .session-panel-empty {
+    color: var(--text-dim);
+    font-size: 0.8125rem;
+    text-align: center;
+    padding: 1rem 0;
+  }
+
+  .session-panel-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .session-panel-item {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem;
+    border-radius: 6px;
+    cursor: pointer;
+    gap: 0.5rem;
+  }
+
+  .session-panel-item:hover {
+    background: var(--border);
+  }
+
+  .session-panel-item--active {
+    background: var(--border);
+    border-left: 2px solid var(--accent);
+  }
+
+  .session-panel-item-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .session-panel-item-summary {
+    font-size: 0.8125rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .session-panel-item-meta {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.6875rem;
+    color: var(--text-dim);
+    margin-top: 0.125rem;
+  }
+
+  .session-panel-item-branch {
+    font-family: var(--code-font);
+  }
+
+  .session-panel-delete {
+    opacity: 0;
+    padding: 0.125rem 0.375rem;
+    font-size: 0.875rem;
+    color: var(--text-dim);
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  .session-panel-item:hover .session-panel-delete {
+    opacity: 1;
+  }
+
+  .session-panel-delete:hover {
+    color: var(--danger);
+    background: rgba(244, 67, 54, 0.1);
+  }
+
+  /* === Context Panel === */
+  .context-panel {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem;
+  }
+
+  .context-panel-header {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    padding: 0.25rem 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .context-panel-empty {
+    color: var(--text-dim);
+    font-size: 0.8125rem;
+    padding: 0.5rem;
+  }
+
+  .context-panel-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .context-panel-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    text-align: left;
+    width: 100%;
+  }
+
+  .context-panel-item:hover {
+    background: var(--border);
+  }
+
+  .context-panel-item--selected {
+    background: rgba(108, 99, 255, 0.1);
+  }
+
+  .context-panel-item--selected:hover {
+    background: rgba(108, 99, 255, 0.15);
+  }
+
+  .context-panel-check {
+    width: 1rem;
+    text-align: center;
+    color: var(--accent);
+    font-size: 0.75rem;
+    flex-shrink: 0;
+  }
+
+  .context-panel-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .context-panel-size {
+    font-size: 0.6875rem;
+    color: var(--text-dim);
+    font-family: var(--code-font);
+    flex-shrink: 0;
+  }
+
+  /* === File Browser Panel === */
+  .file-browser-panel {
+    display: flex;
+    flex-direction: column;
+    padding: 0.5rem;
+    border-top: 1px solid var(--border);
+    flex: 1;
+    min-height: 0;
+  }
+
+  .file-browser-header {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-dim);
+    padding: 0.25rem 0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .file-browser-roots {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0 0.25rem;
+    margin-bottom: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .file-browser-root {
+    font-size: 0.6875rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 4px;
+    background: var(--border);
+    color: var(--text-dim);
+  }
+
+  .file-browser-root:hover {
+    color: var(--text);
+  }
+
+  .file-browser-root--active {
+    background: var(--accent);
+    color: #fff;
+  }
+
+  .file-browser-listing {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .file-browser-entry {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8125rem;
+    border-radius: 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .file-browser-entry:hover {
+    background: var(--border);
+  }
+
+  .file-browser-entry--dir {
+    color: var(--accent);
+  }
+
+  .file-browser-empty {
+    color: var(--text-dim);
+    font-size: 0.8125rem;
+    padding: 0.5rem;
+  }
+
+  .file-browser-back {
+    font-size: 0.8125rem;
+    padding: 0.25rem 0.5rem;
+    color: var(--text-dim);
+    text-align: left;
+    width: 100%;
+  }
+
+  .file-browser-back:hover {
+    color: var(--text);
+  }
+
+  .file-browser-preview {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .file-browser-preview-content {
+    flex: 1;
+    overflow: auto;
+    font-family: var(--code-font);
+    font-size: 0.75rem;
+    line-height: 1.5;
+    padding: 0.5rem;
+    background: var(--code-bg);
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  /* === Right sidebar split === */
+  .desktop-right-panels {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+}

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -302,6 +302,16 @@ describe('config routes', () => {
     expect(typeof res.body.contextBlocks).toBe('object');
   });
 
+  it('GET /api/config — includes fileViewerRoots from repoConfig.roots', async () => {
+    const res = await request(app).get('/api/config').set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('fileViewerRoots');
+    expect(res.body.fileViewerRoots).toEqual([
+      { label: 'Main', path: TEST_REPO },
+      { label: 'Tools', path: '/some/tools' },
+    ]);
+  });
+
   it('GET /api/worktrees — returns worktree list', async () => {
     const res = await request(app).get('/api/worktrees').set('Cookie', authCookie);
     expect(res.status).toBe(200);
@@ -380,6 +390,26 @@ describe('file routes', () => {
   it('PUT /api/files/write — missing body fields returns 400', async () => {
     const res = await request(app).put('/api/files/write').set('Cookie', authCookie).send({});
     expect(res.status).toBe(400);
+  });
+
+  it('GET /api/files/list — returns entries and currentDir', async () => {
+    const res = await request(app)
+      .get('/api/files/list')
+      .query({ dir: TEST_REPO })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('currentDir', TEST_REPO);
+    expect(res.body).toHaveProperty('entries');
+    const names = res.body.entries.map((e: { name: string }) => e.name);
+    expect(names).toContain('test.txt');
+  });
+
+  it('GET /api/files/list — path traversal returns 403', async () => {
+    const res = await request(app)
+      .get('/api/files/list')
+      .query({ dir: '/etc' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(403);
   });
 
   it('GET /api/files/roots — returns configured roots', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -324,11 +324,14 @@ app.get('/api/config', (_req, res) => {
     }
     contextBlocks[name] = { path, sizeBytes };
   }
+  const fileViewerRoots =
+    repoConfig.roots.length > 0 ? repoConfig.roots : [{ label: 'Root', path: BASE_REPO }];
   res.json({
     repoPath: BASE_REPO,
     mcpServers: getMcpServerNames(),
     quickActions: actions,
     contextBlocks,
+    fileViewerRoots,
   });
 });
 
@@ -459,6 +462,43 @@ app.get('/api/git/info', (_req, res) => {
 
 app.get('/api/files/roots', (_req, res) => {
   res.json(getRepoConfig().roots);
+});
+
+app.get('/api/files/list', (req, res) => {
+  const root = resolveRoot(req.query.root as string | undefined);
+  const dir = (req.query.dir as string) || root;
+  if (!dir || !isAllowedPath(dir)) {
+    res.status(403).json({ error: 'Path not allowed' });
+    return;
+  }
+  if (!existsSync(dir)) {
+    res.status(404).json({ error: 'Directory not found' });
+    return;
+  }
+  try {
+    const entries = readdirSync(dir)
+      .filter((name) => !name.startsWith('.'))
+      .map((name) => {
+        const full = join(dir, name);
+        try {
+          const stat = statSync(full);
+          return { name, isDir: stat.isDirectory() };
+        } catch {
+          return { name, isDir: false };
+        }
+      })
+      .sort((a, b) => {
+        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+    res.json({ currentDir: dir, entries });
+  } catch (err: unknown) {
+    log.error('failed to read directory', {
+      dir,
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+    res.status(500).json({ error: 'Failed to read directory' });
+  }
 });
 
 app.get('/api/files', (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -325,7 +325,7 @@ app.get('/api/config', (_req, res) => {
     contextBlocks[name] = { path, sizeBytes };
   }
   const fileViewerRoots =
-    repoConfig.roots.length > 0 ? repoConfig.roots : [{ label: 'Root', path: BASE_REPO }];
+    config.roots.length > 0 ? config.roots : [{ label: 'Root', path: BASE_REPO }];
   res.json({
     repoPath: BASE_REPO,
     mcpServers: getMcpServerNames(),


### PR DESCRIPTION
## Summary
- Extracts foundation hooks and ChatArea component for reuse
- Adds desktop three-panel layout: SessionPanel (left) | Chat (center) | ContextPanel + FileBrowser (right)
- Collapsible sidebars with localStorage persistence, 768px breakpoint
- Fixes stale message bleed when switching sessions on desktop
- Adds `/api/files/list` endpoint and `fileViewerRoots` to `/api/config` for FileBrowserPanel

## Test plan
- [x] Tests pass (793/793 — includes new tests for desktop components)
- [ ] Manual: verify mobile layout unchanged below 768px
- [ ] Manual: verify desktop layout renders correctly above 768px
- [ ] Manual: verify session switching clears messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)