### PR TITLE
feat(chat): clickable file paths in agent output

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,6 +1,8 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useNavigate, useLocation } from 'react-router-dom';
 import type { FinishedMessage } from '../types/chat';
+import { linkifyFilePaths, FILE_SCHEME } from '../lib/file-paths';
 
 interface UserBubbleProps {
   text?: string;
@@ -32,6 +34,11 @@ interface TextBubbleProps {
 }
 
 export function TextBubble({ content, streaming = false }: TextBubbleProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const processed = streaming ? content : linkifyFilePaths(content);
+  const currentPath = location.pathname + location.search;
+
   return (
     <div className={`msg-bubble msg-bubble--assistant${streaming ? ' msg-bubble--streaming' : ''}`}>
       <div className="msg-bubble-markdown">
@@ -43,9 +50,33 @@ export function TextBubble({ content, streaming = false }: TextBubbleProps) {
                 <table {...props}>{children}</table>
               </div>
             ),
+            a: ({ href, children }) => {
+              if (href?.startsWith(FILE_SCHEME)) {
+                const filePath = decodeURIComponent(href.slice(FILE_SCHEME.length));
+                return (
+                  <a
+                    href="#"
+                    className="file-path-link"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      navigate(
+                        `/files?path=${encodeURIComponent(filePath)}&from=${encodeURIComponent(currentPath)}`,
+                      );
+                    }}
+                  >
+                    {children}
+                  </a>
+                );
+              }
+              return (
+                <a href={href} target="_blank" rel="noopener noreferrer">
+                  {children}
+                </a>
+              );
+            },
           }}
         >
-          {content}
+          {processed}
         </ReactMarkdown>
       </div>
     </div>

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -100,6 +100,17 @@ describe('MessageBubble', () => {
     const html = renderToStaticMarkup(el);
 
     expect(html).toContain('file-path-link');
+
+    // Simulate click to verify navigate is called with the correct route
+    const clickEvent = { preventDefault: vi.fn() };
+    // Extract onClick from rendered component — render via createElement to get props
+    const rendered = anchor({ href: fileHref, children: '/tmp/output.md' });
+    rendered.props.onClick(clickEvent);
+
+    expect(clickEvent.preventDefault).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/files?path=${encodeURIComponent('/tmp/output.md')}&from=${encodeURIComponent('/chat/test-session')}`,
+    );
   });
 
   it('custom anchor renders normal links for non-file URLs', () => {

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 // Mock react-markdown and remark-gfm before importing the component
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedComponents: Record<string, any> | undefined;
+let capturedContent: string | undefined;
 vi.mock('react-markdown', () => ({
   default: ({
     children,
@@ -12,14 +13,22 @@ vi.mock('react-markdown', () => ({
     components?: Record<string, unknown>;
   }) => {
     capturedComponents = components;
+    capturedContent = children;
     return children;
   },
 }));
 vi.mock('remark-gfm', () => ({ default: () => {} }));
 
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/chat/test-session', search: '' }),
+}));
+
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MessageBubble, TextBubble } from '../MessageBubble';
+import { FILE_SCHEME } from '../../lib/file-paths';
 import type { FinishedMessage } from '../../types/chat';
 
 function userMessage(text: string): FinishedMessage {
@@ -60,5 +69,49 @@ describe('MessageBubble', () => {
     );
     // The raw text should contain newlines (CSS white-space: pre-wrap handles display)
     expect(html).toContain('line one\nline two\nline three');
+  });
+
+  it('linkifies file paths in assistant content', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'Created /tmp/output.md for you.' }));
+    expect(capturedContent).toContain(`[/tmp/output.md](${FILE_SCHEME}`);
+  });
+
+  it('does not linkify while streaming', () => {
+    renderToStaticMarkup(
+      createElement(TextBubble, { content: 'Created /tmp/output.md for you.', streaming: true }),
+    );
+    expect(capturedContent).not.toContain(FILE_SCHEME);
+    expect(capturedContent).toBe('Created /tmp/output.md for you.');
+  });
+
+  it('provides a custom anchor component for file-path links', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    expect(capturedComponents).toBeDefined();
+    expect(capturedComponents!.a).toBeDefined();
+  });
+
+  it('custom anchor navigates to FileViewer for file-path links', () => {
+    mockNavigate.mockClear();
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+
+    const anchor = capturedComponents!.a;
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/output.md')}`;
+    const el = createElement(anchor, { href: fileHref, children: '/tmp/output.md' });
+    const html = renderToStaticMarkup(el);
+
+    expect(html).toContain('file-path-link');
+  });
+
+  it('custom anchor renders normal links for non-file URLs', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const anchor = capturedComponents!.a;
+    const el = createElement(anchor, {
+      href: 'https://example.com',
+      children: 'Example',
+    });
+    const html = renderToStaticMarkup(el);
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('target="_blank"');
+    expect(html).not.toContain('file-path-link');
   });
 });

