### PR TITLE
chore: add branch guard to prevent direct commits to main

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$branch" = "main" ]; then
+  echo "ERROR: Direct commits to main are not allowed. Create a feature branch first."
+  exit 1
+fi
+
 npx lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Step N: Build <component> (test-first)
 
 ## Git Workflow
 
-**Never push to main.** All work — features, fixes, docs, CI config, rule changes, typo corrections — goes through a branch and PR. No exceptions.
+**Never push to main.** All work — features, fixes, docs, CI config, rule changes, typo corrections — goes through a branch and PR. No exceptions. This is enforced by a pre-commit hook (`.husky/pre-commit`) that rejects commits on `main`.
 
 1. `git checkout -b <type>/<name>` from main
 2. Develop and commit on the branch


### PR DESCRIPTION
## Summary

- Adds branch check to `.husky/pre-commit` that rejects commits when on `main`
- All changes must go through feature branches and PRs

## Test plan

- [ ] `git checkout main && touch test && git add test && git commit -m "test"` is rejected
- [ ] Commits on feature branches work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)