### PR TITLE
feat: task board phase 1 — persistent CRUD with tree UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { InboxView } from './pages/InboxView';
 import { CalendarView } from './pages/CalendarView';
 import { TodoView } from './pages/TodoView';
 import { TodoDetailView } from './pages/TodoDetailView';
+import { TaskBoard } from './pages/TaskBoard';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useIsDesktop } from './hooks/useMediaQuery';
 
@@ -101,6 +102,14 @@ export function App() {
             element={
               <ProtectedRoute>
                 <TodoDetailView />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/tasks"
+            element={
+              <ProtectedRoute>
+                <TaskBoard />
               </ProtectedRoute>
             }
           />

--- a/frontend/src/components/TaskCreateForm.tsx
+++ b/frontend/src/components/TaskCreateForm.tsx
@@ -1,0 +1,47 @@
+import { useState, useRef, useEffect } from 'react';
+
+interface TaskCreateFormProps {
+  parentId?: string;
+  onCreate: (title: string, parentId?: string) => void;
+  onCancel: () => void;
+}
+
+export function TaskCreateForm({ parentId, onCreate, onCancel }: TaskCreateFormProps) {
+  const [title, setTitle] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const text = title.trim();
+    if (!text) return;
+    onCreate(text, parentId);
+    setTitle('');
+  }
+
+  return (
+    <form className="task-create-form" onSubmit={handleSubmit}>
+      <input
+        ref={inputRef}
+        className="task-create-input"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder={parentId ? 'Add sub-task...' : 'Add task...'}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <div className="task-create-actions">
+        <button type="submit" className="task-create-submit" disabled={!title.trim()}>
+          Add
+        </button>
+        <button type="button" className="task-create-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -34,7 +34,7 @@ export function TaskNode({ task, depth, onStatusChange, onDelete, onAddChild }: 
   const hasChildren = task.children.length > 0;
 
   return (
-    <div className="task-node" style={{ paddingLeft: `${depth * 16}px` }}>
+    <div className="task-node">
       <div className="task-node-row">
         {hasChildren && (
           <button

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import type { Task, TaskStatus } from '../types/task';
+
+const STATUS_ICONS: Record<TaskStatus, string> = {
+  pending: '\u25CB', // ○
+  active: '\u25C9', // ◉
+  done: '\u2713', // ✓
+  pending_review: '\u25D4', // ◔
+  blocked: '\u2298', // ⊘
+  skipped: '\u2014', // —
+  failed: '\u2717', // ✗
+};
+
+const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
+  pending: 'active',
+  active: 'done',
+  done: 'pending',
+  pending_review: 'done',
+  blocked: 'active',
+  skipped: 'pending',
+  failed: 'pending',
+};
+
+interface TaskNodeProps {
+  task: Task;
+  depth: number;
+  onStatusChange: (id: string, status: TaskStatus) => void;
+  onDelete: (id: string) => void;
+  onAddChild: (parentId: string) => void;
+}
+
+export function TaskNode({ task, depth, onStatusChange, onDelete, onAddChild }: TaskNodeProps) {
+  const [expanded, setExpanded] = useState(true);
+  const hasChildren = task.children.length > 0;
+
+  return (
+    <div className="task-node" style={{ paddingLeft: `${depth * 16}px` }}>
+      <div className="task-node-row">
+        {hasChildren && (
+          <button
+            className="task-node-chevron"
+            onClick={() => setExpanded(!expanded)}
+            aria-label={expanded ? 'Collapse' : 'Expand'}
+          >
+            {expanded ? '\u25BC' : '\u25B6'}
+          </button>
+        )}
+        <button
+          className={`task-node-status task-node-status--${task.status}`}
+          onClick={() => onStatusChange(task.id, NEXT_STATUS[task.status])}
+          aria-label={`Status: ${task.status}`}
+        >
+          {STATUS_ICONS[task.status]}
+        </button>
+        <span
+          className={`task-node-title${task.status === 'done' ? ' task-node-title--done' : ''}`}
+        >
+          {task.title}
+        </span>
+        <div className="task-node-actions">
+          <button
+            className="task-node-action"
+            onClick={() => onAddChild(task.id)}
+            title="Add sub-task"
+          >
+            +
+          </button>
+          <button
+            className="task-node-action task-node-action--danger"
+            onClick={() => onDelete(task.id)}
+            title="Delete task"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+      {hasChildren && expanded && (
+        <div className="task-node-children">
+          {task.children.map((child) => (
+            <TaskNode
+              key={child.id}
+              task={child}
+              depth={depth + 1}
+              onStatusChange={onStatusChange}
+              onDelete={onDelete}
+              onAddChild={onAddChild}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/TaskCreateForm.test.tsx
+++ b/frontend/src/components/__tests__/TaskCreateForm.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TaskCreateForm } from '../TaskCreateForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TaskCreateForm', () => {
+  it('renders the form with input and buttons', () => {
+    render(<TaskCreateForm onCreate={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByPlaceholderText('Add task...')).toBeTruthy();
+    expect(screen.getByText('Add')).toBeTruthy();
+    expect(screen.getByText('Cancel')).toBeTruthy();
+  });
+
+  it('submit calls onCreate with title', async () => {
+    const onCreate = vi.fn();
+    render(<TaskCreateForm onCreate={onCreate} onCancel={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText('Add task...');
+    fireEvent.change(input, { target: { value: 'New task' } });
+    fireEvent.submit(input.closest('form')!);
+
+    expect(onCreate).toHaveBeenCalledWith('New task', undefined);
+  });
+
+  it('submit is disabled when input is empty', () => {
+    render(<TaskCreateForm onCreate={vi.fn()} onCancel={vi.fn()} />);
+    const addBtn = screen.getByText('Add') as HTMLButtonElement;
+    expect(addBtn.disabled).toBe(true);
+  });
+
+  it('escape calls onCancel', () => {
+    const onCancel = vi.fn();
+    render(<TaskCreateForm onCreate={vi.fn()} onCancel={onCancel} />);
+
+    const input = screen.getByPlaceholderText('Add task...');
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('cancel button calls onCancel', () => {
+    const onCancel = vi.fn();
+    render(<TaskCreateForm onCreate={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('shows different placeholder for child task', () => {
+    render(<TaskCreateForm parentId="parent-1" onCreate={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByPlaceholderText('Add sub-task...')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -94,7 +94,7 @@ describe('TaskNode', () => {
     expect(screen.queryByText('Child task')).toBeNull();
   });
 
-  it('applies depth indentation', () => {
+  it('does not apply inline depth indentation (handled by CSS nesting)', () => {
     const { container } = render(
       <TaskNode
         task={makeTask()}
@@ -105,7 +105,7 @@ describe('TaskNode', () => {
       />,
     );
     const node = container.firstElementChild as HTMLElement;
-    expect(node.style.paddingLeft).toBe('32px');
+    expect(node.style.paddingLeft).toBe('');
   });
 
   it('renders children recursively', () => {

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { Task } from '../../types/task';
 import { TaskNode } from '../TaskNode';
 
 afterEach(() => {
   cleanup();
 });
-import type { Task } from '../../types/task';
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -51,6 +51,7 @@ describe('TaskNode', () => {
     ['pending', '\u25CB'],
     ['active', '\u25C9'],
     ['done', '\u2713'],
+    ['pending_review', '\u25D4'],
     ['blocked', '\u2298'],
     ['skipped', '\u2014'],
     ['failed', '\u2717'],

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TaskNode } from '../TaskNode';
+import type { Task } from '../../types/task';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    parentId: null,
+    title: 'Test task',
+    description: null,
+    status: 'pending',
+    sessionId: null,
+    sessionPolicy: 'auto',
+    priority: 0,
+    depth: 0,
+    annotations: [],
+    summary: null,
+    requiresApproval: false,
+    tokenUsage: 0,
+    claimedBy: null,
+    claimedAt: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    completedAt: null,
+    children: [],
+    ...overrides,
+  };
+}
+
+describe('TaskNode', () => {
+  it('renders title', () => {
+    render(
+      <TaskNode
+        task={makeTask({ title: 'My Task' })}
+        depth={0}
+        onStatusChange={vi.fn()}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('My Task')).toBeTruthy();
+  });
+
+  it.each([
+    ['pending', '\u25CB'],
+    ['active', '\u25C9'],
+    ['done', '\u2713'],
+    ['blocked', '\u2298'],
+    ['skipped', '\u2014'],
+    ['failed', '\u2717'],
+  ] as const)('renders correct icon for status %s', (status, expectedIcon) => {
+    const { container } = render(
+      <TaskNode
+        task={makeTask({ status })}
+        depth={0}
+        onStatusChange={vi.fn()}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+    const statusBtn = container.querySelector('.task-node-status');
+    expect(statusBtn?.textContent).toBe(expectedIcon);
+  });
+
+  it('toggles expand/collapse for tasks with children', () => {
+    const child = makeTask({ id: 'child-1', parentId: 'task-1', title: 'Child task', depth: 1 });
+    const task = makeTask({ children: [child] });
+
+    render(
+      <TaskNode
+        task={task}
+        depth={0}
+        onStatusChange={vi.fn()}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+
+    // Children should be visible by default
+    expect(screen.getByText('Child task')).toBeTruthy();
+
+    // Click collapse
+    const chevron = screen.getByText('\u25BC');
+    fireEvent.click(chevron);
+
+    // Children should be hidden
+    expect(screen.queryByText('Child task')).toBeNull();
+  });
+
+  it('applies depth indentation', () => {
+    const { container } = render(
+      <TaskNode
+        task={makeTask()}
+        depth={2}
+        onStatusChange={vi.fn()}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+    const node = container.firstElementChild as HTMLElement;
+    expect(node.style.paddingLeft).toBe('32px');
+  });
+
+  it('renders children recursively', () => {
+    const grandchild = makeTask({
+      id: 'gc-1',
+      parentId: 'child-1',
+      title: 'Grandchild',
+      depth: 2,
+    });
+    const child = makeTask({
+      id: 'child-1',
+      parentId: 'task-1',
+      title: 'Child',
+      depth: 1,
+      children: [grandchild],
+    });
+    const task = makeTask({ children: [child] });
+
+    render(
+      <TaskNode
+        task={task}
+        depth={0}
+        onStatusChange={vi.fn()}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Child')).toBeTruthy();
+    expect(screen.getByText('Grandchild')).toBeTruthy();
+  });
+
+  it('calls onStatusChange when status icon clicked', () => {
+    const onStatusChange = vi.fn();
+    const { container } = render(
+      <TaskNode
+        task={makeTask({ id: 'sc-1', status: 'pending' })}
+        depth={0}
+        onStatusChange={onStatusChange}
+        onDelete={vi.fn()}
+        onAddChild={vi.fn()}
+      />,
+    );
+
+    const statusBtn = container.querySelector('.task-node-status')!;
+    fireEvent.click(statusBtn);
+    expect(onStatusChange).toHaveBeenCalledWith('sc-1', expect.any(String));
+  });
+
+  it('calls onDelete when delete button clicked', () => {
+    const onDelete = vi.fn();
+    const { container } = render(
+      <TaskNode
+        task={makeTask({ id: 'del-1' })}
+        depth={0}
+        onStatusChange={vi.fn()}
+        onDelete={onDelete}
+        onAddChild={vi.fn()}
+      />,
+    );
+
+    const deleteBtn = container.querySelector('.task-node-action--danger')!;
+    fireEvent.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledWith('del-1');
+  });
+});

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { TaskNode } from '../TaskNode';
+
+afterEach(() => {
+  cleanup();
+});
 import type { Task } from '../../types/task';
 
 function makeTask(overrides: Partial<Task> = {}): Task {

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTaskBoard } from '../useTaskBoard';
+import type { Task } from '../../types/task';
+
+// Mock ws-pool
+const listeners: Array<(msg: unknown) => void> = [];
+vi.mock('../../lib/ws-pool', () => ({
+  wsSubscribe: vi.fn((_key: string, listener: (msg: unknown) => void) => {
+    listeners.push(listener);
+    return () => {
+      const idx = listeners.indexOf(listener);
+      if (idx >= 0) listeners.splice(idx, 1);
+    };
+  }),
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    parentId: null,
+    title: 'Test task',
+    description: null,
+    status: 'pending',
+    sessionId: null,
+    sessionPolicy: 'auto',
+    priority: 0,
+    depth: 0,
+    annotations: [],
+    summary: null,
+    requiresApproval: false,
+    tokenUsage: 0,
+    claimedBy: null,
+    claimedAt: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    completedAt: null,
+    children: [],
+    ...overrides,
+  };
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  listeners.length = 0;
+  fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ tasks: [] }),
+  });
+  globalThis.fetch = fetchMock;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useTaskBoard', () => {
+  it('fetches tasks on mount', async () => {
+    const tasks = [makeTask()];
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tasks }),
+    });
+
+    const { result } = renderHook(() => useTaskBoard());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tasks).toEqual(tasks);
+    expect(fetchMock).toHaveBeenCalledWith('/api/tasks');
+  });
+
+  it('createTask calls POST and relies on WS for state', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ task: makeTask() }),
+      });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.createTask({ title: 'New task' });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tasks',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('updateTask calls PATCH', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [makeTask()] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ task: makeTask({ title: 'Updated' }) }),
+      });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateTask('task-1', { title: 'Updated' });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tasks/task-1',
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  it('deleteTask calls DELETE', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ tasks: [makeTask()] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.deleteTask('task-1');
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tasks/task-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('WS task_state replaces state', async () => {
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const newTasks = [makeTask({ id: 'ws-1', title: 'From WS' })];
+    act(() => {
+      listeners.forEach((l) => l({ type: 'task_state', tasks: newTasks }));
+    });
+
+    expect(result.current.tasks).toEqual(newTasks);
+  });
+
+  it('WS task_updated upserts a new task into roots', async () => {
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const newTask = makeTask({ id: 'new-1', title: 'New via WS' });
+    act(() => {
+      listeners.forEach((l) => l({ type: 'task_updated', task: newTask }));
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].title).toBe('New via WS');
+  });
+
+  it('WS task_updated updates existing task', async () => {
+    const original = makeTask({ id: 'u-1', title: 'Original' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tasks: [original] }),
+    });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tasks[0].title).toBe('Original');
+
+    const updated = makeTask({ id: 'u-1', title: 'Updated via WS' });
+    act(() => {
+      listeners.forEach((l) => l({ type: 'task_updated', task: updated }));
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].title).toBe('Updated via WS');
+  });
+
+  it('WS task_deleted removes task', async () => {
+    const tasks = [makeTask({ id: 'del-1' }), makeTask({ id: 'del-2' })];
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tasks }),
+    });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tasks).toHaveLength(2);
+
+    act(() => {
+      listeners.forEach((l) => l({ type: 'task_deleted', taskId: 'del-1' }));
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].id).toBe('del-2');
+  });
+
+  it('refresh triggers refetch', async () => {
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tasks: [makeTask({ id: 'refreshed' })] }),
+    });
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.tasks[0]?.id).toBe('refreshed'));
+  });
+
+  it('handles fetch error gracefully', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tasks).toEqual([]);
+  });
+});

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -231,4 +231,43 @@ describe('useTaskBoard', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.tasks).toEqual([]);
   });
+
+  it('createTask throws on non-ok response', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(act(() => result.current.createTask({ title: 'Fail' }))).rejects.toThrow(
+      'Create task failed: 500',
+    );
+  });
+
+  it('updateTask throws on non-ok response', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [makeTask()] }) })
+      .mockResolvedValueOnce({ ok: false, status: 404 });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(act(() => result.current.updateTask('task-1', { title: 'Nope' }))).rejects.toThrow(
+      'Update task failed: 404',
+    );
+  });
+
+  it('deleteTask throws on non-ok response', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [makeTask()] }) })
+      .mockResolvedValueOnce({ ok: false, status: 403 });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(act(() => result.current.deleteTask('task-1'))).rejects.toThrow(
+      'Delete task failed: 403',
+    );
+  });
 });

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -49,7 +49,7 @@ beforeEach(() => {
     ok: true,
     json: () => Promise.resolve({ tasks: [] }),
   });
