### PR TITLE
fix(tests): fix useDocumentReader test failures

### DIFF
--- a/frontend/src/hooks/__tests__/useDocumentReader.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentReader.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../lib/constants', () => ({
   YAPPER_URL: 'http://test-yapper',
   YAPPER_HEALTH_POLL_MS: 30000,
   DEFAULT_TTS_VOICE: 'af_heart',
+  DOCUMENT_READ_MAX_CHARS: 50_000,
 }));
 
 const mockFetch = vi.fn();
@@ -98,6 +99,9 @@ describe('useDocumentReader', () => {
   });
 
   it('stops playback on stop()', async () => {
+    // Make play() hang so state stays 'playing' until stop() is called
+    mockPlayHandle.play.mockReturnValue(new Promise(() => {}));
+
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: 'ready' }),
@@ -106,9 +110,14 @@ describe('useDocumentReader', () => {
     const { result } = renderHook(() => useDocumentReader());
     await act(async () => {});
 
-    await act(async () => {
+    act(() => {
       result.current.read('Hello');
     });
+
+    // Flush async pipeline up to playAudio()
+    await act(async () => {});
+
+    expect(result.current.state).toBe('playing');
 
     act(() => {
       result.current.stop();
@@ -116,5 +125,8 @@ describe('useDocumentReader', () => {
 
     expect(mockPlayHandle.stop).toHaveBeenCalled();
     expect(result.current.state).toBe('idle');
+
+    // Restore default mock for other tests
+    mockPlayHandle.play.mockResolvedValue(undefined);
   });
 });


### PR DESCRIPTION
## Summary
- Add missing `DOCUMENT_READ_MAX_CHARS` to constants mock (caused import error, broke `read()` test)
- Make `play()` return a hanging promise in stop test so state stays `'playing'` until `stop()` is called (mock was resolving instantly, racing past the playing state)

Both tests were pre-existing failures from PR #166.

## Test plan
- [x] All 6 useDocumentReader tests pass
- [x] No other test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)