### PR TITLE
feat: capture token usage from SDK result events

### DIFF
--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -93,6 +93,16 @@ interface SessionEndMsg {
   type: 'session_end';
   v: 2;
   sessionId?: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+    totalCostUsd: number;
+    numTurns: number;
+    durationMs: number;
+    durationApiMs: number;
+  };
 }
 
 interface PermissionRequestMsg {

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -882,6 +882,146 @@ describe('runQueryLoop', () => {
     });
   });
 
+  describe('usage data extraction', () => {
+    let store: EventStore;
+
+    beforeEach(() => {
+      store = new EventStore(':memory:');
+    });
+
+    afterEach(() => {
+      store.close();
+    });
+
+    it('extracts usage data from SDK result event and persists to store', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-usage' },
+        {
+          type: 'result',
+          session_id: 'sess-usage',
+          usage: {
+            input_tokens: 1500,
+            output_tokens: 800,
+            cache_read_input_tokens: 200,
+            cache_creation_input_tokens: 50,
+          },
+          total_cost_usd: 0.0042,
+          num_turns: 3,
+          duration_ms: 12000,
+          duration_api_ms: 8000,
+        },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, ws, store);
+
+      const session = store.getSession('sess-usage');
+      expect(session).not.toBeNull();
+      expect(session!.inputTokens).toBe(1500);
+      expect(session!.outputTokens).toBe(800);
+      expect(session!.cacheReadTokens).toBe(200);
+      expect(session!.cacheCreationTokens).toBe(50);
+      expect(session!.totalCostUsd).toBeCloseTo(0.0042);
+      expect(session!.numTurns).toBe(3);
+      expect(session!.durationMs).toBe(12000);
+      expect(session!.durationApiMs).toBe(8000);
+    });
+
+    it('includes usage data in session_end message', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-usage-msg' },
+        {
+          type: 'result',
+          session_id: 'sess-usage-msg',
+          usage: {
+            input_tokens: 2000,
+            output_tokens: 1000,
+            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 25,
+          },
+          total_cost_usd: 0.005,
+          num_turns: 2,
+          duration_ms: 8000,
+          duration_api_ms: 5000,
+        },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, ws, store);
+
+      const sessionEnd = ws.sent.find((m) => m.type === 'session_end');
+      expect(sessionEnd).toBeDefined();
+      expect(sessionEnd!.usage).toBeDefined();
+      expect(sessionEnd!.usage).toMatchObject({
+        inputTokens: 2000,
+        outputTokens: 1000,
+        cacheReadTokens: 100,
+        cacheCreationTokens: 25,
+        totalCostUsd: 0.005,
+        numTurns: 2,
+        durationMs: 8000,
+        durationApiMs: 5000,
+      });
+    });
+
+    it('handles missing usage fields gracefully (defaults to 0)', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-no-usage' },
+        {
+          type: 'result',
+          session_id: 'sess-no-usage',
+          // No usage data provided
+        },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, ws, store);
+
+      const sessionEnd = ws.sent.find((m) => m.type === 'session_end');
+      expect(sessionEnd).toBeDefined();
+      expect(sessionEnd!.usage).toMatchObject({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalCostUsd: 0,
+        numTurns: 0,
+        durationMs: 0,
+        durationApiMs: 0,
+      });
+
+      const session = store.getSession('sess-no-usage');
+      expect(session!.inputTokens).toBe(0);
+      expect(session!.outputTokens).toBe(0);
+    });
+
+    it('handles partial usage data (some fields present)', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-partial' },
+        {
+          type: 'result',
+          session_id: 'sess-partial',
+          usage: {
+            input_tokens: 500,
+            output_tokens: 300,
+            // cache fields missing
+          },
+          total_cost_usd: 0.002,
+          // num_turns, duration_ms, duration_api_ms missing
+        },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, ws, store);
+
+      const session = store.getSession('sess-partial');
+      expect(session!.inputTokens).toBe(500);
+      expect(session!.outputTokens).toBe(300);
+      expect(session!.cacheReadTokens).toBe(0);
+      expect(session!.cacheCreationTokens).toBe(0);
+      expect(session!.totalCostUsd).toBeCloseTo(0.002);
+      expect(session!.numTurns).toBe(0);
+      expect(session!.durationMs).toBe(0);
+      expect(session!.durationApiMs).toBe(0);
+    });
+  });
+
   describe('observer broadcast', () => {
     it('sends events to observer WebSockets alongside the driver', async () => {
       const observerWs = fakeWs();

--- a/server/__tests__/token-capture.test.ts
+++ b/server/__tests__/token-capture.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EventStore } from '../event-store.js';
+
+describe('Token capture — usage tracking', () => {
+  let store: EventStore;
+
+  beforeEach(() => {
+    store = new EventStore(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  describe('migrateUsageTracking', () => {
+    it('adds usage columns to sessions table', () => {
+      const session = store.getSession('test-session');
+      // Session doesn't exist yet, but creating one should include the new fields
+      store.upsertSession({ sessionId: 'test-session', summary: 'Test' });
+      const result = store.getSession('test-session');
+
+      expect(result).not.toBeNull();
+      expect(result!.inputTokens).toBe(0);
+      expect(result!.outputTokens).toBe(0);
+      expect(result!.cacheReadTokens).toBe(0);
+      expect(result!.cacheCreationTokens).toBe(0);
+      expect(result!.totalCostUsd).toBe(0);
+      expect(result!.numTurns).toBe(0);
+      expect(result!.durationMs).toBe(0);
+      expect(result!.durationApiMs).toBe(0);
+      expect(result!.goalId).toBeNull();
+    });
+
+    it('migration is idempotent — opening a second store on same db does not crash', () => {
+      // The in-memory store already ran migration once in beforeEach.
+      // Simulating re-open by creating another store on a file-based db would
+      // test idempotency, but :memory: suffices for column presence.
+      store.upsertSession({ sessionId: 's1' });
+      const s = store.getSession('s1');
+      expect(s!.inputTokens).toBe(0);
+    });
+  });
+
+  describe('recordUsage', () => {
+    it('stores usage data on an existing session', () => {
+      store.upsertSession({ sessionId: 'sess-usage', summary: 'Usage test' });
+
+      store.recordUsage('sess-usage', {
+        inputTokens: 1500,
+        outputTokens: 800,
+        cacheReadTokens: 200,
+        cacheCreationTokens: 50,
+        totalCostUsd: 0.0042,
+        numTurns: 3,
+        durationMs: 12000,
+        durationApiMs: 8000,
+      });
+
+      const session = store.getSession('sess-usage');
+      expect(session).not.toBeNull();
+      expect(session!.inputTokens).toBe(1500);
+      expect(session!.outputTokens).toBe(800);
+      expect(session!.cacheReadTokens).toBe(200);
+      expect(session!.cacheCreationTokens).toBe(50);
+      expect(session!.totalCostUsd).toBeCloseTo(0.0042);
+      expect(session!.numTurns).toBe(3);
+      expect(session!.durationMs).toBe(12000);
+      expect(session!.durationApiMs).toBe(8000);
+    });
+
+    it('does not crash on non-existent session', () => {
+      // Should silently do nothing (UPDATE on non-existent row = 0 rows affected)
+      expect(() => {
+        store.recordUsage('nonexistent-session', {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          totalCostUsd: 0.001,
+          numTurns: 1,
+          durationMs: 1000,
+          durationApiMs: 500,
+        });
+      }).not.toThrow();
+    });
+
+    it('overwrites previous usage data on repeated calls', () => {
+      store.upsertSession({ sessionId: 'sess-overwrite' });
+
+      store.recordUsage('sess-overwrite', {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalCostUsd: 0.001,
+        numTurns: 1,
+        durationMs: 1000,
+        durationApiMs: 500,
+      });
+
+      store.recordUsage('sess-overwrite', {
+        inputTokens: 5000,
+        outputTokens: 2000,
+        cacheReadTokens: 300,
+        cacheCreationTokens: 100,
+        totalCostUsd: 0.05,
+        numTurns: 10,
+        durationMs: 60000,
+        durationApiMs: 45000,
+      });
+
+      const session = store.getSession('sess-overwrite');
+      expect(session!.inputTokens).toBe(5000);
+      expect(session!.outputTokens).toBe(2000);
+      expect(session!.numTurns).toBe(10);
+    });
+  });
+
+  describe('usage fields in listing', () => {
+    it('usage fields appear in listSessions() results', () => {
+      store.upsertSession({ sessionId: 'sess-list' });
+      store.recordUsage('sess-list', {
+        inputTokens: 999,
+        outputTokens: 444,
+        cacheReadTokens: 111,
+        cacheCreationTokens: 22,
+        totalCostUsd: 0.01,
+        numTurns: 5,
+        durationMs: 30000,
+        durationApiMs: 20000,
+      });
+
+      const sessions = store.listSessions();
+      const found = sessions.find((s) => s.sessionId === 'sess-list');
+      expect(found).not.toBeUndefined();
+      expect(found!.inputTokens).toBe(999);
+      expect(found!.outputTokens).toBe(444);
+      expect(found!.cacheReadTokens).toBe(111);
+      expect(found!.cacheCreationTokens).toBe(22);
+      expect(found!.totalCostUsd).toBeCloseTo(0.01);
+      expect(found!.numTurns).toBe(5);
+      expect(found!.durationMs).toBe(30000);
+      expect(found!.durationApiMs).toBe(20000);
+      expect(found!.goalId).toBeNull();
+    });
+
+    it('usage fields appear in getSession() results', () => {
+      store.upsertSession({ sessionId: 'sess-get' });
+      store.recordUsage('sess-get', {
+        inputTokens: 2500,
+        outputTokens: 1200,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        totalCostUsd: 0.025,
+        numTurns: 7,
+        durationMs: 45000,
+        durationApiMs: 30000,
+      });
+
+      const session = store.getSession('sess-get');
+      expect(session!.inputTokens).toBe(2500);
+      expect(session!.outputTokens).toBe(1200);
+      expect(session!.totalCostUsd).toBeCloseTo(0.025);
+      expect(session!.numTurns).toBe(7);
+    });
+  });
+});

--- a/server/__tests__/token-capture.test.ts
+++ b/server/__tests__/token-capture.test.ts
@@ -14,7 +14,6 @@ describe('Token capture — usage tracking', () => {
 
   describe('migrateUsageTracking', () => {
     it('adds usage columns to sessions table', () => {
-      const session = store.getSession('test-session');
       // Session doesn't exist yet, but creating one should include the new fields
       store.upsertSession({ sessionId: 'test-session', summary: 'Test' });
       const result = store.getSession('test-session');

--- a/server/event-store.ts
+++ b/server/event-store.ts
@@ -22,6 +22,15 @@ export interface SessionMeta {
   promptCount: number;
   manuallyRenamed: boolean;
   initialPrompt: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalCostUsd: number;
+  numTurns: number;
+  durationMs: number;
+  durationApiMs: number;
+  goalId: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -45,6 +54,15 @@ interface SessionRow {
   prompt_count: number;
   manually_renamed: number;
   initial_prompt: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  total_cost_usd: number;
+  num_turns: number;
+  duration_ms: number;
+  duration_api_ms: number;
+  goal_id: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -99,6 +117,7 @@ export class EventStore {
 
     // Migrate existing databases that lack the new columns
     this.migratePromptTracking(db);
+    this.migrateUsageTracking(db);
 
     this.stmts = {
       append: db.prepare('INSERT INTO events (session_id, type, payload) VALUES (?, ?, ?)'),
@@ -144,6 +163,41 @@ export class EventStore {
     if (!columnNames.has('initial_prompt')) {
       db.exec('ALTER TABLE sessions ADD COLUMN initial_prompt TEXT');
       log.info('migrated sessions table: added initial_prompt');
+    }
+  }
+
+  /** Add usage tracking columns if they don't exist yet. */
+  private migrateUsageTracking(db: Database.Database): void {
+    const columns = db.prepare("PRAGMA table_info('sessions')").all() as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((c) => c.name));
+    const migrations: Array<[string, string]> = [
+      ['input_tokens', 'ALTER TABLE sessions ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0'],
+      ['output_tokens', 'ALTER TABLE sessions ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0'],
+      [
+        'cache_read_tokens',
+        'ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0',
+      ],
+      [
+        'cache_creation_tokens',
+        'ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0',
+      ],
+      [
+        'total_cost_usd',
+        'ALTER TABLE sessions ADD COLUMN total_cost_usd REAL NOT NULL DEFAULT 0',
+      ],
+      ['num_turns', 'ALTER TABLE sessions ADD COLUMN num_turns INTEGER NOT NULL DEFAULT 0'],
+      ['duration_ms', 'ALTER TABLE sessions ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0'],
+      [
+        'duration_api_ms',
+        'ALTER TABLE sessions ADD COLUMN duration_api_ms INTEGER NOT NULL DEFAULT 0',
+      ],
+      ['goal_id', 'ALTER TABLE sessions ADD COLUMN goal_id TEXT'],
+    ];
+    for (const [col, sql] of migrations) {
+      if (!columnNames.has(col)) {
+        db.exec(sql);
+        log.info(`migrated sessions table: added ${col}`);
+      }
     }
   }
 
@@ -265,6 +319,48 @@ export class EventStore {
       "UPDATE sessions SET manually_renamed = 1, updated_at = unixepoch('now', 'subsec') * 1000 WHERE session_id = ?",
     ).run(sessionId);
   }
+
+  /**
+   * Record token usage and timing data for a session.
+   * Overwrites any previous usage data (final totals from SDK result event).
+   */
+  recordUsage(
+    sessionId: string,
+    usage: {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheCreationTokens: number;
+      totalCostUsd: number;
+      numTurns: number;
+      durationMs: number;
+      durationApiMs: number;
+    },
+  ): void {
+    this.db!.prepare(
+      `UPDATE sessions SET
+        input_tokens = ?,
+        output_tokens = ?,
+        cache_read_tokens = ?,
+        cache_creation_tokens = ?,
+        total_cost_usd = ?,
+        num_turns = ?,
+        duration_ms = ?,
+        duration_api_ms = ?,
+        updated_at = unixepoch('now', 'subsec') * 1000
+      WHERE session_id = ?`,
+    ).run(
+      usage.inputTokens,
+      usage.outputTokens,
+      usage.cacheReadTokens,
+      usage.cacheCreationTokens,
+      usage.totalCostUsd,
+      usage.numTurns,
+      usage.durationMs,
+      usage.durationApiMs,
+      sessionId,
+    );
+  }
 }
 
 function rowToEvent(row: EventRow): StoredEvent {
@@ -289,6 +385,15 @@ function rowToSession(row: SessionRow): SessionMeta {
     promptCount: row.prompt_count ?? 0,
     manuallyRenamed: (row.manually_renamed ?? 0) === 1,
     initialPrompt: row.initial_prompt ?? null,
+    inputTokens: row.input_tokens ?? 0,
+    outputTokens: row.output_tokens ?? 0,
+    cacheReadTokens: row.cache_read_tokens ?? 0,
+    cacheCreationTokens: row.cache_creation_tokens ?? 0,
+    totalCostUsd: row.total_cost_usd ?? 0,
+    numTurns: row.num_turns ?? 0,
+    durationMs: row.duration_ms ?? 0,
+    durationApiMs: row.duration_api_ms ?? 0,
+    goalId: row.goal_id ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/server/event-store.ts
+++ b/server/event-store.ts
@@ -105,6 +105,7 @@ export class EventStore {
     listSessionsLimited: Database.Statement;
     markInactive: Database.Statement;
     hide: Database.Statement;
+    recordUsage: Database.Statement;
   };
 
   constructor(dbPath: string) {
@@ -142,6 +143,19 @@ export class EventStore {
       ),
       hide: db.prepare(
         "UPDATE sessions SET is_hidden = 1, updated_at = unixepoch('now', 'subsec') * 1000 WHERE session_id = ?",
+      ),
+      recordUsage: db.prepare(
+        `UPDATE sessions SET
+          input_tokens = ?,
+          output_tokens = ?,
+          cache_read_tokens = ?,
+          cache_creation_tokens = ?,
+          total_cost_usd = ?,
+          num_turns = ?,
+          duration_ms = ?,
+          duration_api_ms = ?,
+          updated_at = unixepoch('now', 'subsec') * 1000
+        WHERE session_id = ?`,
       ),
     };
 
@@ -337,19 +351,7 @@ export class EventStore {
       durationApiMs: number;
     },
   ): void {
-    this.db!.prepare(
-      `UPDATE sessions SET
-        input_tokens = ?,
-        output_tokens = ?,
-        cache_read_tokens = ?,
-        cache_creation_tokens = ?,
-        total_cost_usd = ?,
-        num_turns = ?,
-        duration_ms = ?,
-        duration_api_ms = ?,
-        updated_at = unixepoch('now', 'subsec') * 1000
-      WHERE session_id = ?`,
-    ).run(
+    this.stmts.recordUsage.run(
       usage.inputTokens,
       usage.outputTokens,
       usage.cacheReadTokens,

--- a/server/event-store.ts
+++ b/server/event-store.ts
@@ -195,10 +195,7 @@ export class EventStore {
         'cache_creation_tokens',
         'ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0',
       ],
-      [
-        'total_cost_usd',
-        'ALTER TABLE sessions ADD COLUMN total_cost_usd REAL NOT NULL DEFAULT 0',
-      ],
+      ['total_cost_usd', 'ALTER TABLE sessions ADD COLUMN total_cost_usd REAL NOT NULL DEFAULT 0'],
       ['num_turns', 'ALTER TABLE sessions ADD COLUMN num_turns INTEGER NOT NULL DEFAULT 0'],
       ['duration_ms', 'ALTER TABLE sessions ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0'],
       [

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -239,23 +239,22 @@ export async function runQueryLoop(
         doneSent = true;
 
         // Extract usage data from SDK result event
+        const result = msg as {
+          usage?: Record<string, number>;
+          total_cost_usd?: number;
+          num_turns?: number;
+          duration_ms?: number;
+          duration_api_ms?: number;
+        };
         const usageData = {
-          inputTokens: (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
-            ?.input_tokens ?? 0,
-          outputTokens: (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
-            ?.output_tokens ?? 0,
-          cacheReadTokens:
-            (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
-              ?.cache_read_input_tokens ?? 0,
-          cacheCreationTokens:
-            (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
-              ?.cache_creation_input_tokens ?? 0,
-          totalCostUsd:
-            (msg as Record<string, unknown> & { total_cost_usd?: number }).total_cost_usd ?? 0,
-          numTurns: (msg as Record<string, unknown> & { num_turns?: number }).num_turns ?? 0,
-          durationMs: (msg as Record<string, unknown> & { duration_ms?: number }).duration_ms ?? 0,
-          durationApiMs:
-            (msg as Record<string, unknown> & { duration_api_ms?: number }).duration_api_ms ?? 0,
+          inputTokens: result.usage?.input_tokens ?? 0,
+          outputTokens: result.usage?.output_tokens ?? 0,
+          cacheReadTokens: result.usage?.cache_read_input_tokens ?? 0,
+          cacheCreationTokens: result.usage?.cache_creation_input_tokens ?? 0,
+          totalCostUsd: result.total_cost_usd ?? 0,
+          numTurns: result.num_turns ?? 0,
+          durationMs: result.duration_ms ?? 0,
+          durationApiMs: result.duration_api_ms ?? 0,
         };
 
         // Persist usage to durable store

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -20,6 +20,20 @@ function send(ws: WebSocket, data: unknown) {
   }
 }
 
+/** Shape of the SDK result event — fields we extract for usage tracking. */
+interface SdkResultEvent {
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+  total_cost_usd?: number;
+  num_turns?: number;
+  duration_ms?: number;
+  duration_api_ms?: number;
+}
+
 /**
  * Broadcast a message to all observers of a session.
  * Each send is wrapped in try/catch to prevent a single failing socket
@@ -239,13 +253,7 @@ export async function runQueryLoop(
         doneSent = true;
 
         // Extract usage data from SDK result event
-        const result = msg as {
-          usage?: Record<string, number>;
-          total_cost_usd?: number;
-          num_turns?: number;
-          duration_ms?: number;
-          duration_api_ms?: number;
-        };
+        const result = msg as SdkResultEvent;
         const usageData = {
           inputTokens: result.usage?.input_tokens ?? 0,
           outputTokens: result.usage?.output_tokens ?? 0,

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -237,7 +237,33 @@ export async function runQueryLoop(
         if (msg.session_id) emit(currentWs, { type: 'session_id', sessionId: msg.session_id });
         forceFlushPendingMessage(currentWs, currentSession);
         doneSent = true;
-        emit(currentWs, v2('session_end', { sessionId: msg.session_id }));
+
+        // Extract usage data from SDK result event
+        const usageData = {
+          inputTokens: (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
+            ?.input_tokens ?? 0,
+          outputTokens: (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
+            ?.output_tokens ?? 0,
+          cacheReadTokens:
+            (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
+              ?.cache_read_input_tokens ?? 0,
+          cacheCreationTokens:
+            (msg as Record<string, unknown> & { usage?: Record<string, number> }).usage
+              ?.cache_creation_input_tokens ?? 0,
+          totalCostUsd:
+            (msg as Record<string, unknown> & { total_cost_usd?: number }).total_cost_usd ?? 0,
+          numTurns: (msg as Record<string, unknown> & { num_turns?: number }).num_turns ?? 0,
+          durationMs: (msg as Record<string, unknown> & { duration_ms?: number }).duration_ms ?? 0,
+          durationApiMs:
+            (msg as Record<string, unknown> & { duration_api_ms?: number }).duration_api_ms ?? 0,
+        };
+
+        // Persist usage to durable store
+        if (store && resolvedSessionId) {
+          store.recordUsage(resolvedSessionId, usageData);
+        }
+
+        emit(currentWs, v2('session_end', { sessionId: msg.session_id, usage: usageData }));
         if (!registry.isAttached(clientId)) {
           const snippet = extractSnippet(snapshotBlocks, NOTIFY_SNIPPET_MAX_CHARS);
           const sid = (msg.session_id as string) || currentSession.sessionId;


### PR DESCRIPTION
## Summary
- Extract token usage data (input/output/cache tokens, cost, turns, duration) from Claude Agent SDK `result` events
- Persist usage to SQLite via new `recordUsage()` method on EventStore with automatic schema migration
- Include usage data in `session_end` WebSocket events for frontend consumption

Phase 1 of the **tokens-to-goal** system — captures the raw token data at the Mitzo boundary. Goal attribution (linking sessions to goals via `goalId`) is wired in the schema but activated in Phase 2 when ContexGin's Goal Registry is integrated.

## Changes
- `server/event-store.ts` — 9 new columns (usage + goalId), migration, `recordUsage()` method
- `server/query-loop.ts` — extract usage from SDK result, persist + emit
- `server/__tests__/token-capture.test.ts` — 7 new tests (migration, store/retrieve, overwrite, listing)

## Test plan
- [x] `npm test` — 95 tests passing
- [ ] Manual: start session, verify `session_end` WS event includes `usage` object
- [ ] Manual: check SQLite DB for populated usage columns after session completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)