### PR TITLE
feat(todo): hierarchical sub-tasks with create, expand/collapse UI

### DIFF
--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -1,11 +1,13 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import type { TodoItem } from '../types/todo';
 
 interface TodoCardProps {
   item: TodoItem;
+  depth?: number;
   onAck: (id: string) => void;
   onDone: (id: string) => void;
   onTap: (item: TodoItem) => void;
+  onAddChild: (parentId: string) => void;
 }
 
 function urgencyBar(urgency: number): string {
@@ -30,13 +32,14 @@ function sourceIcon(type: string): string {
   }
 }
 
-export function TodoCard({ item, onAck, onDone, onTap }: TodoCardProps) {
+export function TodoCard({ item, depth = 0, onAck, onDone, onTap, onAddChild }: TodoCardProps) {
   const ref = useRef<HTMLDivElement>(null);
   const startX = useRef(0);
   const currentX = useRef(0);
   const swiping = useRef(false);
   const tapped = useRef(false);
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -97,33 +100,82 @@ export function TodoCard({ item, onAck, onDone, onTap }: TodoCardProps) {
   const source = item.sources[0];
   const ageLabel = item.ageDays === 0 ? 'new' : `${item.ageDays}d`;
   const statusIcon = item.status === 'active' ? '\u25CF' : '\u25D0';
+  const children = item.children ?? [];
+  const hasChildren = children.length > 0;
 
   return (
-    <div className="todo-card-wrapper">
-      <div className="todo-card-actions-bg">
-        <span className="todo-action-label todo-action-ack">Seen</span>
-        <span className="todo-action-label todo-action-done">Done</span>
-      </div>
-      <div
-        ref={ref}
-        className="todo-card"
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-      >
-        <div className="todo-card-header">
-          <span className="todo-card-status">{statusIcon}</span>
-          <span className="todo-card-urgency">{urgencyBar(item.urgency)}</span>
-          {source && <span className="todo-card-source">{sourceIcon(source.type)}</span>}
-          <span className="todo-card-age">{ageLabel}</span>
+    <div className={`todo-card-tree-node ${depth > 0 ? 'todo-card-tree-node--child' : ''}`}>
+      <div className="todo-card-wrapper">
+        <div className="todo-card-actions-bg">
+          <span className="todo-action-label todo-action-ack">Seen</span>
+          <span className="todo-action-label todo-action-done">Done</span>
         </div>
-        <div className="todo-card-summary">{item.summary}</div>
-        {source && (
-          <div className="todo-card-meta">
-            <span className="todo-card-author">{source.author}</span>
+        <div
+          ref={ref}
+          className="todo-card"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className="todo-card-header">
+            {hasChildren && (
+              <button
+                className="todo-card-expand"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setExpanded(!expanded);
+                }}
+              >
+                {expanded ? '\u25BC' : '\u25B6'}
+              </button>
+            )}
+            <span className="todo-card-status">{statusIcon}</span>
+            <span className="todo-card-urgency">{urgencyBar(item.urgency)}</span>
+            {source ? (
+              <span className="todo-card-source">{sourceIcon(source.type)}</span>
+            ) : (
+              <span className="todo-card-source todo-card-source--manual">+</span>
+            )}
+            <span className="todo-card-age">{ageLabel}</span>
+            {hasChildren && (
+              <span className="todo-card-progress">
+                {item.completedChildCount ?? 0}/{item.childCount ?? children.length}
+              </span>
+            )}
           </div>
-        )}
+          <div className="todo-card-summary">{item.summary}</div>
+          {source && (
+            <div className="todo-card-meta">
+              <span className="todo-card-author">{source.author}</span>
+            </div>
+          )}
+          <button
+            className="todo-card-add-child"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddChild(item.id);
+            }}
+          >
+            + sub-task
+          </button>
+        </div>
       </div>
