### PR TITLE
feat(calendar): add release milestone filter toggle

### DIFF
--- a/frontend/src/pages/CalendarView.tsx
+++ b/frontend/src/pages/CalendarView.tsx
@@ -40,12 +40,14 @@ function getToday(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+const DEFAULT_VIEW_DAYS = 7;
+
 export function CalendarView() {
   const navigate = useNavigate();
   const [baseDate, setBaseDate] = useState(getToday);
-  const [viewDays, setViewDays] = useState(7);
+  const [viewDays, setViewDays] = useState(DEFAULT_VIEW_DAYS);
   const [filterMode, setFilterMode] = useState<'all' | 'releases'>('all');
-  const [savedViewDays, setSavedViewDays] = useState(7);
+  const [savedViewDays, setSavedViewDays] = useState(DEFAULT_VIEW_DAYS);
 
   const { loading, events, sprints } = useCalendarData(baseDate, viewDays);
 
@@ -78,12 +80,14 @@ export function CalendarView() {
 
   const dates = useMemo(() => Array.from(eventsByDate.keys()).sort(), [eventsByDate]);
 
+  const navStep = filterMode === 'releases' ? 30 : viewDays;
+
   function handlePrev() {
-    setBaseDate(addDays(baseDate, -viewDays));
+    setBaseDate(addDays(baseDate, -navStep));
   }
 
   function handleNext() {
-    setBaseDate(addDays(baseDate, viewDays));
+    setBaseDate(addDays(baseDate, navStep));
   }
 
   function handleToday() {
@@ -132,12 +136,14 @@ export function CalendarView() {
         <div className="cal-view-toggle">
           <button
             className={`cal-view-btn${viewDays === 1 ? ' cal-view-btn--active' : ''}`}
+            disabled={filterMode === 'releases'}
             onClick={() => setViewDays(1)}
           >
             Day
           </button>
           <button
             className={`cal-view-btn${viewDays === 7 ? ' cal-view-btn--active' : ''}`}
+            disabled={filterMode === 'releases'}
             onClick={() => setViewDays(7)}
           >
             Week

--- a/frontend/src/pages/CalendarView.tsx
+++ b/frontend/src/pages/CalendarView.tsx
@@ -44,8 +44,18 @@ export function CalendarView() {
   const navigate = useNavigate();
   const [baseDate, setBaseDate] = useState(getToday);
   const [viewDays, setViewDays] = useState(7);
+  const [filterMode, setFilterMode] = useState<'all' | 'releases'>('all');
+  const [savedViewDays, setSavedViewDays] = useState(7);
 
   const { loading, events, sprints } = useCalendarData(baseDate, viewDays);
+
+  // Filter events based on filter mode
+  const filteredEvents = useMemo(() => {
+    if (filterMode === 'releases') {
+      return events.filter((e) => e.type === 'milestone');
+    }
+    return events;
+  }, [events, filterMode]);
 
   // Group events by date
   const eventsByDate = useMemo(() => {
@@ -54,7 +64,7 @@ export function CalendarView() {
       const d = addDays(baseDate, i);
       map.set(d, []);
     }
-    for (const evt of events) {
+    for (const evt of filteredEvents) {
       const d = toLocalDate(evt.start);
       const existing = map.get(d);
       if (existing) {
@@ -64,7 +74,7 @@ export function CalendarView() {
       }
     }
     return map;
-  }, [events, baseDate, viewDays]);
+  }, [filteredEvents, baseDate, viewDays]);
 
   const dates = useMemo(() => Array.from(eventsByDate.keys()).sort(), [eventsByDate]);
 
@@ -78,6 +88,19 @@ export function CalendarView() {
 
   function handleToday() {
     setBaseDate(getToday());
+  }
+
+  function handleFilterAll() {
+    setFilterMode('all');
+    setViewDays(savedViewDays);
+  }
+
+  function handleFilterReleases() {
+    if (filterMode !== 'releases') {
+      setSavedViewDays(viewDays);
+    }
+    setFilterMode('releases');
+    setViewDays(90);
   }
 
   const startLabel = new Date(baseDate + 'T12:00:00').toLocaleDateString([], {
@@ -118,6 +141,20 @@ export function CalendarView() {
             onClick={() => setViewDays(7)}
           >
             Week
+          </button>
+        </div>
+        <div className="cal-filter-toggle cal-view-toggle">
+          <button
+            className={`cal-view-btn${filterMode === 'all' ? ' cal-view-btn--active' : ''}`}
+            onClick={handleFilterAll}
+          >
+            All
+          </button>
+          <button
+            className={`cal-view-btn${filterMode === 'releases' ? ' cal-view-btn--active' : ''}`}
+            onClick={handleFilterReleases}
+          >
+            Releases
           </button>
         </div>
       </header>

--- a/frontend/src/pages/__tests__/CalendarView.test.tsx
+++ b/frontend/src/pages/__tests__/CalendarView.test.tsx
@@ -287,4 +287,169 @@ describe('CalendarView', () => {
     expect(detail!.textContent).toContain('24 of our features');
     expect(detail!.textContent).toContain('66 total');
   });
+
+  it('renders filter toggle with All and Releases buttons', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const filterToggle = container.querySelector('.cal-filter-toggle');
+    expect(filterToggle).not.toBeNull();
+
+    const buttons = filterToggle!.querySelectorAll('.cal-view-btn');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].textContent).toBe('All');
+    expect(buttons[1].textContent).toBe('Releases');
+
+    // All should be active by default
+    expect(buttons[0].classList.contains('cal-view-btn--active')).toBe(true);
+    expect(buttons[1].classList.contains('cal-view-btn--active')).toBe(false);
+  });
+
+  it('hides meeting events when Releases filter is active', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Both meeting and milestone should be visible initially
+    expect(container.querySelectorAll('.cal-event-meeting').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelectorAll('.cal-event-milestone').length).toBeGreaterThanOrEqual(1);
+
+    // Click Releases button
+    const releasesBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Releases',
+    ) as HTMLButtonElement;
+    expect(releasesBtn).not.toBeNull();
+
+    act(() => {
+      releasesBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Meeting events should be hidden
+    expect(container.querySelectorAll('.cal-event-meeting').length).toBe(0);
+    // Milestone events should still be visible
+    expect(container.querySelectorAll('.cal-event-milestone').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('switches to 90-day view when Releases filter is selected', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Click Releases button
+    const releasesBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Releases',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      releasesBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Should have fetched with days=90
+    const calls = vi.mocked(fetch).mock.calls.map((c) => c[0]);
+    expect(calls.some((url) => (url as string).includes('days=90'))).toBe(true);
+  });
+
+  it('restores previous view days when switching back to All', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Switch to Releases
+    const releasesBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Releases',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      releasesBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Switch back to All
+    const allBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'All',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      allBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Should restore to 7 days (the last fetch should have days=7)
+    const calls = vi.mocked(fetch).mock.calls.map((c) => c[0] as string);
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall).toContain('days=7');
+  });
+
+  it('still shows sprint bars when Releases filter is active', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Click Releases button
+    const releasesBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Releases',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      releasesBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Sprint bar should still be visible
+    const sprint = container.querySelector('.cal-sprint');
+    expect(sprint).not.toBeNull();
+    expect(sprint!.textContent).toContain('Sprint 2026-08');
+  });
+
+  it('disables Day/Week toggle when in Releases mode', async () => {
+    renderCalendar();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Click Releases button
+    const releasesBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Releases',
+    ) as HTMLButtonElement;
+
+    act(() => {
+      releasesBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Releases button should be active
+    expect(releasesBtn.classList.contains('cal-view-btn--active')).toBe(true);
+  });
 });

--- a/frontend/src/pages/__tests__/CalendarView.test.tsx
+++ b/frontend/src/pages/__tests__/CalendarView.test.tsx
@@ -449,7 +449,30 @@ describe('CalendarView', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    // Releases button should be active
-    expect(releasesBtn.classList.contains('cal-view-btn--active')).toBe(true);
+    // Day and Week buttons should be disabled
+    const dayBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Day',
+    ) as HTMLButtonElement;
+    const weekBtn = Array.from(container.querySelectorAll('.cal-view-btn')).find(
+      (b) => b.textContent === 'Week',
+    ) as HTMLButtonElement;
+
+    expect(dayBtn.disabled).toBe(true);
+    expect(weekBtn.disabled).toBe(true);
+
+    // Record fetch count before clicking disabled buttons
+    const fetchCountBefore = vi.mocked(fetch).mock.calls.length;
+
+    // Clicking them should not change viewDays (no new fetch with different days)
+    act(() => {
+      dayBtn.click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Fetch count should not increase (disabled buttons don't fire onClick)
+    expect(vi.mocked(fetch).mock.calls.length).toBe(fetchCountBefore);
   });
 });

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -79,6 +79,10 @@
   padding: 2px;
 }
 
+.cal-filter-toggle {
+  margin-left: 4px;
+}
+
 .cal-view-btn {
   background: none;
   border: none;

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -98,6 +98,11 @@
   color: #fff;
 }
 
+.cal-view-btn:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 /* Sprint bar */
 
 .cal-sprints {


### PR DESCRIPTION
## Summary
- Add All/Releases toggle to calendar header, visually consistent with existing Day/Week toggle
- When "Releases" is selected, meeting events are hidden and only milestones are shown, with the view extended to 90 days
- Sprint bars remain visible in both modes; switching back to "All" restores the previous Day/Week setting

## Test plan
- [x] 6 new tests added covering: toggle rendering, event filtering, 90-day view switch, view restoration, sprint persistence, active state
- [x] All 28 CalendarView tests pass
- [x] Full test suite passes (pre-existing failures in useDocumentReader are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)