### PR TITLE
feat: add Read Aloud button for markdown files

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentReader.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentReader.test.ts
@@ -18,39 +18,42 @@ vi.mock('../../lib/constants', () => ({
   DEFAULT_TTS_VOICE: 'af_heart',
 }));
 
+const mockFetch = vi.fn();
+
 describe('useDocumentReader', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('starts unavailable before health check', () => {
     // Make fetch hang forever
-    global.fetch = vi.fn(() => new Promise(() => {}));
+    mockFetch.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() => useDocumentReader());
     expect(result.current.available).toBe(false);
     expect(result.current.state).toBe('idle');
   });
 
   it('becomes available after successful health check', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: true } }),
     });
 
     const { result } = renderHook(() => useDocumentReader());
-    // Flush the health check promise
     await act(async () => {});
 
     expect(result.current.available).toBe(true);
   });
 
   it('stays unavailable when TTS model is not ready', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: false } }),
     });
@@ -62,7 +65,7 @@ describe('useDocumentReader', () => {
   });
 
   it('stays unavailable when health check fails', async () => {
-    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    mockFetch.mockRejectedValue(new Error('network'));
 
     const { result } = renderHook(() => useDocumentReader());
     await act(async () => {});
@@ -72,7 +75,7 @@ describe('useDocumentReader', () => {
 
   it('calls synthesizeDocument and playAudio on read()', async () => {
     const { synthesizeDocument, playAudio } = await import('../../lib/tts');
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: 'ready' }),
     });
@@ -95,7 +98,7 @@ describe('useDocumentReader', () => {
   });
 
   it('stops playback on stop()', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: 'ready' }),
     });

--- a/frontend/src/hooks/__tests__/useDocumentReader.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentReader.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDocumentReader } from '../useDocumentReader';
+
+// Mock tts module
+const mockPlayHandle = { play: vi.fn().mockResolvedValue(undefined), stop: vi.fn() };
+vi.mock('../../lib/tts', () => ({
+  synthesizeDocument: vi.fn().mockResolvedValue(new Blob(['audio'])),
+  playAudio: vi.fn(() => mockPlayHandle),
+  unlockAudioContext: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock constants
+vi.mock('../../lib/constants', () => ({
+  YAPPER_URL: 'http://test-yapper',
+  YAPPER_HEALTH_POLL_MS: 30000,
+  DEFAULT_TTS_VOICE: 'af_heart',
+}));
+
+describe('useDocumentReader', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts unavailable before health check', () => {
+    // Make fetch hang forever
+    global.fetch = vi.fn(() => new Promise(() => {}));
+    const { result } = renderHook(() => useDocumentReader());
+    expect(result.current.available).toBe(false);
+    expect(result.current.state).toBe('idle');
+  });
+
+  it('becomes available after successful health check', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: true } }),
+    });
+
+    const { result } = renderHook(() => useDocumentReader());
+    // Flush the health check promise
+    await act(async () => {});
+
+    expect(result.current.available).toBe(true);
+  });
+
+  it('stays unavailable when TTS model is not ready', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: false } }),
+    });
+
+    const { result } = renderHook(() => useDocumentReader());
+    await act(async () => {});
+
+    expect(result.current.available).toBe(false);
+  });
+
+  it('stays unavailable when health check fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() => useDocumentReader());
+    await act(async () => {});
+
+    expect(result.current.available).toBe(false);
+  });
+
+  it('calls synthesizeDocument and playAudio on read()', async () => {
+    const { synthesizeDocument, playAudio } = await import('../../lib/tts');
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ready' }),
+    });
+
+    const { result } = renderHook(() => useDocumentReader());
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.read('# Hello\n\nWorld');
+    });
+
+    expect(synthesizeDocument).toHaveBeenCalledWith(
+      '# Hello\n\nWorld',
+      'af_heart',
+      'http://test-yapper',
+      expect.any(AbortSignal),
+    );
+    expect(playAudio).toHaveBeenCalled();
+    expect(mockPlayHandle.play).toHaveBeenCalled();
+  });
+
+  it('stops playback on stop()', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ready' }),
+    });
+
+    const { result } = renderHook(() => useDocumentReader());
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.read('Hello');
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(mockPlayHandle.stop).toHaveBeenCalled();
+    expect(result.current.state).toBe('idle');
+  });
+});

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { YAPPER_URL, YAPPER_HEALTH_POLL_MS, DEFAULT_TTS_VOICE } from '../lib/constants';
+import {
+  YAPPER_URL,
+  YAPPER_HEALTH_POLL_MS,
+  DEFAULT_TTS_VOICE,
+  DOCUMENT_READ_MAX_CHARS,
+} from '../lib/constants';
 import { synthesizeDocument, playAudio, unlockAudioContext } from '../lib/tts';
 
 export type ReaderState = 'idle' | 'loading' | 'playing';
