### PR TITLE
feat(desktop): WIP tab bar for desktop view

### DIFF
--- a/frontend/src/components/FileTab.tsx
+++ b/frontend/src/components/FileTab.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface FileTabProps {
+  filePath: string;
+}
+
+export function FileTab({ filePath }: FileTabProps) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setContent(null);
+    setError(false);
+    fetch(`/api/files/read?path=${encodeURIComponent(filePath)}`, { credentials: 'include' })
+      .then((r) => {
+        if (!r.ok) throw new Error('fetch failed');
+        return r.json();
+      })
+      .then((data: { content: string }) => setContent(data.content))
+      .catch(() => setError(true));
+  }, [filePath]);
+
+  if (error) {
+    return <div className="file-tab-error">Failed to load file</div>;
+  }
+
+  if (content === null) {
+    return <div className="file-tab-loading">Loading...</div>;
+  }
+
+  const isMarkdown = /\.mdx?$/i.test(filePath);
+
+  return (
+    <div className="file-tab">
+      <div className="file-tab-path">{filePath}</div>
+      {isMarkdown ? (
+        <div className="file-tab-content viewer-markdown">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        </div>
+      ) : (
+        <pre className="file-tab-content file-tab-code">{content}</pre>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -14,27 +14,29 @@ export function TabBar({ tabs, activeTabId, onActivate, onClose, chatTabId }: Ta
   return (
     <div className="tab-bar">
       {tabs.map((tab) => (
-        <button
+        <div
           key={tab.id}
           className={`tab-bar-item${tab.id === activeTabId ? ' tab-bar-item--active' : ''}`}
           onClick={() => onActivate(tab.id)}
           title={tab.type === 'file' ? tab.filePath : tab.label}
+          role="tab"
+          aria-selected={tab.id === activeTabId}
         >
           <span className="tab-bar-icon">{tab.type === 'file' ? '\u2630' : '\u2726'}</span>
           <span className="tab-bar-label">{tab.label}</span>
           {tab.id !== chatTabId && (
-            <span
+            <button
               className="tab-bar-close"
-              role="button"
+              aria-label="Close tab"
               onClick={(e) => {
                 e.stopPropagation();
                 onClose(tab.id);
               }}
             >
               &times;
-            </span>
+            </button>
           )}
-        </button>
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,0 +1,41 @@
+import type { Tab } from '../hooks/useDesktopTabs';
+
+interface TabBarProps {
+  tabs: Tab[];
+  activeTabId: string;
+  onActivate: (tabId: string) => void;
+  onClose: (tabId: string) => void;
+  chatTabId: string;
+}
+
+export function TabBar({ tabs, activeTabId, onActivate, onClose, chatTabId }: TabBarProps) {
+  if (tabs.length <= 1) return null;
+
+  return (
+    <div className="tab-bar">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          className={`tab-bar-item${tab.id === activeTabId ? ' tab-bar-item--active' : ''}`}
+          onClick={() => onActivate(tab.id)}
+          title={tab.type === 'file' ? tab.filePath : tab.label}
+        >
+          <span className="tab-bar-icon">{tab.type === 'file' ? '\u2630' : '\u2726'}</span>
+          <span className="tab-bar-label">{tab.label}</span>
+          {tab.id !== chatTabId && (
+            <span
+              className="tab-bar-close"
+              role="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose(tab.id);
+              }}
+            >
+              &times;
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/FileTab.test.tsx
+++ b/frontend/src/components/__tests__/FileTab.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { FileTab } from '../FileTab';
+
+afterEach(() => cleanup());
+
+// Mock react-markdown — renders children as plain text
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock('remark-gfm', () => ({ default: () => {} }));
+
+function mockFetchSuccess(content: string) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ content }),
+  });
+}
+
+function mockFetchError() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    json: () => Promise.reject(new Error('fail')),
+  });
+}
+
+describe('FileTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    // Fetch that never resolves
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<FileTab filePath="/src/index.ts" />);
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+
+  it('shows error state on fetch failure', async () => {
+    mockFetchError();
+    render(<FileTab filePath="/src/index.ts" />);
+    await waitFor(() => expect(screen.getByText('Failed to load file')).toBeTruthy());
+  });
+
+  it('renders markdown for .md files', async () => {
+    mockFetchSuccess('# Hello');
+    render(<FileTab filePath="/docs/readme.md" />);
+    await waitFor(() => expect(screen.getByTestId('markdown')).toBeTruthy());
+    expect(screen.getByText('# Hello')).toBeTruthy();
+  });
+
+  it('renders markdown for .mdx files', async () => {
+    mockFetchSuccess('## MDX content');
+    render(<FileTab filePath="/docs/page.mdx" />);
+    await waitFor(() => expect(screen.getByTestId('markdown')).toBeTruthy());
+  });
+
+  it('renders plain pre for non-markdown files', async () => {
+    mockFetchSuccess('const x = 1;');
+    const { container } = render(<FileTab filePath="/src/index.ts" />);
+    await waitFor(() => expect(screen.getByText('const x = 1;')).toBeTruthy());
+    expect(container.querySelector('pre.file-tab-code')).toBeTruthy();
+    expect(container.querySelector('[data-testid="markdown"]')).toBeNull();
+  });
+
+  it('re-fetches when filePath changes', async () => {
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ content: 'file1' }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ content: 'file2' }),
+    });
+    global.fetch = fetchMock;
+
+    const { rerender } = render(<FileTab filePath="/a.ts" />);
+    await waitFor(() => expect(screen.getByText('file1')).toBeTruthy());
+
+    rerender(<FileTab filePath="/b.ts" />);
+    await waitFor(() => expect(screen.getByText('file2')).toBeTruthy());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/__tests__/TabBar.test.tsx
+++ b/frontend/src/components/__tests__/TabBar.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TabBar } from '../TabBar';
+import type { Tab } from '../../hooks/useDesktopTabs';
+
+afterEach(() => cleanup());
+
+const CHAT_TAB_ID = 'chat';
+
+const chatTab: Tab = { id: CHAT_TAB_ID, type: 'chat', label: 'Chat' };
+const fileTab: Tab = {
+  id: 'file:/src/a.ts',
+  type: 'file',
+  label: 'a.ts',
+  filePath: '/src/a.ts',
+};
+
+describe('TabBar', () => {
+  it('is hidden when there is only one tab', () => {
+    const { container } = render(
+      <TabBar
+        tabs={[chatTab]}
+        activeTabId={CHAT_TAB_ID}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders all tabs', () => {
+    render(
+      <TabBar
+        tabs={[chatTab, fileTab]}
+        activeTabId={CHAT_TAB_ID}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    expect(screen.getByText('Chat')).toBeTruthy();
+    expect(screen.getByText('a.ts')).toBeTruthy();
+  });
+
+  it('applies active class to the active tab', () => {
+    const { container } = render(
+      <TabBar
+        tabs={[chatTab, fileTab]}
+        activeTabId={fileTab.id}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    const items = container.querySelectorAll('.tab-bar-item');
+    expect(items[0].classList.contains('tab-bar-item--active')).toBe(false);
+    expect(items[1].classList.contains('tab-bar-item--active')).toBe(true);
+  });
+
+  it('does not show close button on chat tab', () => {
+    const { container } = render(
+      <TabBar
+        tabs={[chatTab, fileTab]}
+        activeTabId={CHAT_TAB_ID}
+        onActivate={vi.fn()}
+        onClose={vi.fn()}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    const closeButtons = container.querySelectorAll('.tab-bar-close');
+    // Only file tab has a close button
+    expect(closeButtons).toHaveLength(1);
+  });
+
+  it('close button fires onClose with stopPropagation', () => {
+    const onClose = vi.fn();
+    const onActivate = vi.fn();
+    const { container } = render(
+      <TabBar
+        tabs={[chatTab, fileTab]}
+        activeTabId={CHAT_TAB_ID}
+        onActivate={onActivate}
+        onClose={onClose}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    const closeBtn = container.querySelector('.tab-bar-close') as HTMLElement;
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledWith(fileTab.id);
+    // The parent onActivate should not fire (stopPropagation)
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it('calls onActivate when a tab is clicked', () => {
+    const onActivate = vi.fn();
+    render(
+      <TabBar
+        tabs={[chatTab, fileTab]}
+        activeTabId={CHAT_TAB_ID}
+        onActivate={onActivate}
+        onClose={vi.fn()}
+        chatTabId={CHAT_TAB_ID}
+      />,
+    );
+    fireEvent.click(screen.getByText('a.ts'));
+    expect(onActivate).toHaveBeenCalledWith(fileTab.id);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDesktopTabs.test.ts
+++ b/frontend/src/hooks/__tests__/useDesktopTabs.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDesktopTabs } from '../useDesktopTabs';
+
+describe('useDesktopTabs', () => {
+  it('starts with only the chat tab active', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    expect(result.current.tabs).toHaveLength(1);
+    expect(result.current.tabs[0].type).toBe('chat');
+    expect(result.current.activeTabId).toBe(result.current.CHAT_TAB_ID);
+  });
+
+  it('opens a file tab and activates it', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/src/index.ts', 'index.ts'));
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe('file:/src/index.ts');
+    const fileTab = result.current.tabs[1];
+    expect(fileTab.type).toBe('file');
+    if (fileTab.type === 'file') {
+      expect(fileTab.filePath).toBe('/src/index.ts');
+    }
+  });
+
+  it('opening a duplicate file tab is idempotent (no new tab)', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/src/a.ts', 'a.ts'));
+    act(() => result.current.openFileTab('/src/a.ts', 'a.ts'));
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe('file:/src/a.ts');
+  });
+
+  it('closing the active tab activates the neighbor', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/a.ts', 'a.ts'));
+    act(() => result.current.openFileTab('/b.ts', 'b.ts'));
+    // Active is b.ts (last opened). Close it.
+    act(() => result.current.closeTab('file:/b.ts'));
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe('file:/a.ts');
+  });
+
+  it('closing a non-active tab preserves the active tab', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/a.ts', 'a.ts'));
+    act(() => result.current.openFileTab('/b.ts', 'b.ts'));
+    // Active is b.ts. Close a.ts.
+    act(() => result.current.closeTab('file:/a.ts'));
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.activeTabId).toBe('file:/b.ts');
+  });
+
+  it('chat tab cannot be closed', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/a.ts', 'a.ts'));
+    act(() => result.current.closeTab(result.current.CHAT_TAB_ID));
+    expect(result.current.tabs).toHaveLength(2);
+    expect(result.current.tabs[0].type).toBe('chat');
+  });
+
+  it('activateChatTab resets to chat', () => {
+    const { result } = renderHook(() => useDesktopTabs());
+    act(() => result.current.openFileTab('/a.ts', 'a.ts'));
+    expect(result.current.activeTabId).toBe('file:/a.ts');
+    act(() => result.current.activateChatTab());
+    expect(result.current.activeTabId).toBe(result.current.CHAT_TAB_ID);
+  });
+});

--- a/frontend/src/hooks/useDesktopTabs.ts
+++ b/frontend/src/hooks/useDesktopTabs.ts
@@ -1,57 +1,100 @@
-import { useState, useCallback } from 'react';
+import { useReducer, useCallback } from 'react';
 
 export type TabType = 'chat' | 'file';
 
-export interface Tab {
+/** Discriminated union: chat tabs have no filePath, file tabs require one. */
+export type Tab = ChatTab | FileTab;
+
+export interface ChatTab {
   id: string;
-  type: TabType;
+  type: 'chat';
   label: string;
-  /** Session ID for chat tabs */
-  sessionId?: string;
-  /** Absolute file path for file tabs */
-  filePath?: string;
+}
+
+export interface FileTab {
+  id: string;
+  type: 'file';
+  label: string;
+  filePath: string;
 }
 
 const CHAT_TAB_ID = 'chat'; // singleton chat tab
 
+interface TabState {
+  tabs: Tab[];
+  activeTabId: string;
+}
+
+type TabAction =
+  | { type: 'OPEN_FILE'; filePath: string; label: string }
+  | { type: 'CLOSE'; tabId: string }
+  | { type: 'ACTIVATE'; tabId: string }
+  | { type: 'ACTIVATE_CHAT' };
+
+function tabReducer(state: TabState, action: TabAction): TabState {
+  switch (action.type) {
+    case 'OPEN_FILE': {
+      const tabId = `file:${action.filePath}`;
+      const alreadyOpen = state.tabs.some((t) => t.id === tabId);
+      return {
+        tabs: alreadyOpen
+          ? state.tabs
+          : [
+              ...state.tabs,
+              { id: tabId, type: 'file', label: action.label, filePath: action.filePath },
+            ],
+        activeTabId: tabId,
+      };
+    }
+    case 'CLOSE': {
+      if (action.tabId === CHAT_TAB_ID) return state;
+      const idx = state.tabs.findIndex((t) => t.id === action.tabId);
+      const next = state.tabs.filter((t) => t.id !== action.tabId);
+      let { activeTabId } = state;
+      if (action.tabId === activeTabId && next.length > 0) {
+        const newIdx = Math.min(idx, next.length - 1);
+        activeTabId = next[newIdx].id;
+      }
+      return { tabs: next, activeTabId };
+    }
+    case 'ACTIVATE':
+      return { ...state, activeTabId: action.tabId };
+    case 'ACTIVATE_CHAT':
+      return { ...state, activeTabId: CHAT_TAB_ID };
+  }
+}
+
+const initialState: TabState = {
+  tabs: [{ id: CHAT_TAB_ID, type: 'chat', label: 'Chat' }],
+  activeTabId: CHAT_TAB_ID,
+};
+
 export function useDesktopTabs() {
-  const [tabs, setTabs] = useState<Tab[]>([{ id: CHAT_TAB_ID, type: 'chat', label: 'Chat' }]);
-  const [activeTabId, setActiveTabId] = useState(CHAT_TAB_ID);
+  const [state, dispatch] = useReducer(tabReducer, initialState);
 
   const openFileTab = useCallback((filePath: string, label: string) => {
-    const tabId = `file:${filePath}`;
-    setTabs((prev) => {
-      if (prev.some((t) => t.id === tabId)) return prev;
-      return [...prev, { id: tabId, type: 'file', label, filePath }];
-    });
-    setActiveTabId(tabId);
+    dispatch({ type: 'OPEN_FILE', filePath, label });
   }, []);
 
-  const closeTab = useCallback(
-    (tabId: string) => {
-      // Can't close the chat tab
-      if (tabId === CHAT_TAB_ID) return;
-      setTabs((prev) => {
-        const idx = prev.findIndex((t) => t.id === tabId);
-        const next = prev.filter((t) => t.id !== tabId);
-        // If closing the active tab, activate the neighbor
-        if (tabId === activeTabId && next.length > 0) {
-          const newIdx = Math.min(idx, next.length - 1);
-          setActiveTabId(next[newIdx].id);
-        }
-        return next;
-      });
-    },
-    [activeTabId],
-  );
+  const closeTab = useCallback((tabId: string) => {
+    dispatch({ type: 'CLOSE', tabId });
+  }, []);
 
   const activateTab = useCallback((tabId: string) => {
-    setActiveTabId(tabId);
+    dispatch({ type: 'ACTIVATE', tabId });
   }, []);
 
   const activateChatTab = useCallback(() => {
-    setActiveTabId(CHAT_TAB_ID);
+    dispatch({ type: 'ACTIVATE_CHAT' });
   }, []);
 
-  return { tabs, activeTabId, openFileTab, closeTab, activateTab, activateChatTab, CHAT_TAB_ID };
+  return {
+    tabs: state.tabs,
+    activeTabId: state.activeTabId,
+    openFileTab,
+    closeTab,
+    activateTab,
+    activateChatTab,
+    CHAT_TAB_ID,
+  };
 }

--- a/frontend/src/hooks/useDesktopTabs.ts
+++ b/frontend/src/hooks/useDesktopTabs.ts
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react';
+
+export type TabType = 'chat' | 'file';
+
+export interface Tab {
+  id: string;
+  type: TabType;
+  label: string;
+  /** Session ID for chat tabs */
+  sessionId?: string;
+  /** Absolute file path for file tabs */
+  filePath?: string;
+}
+
+const CHAT_TAB_ID = 'chat'; // singleton chat tab
+
+export function useDesktopTabs() {
+  const [tabs, setTabs] = useState<Tab[]>([{ id: CHAT_TAB_ID, type: 'chat', label: 'Chat' }]);
+  const [activeTabId, setActiveTabId] = useState(CHAT_TAB_ID);
+
+  const openFileTab = useCallback((filePath: string, label: string) => {
+    const tabId = `file:${filePath}`;
+    setTabs((prev) => {
+      if (prev.some((t) => t.id === tabId)) return prev;
+      return [...prev, { id: tabId, type: 'file', label, filePath }];
+    });
+    setActiveTabId(tabId);
+  }, []);
+
+  const closeTab = useCallback(
+    (tabId: string) => {
+      // Can't close the chat tab
+      if (tabId === CHAT_TAB_ID) return;
+      setTabs((prev) => {
+        const idx = prev.findIndex((t) => t.id === tabId);
+        const next = prev.filter((t) => t.id !== tabId);
+        // If closing the active tab, activate the neighbor
+        if (tabId === activeTabId && next.length > 0) {
+          const newIdx = Math.min(idx, next.length - 1);
+          setActiveTabId(next[newIdx].id);
+        }
+        return next;
+      });
+    },
+    [activeTabId],
+  );
+
+  const activateTab = useCallback((tabId: string) => {
+    setActiveTabId(tabId);
+  }, []);
+
+  const activateChatTab = useCallback(() => {
+    setActiveTabId(CHAT_TAB_ID);
+  }, []);
+
+  return { tabs, activeTabId, openFileTab, closeTab, activateTab, activateChatTab, CHAT_TAB_ID };
+}


### PR DESCRIPTION
## Summary

- **TabBar** component — renders tabs, supports activate/close
- **FileTab** component — fetches and renders a file with markdown support
- **useDesktopTabs** hook — state management for tab lifecycle (open, close, activate)

WIP — no tests, not wired into DesktopChatView yet. Parking this for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)