+
+      {hasChildren && expanded && (
+        <div className="todo-card-children">
+          {children.map((child) => (
+            <TodoCard
+              key={child.id}
+              item={child}
+              depth={depth + 1}
+              onAck={onAck}
+              onDone={onDone}
+              onTap={onTap}
+              onAddChild={onAddChild}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/TodoCard.test.tsx
+++ b/frontend/src/components/__tests__/TodoCard.test.tsx
@@ -38,13 +38,27 @@ const mockItem: TodoItem = {
 
 describe('TodoCard', () => {
   it('renders item summary', () => {
-    render(<TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
+    render(
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
     expect(screen.getByText('[dimakis/mitzo#1] Fix bug')).toBeTruthy();
   });
 
   it('renders source badge and age', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     expect(container.querySelector('.todo-card-source')?.textContent).toBe('GH');
     expect(container.querySelector('.todo-card-age')?.textContent).toBe('3d');
@@ -52,7 +66,13 @@ describe('TodoCard', () => {
 
   it('renders author', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     expect(container.querySelector('.todo-card-author')?.textContent).toBe('dimakis');
   });
@@ -60,7 +80,13 @@ describe('TodoCard', () => {
   it('calls onTap on tap (touchstart + touchend without move)', () => {
     const onTap = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={onTap} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={onTap}
+        onAddChild={vi.fn()}
+      />,
     );
     const card = container.querySelector('.todo-card')!;
     fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
@@ -70,13 +96,29 @@ describe('TodoCard', () => {
 
   it('shows new label for 0 day age', () => {
     const newItem = { ...mockItem, ageDays: 0 };
-    render(<TodoCard item={newItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
+    render(
+      <TodoCard
+        item={newItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
     expect(screen.getByText('new')).toBeTruthy();
   });
 
   it('shows acknowledged icon for acknowledged status', () => {
     const ackItem = { ...mockItem, status: 'acknowledged' as const };
-    render(<TodoCard item={ackItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
+    render(
+      <TodoCard
+        item={ackItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
     // ◐ character for acknowledged
     expect(screen.getByText('\u25D0')).toBeTruthy();
   });
@@ -85,7 +127,13 @@ describe('TodoCard', () => {
     vi.useFakeTimers();
     const onAck = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={onAck} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={onAck}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     const card = container.querySelector('.todo-card')!;
 
@@ -102,7 +150,13 @@ describe('TodoCard', () => {
     vi.useFakeTimers();
     const onDone = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={onDone} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={onDone}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     const card = container.querySelector('.todo-card')!;
 
@@ -119,7 +173,13 @@ describe('TodoCard', () => {
     const onAck = vi.fn();
     const onDone = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={onAck} onDone={onDone} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={onAck}
+        onDone={onDone}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     const card = container.querySelector('.todo-card')!;
 
@@ -134,7 +194,13 @@ describe('TodoCard', () => {
 
   it('does not show expand button when no children', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
     expect(container.querySelector('.todo-card-expand')).toBeNull();
   });
@@ -157,7 +223,13 @@ describe('TodoCard', () => {
     };
 
     const { container } = render(
-      <TodoCard item={parentItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={parentItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
 
     const expandBtn = container.querySelector('.todo-card-expand')!;
@@ -187,7 +259,13 @@ describe('TodoCard', () => {
     };
 
     const { container } = render(
-      <TodoCard item={parentItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={parentItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
 
     const progress = container.querySelector('.todo-card-progress');
@@ -197,7 +275,13 @@ describe('TodoCard', () => {
   it('calls onAddChild when sub-task button is clicked', () => {
     const onAddChild = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={onAddChild} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={onAddChild}
+      />,
     );
 
     const addBtn = container.querySelector('.todo-card-add-child')!;
@@ -207,7 +291,14 @@ describe('TodoCard', () => {
 
   it('applies depth indentation via tree node class', () => {
     const { container } = render(
-      <TodoCard item={mockItem} depth={1} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        depth={1}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
 
     const treeNode = container.querySelector('.todo-card-tree-node');
@@ -216,7 +307,13 @@ describe('TodoCard', () => {
 
   it('does not apply child class at depth 0', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+      <TodoCard
+        item={mockItem}
+        onAck={vi.fn()}
+        onDone={vi.fn()}
+        onTap={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
     );
 
     const treeNode = container.querySelector('.todo-card-tree-node');

--- a/frontend/src/components/__tests__/TodoCard.test.tsx
+++ b/frontend/src/components/__tests__/TodoCard.test.tsx
@@ -131,4 +131,95 @@ describe('TodoCard', () => {
     expect(onDone).not.toHaveBeenCalled();
     expect((card as HTMLElement).style.transform).toBe('translateX(0)');
   });
+
+  it('does not show expand button when no children', () => {
+    const { container } = render(
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+    );
+    expect(container.querySelector('.todo-card-expand')).toBeNull();
+  });
+
+  it('shows expand button and toggles children', () => {
+    const childItem: TodoItem = {
+      ...mockItem,
+      id: 'child-1',
+      summary: 'Child task',
+      parentId: 'abc123',
+      children: [],
+      childCount: 0,
+      completedChildCount: 0,
+    };
+    const parentItem: TodoItem = {
+      ...mockItem,
+      children: [childItem],
+      childCount: 1,
+      completedChildCount: 0,
+    };
+
+    const { container } = render(
+      <TodoCard item={parentItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+    );
+
+    const expandBtn = container.querySelector('.todo-card-expand')!;
+    expect(expandBtn).toBeTruthy();
+    expect(expandBtn.textContent).toBe('\u25B6'); // collapsed
+
+    // Children not visible yet
+    expect(container.querySelector('.todo-card-children')).toBeNull();
+
+    // Expand
+    fireEvent.click(expandBtn);
+    expect(expandBtn.textContent).toBe('\u25BC'); // expanded
+    expect(container.querySelector('.todo-card-children')).toBeTruthy();
+    expect(screen.getByText('Child task')).toBeTruthy();
+
+    // Collapse
+    fireEvent.click(expandBtn);
+    expect(container.querySelector('.todo-card-children')).toBeNull();
+  });
+
+  it('shows progress counter for parent items', () => {
+    const parentItem: TodoItem = {
+      ...mockItem,
+      children: [{ ...mockItem, id: 'c1' }],
+      childCount: 3,
+      completedChildCount: 1,
+    };
+
+    const { container } = render(
+      <TodoCard item={parentItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+    );
+
+    const progress = container.querySelector('.todo-card-progress');
+    expect(progress?.textContent).toBe('1/3');
+  });
+
+  it('calls onAddChild when sub-task button is clicked', () => {
+    const onAddChild = vi.fn();
+    const { container } = render(
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={onAddChild} />,
+    );
+
+    const addBtn = container.querySelector('.todo-card-add-child')!;
+    fireEvent.click(addBtn);
+    expect(onAddChild).toHaveBeenCalledWith('abc123');
+  });
+
+  it('applies depth indentation via tree node class', () => {
+    const { container } = render(
+      <TodoCard item={mockItem} depth={1} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+    );
+
+    const treeNode = container.querySelector('.todo-card-tree-node');
+    expect(treeNode?.classList.contains('todo-card-tree-node--child')).toBe(true);
+  });
+
+  it('does not apply child class at depth 0', () => {
+    const { container } = render(
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
+    );
+
+    const treeNode = container.querySelector('.todo-card-tree-node');
+    expect(treeNode?.classList.contains('todo-card-tree-node--child')).toBe(false);
+  });
 });

--- a/frontend/src/components/__tests__/TodoCard.test.tsx
+++ b/frontend/src/components/__tests__/TodoCard.test.tsx
@@ -11,6 +11,10 @@ const mockItem: TodoItem = {
   urgency: 0.5,
   status: 'active',
   ageDays: 3,
+  parentId: null,
+  children: [],
+  childCount: 0,
+  completedChildCount: 0,
   sources: [
     {
       type: 'github',
@@ -34,13 +38,13 @@ const mockItem: TodoItem = {
 
 describe('TodoCard', () => {
   it('renders item summary', () => {
-    render(<TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} />);
+    render(<TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
     expect(screen.getByText('[dimakis/mitzo#1] Fix bug')).toBeTruthy();
   });
 
   it('renders source badge and age', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} />,
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
     );
     expect(container.querySelector('.todo-card-source')?.textContent).toBe('GH');
     expect(container.querySelector('.todo-card-age')?.textContent).toBe('3d');
@@ -48,7 +52,7 @@ describe('TodoCard', () => {
 
   it('renders author', () => {
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} />,
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
     );
     expect(container.querySelector('.todo-card-author')?.textContent).toBe('dimakis');
   });
@@ -56,7 +60,7 @@ describe('TodoCard', () => {
   it('calls onTap on tap (touchstart + touchend without move)', () => {
     const onTap = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={onTap} />,
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={vi.fn()} onTap={onTap} onAddChild={vi.fn()} />,
     );
     const card = container.querySelector('.todo-card')!;
     fireEvent.touchStart(card, { touches: [{ clientX: 100 }] });
@@ -66,13 +70,13 @@ describe('TodoCard', () => {
 
   it('shows new label for 0 day age', () => {
     const newItem = { ...mockItem, ageDays: 0 };
-    render(<TodoCard item={newItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} />);
+    render(<TodoCard item={newItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
     expect(screen.getByText('new')).toBeTruthy();
   });
 
   it('shows acknowledged icon for acknowledged status', () => {
     const ackItem = { ...mockItem, status: 'acknowledged' as const };
-    render(<TodoCard item={ackItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} />);
+    render(<TodoCard item={ackItem} onAck={vi.fn()} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />);
     // ◐ character for acknowledged
     expect(screen.getByText('\u25D0')).toBeTruthy();
   });
@@ -81,7 +85,7 @@ describe('TodoCard', () => {
     vi.useFakeTimers();
     const onAck = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={onAck} onDone={vi.fn()} onTap={vi.fn()} />,
+      <TodoCard item={mockItem} onAck={onAck} onDone={vi.fn()} onTap={vi.fn()} onAddChild={vi.fn()} />,
     );
     const card = container.querySelector('.todo-card')!;
 
@@ -98,7 +102,7 @@ describe('TodoCard', () => {
     vi.useFakeTimers();
     const onDone = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={vi.fn()} onDone={onDone} onTap={vi.fn()} />,
+      <TodoCard item={mockItem} onAck={vi.fn()} onDone={onDone} onTap={vi.fn()} onAddChild={vi.fn()} />,
     );
     const card = container.querySelector('.todo-card')!;
 
@@ -115,7 +119,7 @@ describe('TodoCard', () => {
     const onAck = vi.fn();
     const onDone = vi.fn();
     const { container } = render(
-      <TodoCard item={mockItem} onAck={onAck} onDone={onDone} onTap={vi.fn()} />,
+      <TodoCard item={mockItem} onAck={onAck} onDone={onDone} onTap={vi.fn()} onAddChild={vi.fn()} />,
     );
     const card = container.querySelector('.todo-card')!;
 

--- a/frontend/src/hooks/__tests__/useTodoData.test.ts
+++ b/frontend/src/hooks/__tests__/useTodoData.test.ts
@@ -170,4 +170,62 @@ describe('useTodoData', () => {
     // Item should still be in the list since action failed
     expect(result.current.items).toHaveLength(1);
   });
+
+  it('create posts to /api/todos and triggers refresh', async () => {
+    const { result } = renderHook(() => useTodoData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    } as Response);
+
+    await act(async () => {
+      await result.current.create('New task', 'work');
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ summary: 'New task', profile: 'work' }),
+    });
+  });
+
+  it('create passes parentId when provided', async () => {
+    const { result } = renderHook(() => useTodoData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    } as Response);
+
+    await act(async () => {
+      await result.current.create('Sub task', 'work', 'parent-123');
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ summary: 'Sub task', profile: 'work', parentId: 'parent-123' }),
+    });
+  });
+
+  it('create handles network error gracefully', async () => {
+    const { result } = renderHook(() => useTodoData());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+    await act(async () => {
+      await result.current.create('New task', 'work');
+    });
+
+    // Should not throw — items unchanged
+    expect(result.current.items).toHaveLength(1);
+  });
 });

--- a/frontend/src/hooks/useTodoData.ts
+++ b/frontend/src/hooks/useTodoData.ts
@@ -15,11 +15,15 @@ export interface UseTodoDataResult {
 function removeFromTree(items: TodoItem[], id: string): TodoItem[] {
   return items
     .filter((item) => item.id !== id)
-    .map((item) => ({
-      ...item,
-      children: removeFromTree(item.children, id),
-      childCount: item.children.filter((c) => c.id !== id).length,
-    }));
+    .map((item) => {
+      const updatedChildren = removeFromTree(item.children, id);
+      return {
+        ...item,
+        children: updatedChildren,
+        childCount: updatedChildren.length,
+        completedChildCount: updatedChildren.filter((c) => c.status === 'completed').length,
+      };
+    });
 }
 
 export function useTodoData(profile?: string): UseTodoDataResult {

--- a/frontend/src/hooks/useTodoData.ts
+++ b/frontend/src/hooks/useTodoData.ts
@@ -8,7 +8,18 @@ export interface UseTodoDataResult {
   ack: (id: string) => Promise<void>;
   snooze: (id: string, days?: number) => Promise<void>;
   done: (id: string) => Promise<void>;
+  create: (summary: string, profile: string, parentId?: string) => Promise<void>;
   refresh: () => void;
+}
+
+function removeFromTree(items: TodoItem[], id: string): TodoItem[] {
+  return items
+    .filter((item) => item.id !== id)
+    .map((item) => ({
+      ...item,
+      children: removeFromTree(item.children, id),
+      childCount: item.children.filter((c) => c.id !== id).length,
+    }));
 }
 
 export function useTodoData(profile?: string): UseTodoDataResult {
@@ -57,10 +68,7 @@ export function useTodoData(profile?: string): UseTodoDataResult {
       });
 
       if (res.ok) {
-        // Optimistically remove from list
-        setData((prev) =>
-          prev ? { ...prev, items: prev.items.filter((item) => item.id !== id) } : prev,
-        );
+        setData((prev) => (prev ? { ...prev, items: removeFromTree(prev.items, id) } : prev));
       }
     } catch {
       // Network error — leave item in list
@@ -75,6 +83,27 @@ export function useTodoData(profile?: string): UseTodoDataResult {
   const done = useCallback((id: string) => performAction(id, 'done'), [performAction]);
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
 
+  const create = useCallback(
+    async (summary: string, profileName: string, parentId?: string) => {
+      const body: Record<string, string> = { summary, profile: profileName };
+      if (parentId) body.parentId = parentId;
+
+      try {
+        const res = await fetch('/api/todos', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (res.ok) {
+          refresh();
+        }
+      } catch {
+        // Network error
+      }
+    },
+    [refresh],
+  );
+
   return {
     loading,
     items: data?.items ?? [],
@@ -82,6 +111,7 @@ export function useTodoData(profile?: string): UseTodoDataResult {
     ack,
     snooze,
     done,
+    create,
     refresh,
   };
 }

--- a/frontend/src/pages/TodoView.tsx
+++ b/frontend/src/pages/TodoView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TodoCard } from '../components/TodoCard';
 import { useTodoData } from '../hooks/useTodoData';
@@ -35,10 +35,78 @@ function buildPrompt(item: TodoItem): string {
   return lines.join('\n');
 }
 
+function TodoCreateForm({
+  parentId,
+  profile,
+  profiles,
+  onCreate,
+  onCancel,
+}: {
+  parentId?: string;
+  profile?: string;
+  profiles: string[];
+  onCreate: (summary: string, profile: string, parentId?: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [summary, setSummary] = useState('');
+  const [selectedProfile, setSelectedProfile] = useState(profile || profiles[0] || '');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const text = summary.trim();
+    if (!text || !selectedProfile) return;
+    await onCreate(text, selectedProfile, parentId);
+    setSummary('');
+    onCancel();
+  }
+
+  return (
+    <form className="todo-create-form" onSubmit={handleSubmit}>
+      <input
+        ref={inputRef}
+        className="todo-create-input"
+        value={summary}
+        onChange={(e) => setSummary(e.target.value)}
+        placeholder={parentId ? 'Add sub-task...' : 'Add todo...'}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      {!profile && profiles.length > 1 && (
+        <select
+          className="todo-create-profile"
+          value={selectedProfile}
+          onChange={(e) => setSelectedProfile(e.target.value)}
+        >
+          {profiles.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      )}
+      <div className="todo-create-actions">
+        <button type="submit" className="todo-create-submit" disabled={!summary.trim()}>
+          Add
+        </button>
+        <button type="button" className="todo-create-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
 export function TodoView() {
   const navigate = useNavigate();
   const [activeProfile, setActiveProfile] = useState<string | undefined>(undefined);
-  const { loading, items, profiles, ack, done, refresh } = useTodoData(activeProfile);
+  const { loading, items, profiles, ack, done, create, refresh } = useTodoData(activeProfile);
+  const [creating, setCreating] = useState<{ parentId?: string } | null>(null);
 
   function handleTap(item: TodoItem) {
     const prompt = buildPrompt(item);
@@ -48,6 +116,10 @@ export function TodoView() {
     navigate(`/chat?${params.toString()}`);
   }
 
+  function handleAddChild(parentId: string) {
+    setCreating({ parentId });
+  }
+
   return (
     <div className="todo-page">
       <header className="todo-header">
@@ -55,6 +127,13 @@ export function TodoView() {
           &lsaquo;
         </button>
         <h1>Todos {items.length > 0 && <span className="todo-count">{items.length}</span>}</h1>
+        <button
+          className="todo-add-btn"
+          onClick={() => setCreating({ parentId: undefined })}
+          title="Add todo"
+        >
+          +
+        </button>
         <button className="todo-refresh" onClick={refresh}>
           &#x21bb;
         </button>
@@ -80,6 +159,16 @@ export function TodoView() {
         </div>
       )}
 
+      {creating && (
+        <TodoCreateForm
+          parentId={creating.parentId}
+          profile={activeProfile}
+          profiles={profiles}
+          onCreate={create}
+          onCancel={() => setCreating(null)}
+        />
+      )}
+
       {loading && <p className="todo-empty">Loading...</p>}
 
       {!loading && items.length === 0 && (
@@ -98,7 +187,14 @@ export function TodoView() {
 
       <div className="todo-list">
         {items.map((item) => (
-          <TodoCard key={item.id} item={item} onAck={ack} onDone={done} onTap={handleTap} />
+          <TodoCard
+            key={item.id}
+            item={item}
+            onAck={ack}
+            onDone={done}
+            onTap={handleTap}
+            onAddChild={handleAddChild}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/pages/__tests__/TodoView.test.tsx
+++ b/frontend/src/pages/__tests__/TodoView.test.tsx
@@ -27,6 +27,7 @@ describe('TodoView', () => {
       profiles: [],
       ack: vi.fn(),
       done: vi.fn(),
+      create: vi.fn(),
       refresh: vi.fn(),
     });
 
@@ -46,6 +47,7 @@ describe('TodoView', () => {
       profiles: ['work'],
       ack: vi.fn(),
       done: vi.fn(),
+      create: vi.fn(),
       refresh: vi.fn(),
     });
 
@@ -69,6 +71,10 @@ describe('TodoView', () => {
           urgency: 0.5,
           status: 'active',
           ageDays: 2,
+          parentId: null,
+          children: [],
+          childCount: 0,
+          completedChildCount: 0,
           sources: [
             { type: 'github', url: 'https://example.com', title: 'Fix', author: 'me', snippet: '' },
           ],
@@ -87,6 +93,7 @@ describe('TodoView', () => {
       profiles: ['centaur', 'work'],
       ack: vi.fn(),
       done: vi.fn(),
+      create: vi.fn(),
       refresh: vi.fn(),
     });
 
@@ -109,6 +116,7 @@ describe('TodoView', () => {
       profiles: ['centaur', 'work'],
       ack: vi.fn(),
       done: vi.fn(),
+      create: vi.fn(),
       refresh: vi.fn(),
     });
 
@@ -132,6 +140,7 @@ describe('TodoView', () => {
       profiles: [],
       ack: vi.fn(),
       done: vi.fn(),
+      create: vi.fn(),
       refresh: vi.fn(),
     });
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2945,12 +2945,13 @@ textarea:focus {
   border-radius: 10px;
   cursor: pointer;
   margin-top: 4px;
-  opacity: 0;
+  opacity: 0.4;
   transition: opacity 0.15s;
 }
 
 .todo-card:hover .todo-card-add-child,
-.todo-card:active .todo-card-add-child {
+.todo-card:active .todo-card-add-child,
+.todo-card-add-child:active {
   opacity: 1;
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2897,3 +2897,141 @@ textarea:focus {
 .todo-card-author {
   color: var(--text-dim);
 }
+
+/* --- Hierarchical todo tree --- */
+
+.todo-card-tree-node--child {
+  margin-left: 20px;
+  border-left: 2px solid var(--border);
+  padding-left: 8px;
+}
+
+.todo-card-expand {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 0.65rem;
+  padding: 2px 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.todo-card-progress {
+  font-size: 0.65rem;
+  color: var(--accent);
+  margin-left: auto;
+  font-weight: 600;
+}
+
+.todo-card-source--manual {
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 50%;
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: bold;
+}
+
+.todo-card-add-child {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.65rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  margin-top: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.todo-card:hover .todo-card-add-child,
+.todo-card:active .todo-card-add-child {
+  opacity: 1;
+}
+
+.todo-card-children {
+  margin-top: 4px;
+}
+
+/* --- Add button in header --- */
+
+.todo-add-btn {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 1.2rem;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+/* --- Create form --- */
+
+.todo-create-form {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.todo-create-input {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 0.85rem;
+  width: 100%;
+}
+
+.todo-create-profile {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 10px;
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.todo-create-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.todo-create-submit {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: 8px;
+  padding: 6px 16px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.todo-create-submit:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.todo-create-cancel {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  border-radius: 8px;
+  padding: 6px 16px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}

--- a/frontend/src/types/todo.ts
+++ b/frontend/src/types/todo.ts
@@ -24,6 +24,10 @@ export interface TodoItem {
   urgency: number;
   status: 'active' | 'acknowledged' | 'snoozed' | 'completed';
   ageDays: number;
+  parentId: string | null;
+  children: TodoItem[];
+  childCount: number;
+  completedChildCount: number;
   sources: TodoSource[];
   contextHints: TodoContextHints;
 }

--- a/server/__tests__/todos.test.ts
+++ b/server/__tests__/todos.test.ts
@@ -121,4 +121,57 @@ describe('todo routes', () => {
     expect(res.status).toBe(500);
     expect(res.body.ok).toBe(false);
   });
+
+  it('POST /api/todos — unauthenticated returns 401', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ summary: 'Test task', profile: 'work' });
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/todos — missing summary returns 400', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ profile: 'work' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('POST /api/todos — missing profile returns 400', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ summary: 'Test task' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('POST /api/todos — empty summary returns 400', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ summary: '', profile: 'work' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('POST /api/todos — valid body returns error when script not found', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ summary: 'New task', profile: 'work' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('POST /api/todos — accepts optional parentId', async () => {
+    const res = await request(app)
+      .post('/api/todos')
+      .send({ summary: 'Sub task', profile: 'work', parentId: 'parent-123' })
+      .set('Cookie', authCookie);
+    // Script won't exist in test env, but validates input is accepted
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
 });

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -67,20 +67,32 @@ const TodoContextHintsSchema = z.object({
   taskHint: z.string().optional().default(''),
 });
 
-const TodoItemSchema = z.object({
-  id: z.string(),
-  summary: z.string(),
-  profile: z.string(),
-  urgency: z.number(),
-  status: z.enum(['active', 'acknowledged', 'snoozed', 'completed']),
-  ageDays: z.number(),
-  sources: z.array(TodoSourceSchema),
-  contextHints: TodoContextHintsSchema,
-});
+const TodoItemSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.object({
+    id: z.string(),
+    summary: z.string(),
+    profile: z.string(),
+    urgency: z.number(),
+    status: z.enum(['active', 'acknowledged', 'snoozed', 'completed']),
+    ageDays: z.number(),
+    parentId: z.string().nullable().optional().default(null),
+    children: z.array(TodoItemSchema).optional().default([]),
+    childCount: z.number().optional().default(0),
+    completedChildCount: z.number().optional().default(0),
+    sources: z.array(TodoSourceSchema),
+    contextHints: TodoContextHintsSchema,
+  }),
+);
 
 export const TodoListResponse = z.object({
   profiles: z.array(z.string()),
   items: z.array(TodoItemSchema),
+});
+
+export const TodoCreateBody = z.object({
+  summary: z.string().min(1).max(500),
+  profile: z.string().min(1).max(100),
+  parentId: z.string().optional(),
 });
 
 export const TodoActionBody = z.object({

--- a/server/app.ts
+++ b/server/app.ts
@@ -773,6 +773,45 @@ app.get('/api/todos', async (req, res) => {
   }
 });
 
+app.post('/api/todos', async (req, res) => {
+  const { summary, profile, parentId } = req.body as {
+    summary?: string;
+    profile?: string;
+    parentId?: string;
+  };
+
+  if (!summary || !profile) {
+    res.status(400).json({ ok: false, error: 'summary and profile are required' });
+    return;
+  }
+
+  if (!existsSync(TODO_SCRIPT)) {
+    res.status(500).json({ ok: false, error: 'Todo script not found' });
+    return;
+  }
+
+  try {
+    const args = [TODO_SCRIPT, '--create', summary, '--profile', profile];
+    if (parentId) {
+      args.push('--parent', parentId);
+    }
+
+    const { stdout } = await execFileAsync('python3', args, {
+      timeout: TODO_TIMEOUT_MS,
+    });
+    const parsed = JSON.parse(stdout);
+    if (!parsed.ok) {
+      res.status(400).json(parsed);
+      return;
+    }
+    res.status(201).json(parsed);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    log.warn('todo create failed', { error: message });
+    res.status(500).json({ ok: false, error: message });
+  }
+});
+
 app.post('/api/todos/:id/action', async (req, res) => {
   const { id } = req.params;
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -35,6 +35,7 @@ import {
   PermissionDecision,
   CalendarResponse,
   TodoListResponse,
+  TodoCreateBody,
   TodoActionBody,
   TodoActionResponse,
 } from './api-schemas.js';
@@ -774,16 +775,12 @@ app.get('/api/todos', async (req, res) => {
 });
 
 app.post('/api/todos', async (req, res) => {
-  const { summary, profile, parentId } = req.body as {
-    summary?: string;
-    profile?: string;
-    parentId?: string;
-  };
-
-  if (!summary || !profile) {
-    res.status(400).json({ ok: false, error: 'summary and profile are required' });
+  const body = TodoCreateBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ ok: false, error: body.error.issues[0]?.message ?? 'Invalid input' });
     return;
   }
+  const { summary, profile, parentId } = body.data;
 
   if (!existsSync(TODO_SCRIPT)) {
     res.status(500).json({ ok: false, error: 'Todo script not found' });


### PR DESCRIPTION
## Summary
- Adds parent-child relationship support to TodoCard with expand/collapse
- New "create sub-task" and "create item" flows in TodoView
- Server endpoint for manual item creation with optional parent_id
- Progress indicators showing completed/total child counts

## Test plan
- [ ] Create a manual todo item via the UI
- [ ] Create a sub-task under an existing item
- [ ] Expand/collapse parent items
- [ ] Verify child progress counts display correctly
- [x] Existing TodoCard and TodoView tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)