### PR TITLE
feat(skills): add /person bundled skill

### DIFF
--- a/server/__tests__/bundled-skills.test.ts
+++ b/server/__tests__/bundled-skills.test.ts
@@ -35,9 +35,10 @@ describe('bundled skills', () => {
     }
   });
 
-  it('analysis-only bundled skills do not include Write or Edit in allowed-tools', () => {
-    const analysisOnly = skills.filter((s) => s.name !== 'person');
-    for (const skill of analysisOnly) {
+  it('non-mutating bundled skills do not include Write or Edit in allowed-tools', () => {
+    const nonMutating = skills.filter((s) => !s.mutating);
+    expect(nonMutating.length).toBeGreaterThan(0);
+    for (const skill of nonMutating) {
       if (skill.allowedTools) {
         expect(skill.allowedTools).not.toContain('Write');
         expect(skill.allowedTools).not.toContain('Edit');
@@ -45,11 +46,24 @@ describe('bundled skills', () => {
     }
   });
 
-  it('analysis bundled skills contain an approval gate instruction', () => {
-    // Analysis skills must include BOTH "present" AND "before making changes"
+  it('mutating skills declare the flag in frontmatter and have write access', () => {
+    const mutating = skills.filter((s) => s.mutating);
+    expect(mutating.length).toBeGreaterThan(0);
+    for (const skill of mutating) {
+      const hasWriteAccess =
+        skill.allowedTools?.includes('Edit') || skill.allowedTools?.includes('Write');
+      expect(
+        hasWriteAccess,
+        `Mutating skill "${skill.name}" should have Edit or Write in allowed-tools`,
+      ).toBe(true);
+    }
+  });
+
+  it('non-mutating bundled skills contain an approval gate instruction', () => {
+    // Non-mutating skills must include BOTH "present" AND "before making changes"
     // so users always see findings before any modifications happen.
-    const analysisSkills = skills.filter((s) => s.name !== 'person');
-    for (const skill of analysisSkills) {
+    const nonMutating = skills.filter((s) => !s.mutating);
+    for (const skill of nonMutating) {
       const body = registry.getBody(skill.name)!;
       expect(body).toBeDefined();
       const lower = body.toLowerCase();

--- a/server/__tests__/bundled-skills.test.ts
+++ b/server/__tests__/bundled-skills.test.ts
@@ -12,9 +12,9 @@ describe('bundled skills', () => {
   const registry = new SkillRegistry({ bundledDir: SKILLS_DIR });
   const skills = registry.list();
 
-  it('discovers all four bundled skills', () => {
+  it('discovers all five bundled skills', () => {
     const names = skills.map((s) => s.name).sort();
-    expect(names).toEqual(['pr-review', 'review-response', 'risk-scan', 'simplify']);
+    expect(names).toEqual(['person', 'pr-review', 'review-response', 'risk-scan', 'simplify']);
   });
 
   it('has unique names', () => {
@@ -35,8 +35,9 @@ describe('bundled skills', () => {
     }
   });
 
-  it('no bundled skill includes Write or Edit in allowed-tools', () => {
-    for (const skill of skills) {
+  it('analysis-only bundled skills do not include Write or Edit in allowed-tools', () => {
+    const analysisOnly = skills.filter((s) => s.name !== 'person');
+    for (const skill of analysisOnly) {
       if (skill.allowedTools) {
         expect(skill.allowedTools).not.toContain('Write');
         expect(skill.allowedTools).not.toContain('Edit');
@@ -44,10 +45,11 @@ describe('bundled skills', () => {
     }
   });
 
-  it('each bundled skill body contains an approval gate instruction', () => {
-    // All bundled skills must include BOTH "present" AND "before making changes"
+  it('analysis bundled skills contain an approval gate instruction', () => {
+    // Analysis skills must include BOTH "present" AND "before making changes"
     // so users always see findings before any modifications happen.
-    for (const skill of skills) {
+    const analysisSkills = skills.filter((s) => s.name !== 'person');
+    for (const skill of analysisSkills) {
       const body = registry.getBody(skill.name)!;
       expect(body).toBeDefined();
       const lower = body.toLowerCase();
@@ -99,6 +101,25 @@ describe('bundled skills', () => {
     // But not Write/Edit — analysis first
     expect(prReview!.allowedTools).not.toContain('Write');
     expect(prReview!.allowedTools).not.toContain('Edit');
+  });
+
+  it('/person includes Read, Edit, Glob, and Grep in allowed-tools', () => {
+    const person = skills.find((s) => s.name === 'person');
+    expect(person).toBeDefined();
+    expect(person!.allowedTools).toBeDefined();
+    expect(person!.allowedTools).toContain('Read');
+    expect(person!.allowedTools).toContain('Edit');
+    expect(person!.allowedTools).toContain('Glob');
+    expect(person!.allowedTools).toContain('Grep');
+    expect(person!.allowedTools).not.toContain('Bash');
+    expect(person!.allowedTools).not.toContain('Write');
+  });
+
+  it('/person body references people profile path and $ARGUMENTS', () => {
+    const body = registry.getBody('person')!;
+    expect(body).toBeDefined();
+    expect(body).toContain('$ARGUMENTS');
+    expect(body).toContain('command_center/context/people');
   });
 
   it('all bundled skills are scoped as bundled', () => {

--- a/server/skills.ts
+++ b/server/skills.ts
@@ -13,6 +13,8 @@ export interface SkillMetadata {
   description: string;
   scope: SkillScope;
   allowedTools?: string[];
+  /** Skill intentionally needs write access (Edit/Write in allowed-tools). */
+  mutating?: boolean;
   collisions?: Array<{ scope: SkillScope; description: string }>;
   /** Absolute path to the SKILL.md file — internal use only */
   filePath: string;
@@ -31,6 +33,7 @@ interface SkillRegistryOptions {
 interface ParsedSkill {
   description: string;
   allowedTools?: string[];
+  mutating?: boolean;
   body: string;
   filePath: string;
 }
@@ -92,7 +95,7 @@ function parseFrontmatter(raw: string): { meta: Record<string, unknown>; body: s
     meta[currentKey] = currentList;
   }
 
-  const KNOWN_KEYS = new Set(['description', 'allowed-tools']);
+  const KNOWN_KEYS = new Set(['description', 'allowed-tools', 'mutating']);
   for (const key of Object.keys(meta)) {
     if (!KNOWN_KEYS.has(key)) {
       log.warn(`Unknown frontmatter key "${key}" — check for typos`);
@@ -168,9 +171,12 @@ function discoverScope(dir: string): Map<string, ParsedSkill> {
       ? (meta['allowed-tools'] as unknown[]).filter((t): t is string => typeof t === 'string')
       : undefined;
 
+    const mutating = meta['mutating'] === 'true' ? true : undefined;
+
     skills.set(entry, {
       description: meta.description,
       allowedTools,
+      mutating,
       body,
       filePath,
     });
@@ -228,6 +234,7 @@ export class SkillRegistry {
             description: parsed.description,
             scope,
             allowedTools: parsed.allowedTools,
+            mutating: parsed.mutating,
             filePath: parsed.filePath,
           });
           // Store body for lazy loading

--- a/skills/person/SKILL.md
+++ b/skills/person/SKILL.md
@@ -33,9 +33,11 @@ Read and display the matching profile file. Show the full content (frontmatter a
 Check `$ARGUMENTS` for update instructions:
 
 - **If `--note <text>` is present:** Append a new line to the "Notes" section of the profile:
+
   ```
   - [YYYY-MM-DD] <text>
   ```
+
   Use today's date. If no "Notes" section exists, create one at the end of the file with a `## Notes` header.
 
 - **If additional text is provided after the person's name (without `--note`):** Append the text as a new bullet point under the "Open Threads" section. If no "Open Threads" section exists, create one before "Notes" (or at the end if no Notes section).

--- a/skills/person/SKILL.md
+++ b/skills/person/SKILL.md
@@ -1,5 +1,6 @@
 ---
 description: View and update people profiles
+mutating: true
 allowed-tools:
   - Read
   - Edit

--- a/skills/person/SKILL.md
+++ b/skills/person/SKILL.md
@@ -1,0 +1,46 @@
+---
+description: View and update people profiles
+allowed-tools:
+  - Read
+  - Edit
+  - Glob
+  - Grep
+---
+
+Look up and optionally update a person's profile stored under `command_center/context/people/` in the repo.
+
+## Instructions
+
+The user provides a person's name or email prefix via `$ARGUMENTS`. Follow these steps:
+
+### 1. Find the profile
+
+Use Glob to search for matching files:
+
+```
+command_center/context/people/*$ARGUMENTS*.md
+```
+
+If no exact match, use Grep to search file contents for the name or email prefix across all `command_center/context/people/*.md` files. If multiple matches are found, list them and ask the user to clarify.
+
+### 2. Display the profile
+
+Read and display the matching profile file. Show the full content (frontmatter and body) so the user can see all available context.
+
+### 3. Handle updates (if requested)
+
+Check `$ARGUMENTS` for update instructions:
+
+- **If `--note <text>` is present:** Append a new line to the "Notes" section of the profile:
+  ```
+  - [YYYY-MM-DD] <text>
+  ```
+  Use today's date. If no "Notes" section exists, create one at the end of the file with a `## Notes` header.
+
+- **If additional text is provided after the person's name (without `--note`):** Append the text as a new bullet point under the "Open Threads" section. If no "Open Threads" section exists, create one before "Notes" (or at the end if no Notes section).
+
+Use the Edit tool to make any updates. After editing, read and display the updated file to confirm the change.
+
+### 4. Confirm
+
+If an update was made, show a brief confirmation of what was added and where.


### PR DESCRIPTION
## Summary
- Adds a new `/person` bundled skill for viewing and updating people profiles in `command_center/context/people/`
- Supports name/email prefix lookup, `--note` flag for dated notes, and inline text for open threads
- Updates bundled-skills tests to account for the new skill (5 skills total), adjusting analysis-only constraints to exclude `/person` which needs Edit access

## Test plan
- [x] New tests for `/person` skill discovery, allowed-tools, and body content
- [x] Existing bundled-skills tests updated and passing
- [x] Full test suite passes (pre-existing useDocumentReader failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)