@@ -67,7 +72,11 @@ export function useDocumentReader(): DocumentReader {
       (async () => {
         try {
           await unlockAudioContext();
-          const blob = await synthesizeDocument(content, DEFAULT_TTS_VOICE, YAPPER_URL, abort.signal);
+          const trimmed =
+            content.length > DOCUMENT_READ_MAX_CHARS
+              ? content.slice(0, DOCUMENT_READ_MAX_CHARS)
+              : content;
+          const blob = await synthesizeDocument(trimmed, DEFAULT_TTS_VOICE, YAPPER_URL, abort.signal);
           if (abort.signal.aborted) return;
 
           const handle = playAudio(blob);

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -93,7 +93,8 @@ export function useDocumentReader(): DocumentReader {
             setState('idle');
             playRef.current = null;
           }
-        } catch {
+        } catch (err) {
+          console.warn('Document read-aloud failed:', err);
           if (!abort.signal.aborted) {
             setState('idle');
           }

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -76,7 +76,12 @@ export function useDocumentReader(): DocumentReader {
             content.length > DOCUMENT_READ_MAX_CHARS
               ? content.slice(0, DOCUMENT_READ_MAX_CHARS)
               : content;
-          const blob = await synthesizeDocument(trimmed, DEFAULT_TTS_VOICE, YAPPER_URL, abort.signal);
+          const blob = await synthesizeDocument(
+            trimmed,
+            DEFAULT_TTS_VOICE,
+            YAPPER_URL,
+            abort.signal,
+          );
           if (abort.signal.aborted) return;
 
           const handle = playAudio(blob);

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -88,7 +88,7 @@ export function useDocumentReader(): DocumentReader {
             setState('idle');
             playRef.current = null;
           }
-        } catch (err) {
+        } catch {
           if (!abort.signal.aborted) {
             setState('idle');
           }

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { YAPPER_URL, YAPPER_HEALTH_POLL_MS, DEFAULT_TTS_VOICE } from '../lib/constants';
+import { synthesizeDocument, playAudio, unlockAudioContext } from '../lib/tts';
+
+export type ReaderState = 'idle' | 'loading' | 'playing';
+
+export interface DocumentReader {
+  available: boolean;
+  state: ReaderState;
+  read: (content: string) => void;
+  stop: () => void;
+}
+
+/**
+ * Lightweight hook for document read-aloud in the file viewer.
+ * Checks Yapper TTS availability and manages document playback lifecycle.
+ */
+export function useDocumentReader(): DocumentReader {
+  const [available, setAvailable] = useState(false);
+  const [state, setState] = useState<ReaderState>('idle');
+  const abortRef = useRef<AbortController | null>(null);
+  const playRef = useRef<{ stop: () => void } | null>(null);
+
+  // Health poll — reuses same pattern as useVoice
+  useEffect(() => {
+    let mounted = true;
+    async function check() {
+      try {
+        const res = await fetch(`${YAPPER_URL}/health`);
+        if (!res.ok) {
+          if (mounted) setAvailable(false);
+          return;
+        }
+        const data = await res.json();
+        const ready = data.status === 'ready' || data.status === 'ok';
+        const tts = data.models ? data.models.tts === true : ready;
+        if (mounted) setAvailable(ready && tts);
+      } catch {
+        if (mounted) setAvailable(false);
+      }
+    }
+    check();
+    const timer = setInterval(check, YAPPER_HEALTH_POLL_MS);
+    return () => {
+      mounted = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    playRef.current?.stop();
+    playRef.current = null;
+    setState('idle');
+  }, []);
+
+  const read = useCallback(
+    (content: string) => {
+      // Stop any in-progress playback
+      stop();
+
+      const abort = new AbortController();
+      abortRef.current = abort;
+      setState('loading');
+
+      (async () => {
+        try {
+          await unlockAudioContext();
+          const blob = await synthesizeDocument(content, DEFAULT_TTS_VOICE, YAPPER_URL, abort.signal);
+          if (abort.signal.aborted) return;
+
+          const handle = playAudio(blob);
+          playRef.current = handle;
+          setState('playing');
+          await handle.play();
+          // Playback finished naturally
+          if (!abort.signal.aborted) {
+            setState('idle');
+            playRef.current = null;
+          }
+        } catch (err) {
+          if (!abort.signal.aborted) {
+            setState('idle');
+          }
+        }
+      })();
+    },
+    [stop],
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+      playRef.current?.stop();
+    };
+  }, []);
+
+  return { available, state, read, stop };
+}

--- a/frontend/src/lib/__tests__/tts.test.ts
+++ b/frontend/src/lib/__tests__/tts.test.ts
@@ -4,6 +4,7 @@ import {
   stripCodeForTts,
   truncateForTts,
   synthesize,
+  synthesizeDocument,
   getOrCreateAudioContext,
   closeAudioContext,
   playAudio,
@@ -197,6 +198,56 @@ describe('synthesize', () => {
 
     await expect(synthesize('hello', 'af_heart', 'http://localhost:8700')).rejects.toThrow(
       'Synthesis failed (500)',
+    );
+  });
+});
+
+// --- synthesizeDocument ---
+
+describe('synthesizeDocument', () => {
+  it('returns a Blob on successful fetch', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/wav' });
+    mockFetch.mockResolvedValueOnce({ ok: true, blob: () => Promise.resolve(blob) });
+
+    const result = await synthesizeDocument('# Hello', 'af_heart', 'http://localhost:8700');
+
+    expect(result).toBe(blob);
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+
+    await expect(
+      synthesizeDocument('# Hello', 'af_heart', 'http://localhost:8700'),
+    ).rejects.toThrow('Document synthesis failed (503)');
+  });
+
+  it('sends correct URL, method, headers, and body', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/wav' });
+    mockFetch.mockResolvedValueOnce({ ok: true, blob: () => Promise.resolve(blob) });
+
+    await synthesizeDocument('some content', 'af_heart', 'http://localhost:8700');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8700/v1/synthesize/document',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: 'some content', voice: 'af_heart' }),
+      }),
+    );
+  });
+
+  it('passes AbortSignal when provided', async () => {
+    const blob = new Blob(['audio'], { type: 'audio/wav' });
+    mockFetch.mockResolvedValueOnce({ ok: true, blob: () => Promise.resolve(blob) });
+    const controller = new AbortController();
+
+    await synthesizeDocument('doc', 'af_heart', 'http://localhost:8700', controller.signal);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8700/v1/synthesize/document',
+      expect.objectContaining({ signal: controller.signal }),
     );
   });
 });

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -28,3 +28,4 @@ export const TTS_MAX_SPEAK_CHARS = 2000;
 export const TTS_ENABLED_KEY = 'mitzo-tts-enabled';
 export const TTS_VOICE_KEY = 'mitzo-tts-voice';
 export const DEFAULT_TTS_VOICE = 'af_heart';