-  globalThis.fetch = fetchMock;
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 });
 
 afterEach(() => {

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -189,6 +189,32 @@ describe('useTaskBoard', () => {
     expect(result.current.tasks[0].title).toBe('Updated via WS');
   });
 
+  it('WS task_updated inserts child under existing parent', async () => {
+    const parent = makeTask({ id: 'parent-1', title: 'Parent' });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tasks: [parent] }),
+    });
+
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.tasks).toHaveLength(1);
+
+    const child = makeTask({
+      id: 'child-1',
+      parentId: 'parent-1',
+      title: 'Child via WS',
+      depth: 1,
+    });
+    act(() => {
+      listeners.forEach((l) => l({ type: 'task_updated', task: child }));
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].children).toHaveLength(1);
+    expect(result.current.tasks[0].children[0].title).toBe('Child via WS');
+  });
+
   it('WS task_deleted removes task', async () => {
     const tasks = [makeTask({ id: 'del-1' }), makeTask({ id: 'del-2' })];
     fetchMock.mockResolvedValueOnce({

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -1,0 +1,152 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Task } from '../types/task';
+import { wsSubscribe } from '../lib/ws-pool';
+import type { WsMsg } from '../lib/ws-pool';
+
+export interface TaskCreateInput {
+  title: string;
+  parentId?: string;
+  description?: string;
+  priority?: number;
+  sessionPolicy?: string;
+  annotations?: string[];
+}
+
+export interface TaskUpdateInput {
+  title?: string;
+  description?: string;
+  status?: string;
+  priority?: number;
+  sessionPolicy?: string;
+  annotations?: string[];
+  summary?: string;
+  requiresApproval?: boolean;
+}
+
+export interface UseTaskBoardResult {
+  loading: boolean;
+  tasks: Task[];
+  createTask: (input: TaskCreateInput) => Promise<void>;
+  updateTask: (id: string, input: TaskUpdateInput) => Promise<void>;
+  deleteTask: (id: string) => Promise<void>;
+  refresh: () => void;
+}
+
+function removeFromTree(tasks: Task[], id: string): Task[] {
+  return tasks
+    .filter((t) => t.id !== id)
+    .map((t) => ({
+      ...t,
+      children: removeFromTree(t.children, id),
+    }));
+}
+
+function upsertInTree(tasks: Task[], task: Task): Task[] {
+  // If the task exists at root level, replace it
+  let found = false;
+  const updated = tasks.map((t) => {
+    if (t.id === task.id) {
+      found = true;
+      return { ...task, children: t.children };
+    }
+    // Check children recursively
+    const updatedChildren = upsertInTree(t.children, task);
+    if (updatedChildren !== t.children) {
+      found = true;
+      return { ...t, children: updatedChildren };
+    }
+    return t;
+  });
+
+  if (found) return updated;
+
+  // New root task — append
+  if (!task.parentId) {
+    return [...tasks, task];
+  }
+
+  // New child task — find parent and append
+  return tasks.map((t) => {
+    if (t.id === task.parentId) {
+      return { ...t, children: [...t.children, task] };
+    }
+    return { ...t, children: upsertInTree(t.children, task) };
+  });
+}
+
+export function useTaskBoard(): UseTaskBoardResult {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Fetch tasks from REST API
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    fetch('/api/tasks')
+      .then((r) => {
+        if (!r.ok) throw new Error(`Task API returned ${r.status}`);
+        return r.json();
+      })
+      .then((result: { tasks: Task[] }) => {
+        if (!cancelled) {
+          setTasks(result.tasks);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTasks([]);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  // Subscribe to WS events
+  useEffect(() => {
+    const unsub = wsSubscribe('global', (msg: WsMsg) => {
+      if (msg.type === 'task_state') {
+        const m = msg as unknown as { tasks: Task[] };
+        setTasks(m.tasks);
+      } else if (msg.type === 'task_updated') {
+        const m = msg as unknown as { task: Task };
+        setTasks((prev) => upsertInTree(prev, m.task));
+      } else if (msg.type === 'task_deleted') {
+        const m = msg as unknown as { taskId: string };
+        setTasks((prev) => removeFromTree(prev, m.taskId));
+      }
+    });
+    return unsub;
+  }, []);
+
+  const createTask = useCallback(async (input: TaskCreateInput) => {
+    await fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  }, []);
+
+  const updateTask = useCallback(async (id: string, input: TaskUpdateInput) => {
+    await fetch(`/api/tasks/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  }, []);
+
+  const deleteTask = useCallback(async (id: string) => {
+    await fetch(`/api/tasks/${id}`, {
+      method: 'DELETE',
+    });
+  }, []);
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  return { loading, tasks, createTask, updateTask, deleteTask, refresh };
+}

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -41,37 +41,47 @@ function removeFromTree(tasks: Task[], id: string): Task[] {
     }));
 }
 
-function upsertInTree(tasks: Task[], task: Task): Task[] {
-  // If the task exists at root level, replace it
+function upsertInTree(tasks: Task[], task: Task): [Task[], boolean] {
   let found = false;
   const updated = tasks.map((t) => {
     if (t.id === task.id) {
       found = true;
       return { ...task, children: t.children };
     }
-    // Check children recursively
-    const updatedChildren = upsertInTree(t.children, task);
-    if (updatedChildren !== t.children) {
-      found = true;
-      return { ...t, children: updatedChildren };
+    if (t.children.length > 0) {
+      const [updatedChildren, childFound] = upsertInTree(t.children, task);
+      if (childFound) {
+        found = true;
+        return { ...t, children: updatedChildren };
+      }
     }
     return t;
   });
 
-  if (found) return updated;
+  if (found) return [updated, true];
 
   // New root task — append
   if (!task.parentId) {
-    return [...tasks, task];
+    return [[...tasks, task], true];
   }
 
   // New child task — find parent and append
-  return tasks.map((t) => {
+  let inserted = false;
+  const withChild = tasks.map((t) => {
     if (t.id === task.parentId) {
+      inserted = true;
       return { ...t, children: [...t.children, task] };
     }
-    return { ...t, children: upsertInTree(t.children, task) };
+    if (t.children.length > 0) {
+      const [updatedChildren, childInserted] = upsertInTree(t.children, task);
+      if (childInserted) {
+        inserted = true;
+        return { ...t, children: updatedChildren };
+      }
+    }
+    return t;
   });
+  return [inserted ? withChild : tasks, inserted];
 }
 
 export function useTaskBoard(): UseTaskBoardResult {
@@ -111,39 +121,39 @@ export function useTaskBoard(): UseTaskBoardResult {
   useEffect(() => {
     const unsub = wsSubscribe('global', (msg: WsMsg) => {
       if (msg.type === 'task_state') {
-        const m = msg as unknown as { tasks: Task[] };
-        setTasks(m.tasks);
+        setTasks(msg.tasks);
       } else if (msg.type === 'task_updated') {
-        const m = msg as unknown as { task: Task };
-        setTasks((prev) => upsertInTree(prev, m.task));
+        setTasks((prev) => upsertInTree(prev, msg.task)[0]);
       } else if (msg.type === 'task_deleted') {
-        const m = msg as unknown as { taskId: string };
-        setTasks((prev) => removeFromTree(prev, m.taskId));
+        setTasks((prev) => removeFromTree(prev, msg.taskId));
       }
     });
     return unsub;
   }, []);
 
   const createTask = useCallback(async (input: TaskCreateInput) => {
-    await fetch('/api/tasks', {
+    const r = await fetch('/api/tasks', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
     });
+    if (!r.ok) throw new Error(`Create task failed: ${r.status}`);
   }, []);
 
   const updateTask = useCallback(async (id: string, input: TaskUpdateInput) => {
-    await fetch(`/api/tasks/${id}`, {
+    const r = await fetch(`/api/tasks/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),
     });
+    if (!r.ok) throw new Error(`Update task failed: ${r.status}`);
   }, []);
 
   const deleteTask = useCallback(async (id: string) => {
-    await fetch(`/api/tasks/${id}`, {
+    const r = await fetch(`/api/tasks/${id}`, {
       method: 'DELETE',
     });
+    if (!r.ok) throw new Error(`Delete task failed: ${r.status}`);
   }, []);
 
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -46,7 +46,7 @@ function upsertInTree(tasks: Task[], task: Task): [Task[], boolean] {
   const updated = tasks.map((t) => {
     if (t.id === task.id) {
       found = true;
-      return { ...task, children: t.children };
+      return { ...task, children: task.children.length > 0 ? task.children : t.children };
     }
     if (t.children.length > 0) {
       const [updatedChildren, childFound] = upsertInTree(t.children, task);

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TaskNode } from '../components/TaskNode';
+import { TaskCreateForm } from '../components/TaskCreateForm';
+import { useTaskBoard } from '../hooks/useTaskBoard';
+import type { TaskStatus } from '../types/task';
+
+export function TaskBoard() {
+  const navigate = useNavigate();
+  const { loading, tasks, createTask, updateTask, deleteTask, refresh } = useTaskBoard();
+  const [creating, setCreating] = useState<{ parentId?: string } | null>(null);
+
+  function handleStatusChange(id: string, status: TaskStatus) {
+    updateTask(id, { status });
+  }
+
+  function handleDelete(id: string) {
+    deleteTask(id);
+  }
+
+  function handleAddChild(parentId: string) {
+    setCreating({ parentId });
+  }
+
+  function handleCreate(title: string, parentId?: string) {
+    createTask({ title, parentId });
+    setCreating(null);
+  }
+
+  return (
+    <div className="task-board-page">
+      <header className="task-board-header">
+        <button className="task-board-back" onClick={() => navigate('/')}>
+          &lsaquo;
+        </button>
+        <h1>
+          Tasks {tasks.length > 0 && <span className="task-board-count">{tasks.length}</span>}
+        </h1>
+        <button
+          className="task-board-add-btn"
+          onClick={() => setCreating({ parentId: undefined })}
+          title="Add task"
+        >
+          +
+        </button>
+        <button className="task-board-refresh" onClick={refresh} title="Refresh">
+          &#x21bb;
+        </button>
+      </header>
+
+      {creating && (
+        <TaskCreateForm
+          parentId={creating.parentId}
+          onCreate={handleCreate}
+          onCancel={() => setCreating(null)}
+        />
+      )}
+
+      {loading && <p className="task-board-empty">Loading...</p>}
+
+      {!loading && tasks.length === 0 && (
+        <div className="task-board-empty">
+          <div className="task-board-empty-icon">&#x2610;</div>
+          <p>No tasks yet</p>
+          <p className="task-board-empty-hint">Add a task to get started</p>
+        </div>
+      )}
+
+      <div className="task-board-list">
+        {tasks.map((task) => (
+          <TaskNode
+            key={task.id}
+            task={task}
+            depth={0}
+            onStatusChange={handleStatusChange}
+            onDelete={handleDelete}
+            onAddChild={handleAddChild}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/TaskBoard.test.tsx
+++ b/frontend/src/pages/__tests__/TaskBoard.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TaskBoard } from '../TaskBoard';
+import type { Task } from '../../types/task';
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    parentId: null,
+    title: 'Test task',
+    description: null,
+    status: 'pending',
+    sessionId: null,
+    sessionPolicy: 'auto',
+    priority: 0,
+    depth: 0,
+    annotations: [],
+    summary: null,
+    requiresApproval: false,
+    tokenUsage: 0,
+    claimedBy: null,
+    claimedAt: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    completedAt: null,
+    children: [],
+    ...overrides,
+  };
+}
+
+// Mock useTaskBoard
+const mockRefresh = vi.fn();
+const mockCreateTask = vi.fn();
+const mockUpdateTask = vi.fn();
+const mockDeleteTask = vi.fn();
+let mockLoading = false;
+let mockTasks: Task[] = [];
+
+vi.mock('../../hooks/useTaskBoard', () => ({
+  useTaskBoard: () => ({
+    loading: mockLoading,
+    tasks: mockTasks,
+    createTask: mockCreateTask,
+    updateTask: mockUpdateTask,
+    deleteTask: mockDeleteTask,
+    refresh: mockRefresh,
+  }),
+}));
+
+function renderBoard() {
+  return render(
+    <MemoryRouter>
+      <TaskBoard />
+    </MemoryRouter>,
+  );
+}
+
+describe('TaskBoard', () => {
+  it('shows loading state', () => {
+    mockLoading = true;
+    mockTasks = [];
+    renderBoard();
+    expect(screen.getByText('Loading...')).toBeTruthy();
+    mockLoading = false;
+  });
+
+  it('shows empty state when no tasks', () => {
+    mockLoading = false;
+    mockTasks = [];
+    renderBoard();
+    expect(screen.getByText('No tasks yet')).toBeTruthy();
+  });
+
+  it('renders task list', () => {
+    mockLoading = false;
+    mockTasks = [makeTask({ title: 'Task A' }), makeTask({ id: 'task-2', title: 'Task B' })];
+    renderBoard();
+    expect(screen.getByText('Task A')).toBeTruthy();
+    expect(screen.getByText('Task B')).toBeTruthy();
+  });
+
+  it('add button toggles create form', () => {
+    mockLoading = false;
+    mockTasks = [];
+    renderBoard();
+
+    // Click add button
+    const addBtn = screen.getByTitle('Add task');
+    fireEvent.click(addBtn);
+
+    // Form should appear
+    expect(screen.getByPlaceholderText('Add task...')).toBeTruthy();
+
+    // Click cancel to hide
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByPlaceholderText('Add task...')).toBeNull();
+  });
+
+  it('refresh button calls refresh', () => {
+    mockLoading = false;
+    mockTasks = [];
+    renderBoard();
+
+    const refreshBtn = screen.getByTitle('Refresh');
+    fireEvent.click(refreshBtn);
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -3292,3 +3292,261 @@ textarea:focus {
   background: var(--accent);
   color: var(--bg);
 }
+
+/* ── Task Board ─────────────────────────────────────────── */
+
+.task-board-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0 16px 32px;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.task-board-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0 8px;
+}
+
+.task-board-header h1 {
+  flex: 1;
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.task-board-back,
+.task-board-refresh {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.task-board-count {
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  vertical-align: middle;
+  margin-left: 4px;
+}
+
+.task-board-add-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.task-board-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.task-board-empty {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-dim);
+}
+
+.task-board-empty-icon {
+  font-size: 2rem;
+  margin-bottom: 8px;
+}
+
+.task-board-empty-hint {
+  font-size: 0.8rem;
+  margin-top: 8px;
+}
+
+/* ── Task Node ──────────────────────────────────────────── */
+
+.task-node {
+  padding: 4px 0;
+}
+
+.task-node-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.task-node-row:hover {
+  background: var(--border);
+}
+
+.task-node-chevron {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 0.7rem;
+  cursor: pointer;
+  padding: 2px 4px;
+  min-width: 20px;
+}
+
+.task-node-status {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 2px;
+  min-width: 20px;
+  text-align: center;
+}
+
+.task-node-status--pending {
+  color: var(--text-dim);
+}
+
+.task-node-status--active {
+  color: var(--accent);
+}
+
+.task-node-status--done {
+  color: var(--success);
+}
+
+.task-node-status--pending_review {
+  color: var(--accent);
+}
+
+.task-node-status--blocked {
+  color: #ff9800;
+}
+
+.task-node-status--skipped {
+  color: var(--text-dim);
+}
+
+.task-node-status--failed {
+  color: var(--danger);
+}
+
+.task-node-title {
+  flex: 1;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.task-node-title--done {
+  text-decoration: line-through;
+  color: var(--text-dim);
+}
+
+.task-node-actions {
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.task-node-row:hover .task-node-actions {
+  opacity: 1;
+}
+
+.task-node-action {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.task-node-action:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+.task-node-action--danger:hover {
+  color: var(--danger);
+}
+
+.task-node-children {
+  margin-left: 8px;
+  border-left: 1px solid var(--border);
+}
+
+/* ── Task Create Form ───────────────────────────────────── */
+
+.task-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  margin: 8px 0;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.task-create-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--text);
+  font-size: 0.9rem;
+  outline: none;
+}
+
+.task-create-input:focus {
+  border-color: var(--accent);
+}
+
+.task-create-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.task-create-submit {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.task-create-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.task-create-submit:not(:disabled):hover {
+  background: var(--accent-hover);
+}
+
+.task-create-cancel {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.task-create-cancel:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -1,0 +1,32 @@
+export type TaskStatus =
+  | 'pending'
+  | 'active'
+  | 'done'
+  | 'pending_review'
+  | 'blocked'
+  | 'skipped'
+  | 'failed';
+
+export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
+
+export interface Task {
+  id: string;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  sessionId: string | null;
+  sessionPolicy: SessionPolicy;
+  priority: number;
+  depth: number;
+  annotations: string[];
+  summary: string | null;
+  requiresApproval: boolean;
+  tokenUsage: number;
+  claimedBy: string | null;
+  claimedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  children: Task[];
+}

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -1,4 +1,5 @@
 import type { BlockType, FinishedBlock, ToolTier, RawToolInput } from './chat';
+import type { Task } from './task';
 
 interface ClientIdMsg {
   type: 'client_id';
@@ -175,6 +176,21 @@ interface SubscribedMsg {
   running: boolean;
 }
 
+interface TaskStateMsg {
+  type: 'task_state';
+  tasks: Task[];
+}
+
+interface TaskUpdatedMsg {
+  type: 'task_updated';
+  task: Task;
+}
+
+interface TaskDeletedMsg {
+  type: 'task_deleted';
+  taskId: string;
+}
+
 export type ServerMessage =
   | ClientIdMsg
   | ReattachedMsg
@@ -200,7 +216,10 @@ export type ServerMessage =
   | UserMessageMsg
   | SessionRenamedMsg
   | SubscribedMsg
-  | InboxUpdatedMsg;
+  | InboxUpdatedMsg
+  | TaskStateMsg
+  | TaskUpdatedMsg
+  | TaskDeletedMsg;
 
 export interface InboxUpdatedMsg {
   type: 'inbox_updated';

--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import request from 'supertest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const TEST_REPO = join(tmpdir(), `mitzo-task-routes-test-${process.pid}`);
+
+vi.mock('../chat.js', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join: pjoin } = require('path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir: ptmpdir } = require('os');
+  const repo = pjoin(ptmpdir(), `mitzo-task-routes-test-${process.pid}`);
+  return {
+    getSessions: vi.fn().mockResolvedValue([]),
+    getMessages: vi.fn().mockResolvedValue([]),
+    renameSessionById: vi.fn().mockResolvedValue(undefined),
+    hideSession: vi.fn(),
+    clearHiddenSessions: vi.fn(),
+    BASE_REPO: repo,
+    getRepoConfig: vi.fn(() => ({
+      quickActions: [],
+      allowedPaths: [],
+      roots: [{ label: 'Main', path: repo }],
+      resolvedVenvPaths: [],
+      toolTierOverrides: {},
+      inboxPath: 'mgmt_lib/inbox',
+      resolvedInboxPath: pjoin(repo, 'mgmt_lib/inbox'),
+      repos: {},
+      contextBlocks: {},
+    })),
+    getMcpServerNames: vi.fn().mockReturnValue([]),
+    AVAILABLE_MODELS: [{ id: 'test-model', label: 'Test', desc: 'Test model' }],
+    registry: { get: vi.fn() },
+    eventStore: { getEventsAfter: vi.fn().mockReturnValue([]) },
+  };
+});
+
+vi.mock('../permissions.js', () => ({
+  resolvePending: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../worktree.js', () => ({
+  listWorktrees: vi.fn().mockReturnValue([]),
+  cleanupStaleWorktrees: vi.fn(),
+}));
+
+vi.mock('../git-version.js', () => ({
+  getLocalCommit: vi.fn().mockReturnValue('abc1234'),
+  isUpdateAvailable: vi.fn().mockReturnValue(false),
+}));
+
+let app: Express;
+let authCookie: string;
+
+async function getAuthCookie(agent: request.Agent): Promise<string> {
+  const res = await agent.post('/api/auth/login').send({ passphrase: process.env.AUTH_PASSPHRASE });
+  const setCookie = res.headers['set-cookie'];
+  if (!setCookie) throw new Error('No cookie returned from login');
+  const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+  return cookies[0].split(';')[0];
+}
+
+beforeAll(async () => {
+  mkdirSync(TEST_REPO, { recursive: true });
+  mkdirSync(join(TEST_REPO, 'mgmt_lib', 'inbox', 'archive'), { recursive: true });
+  mkdirSync(join(TEST_REPO, '.mitzo'), { recursive: true });
+
+  const mod = await import('../app.js');
+  app = mod.app;
+
+  const agent = request(app);
+  authCookie = await getAuthCookie(agent);
+});
+
+afterAll(async () => {
+  // Clean up the task store
+  try {
+    const mod = await import('../app.js');
+    if (mod.taskStore?.close) mod.taskStore.close();
+  } catch {
+    // ignore
+  }
+  try {
+    rmSync(TEST_REPO, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('task routes', () => {
+  // --- Auth ---
+
+  it('GET /api/tasks — unauthenticated returns 401', async () => {
+    const res = await request(app).get('/api/tasks');
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /api/tasks — unauthenticated returns 401', async () => {
+    const res = await request(app).post('/api/tasks').send({ title: 'Test' });
+    expect(res.status).toBe(401);
+  });
+
+  // --- GET /api/tasks ---
+
+  it('GET /api/tasks — returns empty task list', async () => {
+    const res = await request(app).get('/api/tasks').set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('tasks');
+    expect(Array.isArray(res.body.tasks)).toBe(true);
+  });
+
+  // --- POST /api/tasks ---
+
+  it('POST /api/tasks — creates a task', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Test task' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('task');
+    expect(res.body.task.title).toBe('Test task');
+    expect(res.body.task.status).toBe('pending');
+    expect(res.body.task.id).toBeTruthy();
+  });
+
+  it('POST /api/tasks — missing title returns 400', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({ description: 'no title' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/tasks — empty title returns 400', async () => {
+    const res = await request(app).post('/api/tasks').send({ title: '' }).set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/tasks — accepts optional fields', async () => {
+    const res = await request(app)
+      .post('/api/tasks')
+      .send({
+        title: 'Full task',
+        description: 'desc',
+        priority: 5,
+        sessionPolicy: 'spawn',
+        annotations: ['a'],
+      })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(201);
+    expect(res.body.task.description).toBe('desc');
+    expect(res.body.task.priority).toBe(5);
+    expect(res.body.task.sessionPolicy).toBe('spawn');
+    expect(res.body.task.annotations).toEqual(['a']);
+  });
+
+  // --- GET /api/tasks/:id ---
+
+  it('GET /api/tasks/:id — returns a task', async () => {
+    const createRes = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Findable' })
+      .set('Cookie', authCookie);
+    const id = createRes.body.task.id;
+
+    const res = await request(app).get(`/api/tasks/${id}`).set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body.task.title).toBe('Findable');
+  });
+
+  it('GET /api/tasks/:id — 404 for nonexistent', async () => {
+    const res = await request(app).get('/api/tasks/nonexistent').set('Cookie', authCookie);
+    expect(res.status).toBe(404);
+  });
+
+  // --- PATCH /api/tasks/:id ---
+
+  it('PATCH /api/tasks/:id — updates a task', async () => {
+    const createRes = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Update me' })
+      .set('Cookie', authCookie);
+    const id = createRes.body.task.id;
+
+    const res = await request(app)
+      .patch(`/api/tasks/${id}`)
+      .send({ title: 'Updated', status: 'active' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body.task.title).toBe('Updated');
+    expect(res.body.task.status).toBe('active');
+  });
+
+  it('PATCH /api/tasks/:id — 404 for nonexistent', async () => {
+    const res = await request(app)
+      .patch('/api/tasks/nonexistent')
+      .send({ title: 'nope' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(404);
+  });
+
+  // --- DELETE /api/tasks/:id ---
+
+  it('DELETE /api/tasks/:id — deletes a task', async () => {
+    const createRes = await request(app)
+      .post('/api/tasks')
+      .send({ title: 'Delete me' })
+      .set('Cookie', authCookie);
+    const id = createRes.body.task.id;
+
+    const res = await request(app).delete(`/api/tasks/${id}`).set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    const getRes = await request(app).get(`/api/tasks/${id}`).set('Cookie', authCookie);
+    expect(getRes.status).toBe(404);
+  });
+
+  it('DELETE /api/tasks/:id — 404 for nonexistent', async () => {
+    const res = await request(app).delete('/api/tasks/nonexistent').set('Cookie', authCookie);
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/__tests__/task-store.test.ts
+++ b/server/__tests__/task-store.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-task-store-test-${process.pid}`);
+
+let store: TaskStore;
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+});
+
+afterEach(() => {
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('TaskStore', () => {
+  // --- Create ---
+
+  it('creates a root task with defaults', () => {
+    const task = store.create({ title: 'Root task' });
+    expect(task.id).toBeTruthy();
+    expect(task.title).toBe('Root task');
+    expect(task.parentId).toBeNull();
+    expect(task.status).toBe('pending');
+    expect(task.depth).toBe(0);
+    expect(task.priority).toBe(0);
+    expect(task.sessionPolicy).toBe('auto');
+    expect(task.annotations).toEqual([]);
+    expect(task.requiresApproval).toBe(false);
+    expect(task.tokenUsage).toBe(0);
+    expect(task.createdAt).toBeGreaterThan(0);
+    expect(task.updatedAt).toBeGreaterThan(0);
+    expect(task.completedAt).toBeNull();
+    expect(task.children).toEqual([]);
+  });
+
+  it('creates a task with all optional fields', () => {
+    const task = store.create({
+      title: 'Full task',
+      description: 'A description',
+      priority: 5,
+      sessionPolicy: 'spawn',
+      annotations: ['tag1', 'tag2'],
+    });
+    expect(task.title).toBe('Full task');
+    expect(task.description).toBe('A description');
+    expect(task.priority).toBe(5);
+    expect(task.sessionPolicy).toBe('spawn');
+    expect(task.annotations).toEqual(['tag1', 'tag2']);
+  });
+
+  it('creates a child task with auto-calculated depth', () => {
+    const parent = store.create({ title: 'Parent' });
+    const child = store.create({ title: 'Child', parentId: parent.id });
+    expect(child.parentId).toBe(parent.id);
+    expect(child.depth).toBe(1);
+
+    const grandchild = store.create({ title: 'Grandchild', parentId: child.id });
+    expect(grandchild.depth).toBe(2);
+  });
+
+  it('throws when creating a child with nonexistent parent', () => {
+    expect(() => store.create({ title: 'Orphan', parentId: 'nonexistent' })).toThrow();
+  });
+
+  // --- Get ---
+
+  it('gets a task by id', () => {
+    const created = store.create({ title: 'Findme' });
+    const found = store.get(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.title).toBe('Findme');
+  });
+
+  it('returns null for nonexistent id', () => {
+    expect(store.get('nonexistent')).toBeNull();
+  });
+
+  // --- Update ---
+
+  it('updates a task title', () => {
+    const task = store.create({ title: 'Original' });
+    const updated = store.update(task.id, { title: 'Updated' });
+    expect(updated).not.toBeNull();
+    expect(updated!.title).toBe('Updated');
+    expect(updated!.updatedAt).toBeGreaterThanOrEqual(task.updatedAt);
+  });
+
+  it('sets completedAt when status transitions to done', () => {
+    const task = store.create({ title: 'Complete me' });
+    expect(task.completedAt).toBeNull();
+
+    const updated = store.update(task.id, { status: 'done' });
+    expect(updated!.completedAt).not.toBeNull();
+    expect(updated!.completedAt).toBeGreaterThan(0);
+  });
+
+  it('sets completedAt when status transitions to skipped', () => {
+    const task = store.create({ title: 'Skip me' });
+    const updated = store.update(task.id, { status: 'skipped' });
+    expect(updated!.completedAt).not.toBeNull();
+  });
+
+  it('sets completedAt when status transitions to failed', () => {
+    const task = store.create({ title: 'Fail me' });
+    const updated = store.update(task.id, { status: 'failed' });
+    expect(updated!.completedAt).not.toBeNull();
+  });
+
+  it('clears completedAt when status transitions from terminal to non-terminal', () => {
+    const task = store.create({ title: 'Reopen me' });
+    store.update(task.id, { status: 'done' });
+    const reopened = store.update(task.id, { status: 'active' });
+    expect(reopened!.completedAt).toBeNull();
+  });
+
+  it('returns null when updating nonexistent id', () => {
+    expect(store.update('nonexistent', { title: 'nope' })).toBeNull();
+  });
+
+  it('updates annotations', () => {
+    const task = store.create({ title: 'Annotate me' });
+    const updated = store.update(task.id, { annotations: ['a', 'b'] });
+    expect(updated!.annotations).toEqual(['a', 'b']);
+  });
+
+  // --- Delete ---
+
+  it('deletes a task', () => {
+    const task = store.create({ title: 'Delete me' });
+    expect(store.delete(task.id)).toBe(true);
+    expect(store.get(task.id)).toBeNull();
+  });
+
+  it('returns false when deleting nonexistent id', () => {
+    expect(store.delete('nonexistent')).toBe(false);
+  });
+
+  it('cascade deletes children', () => {
+    const parent = store.create({ title: 'Parent' });
+    const child = store.create({ title: 'Child', parentId: parent.id });
+    const grandchild = store.create({ title: 'Grandchild', parentId: child.id });
+
+    expect(store.delete(parent.id)).toBe(true);
+    expect(store.get(child.id)).toBeNull();
+    expect(store.get(grandchild.id)).toBeNull();
+  });
+
+  // --- listRoots ---
+
+  it('lists root tasks ordered by priority DESC then created_at ASC', () => {
+    store.create({ title: 'Low', priority: 0 });
+    store.create({ title: 'High', priority: 10 });
+    store.create({ title: 'Medium', priority: 5 });
+
+    const roots = store.listRoots();
+    expect(roots).toHaveLength(3);
+    expect(roots[0].title).toBe('High');
+    expect(roots[1].title).toBe('Medium');
+    expect(roots[2].title).toBe('Low');
+  });
+
+  // --- getChildren ---
+
+  it('gets children of a parent', () => {
+    const parent = store.create({ title: 'Parent' });
+    store.create({ title: 'Child 1', parentId: parent.id });
+    store.create({ title: 'Child 2', parentId: parent.id });
+
+    const children = store.getChildren(parent.id);
+    expect(children).toHaveLength(2);
+  });
+
+  // --- getTree ---
+
+  it('assembles a tree from flat data', () => {
+    const root1 = store.create({ title: 'Root 1', priority: 1 });
+    store.create({ title: 'Root 2', priority: 0 });
+    const child1 = store.create({ title: 'Child 1', parentId: root1.id });
+    store.create({ title: 'Grandchild', parentId: child1.id });
+
+    const tree = store.getTree();
+    expect(tree).toHaveLength(2);
+    // Root 1 has higher priority
+    expect(tree[0].title).toBe('Root 1');
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].title).toBe('Child 1');
+    expect(tree[0].children[0].children).toHaveLength(1);
+    expect(tree[0].children[0].children[0].title).toBe('Grandchild');
+    expect(tree[1].title).toBe('Root 2');
+    expect(tree[1].children).toHaveLength(0);
+  });
+
+  // --- getSubtree ---
+
+  it('gets a subtree rooted at a given task', () => {
+    const root = store.create({ title: 'Root' });
+    const child = store.create({ title: 'Child', parentId: root.id });
+    store.create({ title: 'Grandchild', parentId: child.id });
+    store.create({ title: 'Other root' });
+
+    const subtree = store.getSubtree(root.id);
+    expect(subtree).toHaveLength(1);
+    expect(subtree[0].title).toBe('Root');
+    expect(subtree[0].children).toHaveLength(1);
+    expect(subtree[0].children[0].children).toHaveLength(1);
+  });
+
+  it('returns empty array for nonexistent subtree root', () => {
+    expect(store.getSubtree('nonexistent')).toEqual([]);
+  });
+
+  // --- close ---
+
+  it('can close and reopen', () => {
+    const dbPath = join(TEST_DIR, 'reopen.db');
+    const store1 = new TaskStore(dbPath);
+    store1.create({ title: 'Persist me' });
+    store1.close();
+
+    const store2 = new TaskStore(dbPath);
+    const roots = store2.listRoots();
+    expect(roots).toHaveLength(1);
+    expect(roots[0].title).toBe('Persist me');
+    store2.close();
+  });
+});

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -108,3 +108,27 @@ export const TodoActionResponse = z.object({
   ok: z.boolean(),
   error: z.string().optional(),
 });
+
+// -- Task schemas --
+
+export const TaskCreateBody = z.object({
+  title: z.string().min(1),
+  parentId: z.string().optional(),
+  description: z.string().optional(),
+  priority: z.number().optional(),
+  sessionPolicy: z.enum(['reuse', 'spawn', 'auto']).optional(),
+  annotations: z.array(z.string()).optional(),
+});
+
+export const TaskUpdateBody = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  status: z
+    .enum(['pending', 'active', 'done', 'pending_review', 'blocked', 'skipped', 'failed'])
+    .optional(),
+  priority: z.number().optional(),
+  sessionPolicy: z.enum(['reuse', 'spawn', 'auto']).optional(),
+  annotations: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+  requiresApproval: z.boolean().optional(),
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -38,6 +38,8 @@ import {
   TodoCreateBody,
   TodoActionBody,
   TodoActionResponse,
+  TaskCreateBody,
+  TaskUpdateBody,
 } from './api-schemas.js';
 import {
   listInboxItems,
@@ -48,7 +50,9 @@ import {
 } from './inbox.js';
 import { SkillRegistry } from './skills.js';
 
+import { mkdirSync } from 'fs';
 import { homedir } from 'os';
+import { TaskStore } from './task-store.js';
 
 const log = createLogger('server');
 
@@ -150,6 +154,17 @@ let updateAvailable = false;
 
 let onUpdateAvailable: (() => void) | null = null;
 let onInboxUpdated: (() => void) | null = null;
+let onTaskBroadcast: ((event: Record<string, unknown>) => void) | null = null;
+
+// --- Task store ---
+
+const mitzoDir = join(BASE_REPO, '.mitzo');
+try {
+  mkdirSync(mitzoDir, { recursive: true });
+} catch {
+  // may already exist
+}
+export const taskStore = new TaskStore(join(mitzoDir, 'tasks.db'));
 
 export function setUpdateBroadcast(fn: () => void) {
   onUpdateAvailable = fn;
@@ -157,6 +172,10 @@ export function setUpdateBroadcast(fn: () => void) {
 
 export function setInboxBroadcast(fn: () => void) {
   onInboxUpdated = fn;
+}
+
+export function setTaskBroadcast(fn: (event: Record<string, unknown>) => void) {
+  onTaskBroadcast = fn;
 }
 
 /** Broadcast inbox_updated to all connected WS clients. */
@@ -289,6 +308,62 @@ app.post('/api/repos/open', (req, res) => {
 });
 
 app.use('/api', authMiddleware);
+
+// --- Task Board API ---
+
+app.get('/api/tasks', (_req, res) => {
+  res.json({ tasks: taskStore.getTree() });
+});
+
+app.post('/api/tasks', (req, res) => {
+  const body = TaskCreateBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+  try {
+    const task = taskStore.create(body.data);
+    res.status(201).json({ task });
+    onTaskBroadcast?.({ type: 'task_updated', task });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    res.status(400).json({ error: message });
+  }
+});
+
+app.get('/api/tasks/:id', (req, res) => {
+  const task = taskStore.get(req.params.id);
+  if (!task) {
+    res.status(404).json({ error: 'Task not found' });
+    return;
+  }
+  res.json({ task });
+});
+
+app.patch('/api/tasks/:id', (req, res) => {
+  const body = TaskUpdateBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+  const task = taskStore.update(req.params.id, body.data);
+  if (!task) {
+    res.status(404).json({ error: 'Task not found' });
+    return;
+  }
+  res.json({ task });
+  onTaskBroadcast?.({ type: 'task_updated', task });
+});
+
+app.delete('/api/tasks/:id', (req, res) => {
+  const ok = taskStore.delete(req.params.id);
+  if (!ok) {
+    res.status(404).json({ error: 'Task not found' });
+    return;
+  }
+  res.json({ ok: true });
+  onTaskBroadcast?.({ type: 'task_deleted', taskId: req.params.id });
+});
 
 app.post('/api/auth/login', loginLimiter, async (req, res) => {
   const body = LoginBody.safeParse(req.body);

--- a/server/app.ts
+++ b/server/app.ts
@@ -324,7 +324,8 @@ app.post('/api/tasks', (req, res) => {
   try {
     const task = taskStore.create(body.data);
     res.status(201).json({ task });
-    onTaskBroadcast?.({ type: 'task_updated', task });
+    // Broadcast full tree so child tasks appear correctly in all clients
+    onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     res.status(400).json({ error: message });

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,11 +27,13 @@ import {
   app,
   setUpdateBroadcast,
   setInboxBroadcast,
+  setTaskBroadcast,
   runUpdateCheck,
   buildSkillRegistry,
   NATIVE_COMMAND_NAMES,
   isAllowedPath,
   yapperWsProxy,
+  taskStore,
 } from './app.js';
 import { IncomingWsMessage } from './ws-schemas.js';
 import { resolveSlashCommand } from './slash-commands.js';
@@ -66,6 +68,13 @@ setUpdateBroadcast(() => {
 
 setInboxBroadcast(() => {
   const msg = JSON.stringify({ type: 'inbox_updated' });
+  wss.clients.forEach((client) => {
+    if (client.readyState === client.OPEN) client.send(msg);
+  });
+});
+
+setTaskBroadcast((event) => {
+  const msg = JSON.stringify(event);
   wss.clients.forEach((client) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
@@ -143,6 +152,10 @@ function tryRouteToActiveSession(
 function handleChatWs(ws: WebSocket, initialClientId: string) {
   let clientId = initialClientId;
   ws.send(JSON.stringify({ type: 'client_id', clientId }));
+
+  // Hydrate task board state
+  const taskTree = taskStore.getTree();
+  ws.send(JSON.stringify({ type: 'task_state', tasks: taskTree }));
 
   const heartbeat = setInterval(() => {
     if (ws.readyState === ws.OPEN) {

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -1,0 +1,343 @@
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import { createLogger } from './logger.js';
+
+const log = createLogger('task-store');
+
+export type TaskStatus =
+  | 'pending'
+  | 'active'
+  | 'done'
+  | 'pending_review'
+  | 'blocked'
+  | 'skipped'
+  | 'failed';
+
+export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
+
+const TERMINAL_STATUSES: Set<TaskStatus> = new Set(['done', 'skipped', 'failed']);
+
+export interface Task {
+  id: string;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  sessionId: string | null;
+  sessionPolicy: SessionPolicy;
+  priority: number;
+  depth: number;
+  annotations: string[];
+  summary: string | null;
+  requiresApproval: boolean;
+  tokenUsage: number;
+  claimedBy: string | null;
+  claimedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  children: Task[];
+}
+
+export interface TaskCreateInput {
+  title: string;
+  parentId?: string;
+  description?: string;
+  priority?: number;
+  sessionPolicy?: SessionPolicy;
+  annotations?: string[];
+}
+
+export interface TaskUpdateInput {
+  title?: string;
+  description?: string;
+  status?: TaskStatus;
+  priority?: number;
+  sessionPolicy?: SessionPolicy;
+  annotations?: string[];
+  summary?: string;
+  requiresApproval?: boolean;
+}
+
+interface TaskRow {
+  id: string;
+  parent_id: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  session_id: string | null;
+  session_policy: string;
+  priority: number;
+  depth: number;
+  annotations: string | null;
+  summary: string | null;
+  requires_approval: number;
+  token_usage: number;
+  claimed_by: string | null;
+  claimed_at: number | null;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+}
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS tasks (
+    id              TEXT PRIMARY KEY,
+    parent_id       TEXT REFERENCES tasks(id) ON DELETE CASCADE,
+    title           TEXT NOT NULL,
+    description     TEXT,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK(status IN ('pending','active','done','pending_review','blocked','skipped','failed')),
+    session_id      TEXT,
+    session_policy  TEXT NOT NULL DEFAULT 'auto'
+                    CHECK(session_policy IN ('reuse','spawn','auto')),
+    priority        INTEGER NOT NULL DEFAULT 0,
+    depth           INTEGER NOT NULL DEFAULT 0
+                    CHECK(depth >= 0),
+    annotations     TEXT,
+    summary         TEXT,
+    requires_approval INTEGER NOT NULL DEFAULT 0,
+    token_usage     INTEGER NOT NULL DEFAULT 0,
+    claimed_by      TEXT,
+    claimed_at      REAL,
+    created_at      REAL NOT NULL,
+    updated_at      REAL NOT NULL,
+    completed_at    REAL
+  );
+  CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
+  CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+  CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id);
+`;
+
+function rowToTask(row: TaskRow): Task {
+  let annotations: string[] = [];
+  if (row.annotations) {
+    try {
+      annotations = JSON.parse(row.annotations);
+    } catch {
+      annotations = [];
+    }
+  }
+  return {
+    id: row.id,
+    parentId: row.parent_id,
+    title: row.title,
+    description: row.description,
+    status: row.status as TaskStatus,
+    sessionId: row.session_id,
+    sessionPolicy: row.session_policy as SessionPolicy,
+    priority: row.priority,
+    depth: row.depth,
+    annotations,
+    summary: row.summary,
+    requiresApproval: row.requires_approval === 1,
+    tokenUsage: row.token_usage,
+    claimedBy: row.claimed_by,
+    claimedAt: row.claimed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+    children: [],
+  };
+}
+
+export class TaskStore {
+  private db: Database.Database | null;
+
+  constructor(dbPath: string) {
+    const db = new Database(dbPath);
+    this.db = db;
+    db.pragma('journal_mode = WAL');
+    db.pragma('foreign_keys = ON');
+    db.exec(SCHEMA);
+    log.info('TaskStore initialized', { dbPath });
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  create(input: TaskCreateInput): Task {
+    const db = this.db!;
+    const id = randomUUID();
+    const now = Date.now();
+
+    let depth = 0;
+    if (input.parentId) {
+      const parentRow = db.prepare('SELECT depth FROM tasks WHERE id = ?').get(input.parentId) as
+        | { depth: number }
+        | undefined;
+      if (!parentRow) {
+        throw new Error(`Parent task not found: ${input.parentId}`);
+      }
+      depth = parentRow.depth + 1;
+    }
+
+    const annotations = input.annotations ? JSON.stringify(input.annotations) : null;
+
+    db.prepare(
+      `INSERT INTO tasks (id, parent_id, title, description, status, session_policy, priority, depth, annotations, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      id,
+      input.parentId ?? null,
+      input.title,
+      input.description ?? null,
+      input.sessionPolicy ?? 'auto',
+      input.priority ?? 0,
+      depth,
+      annotations,
+      now,
+      now,
+    );
+
+    return this.get(id)!;
+  }
+
+  get(id: string): Task | null {
+    const row = this.db!.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined;
+    return row ? rowToTask(row) : null;
+  }
+
+  update(id: string, fields: TaskUpdateInput): Task | null {
+    const existing = this.get(id);
+    if (!existing) return null;
+
+    const sets: string[] = [];
+    const values: unknown[] = [];
+
+    if (fields.title !== undefined) {
+      sets.push('title = ?');
+      values.push(fields.title);
+    }
+    if (fields.description !== undefined) {
+      sets.push('description = ?');
+      values.push(fields.description);
+    }
+    if (fields.status !== undefined) {
+      sets.push('status = ?');
+      values.push(fields.status);
+
+      if (TERMINAL_STATUSES.has(fields.status)) {
+        sets.push('completed_at = ?');
+        values.push(Date.now());
+      } else {
+        sets.push('completed_at = ?');
+        values.push(null);
+      }
+    }
+    if (fields.priority !== undefined) {
+      sets.push('priority = ?');
+      values.push(fields.priority);
+    }
+    if (fields.sessionPolicy !== undefined) {
+      sets.push('session_policy = ?');
+      values.push(fields.sessionPolicy);
+    }
+    if (fields.annotations !== undefined) {
+      sets.push('annotations = ?');
+      values.push(JSON.stringify(fields.annotations));
+    }
+    if (fields.summary !== undefined) {
+      sets.push('summary = ?');
+      values.push(fields.summary);
+    }
+    if (fields.requiresApproval !== undefined) {
+      sets.push('requires_approval = ?');
+      values.push(fields.requiresApproval ? 1 : 0);
+    }
+
+    if (sets.length === 0) return existing;
+
+    sets.push('updated_at = ?');
+    values.push(Date.now());
+    values.push(id);
+
+    this.db!.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+
+    return this.get(id);
+  }
+
+  delete(id: string): boolean {
+    const result = this.db!.prepare('DELETE FROM tasks WHERE id = ?').run(id);
+    return result.changes > 0;
+  }
+
+  listRoots(): Task[] {
+    const rows = this.db!.prepare(
+      'SELECT * FROM tasks WHERE parent_id IS NULL ORDER BY priority DESC, created_at ASC',
+    ).all() as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  getChildren(parentId: string): Task[] {
+    const rows = this.db!.prepare(
+      'SELECT * FROM tasks WHERE parent_id = ? ORDER BY priority DESC, created_at ASC',
+    ).all(parentId) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  getTree(): Task[] {
+    const rows = this.db!.prepare(
+      'SELECT * FROM tasks ORDER BY priority DESC, created_at ASC',
+    ).all() as TaskRow[];
+    return this.assembleTree(rows);
+  }
+
+  getSubtree(rootId: string): Task[] {
+    const root = this.get(rootId);
+    if (!root) return [];
+
+    // Fetch all tasks and filter to subtree
+    const allRows = this.db!.prepare(
+      'SELECT * FROM tasks ORDER BY priority DESC, created_at ASC',
+    ).all() as TaskRow[];
+    const allTasks = allRows.map(rowToTask);
+
+    // Build parent->children map
+    const childMap = new Map<string, Task[]>();
+    for (const task of allTasks) {
+      if (task.parentId) {
+        const siblings = childMap.get(task.parentId) ?? [];
+        siblings.push(task);
+        childMap.set(task.parentId, siblings);
+      }
+    }
+
+    // Recursively build tree from root
+    function buildSubtree(task: Task): Task {
+      const children = childMap.get(task.id) ?? [];
+      return { ...task, children: children.map(buildSubtree) };
+    }
+
+    const rootTask = allTasks.find((t) => t.id === rootId);
+    if (!rootTask) return [];
+
+    return [buildSubtree(rootTask)];
+  }
+
+  private assembleTree(rows: TaskRow[]): Task[] {
+    const tasks = rows.map(rowToTask);
+    const taskMap = new Map<string, Task>();
+    for (const task of tasks) {
+      taskMap.set(task.id, task);
+    }
+
+    const roots: Task[] = [];
+    for (const task of tasks) {
+      if (task.parentId) {
+        const parent = taskMap.get(task.parentId);
+        if (parent) {
+          parent.children.push(task);
+        }
+      } else {
+        roots.push(task);
+      }
+    }
+
+    return roots;
+  }
+}

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -160,8 +160,13 @@ export class TaskStore {
     }
   }
 
+  private getDb(): Database.Database {
+    if (!this.db) throw new Error('TaskStore is closed');
+    return this.db;
+  }
+
   create(input: TaskCreateInput): Task {
-    const db = this.db!;
+    const db = this.getDb();
     const id = randomUUID();
     const now = Date.now();
 
@@ -198,7 +203,9 @@ export class TaskStore {
   }
 
   get(id: string): Task | null {
-    const row = this.db!.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined;
+    const row = this.getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(id) as
+      | TaskRow
+      | undefined;
     return row ? rowToTask(row) : null;
   }
 
@@ -256,42 +263,44 @@ export class TaskStore {
     values.push(Date.now());
     values.push(id);
 
-    this.db!.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ?`).run(...values);
+    this.getDb()
+      .prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ?`)
+      .run(...values);
 
     return this.get(id);
   }
 
   delete(id: string): boolean {
-    const result = this.db!.prepare('DELETE FROM tasks WHERE id = ?').run(id);
+    const result = this.getDb().prepare('DELETE FROM tasks WHERE id = ?').run(id);
     return result.changes > 0;
   }
 
   listRoots(): Task[] {
-    const rows = this.db!.prepare(
-      'SELECT * FROM tasks WHERE parent_id IS NULL ORDER BY priority DESC, created_at ASC',
-    ).all() as TaskRow[];
+    const rows = this.getDb()
+      .prepare('SELECT * FROM tasks WHERE parent_id IS NULL ORDER BY priority DESC, created_at ASC')
+      .all() as TaskRow[];
     return rows.map(rowToTask);
   }
 
   getChildren(parentId: string): Task[] {
-    const rows = this.db!.prepare(
-      'SELECT * FROM tasks WHERE parent_id = ? ORDER BY priority DESC, created_at ASC',
-    ).all(parentId) as TaskRow[];
+    const rows = this.getDb()
+      .prepare('SELECT * FROM tasks WHERE parent_id = ? ORDER BY priority DESC, created_at ASC')
+      .all(parentId) as TaskRow[];
     return rows.map(rowToTask);
   }
 
   getTree(): Task[] {
-    const rows = this.db!.prepare(
-      'SELECT * FROM tasks ORDER BY priority DESC, created_at ASC',
-    ).all() as TaskRow[];
+    const rows = this.getDb()
+      .prepare('SELECT * FROM tasks ORDER BY priority DESC, created_at ASC')
+      .all() as TaskRow[];
     return this.assembleTree(rows);
   }
 
   getSubtree(rootId: string): Task[] {
     // Fetch all tasks and filter to subtree
-    const allRows = this.db!.prepare(
-      'SELECT * FROM tasks ORDER BY priority DESC, created_at ASC',
-    ).all() as TaskRow[];
+    const allRows = this.getDb()
+      .prepare('SELECT * FROM tasks ORDER BY priority DESC, created_at ASC')
+      .all() as TaskRow[];
     const allTasks = allRows.map(rowToTask);
 
     const rootTask = allTasks.find((t) => t.id === rootId);

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -288,14 +288,14 @@ export class TaskStore {
   }
 
   getSubtree(rootId: string): Task[] {
-    const root = this.get(rootId);
-    if (!root) return [];
-
     // Fetch all tasks and filter to subtree
     const allRows = this.db!.prepare(
       'SELECT * FROM tasks ORDER BY priority DESC, created_at ASC',
     ).all() as TaskRow[];
     const allTasks = allRows.map(rowToTask);
+
+    const rootTask = allTasks.find((t) => t.id === rootId);
+    if (!rootTask) return [];
 
     // Build parent->children map
     const childMap = new Map<string, Task[]>();
@@ -312,9 +312,6 @@ export class TaskStore {
       const children = childMap.get(task.id) ?? [];
       return { ...task, children: children.map(buildSubtree) };
     }
-
-    const rootTask = allTasks.find((t) => t.id === rootId);
-    if (!rootTask) return [];
 
     return [buildSubtree(rootTask)];
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,24 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Allow frontend tests to resolve deps from frontend/node_modules
+      react: resolve(__dirname, 'frontend/node_modules/react'),
+      'react-dom': resolve(__dirname, 'frontend/node_modules/react-dom'),
+      'react-router-dom': resolve(__dirname, 'frontend/node_modules/react-router-dom'),
+      '@testing-library/react': resolve(__dirname, 'frontend/node_modules/@testing-library/react'),
+      '@testing-library/jest-dom': resolve(
+        __dirname,
+        'frontend/node_modules/@testing-library/jest-dom',
+      ),
+      '@testing-library/user-event': resolve(
+        __dirname,
+        'frontend/node_modules/@testing-library/user-event',
+      ),
+    },
+  },
   test: {
     env: {
       NODE_ENV: 'test',


### PR DESCRIPTION
## Summary
- **TaskStore** — SQLite persistence layer at `.mitzo/tasks.db` with CRUD, tree assembly, cascade delete, and depth tracking
- **REST API** — `GET/POST/PATCH/DELETE /api/tasks` with Zod validation and broadcast-on-mutate
- **WebSocket** — `task_state` hydration on connect, `task_updated`/`task_deleted` live broadcasts
- **Frontend** — `useTaskBoard` hook (REST + WS), `TaskNode` tree component, `TaskCreateForm`, `TaskBoard` page at `/tasks`

## Test plan
- [x] 33 new tests across 6 test files (1088 total passing)
- [x] Lint clean, type-checks, production build passes
- [ ] Manual: create root task, create child task, delete task
- [ ] Manual: open two browser tabs, verify WS sync
- [ ] Manual: refresh page, verify SQLite persistence

Design doc: `docs/design/task-board-phase1-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)