--- a/frontend/src/lib/__tests__/file-paths.test.ts
+++ b/frontend/src/lib/__tests__/file-paths.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { detectFilePaths, isFilePath, linkifyFilePaths, FILE_SCHEME } from '../file-paths';
+
+describe('isFilePath', () => {
+  it('recognises absolute Unix paths', () => {
+    expect(isFilePath('/Users/dsaridak/redhat/mgmt/README.md')).toBe(true);
+    expect(isFilePath('/tmp/output.json')).toBe(true);
+    expect(isFilePath('/etc/nginx/nginx.conf')).toBe(true);
+  });
+
+  it('recognises relative paths with extension', () => {
+    expect(isFilePath('./src/index.ts')).toBe(true);
+    expect(isFilePath('src/components/App.tsx')).toBe(true);
+    expect(isFilePath('../docs/guide.md')).toBe(true);
+  });
+
+  it('rejects URLs', () => {
+    expect(isFilePath('https://example.com/page')).toBe(false);
+    expect(isFilePath('http://localhost:3000')).toBe(false);
+  });
+
+  it('rejects plain words and sentences', () => {
+    expect(isFilePath('hello')).toBe(false);
+    expect(isFilePath('the quick brown fox')).toBe(false);
+    expect(isFilePath('npm install')).toBe(false);
+  });
+
+  it('rejects Unix commands that look path-like', () => {
+    expect(isFilePath('/bin/bash')).toBe(true); // this is a valid path
+  });
+
+  it('handles paths with spaces in quotes', () => {
+    expect(isFilePath('/Users/me/my project/file.ts')).toBe(true);
+  });
+
+  it('rejects root slash alone', () => {
+    expect(isFilePath('/')).toBe(false);
+  });
+
+  it('rejects paths without file-like segments', () => {
+    expect(isFilePath('/just-a-slug')).toBe(false);
+  });
+
+  it('recognises extensionless paths with multiple segments', () => {
+    expect(isFilePath('/Users/dsaridak/redhat/mgmt/scripts/build')).toBe(true);
+  });
+});
+
+describe('detectFilePaths', () => {
+  it('finds absolute paths in text', () => {
+    const text =
+      'I created the file at /Users/dsaridak/redhat/mgmt/architecture/design.md for you.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      path: '/Users/dsaridak/redhat/mgmt/architecture/design.md',
+      start: 22,
+      end: 72,
+    });
+  });
+
+  it('finds multiple paths in text', () => {
+    const text = 'See /tmp/a.md and also ./src/b.ts for details.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].path).toBe('/tmp/a.md');
+    expect(result[1].path).toBe('./src/b.ts');
+  });
+
+  it('returns empty array for text without paths', () => {
+    expect(detectFilePaths('just a normal sentence')).toEqual([]);
+  });
+
+  it('handles backtick-wrapped paths', () => {
+    const text = 'The file is at `/Users/me/project/foo.ts`.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('/Users/me/project/foo.ts');
+  });
+
+  it('does not match URLs', () => {
+    const text = 'Visit https://example.com/path/to/page for info.';
+    expect(detectFilePaths(text)).toEqual([]);
+  });
+
+  it('handles paths at end of line', () => {
+    const text = 'Output written to /tmp/result.json';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('/tmp/result.json');
+  });
+
+  it('handles relative paths starting with dot-slash', () => {
+    const text = 'Check ./architecture/decisions/001.md for context.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('./architecture/decisions/001.md');
+  });
+});
+
+describe('linkifyFilePaths', () => {
+  it('wraps absolute paths in markdown links', () => {
+    const input = 'Created /tmp/output.md for you.';
+    const result = linkifyFilePaths(input);
+    expect(result).toBe(
+      `Created [/tmp/output.md](${FILE_SCHEME}${encodeURIComponent('/tmp/output.md')}) for you.`,
+    );
+  });
+
+  it('wraps relative paths in markdown links', () => {
+    const input = 'See ./src/index.ts for details.';
+    const result = linkifyFilePaths(input);
+    expect(result).toContain(`[./src/index.ts](${FILE_SCHEME}`);
+  });
+
+  it('skips paths inside code blocks', () => {
+    const input = '```\n/tmp/output.md\n```';
+    expect(linkifyFilePaths(input)).toBe(input);
+  });
+
+  it('skips paths inside inline backticks', () => {
+    const input = 'Run `cat /tmp/output.md` to see it.';
+    expect(linkifyFilePaths(input)).toBe(input);
+  });
+
+  it('handles multiple paths on different lines', () => {
+    const input = 'File 1: /tmp/a.md\nFile 2: /tmp/b.md';
+    const result = linkifyFilePaths(input);
+    expect(result).toContain(`[/tmp/a.md]`);
+    expect(result).toContain(`[/tmp/b.md]`);
+  });
+
+  it('does not double-linkify already-linked paths', () => {
+    const input = 'See [/tmp/a.md](/files?path=/tmp/a.md) for details.';
+    const result = linkifyFilePaths(input);
+    // Should not wrap the already-linked path again
+    expect(result).not.toContain(`${FILE_SCHEME}`);
+  });
+
+  it('leaves text without paths unchanged', () => {
+    const input = 'Just a regular sentence.';
+    expect(linkifyFilePaths(input)).toBe(input);
+  });
+});