+export const DOCUMENT_READ_MAX_CHARS = 50_000;

--- a/frontend/src/lib/tts.ts
+++ b/frontend/src/lib/tts.ts
@@ -91,6 +91,27 @@ export async function synthesize(
   return res.blob();
 }
 
+/** Synthesize a markdown/text document via Yapper's document endpoint. */
+export async function synthesizeDocument(
+  content: string,
+  voice: string,
+  url: string,
+  signal?: AbortSignal,
+): Promise<Blob> {
+  const res = await fetch(`${url}/v1/synthesize/document`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content, voice }),
+    signal,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Document synthesis failed (${res.status})`);
+  }
+
+  return res.blob();
+}
+
 // --- AudioContext singleton ---
 
 let audioCtx: AudioContext | null = null;

--- a/frontend/src/pages/FileViewer.tsx
+++ b/frontend/src/pages/FileViewer.tsx
@@ -53,7 +53,11 @@ export function FileViewer() {
             }}
             disabled={reader.state === 'loading'}
           >
-            {reader.state === 'loading' ? 'Loading...' : reader.state === 'playing' ? 'Stop' : 'Read'}
+            {reader.state === 'loading'
+              ? 'Loading...'
+              : reader.state === 'playing'
+                ? 'Stop'
+                : 'Read'}
           </button>
         )}
         {state.isViewing && isMarkdown && !editor.editing && (

--- a/frontend/src/pages/FileViewer.tsx
+++ b/frontend/src/pages/FileViewer.tsx
@@ -4,6 +4,7 @@ import remarkGfm from 'remark-gfm';
 import { MitzoLogo } from '../components/MitzoLogo';
 import { useFileNavigation } from '../hooks/useFileNavigation';
 import { useFileEditor } from '../hooks/useFileEditor';
+import { useDocumentReader } from '../hooks/useDocumentReader';
 
 export function FileViewer() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -11,6 +12,7 @@ export function FileViewer() {
   const { state } = nav;
 
   const editor = useFileEditor(state.content, state.filePath, nav.setError);
+  const reader = useDocumentReader();
 
   const isMarkdown = ['.md', '.mdx'].includes(state.ext);
   const fileName = state.filePath.split('/').pop() || '';
@@ -39,6 +41,21 @@ export function FileViewer() {
 
         {displayBranch && <span className="viewer-header-branch">{displayBranch}</span>}
 
+        {state.isViewing && isMarkdown && !editor.editing && reader.available && (
+          <button
+            className={`viewer-header-action${reader.state !== 'idle' ? ' viewer-header-action--active' : ''}`}
+            onClick={() => {
+              if (reader.state !== 'idle') {
+                reader.stop();
+              } else {
+                reader.read(state.content);
+              }
+            }}
+            disabled={reader.state === 'loading'}
+          >
+            {reader.state === 'loading' ? 'Loading...' : reader.state === 'playing' ? 'Stop' : 'Read'}
+          </button>
+        )}
         {state.isViewing && isMarkdown && !editor.editing && (
           <button className="viewer-header-action" onClick={editor.startEditing}>
             Edit

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2528,6 +2528,11 @@ textarea:focus {
   border: 1px solid var(--border);
 }
 
+.viewer-header-action--active {
+  background: var(--accent-hover);
+  box-shadow: 0 0 0 2px rgba(108, 99, 255, 0.35);
+}
+
 .viewer-root-bar {
   display: flex;
   gap: 0.35rem;


### PR DESCRIPTION
## Summary
- When Yapper TTS is available, markdown files in the file viewer show a "Read" button
- Sends document content to Yapper's new `/v1/synthesize/document` endpoint for audio playback
- New `useDocumentReader` hook handles health polling, synthesis, and playback lifecycle
- Button shows Loading.../Stop states; auto-returns to "Read" when playback finishes

## Dependencies
- Requires dimakis/yapper feat/document-synth branch (new `/v1/synthesize/document` endpoint)

## Test plan
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] 606 tests pass (`npm test`)
- [ ] With Yapper running: open a `.md` file in file viewer, "Read" button appears
- [ ] Click "Read" → shows "Loading..." → plays audio → returns to "Read"
- [ ] Click "Stop" during playback → stops immediately
- [ ] Without Yapper: no "Read" button visible
- [ ] Button does not appear during edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)