--- a/frontend/src/lib/__tests__/file-paths.test.ts
+++ b/frontend/src/lib/__tests__/file-paths.test.ts
@@ -44,6 +44,16 @@ describe('isFilePath', () => {
   it('recognises extensionless paths with multiple segments', () => {
     expect(isFilePath('/Users/dsaridak/redhat/mgmt/scripts/build')).toBe(true);
   });
+
+  it('recognises paths with @ (scoped packages)', () => {
+    expect(isFilePath('./node_modules/@anthropic-ai/sdk/index.ts')).toBe(true);
+    expect(isFilePath('/Users/me/node_modules/@scope/pkg/lib.js')).toBe(true);
+  });
+
+  it('recognises double parent traversal', () => {
+    expect(isFilePath('../../foo.ts')).toBe(true);
+    expect(isFilePath('../../configs/base.json')).toBe(true);
+  });
 });
 
 describe('detectFilePaths', () => {
@@ -88,6 +98,25 @@ describe('detectFilePaths', () => {
     const result = detectFilePaths(text);
     expect(result).toHaveLength(1);
     expect(result[0].path).toBe('/tmp/result.json');
+  });
+
+  it('finds paths with @ in scoped package names', () => {
+    const text = 'Check ./node_modules/@anthropic-ai/sdk/index.ts for the type.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('./node_modules/@anthropic-ai/sdk/index.ts');
+  });
+
+  it('finds double parent traversal paths', () => {
+    const text = 'Config is at ../../configs/base.json relative to here.';
+    const result = detectFilePaths(text);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('../../configs/base.json');
+  });
+
+  it('does not match ..foo/bar (dots without slash)', () => {
+    const text = 'Something like ..foo/bar should not match.';
+    expect(detectFilePaths(text)).toEqual([]);
   });
 
   it('handles relative paths starting with dot-slash', () => {
@@ -135,6 +164,13 @@ describe('linkifyFilePaths', () => {
     const result = linkifyFilePaths(input);
     // Should not wrap the already-linked path again
     expect(result).not.toContain(`${FILE_SCHEME}`);
+  });
+
+  it('linkifies paths outside existing markdown links on the same line', () => {
+    const input = 'See [docs](/docs) and also /tmp/output.md for details.';
+    const result = linkifyFilePaths(input);
+    expect(result).toContain(`[/tmp/output.md](${FILE_SCHEME}`);
+    expect(result).toContain('[docs](/docs)');
   });
 
   it('leaves text without paths unchanged', () => {

--- a/frontend/src/lib/file-paths.ts
+++ b/frontend/src/lib/file-paths.ts
@@ -1,0 +1,123 @@
+/** Internal scheme for file path links — intercepted by the custom renderer. */
+export const FILE_SCHEME = 'file-path://';
+
+/** Detect whether a string looks like a file path (not a URL). */
+export function isFilePath(str: string): boolean {
+  // Reject URLs
+  if (/^https?:\/\//.test(str)) return false;
+
+  // Must start with /, ./, or ../  OR contain a / with a file extension
+  const isAbsolute = str.startsWith('/');
+  const isRelative = str.startsWith('./') || str.startsWith('../');
+  const hasDirSlash = str.includes('/');
+
+  if (!isAbsolute && !isRelative && !hasDirSlash) return false;
+
+  // Reject bare root
+  if (str === '/') return false;
+
+  // Must have either a file extension or multiple path segments
+  const hasExtension = /\.\w+$/.test(str);
+  const segments = str.split('/').filter(Boolean);
+  const hasDepth = segments.length >= 2;
+
+  return hasExtension || hasDepth;
+}
+
+export interface FilePathMatch {
+  path: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Find file paths in a block of text.
+ * Matches absolute paths (/...) and relative paths (./... or ../...).
+ * Skips URLs (http:// or https://).
+ */
+export function detectFilePaths(text: string): FilePathMatch[] {
+  // Match paths: absolute (/...) or relative (./... or ../...)
+  // Path chars: word chars, hyphens, dots, @, slashes — no spaces (too greedy)
+  const pathPattern = /(?<!\w)(?:\.{0,2}\/[\w./@-]+(?:\/[\w./@-]+)*)/g;
+
+  const matches: FilePathMatch[] = [];
+
+  for (const match of text.matchAll(pathPattern)) {
+    const raw = match[0];
+    const start = match.index;
+
+    // Check that the character before isn't part of a URL scheme
+    if (start > 0) {
+      const before = text.slice(Math.max(0, start - 8), start);
+      if (/https?:\/?\/?$/.test(before)) continue;
+    }
+
+    // Strip trailing punctuation that's likely sentence-end
+    const cleaned = raw.replace(/[.,;:!?)]+$/, '');
+
+    if (isFilePath(cleaned)) {
+      matches.push({ path: cleaned, start, end: start + cleaned.length });
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Pre-process markdown content to wrap detected file paths in links.
+ * Already-linked paths (inside []() or backtick fences) are skipped.
+ */
+export function linkifyFilePaths(content: string): string {
+  // Process line by line to skip code blocks
+  const lines = content.split('\n');
+  let inCodeBlock = false;
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (/^```/.test(line.trimStart())) {
+      inCodeBlock = !inCodeBlock;
+      result.push(line);
+      continue;
+    }
+    if (inCodeBlock) {
+      result.push(line);
+      continue;
+    }
+    result.push(linkifyLine(line));
+  }
+
+  return result.join('\n');
+}
+
+function linkifyLine(line: string): string {
+  const matches = detectFilePaths(line);
+  if (matches.length === 0) return line;
+
+  // Check if the line already contains markdown links with paths — skip entirely
+  if (/\[[^\]]*\]\([^)]*\)/.test(line)) return line;
+
+  // Check if there are inline backticks — find backtick ranges and skip paths inside them
+  const backtickRanges: Array<[number, number]> = [];
+  const backtickPattern = /`[^`]+`/g;
+  for (const bm of line.matchAll(backtickPattern)) {
+    backtickRanges.push([bm.index, bm.index + bm[0].length]);
+  }
+
+  let out = '';
+  let cursor = 0;
+
+  for (const m of matches) {
+    // Skip if inside backticks
+    const inBackticks = backtickRanges.some(([s, e]) => m.start >= s && m.end <= e);
+    if (inBackticks) {
+      continue;
+    }
+
+    out += line.slice(cursor, m.start);
+    out += `[${m.path}](${FILE_SCHEME}${encodeURIComponent(m.path)})`;
+    cursor = m.end;
+  }
+
+  out += line.slice(cursor);
+  return out;
+}

--- a/frontend/src/lib/file-paths.ts
+++ b/frontend/src/lib/file-paths.ts
@@ -38,7 +38,7 @@ export interface FilePathMatch {
 export function detectFilePaths(text: string): FilePathMatch[] {
   // Match paths: absolute (/...) or relative (./... or ../...)
   // Path chars: word chars, hyphens, dots, @, slashes — no spaces (too greedy)
-  const pathPattern = /(?<!\w)(?:\.{0,2}\/[\w./@-]+(?:\/[\w./@-]+)*)/g;
+  const pathPattern = /(?<!\w)(?:(?:\.\.?)?\/[\w./@-]+(?:\/[\w./@-]+)*)/g;
 
   const matches: FilePathMatch[] = [];
 
@@ -93,22 +93,25 @@ function linkifyLine(line: string): string {
   const matches = detectFilePaths(line);
   if (matches.length === 0) return line;
 
-  // Check if the line already contains markdown links with paths — skip entirely
-  if (/\[[^\]]*\]\([^)]*\)/.test(line)) return line;
+  // Build exclusion ranges for inline backticks and existing markdown links
+  const excludedRanges: Array<[number, number]> = [];
 
-  // Check if there are inline backticks — find backtick ranges and skip paths inside them
-  const backtickRanges: Array<[number, number]> = [];
   const backtickPattern = /`[^`]+`/g;
   for (const bm of line.matchAll(backtickPattern)) {
-    backtickRanges.push([bm.index, bm.index + bm[0].length]);
+    excludedRanges.push([bm.index, bm.index + bm[0].length]);
+  }
+
+  const linkPattern = /\[[^\]]*\]\([^)]*\)/g;
+  for (const lm of line.matchAll(linkPattern)) {
+    excludedRanges.push([lm.index, lm.index + lm[0].length]);
   }
 
   let out = '';
   let cursor = 0;
 
   for (const m of matches) {
-    // Skip if inside backticks
-    const inBackticks = backtickRanges.some(([s, e]) => m.start >= s && m.end <= e);
+    // Skip if inside backticks or existing markdown links
+    const inBackticks = excludedRanges.some(([s, e]) => m.start >= s && m.end <= e);
     if (inBackticks) {
       continue;
     }

--- a/frontend/src/pages/FileViewer.tsx
+++ b/frontend/src/pages/FileViewer.tsx
@@ -11,7 +11,10 @@ export function FileViewer() {
   const routerNavigate = useNavigate();
   const nav = useFileNavigation(searchParams, setSearchParams);
   const { state } = nav;
-  const fromRoute = searchParams.get('from');
+  const rawFrom = searchParams.get('from');
+  // Validate fromRoute: must be a relative path, no protocol-relative URLs
+  const fromRoute =
+    rawFrom && rawFrom.startsWith('/') && !rawFrom.startsWith('//') ? rawFrom : null;
 
   const editor = useFileEditor(state.content, state.filePath, nav.setError);
   const reader = useDocumentReader();
@@ -32,11 +35,12 @@ export function FileViewer() {
           <button
             className="viewer-header-back"
             onClick={() => {
+              if (editor.dirty && !confirm('Discard unsaved changes?')) return;
               editor.resetEditor();
               if (fromRoute) {
                 routerNavigate(fromRoute);
               } else {
-                nav.handleBack(editor.dirty);
+                nav.handleBack(false); // dirty already checked above
               }
             }}
           >

--- a/frontend/src/pages/FileViewer.tsx
+++ b/frontend/src/pages/FileViewer.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { MitzoLogo } from '../components/MitzoLogo';
@@ -8,8 +8,10 @@ import { useDocumentReader } from '../hooks/useDocumentReader';
 
 export function FileViewer() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const routerNavigate = useNavigate();
   const nav = useFileNavigation(searchParams, setSearchParams);
   const { state } = nav;
+  const fromRoute = searchParams.get('from');
 
   const editor = useFileEditor(state.content, state.filePath, nav.setError);
   const reader = useDocumentReader();
@@ -26,12 +28,16 @@ export function FileViewer() {
     <div className="viewer-page">
       <header className="viewer-header">
         <MitzoLogo />
-        {(state.isViewing || state.currentDir) && (
+        {(state.isViewing || state.currentDir || fromRoute) && (
           <button
             className="viewer-header-back"
             onClick={() => {
               editor.resetEditor();
-              nav.handleBack(editor.dirty);
+              if (fromRoute) {
+                routerNavigate(fromRoute);
+              } else {
+                nav.handleBack(editor.dirty);
+              }
             }}
           >
             &larr;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1145,6 +1145,16 @@ textarea:focus {
   text-underline-offset: 2px;
 }
 
+.msg-bubble--assistant a.file-path-link {
+  color: #7dd3fc;
+  text-decoration: none;
+  background: rgba(125, 211, 252, 0.1);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9em;
+}
+
 .msg-bubble--assistant img {
   max-width: 100%;
   border-radius: 6px;


### PR DESCRIPTION
## Summary

- Detects file paths (absolute `/Users/...` and relative `./src/...`) in assistant chat messages and renders them as tappable links
- Tapping a file path navigates to the FileViewer showing that file
- Back button in FileViewer returns to the originating chat session (via `from` query param)
- File path links are styled distinctly from regular URLs (monospace, subtle background)
- Paths inside code blocks and inline backticks are left alone
- Linkification is skipped during streaming to avoid flicker

## Files

- `frontend/src/lib/file-paths.ts` — `isFilePath()`, `detectFilePaths()`, `linkifyFilePaths()` utilities
- `frontend/src/components/MessageBubble.tsx` — custom `a` renderer for `file-path://` scheme
- `frontend/src/pages/FileViewer.tsx` — back-navigation via `from` query param
- `frontend/src/styles/global.css` — `.file-path-link` styling

## Test plan

- [x] 23 unit tests for path detection and linkification (`file-paths.test.ts`)
- [x] 8 unit tests for MessageBubble rendering (`MessageBubble.test.ts`)
- [x] Full suite: 974 tests passing
- [ ] Manual: send a message that produces a file path, tap it, verify FileViewer opens, back returns to chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)