### PR TITLE
feat: task board phase 2 — autonomous orchestration loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ npm run lint         # ESLint (server + frontend)
 npm run lint:fix     # ESLint with auto-fix
 npm run format       # Prettier (write)
 npm run format:check # Prettier (check only)
-npm test             # Vitest (946 tests, 85 files)
+npm test             # Vitest (2200+ tests, 187 files)
 ```
 
 Pre-commit hooks (husky + lint-staged) run lint and format on staged files. Conventional commit messages enforced via commitlint. **Pre-commit hooks are not a substitute for CI** — they only check staged files of specific types. Always verify CI passes after pushing (see `.cursor/rules/ci-discipline.mdc`).
@@ -49,6 +49,11 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 - `repo-mcp-server.ts` — Repo-scoped MCP server configuration.
 - `notification-helpers.ts` — Shared notification formatting utilities.
 - `inbox.ts` — Inbox integration endpoint.
+- `task-store.ts` — `TaskStore` class: SQLite persistence for tasks with tree queries, cascade status, DFS ordering, orphan detection. WAL mode + foreign keys.
+- `task-tools.ts` — Pure handler functions for agent task tools (TaskSet, TaskComplete, TaskStatus, TaskBlock). Never throw — return error strings.
+- `task-mcp-server.ts` — Stdio MCP server exposing task tools as `mcp__task-board__*`. Calls back to internal HTTP endpoints.
+- `task-context.ts` — XML task context builder for system prompt injection. Includes current task, siblings, parent tree, and summaries (capped at 2000 chars).
+- `task-orchestrator.ts` — `TaskOrchestrator`: event-driven state machine (idle/running/paused) with DFS sequential task assignment. Spec mode for human review of decompositions. Orphan detection reclaims tasks from dead sessions.
 - `mcp-config.ts` — Loads MCP server configs from Cursor mcp.json.
 - `worktree.ts` — Git worktree lifecycle.
 - `repo-config.ts` — `.mitzo.json` reader for quick actions, venv paths, tier overrides.
@@ -63,10 +68,11 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 
 - `types/chat.ts` — v2 types: `StreamingBlock`, `StreamingMessage`, `FinishedBlock`, `FinishedMessage`, `BlockType`, `RawToolInput`, `PermissionRequest`, `ToolTier`, `Session`, `ImageAttachment`.
 - `types/ws-messages.ts` — Typed WebSocket message unions (client → server, server → client).
-- `hooks/` — `useChatMessages` (useReducer for v2 protocol: MESSAGE_START/BLOCK_START/BLOCK_DELTA/BLOCK_END/TOOL_RESULT/MESSAGE_END/SESSION_END/MESSAGE_SNAPSHOT/RESTORE), `useChatSession`, `useChatConnection`, `usePermission`, `useFileNavigation`, `useFileEditor`, `useLongPress`.
+- `types/task.ts` — Task model types (`Task`, `TaskStatus`, `LoopStatus`, `SessionPolicy`).
+- `hooks/` — `useChatMessages` (useReducer for v2 protocol: MESSAGE_START/BLOCK_START/BLOCK_DELTA/BLOCK_END/TOOL_RESULT/MESSAGE_END/SESSION_END/MESSAGE_SNAPSHOT/RESTORE), `useChatSession`, `useChatConnection`, `usePermission`, `useTaskBoard` (task CRUD + loop control + WS subscriptions), `useFileNavigation`, `useFileEditor`, `useLongPress`.
 - `lib/` — `ws-pool` (module-level WebSocket pool with 500-message buffer and auto-reconnect), `groupMessages` (tool block grouping with configurable threshold), `constants`, `formatTime`, `paste-images`, `model-preference`, `rename-session`, `resizeImage`, `swipe-reveal`, `truncate`.
-- Pages: `Login`, `SessionList`, `ChatView` (renders `current` inline + `messages[]` grouped), `DesktopChatView`, `FileViewer`, `InboxView`, `CalendarView`, `TodoView`, `TodoDetailView`.
-- Components: `MessageBubble` (UserBubble/TextBubble), `ThinkingBlock`, `ToolPill`, `ToolGroup`, `PermissionBanner`, `ChatInput`, `SlashPicker`, `ErrorBoundary`, `MitzoLogo`.
+- Pages: `Login`, `SessionList`, `ChatView` (renders `current` inline + `messages[]` grouped), `DesktopChatView`, `FileViewer`, `InboxView`, `CalendarView`, `TodoView`, `TodoDetailView`, `TaskBoard`.
+- Components: `MessageBubble` (UserBubble/TextBubble), `ThinkingBlock`, `ToolPill`, `ToolGroup`, `PermissionBanner`, `ChatInput`, `SlashPicker`, `ErrorBoundary`, `MitzoLogo`, `TaskNode`, `TaskCreateForm`, `LoopControls`, `TaskSidebar`.
 - Auth via `ProtectedRoute` wrapper. Vite dev server proxies `/api` and `/ws` to backend.
 
 **v2 protocol — key reducer behaviors:**
@@ -123,6 +129,19 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 - Claude sessions get all configured MCP tools (Jira, GitLab, etc.) automatically.
 - `GET /api/config` exposes server names (not credentials) to the frontend.
 
+**Task board and orchestration:**
+
+- `TaskStore` uses SQLite (`.mitzo/tasks.db`) with WAL mode and foreign keys. Tasks form a tree (parentId), with status cascade rules: failed > blocked > active > pending_review > all done/skipped = done > pending.
+- `TaskOrchestrator` is a singleton event-driven state machine. `tick()` is stateless — always re-reads from SQLite. No polling; tool completions and REST mutations trigger tick.
+- Agent tools (`TaskSet`, `TaskComplete`, `TaskStatus`, `TaskBlock`) are delivered as `mcp__task-board__*` via a child-process MCP server. Classified as `safe` tier.
+- Spec mode: `start(goalId, { specMode: true })` lets the agent decompose a goal into subtasks, then pauses for human approval before execution begins.
+- Orphan detection: during `tick()`, active tasks whose `session_id` doesn't match any alive session get reclaimed to `pending`.
+- Task context is injected into the system prompt as XML blocks per design doc §8.1.
+- Loop status is broadcast to all clients via WS (`loop_status` event type).
+- REST API: `/api/tasks` CRUD, `/api/loop/{status,start,pause,resume,stop}`, `/api/tasks/:id/{approve,reject}`, `/api/loop/spec/{approve,reject}`.
+- Phase 2 is `reuse` session policy only — `spawn`/`auto` are Phase 3.
+- Design doc: `docs/design/global-task-board.md`.
+
 **Skills system:**
 
 - Skills are reusable prompt packages invoked via `/slash-command` in chat input.
@@ -153,7 +172,7 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 
 ## What is Mitzo?
 
-Mitzo is a web-based command center for Claude Code sessions, built on the Anthropic Agent SDK. It provides a mobile-first interface for managing AI-assisted workflows — chat sessions with slash-command skills, file browsing/editing, worktree isolation, MCP tool integration, voice input/output via Yapper, and quick actions.
+Mitzo is a web-based command center for Claude Code sessions, built on the Anthropic Agent SDK. It provides a mobile-first interface for managing AI-assisted workflows — chat sessions with slash-command skills, file browsing/editing, worktree isolation, MCP tool integration, voice input/output via Yapper, quick actions, and a task board with autonomous orchestration.
 
 Mitzo lives at `~/tools/mitzo/` and is pointed at the `mgmt` workspace via the `REPO_PATH` env var. It is open source and designed to be portable — no hardcoded paths or machine-specific configuration.
 

--- a/docs/design/task-board-phase2-plan.md
+++ b/docs/design/task-board-phase2-plan.md
@@ -1,0 +1,305 @@
+# Task Board Phase 2 — Implementation Plan
+
+## Context
+
+Phase 1 (PR #182) delivered the foundation: `TaskStore` with SQLite CRUD + tree queries, REST API, WS broadcast, `useTaskBoard` hook, and `TaskNode`/`TaskCreateForm`/`TaskBoard` frontend. Phase 2 makes the task board autonomous: agents can read/write tasks via custom tools, an orchestrator loop auto-assigns sequential tasks, spec mode lets users review decompositions before execution, and the frontend gains loop controls, a task sidebar, and approval UI.
+
+Design doc: `docs/design/global-task-board.md` (sections 4.1–4.6, 7.2, 7.4–7.5, 8.1–8.3)
+
+## Key Decisions
+
+| Decision               | Choice                                                       | Rationale                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| Tool delivery          | In-process MCP server via `createSdkMcpServer()`             | Agent SDK native; handlers run in-process, return results directly — no deny/retry issues. Tools appear as `mcp__task-board__*` |
+| Orchestrator state     | Stateless between `tick()` — re-reads from SQLite            | Per design doc critical invariant; prevents races with user actions                                                             |
+| Session policy         | `reuse` only for Phase 2                                     | `spawn`/`auto` scoped to Phase 3; keeps orchestrator simple                                                                     |
+| Spec mode session      | `mode: 'ask'` via existing SDK plan mode                     | Prevents file writes during decomposition                                                                                       |
+| Orchestrator lifecycle | Singleton, event-driven (not polling)                        | WS events + REST mutations trigger `tick()` — no timers                                                                         |
+| Task context format    | XML blocks per design doc §8.1                               | Structured, parseable, consistent with system prompt patterns                                                                   |
+| `deriveParentStatus`   | Method on `TaskStore`                                        | Pure data function; easier to test; orchestrator calls after mutations                                                          |
+| Orphan detection       | `TaskStore.getOrphaned()` + `SessionRegistry` liveness check | Store queries active tasks; registry confirms session alive                                                                     |
+
+## Build Order (14 steps, 1 commit each)
+
+### Step 1: `TaskStore` Extensions — Cascade, DFS, Orphan Detection
+
+**Modified files:** `server/task-store.ts`, `server/__tests__/task-store.test.ts`
+
+Extend `TaskStore` with Phase 2 methods:
+
+- `deriveParentStatus(parentId)` — cascade rules from §2.3: failed > blocked > active > pending_review > all-done/skipped > pending
+- `cascadeStatus(taskId)` — walk up parent chain calling `deriveParentStatus`, stop when status unchanged
+- `getBySession(sessionId)` → Task[] — all tasks assigned to a session
+- `setSessionId(taskId, sessionId | null)` → Task | null
+- `getNextExecutable(parentId?)` → Task | null — DFS: deepest-left pending leaf, ordered by priority/created_at
+- `getOrphaned(activeSessionIds: Set<string>)` → Task[] — active tasks whose session_id is not in the set
+
+**Tests (18):** deriveParentStatus (7 status combos), getBySession (2), setSessionId (2), getNextExecutable (5 incl. DFS ordering, skip done/blocked, null when all done), cascadeStatus (2 multi-level), getOrphaned (2).
+
+**Reference:** `server/task-store.ts`, design doc §2.3
+
+### Step 2: Task Tool Handlers — `server/task-tools.ts`
+
+**New files:** `server/task-tools.ts`, `server/__tests__/task-tools.test.ts`
+
+Pure functions taking `TaskStore` + context, returning result strings:
+
+- `handleTaskSet(store, currentTaskId, tasks: Array<{title, description?, priority?}>)` — delete existing children, create new ones
+- `handleTaskComplete(store, currentTaskId, summary: string)` — mark done or pending_review (based on `requiresApproval`), store summary, cascade
+- `handleTaskStatus(store, currentTaskId)` — formatted status: current task, siblings, progress
+- `handleTaskBlock(store, currentTaskId, reason: string)` — set blocked, add reason to annotations
+
+All return strings (never throw for invalid input — return error strings).
+
+**Tests (14):** TaskSet creates/replaces children (3), TaskComplete done + pending_review + cascade (4), TaskStatus formatted output (2), TaskBlock status + annotation (2), error cases (3).
+
+**Reference:** `server/task-store.ts`
+
+### Step 3: In-Process MCP Server — `server/task-mcp-server.ts`
+
+**New files:** `server/task-mcp-server.ts`, `server/__tests__/task-mcp-server.test.ts`
+**Modified files:** `server/chat.ts`, `server/session-registry.ts`, `server/tool-tiers.ts`, `server/tool-summary.ts`
+
+Create an in-process MCP server via the SDK's `createSdkMcpServer()`:
+
+```typescript
+import { createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+
+export function createTaskMcpServer(store: TaskStore, getTaskContext: () => TaskContext | null) {
+  return createSdkMcpServer({
+    name: 'task-board',
+    tools: [
+      { name: 'TaskSet', inputSchema: { ... }, handler: async (args) => { ... } },
+      { name: 'TaskComplete', inputSchema: { ... }, handler: async (args) => { ... } },
+      { name: 'TaskStatus', inputSchema: {}, handler: async () => { ... } },
+      { name: 'TaskBlock', inputSchema: { ... }, handler: async (args) => { ... } },
+    ],
+  });
+}
+```
+
+Each handler calls the corresponding function from `task-tools.ts`, using `getTaskContext()` to resolve the current task. Returns `{ content: [{ type: 'text', text: resultString }] }`.
+
+In `chat.ts`: when session has task context, add the task MCP server to `mcpServers` in `query()` options. Tools appear as `mcp__task-board__TaskSet` etc — the agent uses them like any other tool.
+
+Add `taskContext: { currentTaskId: string; goalId: string } | null` to `ManagedSession` in `session-registry.ts`.
+
+In `tool-tiers.ts`: classify `mcp__task-board__*` as `safe` tier. In `tool-summary.ts`: add summarization for task tool inputs.
+
+**Tests (10):** MCP server creates with all 4 tools (1), each handler returns correct result format (4), no task context returns error text (1), WS broadcast fires on mutation (1), tool tier classified as safe (1), handler validates input (2).
+
+**Reference:** `server/repo-mcp-server.ts` (MCP pattern), `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts` (`createSdkMcpServer`)
+
+### Step 4: Task Context Injection — `server/chat.ts`
+
+**Modified files:** `server/chat.ts`, `server/session-registry.ts`
+**New file:** `server/__tests__/task-context.test.ts`
+
+`buildTaskContextPrompt(store, taskId)` — assembles XML block per §8.1:
+
+- `<task>` with id, depth, parent title
+- Title, description, annotations
+- Sibling list with status markers
+- `<completed-siblings>` with summaries (capped at 2000 chars each)
+
+Append task board system prompt (§8.2) in `startChat` when `taskContext` is present.
+
+**Tests (8):** XML generation (4 variants), system prompt inclusion (1), no task context unchanged (1), depth >= 5 guard (1), summary truncation (1).
+
+**Reference:** `server/chat.ts` (`assemblePrompt`), design doc §8.1–8.3
+
+### Step 5: Task Orchestrator Core — `server/task-orchestrator.ts`
+
+**New files:** `server/task-orchestrator.ts`, `server/__tests__/task-orchestrator.test.ts`
+
+Class `TaskOrchestrator`:
+
+- State: `status: 'idle' | 'running' | 'paused'`, `activeGoalId`, `activeSessionClientId`
+- `start(goalId, opts?)`, `pause()`, `resume()`, `stop()`, `getStatus()` → LoopStatus
+- `tick()` — the core loop: re-read state, cascade completed, get next executable, assign, inject context, broadcast
+- `onTaskCompleted(taskId)` / `onTaskBlocked(taskId)` — trigger `tick()`
+
+Event-driven: `tick()` called on start, resume, task completion, task block. No polling.
+
+**Tests (16):** start (1), pause (1), resume (1), stop (1), tick assigns DFS (2), tick when paused (1), tick when all done (1), tick skips blocked (1), onTaskCompleted (2), onTaskBlocked (1), getStatus (1), cascade on completion (1), goal completion → idle (1), reuse session (1), broadcast fires (1).
+
+**Reference:** Design doc §4.2, `server/chat.ts` (`sendToChat`)
+
+### Step 6: Orchestrator REST + WS Endpoints
+
+**Modified files:** `server/app.ts`, `server/index.ts`, `server/ws-schemas.ts`, `server/api-schemas.ts`
+**New file:** `server/__tests__/loop-routes.test.ts`
+
+REST:
+
+```
+GET    /api/loop/status
+POST   /api/loop/start    { goalId, specMode? }
+POST   /api/loop/pause
+POST   /api/loop/resume
+POST   /api/loop/stop
+```
+
+WS: `loop_status` event type. Wire orchestrator instantiation in `index.ts`.
+
+**Tests (10):** status (1), start (1), pause (1), resume (1), stop (1), 400 no goalId (1), 409 already running (1), WS broadcast (1), auth required (2).
+
+**Reference:** `server/app.ts`, `server/index.ts`
+
+### Step 7: Spec Mode
+
+**Modified files:** `server/task-orchestrator.ts`, `server/task-store.ts`, `server/__tests__/task-orchestrator.test.ts`
+**New file:** `server/__tests__/spec-mode.test.ts`
+
+`start(goalId, { specMode: true })`:
+
+1. Session with `mode: 'ask'`
+2. Inject planning prompt
+3. After `TaskSet`, stay paused with `awaitingApproval: true`
+4. On user approve → transition to running, begin DFS
+5. On reject → delete proposed children, stop
+
+Add `spec_mode` column to tasks table.
+
+**Tests (8):** ask mode session (1), planning prompt (1), stays paused after TaskSet (1), approve → running (1), reject → children deleted (1), flag persisted (1), non-spec direct start (1), session cleanup on reject (1).
+
+**Reference:** Design doc §4.5
+
+### Step 8: Orphan Detection + `requires_approval`
+
+**Modified files:** `server/task-orchestrator.ts`, `server/task-store.ts`, `server/app.ts`
+**New file:** `server/__tests__/task-orchestrator.test.ts` (extend)
+
+Orphan detection in `tick()`: find active tasks with dead sessions, reset to pending.
+
+`requires_approval` flow: TaskComplete → `pending_review` → user approve (→ done + cascade) or reject (→ active + feedback annotation + interrupt session).
+
+REST: `POST /api/tasks/:id/approve`, `POST /api/tasks/:id/reject { feedback }`.
+
+Add `getActiveSessionIds()` to `SessionRegistry`.
+
+**Tests (12):** orphan detection (3), requires_approval → pending_review (2), approve → done + cascade (2), reject → active + feedback (2), orchestrator skips pending_review (1), approve triggers tick (1), getActiveSessionIds (1).
+
+**Reference:** Design doc §4.6
+
+### Step 9: Frontend Types — Loop Status + WS Events
+
+**Modified files:** `frontend/src/types/task.ts`, `frontend/src/types/ws-messages.ts`
+
+Add `LoopStatus` interface, `LoopStatusMsg`/`TaskApproveMsg`/`TaskRejectMsg` to WS message union.
+
+No tests (pure types).
+
+### Step 10: `useTaskBoard` — Loop State + Approval Actions
+
+**Modified files:** `frontend/src/hooks/useTaskBoard.ts`, `frontend/src/hooks/__tests__/useTaskBoard.test.ts`
+
+Extend hook:
+
+- `loopStatus: LoopStatus`
+- `startLoop(goalId, specMode?)`, `pauseLoop()`, `resumeLoop()`, `stopLoop()`
+- `approveTask(id)`, `rejectTask(id, feedback)`
+- Subscribe to `loop_status` WS events
+
+**Tests (12):** loop status hydration (1), WS updates (1), each loop action (4), approve/reject (2), defaults (1), regression on existing (1), spec mode flow (1), error handling (1).
+
+### Step 11: `LoopControls` Component
+
+**New files:** `frontend/src/components/LoopControls.tsx`, `frontend/src/components/__tests__/LoopControls.test.tsx`
+
+Props: `loopStatus`, `goals`, `onStart`, `onPause`, `onResume`, `onStop`, `specMode`, `onSpecModeToggle`
+
+Renders: status pill (idle/running/paused), goal selector + Start (idle), Pause + Stop (running), Resume + Stop (paused), progress bar, spec mode toggle, approve/reject (awaiting approval).
+
+**Tests (8):** idle UI (1), running UI (1), paused UI (1), progress bar (1), disabled without goals (1), onStart with goalId (1), spec mode toggle (1), awaiting approval UI (1).
+
+### Step 12: `TaskSidebar` Component
+
+**New files:** `frontend/src/components/TaskSidebar.tsx`, `frontend/src/components/__tests__/TaskSidebar.test.tsx`
+
+Props: `currentTask`, `siblings`, `parentProgress`, `onApprove`, `onReject`
+
+Renders: current task title + description, annotations, sibling list with status icons, progress bar, approve/reject for pending_review. Collapsible on mobile.
+
+**Tests (8):** title + description (1), annotations (1), siblings (1), progress (1), approve/reject for pending_review (2), hidden when null (1), reject feedback input (1).
+
+### Step 13: Page Integration
+
+**Modified files:** `frontend/src/pages/TaskBoard.tsx`, `frontend/src/pages/ChatView.tsx`, `frontend/src/pages/DesktopChatView.tsx`, `frontend/src/styles/global.css`
+
+- `TaskBoard`: add LoopControls, highlight active task, inline approve/reject on pending_review
+- `ChatView`/`DesktopChatView`: add TaskSidebar, derive current task from loop status
+
+**Tests (8):** TaskBoard renders LoopControls (1), active task highlighted (1), ChatView renders sidebar (1), sidebar hidden (1), approve/reject wired (1), pending_review inline actions (1), progress matches (1), sidebar collapses mobile (1).
+
+### Step 14: End-to-End Wiring + Cleanup
+
+**Modified files:** `server/index.ts`, `server/app.ts`, `server/query-loop.ts`, `server/constants.ts`
+**New file:** `server/__tests__/task-e2e.test.ts`
+
+Final wiring:
+
+- Orchestrator instantiation in `index.ts`
+- `onTaskCompleted`/`onTaskBlocked` callbacks from tool interception → orchestrator
+- Approve/reject REST → orchestrator
+- Constants: `MAX_TASK_DEPTH = 5`, `TASK_SUMMARY_MAX_CHARS = 2000`, `ORPHAN_CHECK_INTERVAL_MS = 60_000`
+
+**Tests (6):** full flow (1), spec mode flow (1), orphan recovery (1), approval flow (1), loop controls (1), status cascade (1).
+
+## Commit Strategy
+
+Branch: `feat/task-board-phase2` (from main after Phase 1 merge)
+
+1. `feat(server): add deriveParentStatus, getNextExecutable, and cascade methods to TaskStore`
+2. `feat(server): add task tool handlers (TaskSet, TaskComplete, TaskStatus, TaskBlock)`
+3. `feat(server): add task board in-process MCP server`
+4. `feat(server): add task context injection to system prompt`
+5. `feat(server): add TaskOrchestrator with DFS sequential loop`
+6. `feat(server): add orchestrator REST and WS endpoints`
+7. `feat(server): add spec mode to orchestrator`
+8. `feat(server): add orphan detection and requires_approval flow`
+9. `feat(frontend): add loop status types and WS messages`
+10. `feat(frontend): extend useTaskBoard with loop state and approval actions`
+11. `feat(frontend): add LoopControls component`
+12. `feat(frontend): add TaskSidebar component`
+13. `feat(frontend): integrate LoopControls and TaskSidebar into pages`
+14. `feat: wire end-to-end orchestration loop with tool interception`
+
+## Critical Reference Files
+
+- `server/task-store.ts` — extended in steps 1, 7, 8
+- `server/repo-mcp-server.ts` — MCP server pattern for step 3
+- `server/chat.ts` — system prompt assembly, `sendToChat`/`interruptChat`
+- `server/session-registry.ts` — session state, task context
+- `server/query-loop.ts` — tool result events, wiring in step 14
+- `server/index.ts` — WS handlers, orchestrator instantiation
+- `frontend/src/hooks/useTaskBoard.ts` — hook extended in step 10
+- `frontend/src/pages/ChatView.tsx` — TaskSidebar integration
+
+## Verification
+
+1. `npm test` passes after every commit
+2. `npm run lint` and `npm run typecheck` pass
+3. Manual: create goal → start loop → orchestrator assigns first pending task
+4. Manual: agent calls TaskComplete → next task auto-assigned
+5. Manual: pause → no new assignments; resume → assignment resumes
+6. Manual: stop → status returns to idle
+7. Manual: spec mode — create goal → start with spec → agent proposes tree → approve → execution begins
+8. Manual: `requires_approval` — TaskComplete → pending_review → approve → done
+9. Manual: reject pending_review → feedback annotation, task back to active
+10. Manual: TaskSidebar in ChatView when session has active task
+11. Manual: LoopControls on TaskBoard reflect orchestrator state
+12. Manual: two browser tabs — loop status syncs via WS
+
+## Gotchas
+
+- **In-process MCP tool naming**: tools appear as `mcp__task-board__TaskSet` etc. The `allowedTools` list must include `mcp__task-board__*` wildcard. Ensure `tool-tiers.ts` classifies these as `safe` so they auto-allow without prompting.
+- **Orchestrator statelessness**: never cache task state between `tick()` calls — always re-read from SQLite. Prevents races with user edits.
+- **Session reuse only**: always inject follow-up prompts via `sendToChat`, not `startChat`. New sessions are Phase 3 (`spawn` policy).
+- **`cascadeStatus` loop guard**: stop recursing when parent's derived status matches current. Prevents infinite loops.
+- **Spec mode cleanup**: reject must stop the ask-mode session, not leave it orphaned.
+- **`PRAGMA foreign_keys = ON`**: already set in Phase 1 TaskStore constructor — verify survives new methods.
+- **WS pool `"global"` key**: `loop_status` events must broadcast on the same channel `useTaskBoard` subscribes to.
+- **`getNextExecutable` ancestor check**: skip subtrees with blocked/failed ancestors — pending children under a blocked parent are not executable.
+- **Task context prompt size**: cap sibling summaries at 2000 chars when injecting. Store full, truncate on read.
+- **Concurrent mutations**: orchestrator `tick()` and user REST actions can race. SQLite serializes writes, but re-read state after mutations before acting.

--- a/frontend/src/components/LoopControls.tsx
+++ b/frontend/src/components/LoopControls.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import type { LoopStatus } from '../types/task';
+import type { Task } from '../types/task';
+
+interface LoopControlsProps {
+  loopStatus: LoopStatus;
+  goals: Task[];
+  onStart: (goalId: string, specMode?: boolean) => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  onApproveSpec: () => void;
+  onRejectSpec: () => void;
+}
+
+const STATE_LABELS: Record<LoopStatus['state'], string> = {
+  idle: 'Idle',
+  running: 'Running',
+  paused: 'Paused',
+};
+
+export function LoopControls({
+  loopStatus,
+  goals,
+  onStart,
+  onPause,
+  onResume,
+  onStop,
+  onApproveSpec,
+  onRejectSpec,
+}: LoopControlsProps) {
+  const [selectedGoalId, setSelectedGoalId] = useState('');
+  const [specMode, setSpecMode] = useState(false);
+
+  const { state, progress, awaitingApproval } = loopStatus;
+
+  return (
+    <div className="loop-controls">
+      <div className="loop-controls-header">
+        <span className={`loop-controls-pill loop-controls-pill--${state}`}>
+          {STATE_LABELS[state]}
+        </span>
+        {progress && (
+          <span className="loop-controls-progress">
+            {progress.done}/{progress.total}
+          </span>
+        )}
+      </div>
+
+      {state === 'idle' && (
+        <div className="loop-controls-start">
+          <select
+            className="loop-controls-select"
+            value={selectedGoalId}
+            onChange={(e) => setSelectedGoalId(e.target.value)}
+          >
+            <option value="">Select a goal...</option>
+            {goals.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.title}
+              </option>
+            ))}
+          </select>
+          <label className="loop-controls-spec-toggle">
+            <input
+              type="checkbox"
+              checked={specMode}
+              onChange={(e) => setSpecMode(e.target.checked)}
+            />
+            Spec mode
+          </label>
+          <button
+            className="loop-controls-btn loop-controls-btn--start"
+            disabled={!selectedGoalId}
+            onClick={() => onStart(selectedGoalId, specMode || undefined)}
+          >
+            Start
+          </button>
+        </div>
+      )}
+
+      {state === 'running' && !awaitingApproval && (
+        <div className="loop-controls-actions">
+          <button className="loop-controls-btn" onClick={onPause}>
+            Pause
+          </button>
+          <button className="loop-controls-btn loop-controls-btn--danger" onClick={onStop}>
+            Stop
+          </button>
+        </div>
+      )}
+
+      {state === 'paused' && !awaitingApproval && (
+        <div className="loop-controls-actions">
+          <button className="loop-controls-btn loop-controls-btn--start" onClick={onResume}>
+            Resume
+          </button>
+          <button className="loop-controls-btn loop-controls-btn--danger" onClick={onStop}>
+            Stop
+          </button>
+        </div>
+      )}
+
+      {awaitingApproval && (
+        <div className="loop-controls-approval">
+          <p className="loop-controls-approval-msg">Task breakdown ready for review</p>
+          <div className="loop-controls-actions">
+            <button className="loop-controls-btn loop-controls-btn--start" onClick={onApproveSpec}>
+              Approve
+            </button>
+            <button className="loop-controls-btn loop-controls-btn--danger" onClick={onRejectSpec}>
+              Reject
+            </button>
+          </div>
+        </div>
+      )}
+
+      {progress && progress.total > 0 && (
+        <div className="loop-controls-bar">
+          <div
+            className="loop-controls-bar-fill"
+            style={{ width: `${(progress.done / progress.total) * 100}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -24,7 +24,7 @@ const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
 interface TaskNodeProps {
   task: Task;
   depth: number;
-  active?: boolean;
+  activeTaskId?: string | null;
   onStatusChange: (id: string, status: TaskStatus) => void;
   onDelete: (id: string) => void;
   onAddChild: (parentId: string) => void;
@@ -35,7 +35,7 @@ interface TaskNodeProps {
 export function TaskNode({
   task,
   depth,
-  active,
+  activeTaskId,
   onStatusChange,
   onDelete,
   onAddChild,
@@ -46,7 +46,7 @@ export function TaskNode({
   const hasChildren = task.children.length > 0;
 
   return (
-    <div className={`task-node${active ? ' task-node--active' : ''}`}>
+    <div className={`task-node${activeTaskId === task.id ? ' task-node--active' : ''}`}>
       <div className="task-node-row">
         {hasChildren && (
           <button
@@ -111,7 +111,7 @@ export function TaskNode({
               key={child.id}
               task={child}
               depth={depth + 1}
-              active={active}
+              activeTaskId={activeTaskId}
               onStatusChange={onStatusChange}
               onDelete={onDelete}
               onAddChild={onAddChild}

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -24,17 +24,29 @@ const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
 interface TaskNodeProps {
   task: Task;
   depth: number;
+  active?: boolean;
   onStatusChange: (id: string, status: TaskStatus) => void;
   onDelete: (id: string) => void;
   onAddChild: (parentId: string) => void;
+  onApprove?: (id: string) => void;
+  onReject?: (id: string, feedback: string) => void;
 }
 
-export function TaskNode({ task, depth, onStatusChange, onDelete, onAddChild }: TaskNodeProps) {
+export function TaskNode({
+  task,
+  depth,
+  active,
+  onStatusChange,
+  onDelete,
+  onAddChild,
+  onApprove,
+  onReject,
+}: TaskNodeProps) {
   const [expanded, setExpanded] = useState(true);
   const hasChildren = task.children.length > 0;
 
   return (
-    <div className="task-node">
+    <div className={`task-node${active ? ' task-node--active' : ''}`}>
       <div className="task-node-row">
         {hasChildren && (
           <button
@@ -58,6 +70,24 @@ export function TaskNode({ task, depth, onStatusChange, onDelete, onAddChild }: 
           {task.title}
         </span>
         <div className="task-node-actions">
+          {task.status === 'pending_review' && onApprove && (
+            <button
+              className="task-node-action task-node-action--approve"
+              onClick={() => onApprove(task.id)}
+              title="Approve"
+            >
+              &#x2713;
+            </button>
+          )}
+          {task.status === 'pending_review' && onReject && (
+            <button
+              className="task-node-action task-node-action--danger"
+              onClick={() => onReject(task.id, '')}
+              title="Reject"
+            >
+              &#x2717;
+            </button>
+          )}
           <button
             className="task-node-action"
             onClick={() => onAddChild(task.id)}
@@ -81,9 +111,12 @@ export function TaskNode({ task, depth, onStatusChange, onDelete, onAddChild }: 
               key={child.id}
               task={child}
               depth={depth + 1}
+              active={active}
               onStatusChange={onStatusChange}
               onDelete={onDelete}
               onAddChild={onAddChild}
+              onApprove={onApprove}
+              onReject={onReject}
             />
           ))}
         </div>

--- a/frontend/src/components/TaskSidebar.tsx
+++ b/frontend/src/components/TaskSidebar.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import type { Task } from '../types/task';
+
+interface TaskSidebarProps {
+  currentTask: Task | null;
+  siblings: Task[];
+  parentProgress: { done: number; total: number } | null;
+  onApprove: (id: string) => void;
+  onReject: (id: string, feedback: string) => void;
+}
+
+const STATUS_ICONS: Record<string, string> = {
+  pending: '\u25CB',
+  active: '\u25C9',
+  done: '\u2713',
+  pending_review: '\u25D4',
+  blocked: '\u2298',
+  skipped: '\u2014',
+  failed: '\u2717',
+};
+
+export function TaskSidebar({
+  currentTask,
+  siblings,
+  parentProgress,
+  onApprove,
+  onReject,
+}: TaskSidebarProps) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [rejectFeedback, setRejectFeedback] = useState('');
+  const [showRejectInput, setShowRejectInput] = useState(false);
+
+  if (!currentTask) return null;
+
+  return (
+    <div className={`task-sidebar${collapsed ? ' task-sidebar--collapsed' : ''}`}>
+      <button className="task-sidebar-toggle" onClick={() => setCollapsed(!collapsed)}>
+        {collapsed ? '\u25B6' : '\u25BC'} Task
+      </button>
+
+      {!collapsed && (
+        <>
+          <div className="task-sidebar-current">
+            <h3 className="task-sidebar-title">{currentTask.title}</h3>
+            {currentTask.description && (
+              <p className="task-sidebar-desc">{currentTask.description}</p>
+            )}
+            {currentTask.annotations.length > 0 && (
+              <ul className="task-sidebar-annotations">
+                {currentTask.annotations.map((a, i) => (
+                  <li key={i}>{a}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {currentTask.status === 'pending_review' && (
+            <div className="task-sidebar-review">
+              <button
+                className="loop-controls-btn loop-controls-btn--start"
+                onClick={() => onApprove(currentTask.id)}
+              >
+                Approve
+              </button>
+              {!showRejectInput ? (
+                <button
+                  className="loop-controls-btn loop-controls-btn--danger"
+                  onClick={() => setShowRejectInput(true)}
+                >
+                  Reject
+                </button>
+              ) : (
+                <div className="task-sidebar-reject-form">
+                  <input
+                    type="text"
+                    className="task-sidebar-reject-input"
+                    value={rejectFeedback}
+                    onChange={(e) => setRejectFeedback(e.target.value)}
+                    placeholder="Feedback..."
+                    autoFocus
+                  />
+                  <button
+                    className="loop-controls-btn loop-controls-btn--danger"
+                    onClick={() => {
+                      onReject(currentTask.id, rejectFeedback);
+                      setRejectFeedback('');
+                      setShowRejectInput(false);
+                    }}
+                  >
+                    Send
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {siblings.length > 0 && (
+            <div className="task-sidebar-siblings">
+              <h4>Siblings</h4>
+              <ul>
+                {siblings.map((s) => (
+                  <li
+                    key={s.id}
+                    className={`task-sidebar-sibling${s.id === currentTask.id ? ' task-sidebar-sibling--active' : ''}`}
+                  >
+                    <span className={`task-node-status task-node-status--${s.status}`}>
+                      {STATUS_ICONS[s.status] || '\u25CB'}
+                    </span>
+                    {s.title}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {parentProgress && parentProgress.total > 0 && (
+            <div className="task-sidebar-progress">
+              <div className="loop-controls-bar">
+                <div
+                  className="loop-controls-bar-fill"
+                  style={{
+                    width: `${(parentProgress.done / parentProgress.total) * 100}%`,
+                  }}
+                />
+              </div>
+              <span className="task-sidebar-progress-label">
+                {parentProgress.done}/{parentProgress.total}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -41,15 +41,55 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+const defaultLoopStatus = {
+  state: 'idle',
+  goalId: null,
+  activeTaskId: null,
+  progress: null,
+  specMode: false,
+  awaitingApproval: false,
+};
+
 let fetchMock: ReturnType<typeof vi.fn>;
+let taskResponse: { tasks: Task[] };
+let mutationResponses: Array<{ ok: boolean; status?: number; json?: () => Promise<unknown> }>;
+
+function setupFetch(tasks: Task[] = []) {
+  taskResponse = { tasks };
+  mutationResponses = [];
+  fetchMock = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+    if (url === '/api/loop/status') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(defaultLoopStatus),
+      });
+    }
+    if (url === '/api/tasks' && (!opts || opts.method === undefined || opts.method === 'GET')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(taskResponse),
+      });
+    }
+    // Mutation calls — pop from queue or default to ok
+    const resp = mutationResponses.shift();
+    if (resp) {
+      return Promise.resolve({
+        ok: resp.ok,
+        status: resp.status ?? (resp.ok ? 200 : 500),
+        json: resp.json ?? (() => Promise.resolve({})),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+}
 
 beforeEach(() => {
   listeners.length = 0;
-  fetchMock = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ tasks: [] }),
-  });
-  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  setupFetch();
 });
 
 afterEach(() => {
@@ -59,30 +99,16 @@ afterEach(() => {
 describe('useTaskBoard', () => {
   it('fetches tasks on mount', async () => {
     const tasks = [makeTask()];
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ tasks }),
-    });
+    setupFetch(tasks);
 
     const { result } = renderHook(() => useTaskBoard());
 
     expect(result.current.loading).toBe(true);
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.tasks).toEqual(tasks);
-    expect(fetchMock).toHaveBeenCalledWith('/api/tasks');
   });
 
   it('createTask calls POST and relies on WS for state', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ tasks: [] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ task: makeTask() }),
-      });
-
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -97,16 +123,7 @@ describe('useTaskBoard', () => {
   });
 
   it('updateTask calls PATCH', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ tasks: [makeTask()] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ task: makeTask({ title: 'Updated' }) }),
-      });
-
+    setupFetch([makeTask()]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -121,16 +138,7 @@ describe('useTaskBoard', () => {
   });
 
   it('deleteTask calls DELETE', async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ tasks: [makeTask()] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ ok: true }),
-      });
-
+    setupFetch([makeTask()]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -170,12 +178,7 @@ describe('useTaskBoard', () => {
   });
 
   it('WS task_updated updates existing task', async () => {
-    const original = makeTask({ id: 'u-1', title: 'Original' });
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ tasks: [original] }),
-    });
-
+    setupFetch([makeTask({ id: 'u-1', title: 'Original' })]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.tasks[0].title).toBe('Original');
@@ -190,12 +193,7 @@ describe('useTaskBoard', () => {
   });
 
   it('WS task_updated inserts child under existing parent', async () => {
-    const parent = makeTask({ id: 'parent-1', title: 'Parent' });
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ tasks: [parent] }),
-    });
-
+    setupFetch([makeTask({ id: 'parent-1', title: 'Parent' })]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.tasks).toHaveLength(1);
@@ -216,12 +214,7 @@ describe('useTaskBoard', () => {
   });
 
   it('WS task_deleted removes task', async () => {
-    const tasks = [makeTask({ id: 'del-1' }), makeTask({ id: 'del-2' })];
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ tasks }),
-    });
-
+    setupFetch([makeTask({ id: 'del-1' }), makeTask({ id: 'del-2' })]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.tasks).toHaveLength(2);
@@ -238,10 +231,7 @@ describe('useTaskBoard', () => {
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ tasks: [makeTask({ id: 'refreshed' })] }),
-    });
+    taskResponse = { tasks: [makeTask({ id: 'refreshed' })] };
 
     await act(async () => {
       result.current.refresh();
@@ -251,7 +241,16 @@ describe('useTaskBoard', () => {
   });
 
   it('handles fetch error gracefully', async () => {
-    fetchMock.mockRejectedValueOnce(new Error('Network error'));
+    fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url === '/api/loop/status') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(defaultLoopStatus),
+        });
+      }
+      return Promise.reject(new Error('Network error'));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -259,12 +258,10 @@ describe('useTaskBoard', () => {
   });
 
   it('createTask throws on non-ok response', async () => {
-    fetchMock
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [] }) })
-      .mockResolvedValueOnce({ ok: false, status: 500 });
-
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mutationResponses.push({ ok: false, status: 500 });
 
     await expect(act(() => result.current.createTask({ title: 'Fail' }))).rejects.toThrow(
       'Create task failed: 500',
@@ -272,12 +269,11 @@ describe('useTaskBoard', () => {
   });
 
   it('updateTask throws on non-ok response', async () => {
-    fetchMock
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [makeTask()] }) })
-      .mockResolvedValueOnce({ ok: false, status: 404 });
-
+    setupFetch([makeTask()]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mutationResponses.push({ ok: false, status: 404 });
 
     await expect(act(() => result.current.updateTask('task-1', { title: 'Nope' }))).rejects.toThrow(
       'Update task failed: 404',
@@ -285,15 +281,39 @@ describe('useTaskBoard', () => {
   });
 
   it('deleteTask throws on non-ok response', async () => {
-    fetchMock
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ tasks: [makeTask()] }) })
-      .mockResolvedValueOnce({ ok: false, status: 403 });
-
+    setupFetch([makeTask()]);
     const { result } = renderHook(() => useTaskBoard());
     await waitFor(() => expect(result.current.loading).toBe(false));
+
+    mutationResponses.push({ ok: false, status: 403 });
 
     await expect(act(() => result.current.deleteTask('task-1'))).rejects.toThrow(
       'Delete task failed: 403',
     );
+  });
+
+  it('WS loop_status updates loop state', async () => {
+    const { result } = renderHook(() => useTaskBoard());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.loopStatus.state).toBe('idle');
+
+    act(() => {
+      listeners.forEach((l) =>
+        l({
+          type: 'loop_status',
+          state: 'running',
+          goalId: 'g-1',
+          activeTaskId: 't-1',
+          progress: { done: 1, total: 3 },
+          specMode: false,
+          awaitingApproval: false,
+        }),
+      );
+    });
+
+    expect(result.current.loopStatus.state).toBe('running');
+    expect(result.current.loopStatus.goalId).toBe('g-1');
+    expect(result.current.loopStatus.progress).toEqual({ done: 1, total: 3 });
   });
 });

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import type { Task } from '../types/task';
+import type { Task, LoopStatus } from '../types/task';
 import { wsSubscribe } from '../lib/ws-pool';
 import type { WsMsg } from '../lib/ws-pool';
 
@@ -26,9 +26,18 @@ export interface TaskUpdateInput {
 export interface UseTaskBoardResult {
   loading: boolean;
   tasks: Task[];
+  loopStatus: LoopStatus;
   createTask: (input: TaskCreateInput) => Promise<void>;
   updateTask: (id: string, input: TaskUpdateInput) => Promise<void>;
   deleteTask: (id: string) => Promise<void>;
+  startLoop: (goalId: string, specMode?: boolean) => Promise<void>;
+  pauseLoop: () => Promise<void>;
+  resumeLoop: () => Promise<void>;
+  stopLoop: () => Promise<void>;
+  approveTask: (id: string) => Promise<void>;
+  rejectTask: (id: string, feedback: string) => Promise<void>;
+  approveSpec: () => Promise<void>;
+  rejectSpec: () => Promise<void>;
   refresh: () => void;
 }
 
@@ -84,10 +93,20 @@ function upsertInTree(tasks: Task[], task: Task): [Task[], boolean] {
   return [inserted ? withChild : tasks, inserted];
 }
 
+const IDLE_STATUS: LoopStatus = {
+  state: 'idle',
+  goalId: null,
+  activeTaskId: null,
+  progress: null,
+  specMode: false,
+  awaitingApproval: false,
+};
+
 export function useTaskBoard(): UseTaskBoardResult {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [loopStatus, setLoopStatus] = useState<LoopStatus>(IDLE_STATUS);
 
   // Fetch tasks from REST API
   useEffect(() => {
@@ -126,9 +145,28 @@ export function useTaskBoard(): UseTaskBoardResult {
         setTasks((prev) => upsertInTree(prev, msg.task)[0]);
       } else if (msg.type === 'task_deleted') {
         setTasks((prev) => removeFromTree(prev, msg.taskId));
+      } else if (msg.type === 'loop_status') {
+        setLoopStatus({
+          state: msg.state,
+          goalId: msg.goalId,
+          activeTaskId: msg.activeTaskId,
+          progress: msg.progress,
+          specMode: msg.specMode,
+          awaitingApproval: msg.awaitingApproval,
+        });
       }
     });
     return unsub;
+  }, []);
+
+  // Fetch initial loop status
+  useEffect(() => {
+    fetch('/api/loop/status')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((status) => {
+        if (status) setLoopStatus(status);
+      })
+      .catch(() => {});
   }, []);
 
   const createTask = useCallback(async (input: TaskCreateInput) => {
@@ -156,7 +194,71 @@ export function useTaskBoard(): UseTaskBoardResult {
     if (!r.ok) throw new Error(`Delete task failed: ${r.status}`);
   }, []);
 
+  const startLoop = useCallback(async (goalId: string, specMode?: boolean) => {
+    const r = await fetch('/api/loop/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ goalId, specMode }),
+    });
+    if (!r.ok) throw new Error(`Start loop failed: ${r.status}`);
+  }, []);
+
+  const pauseLoop = useCallback(async () => {
+    const r = await fetch('/api/loop/pause', { method: 'POST' });
+    if (!r.ok) throw new Error(`Pause loop failed: ${r.status}`);
+  }, []);
+
+  const resumeLoop = useCallback(async () => {
+    const r = await fetch('/api/loop/resume', { method: 'POST' });
+    if (!r.ok) throw new Error(`Resume loop failed: ${r.status}`);
+  }, []);
+
+  const stopLoop = useCallback(async () => {
+    const r = await fetch('/api/loop/stop', { method: 'POST' });
+    if (!r.ok) throw new Error(`Stop loop failed: ${r.status}`);
+  }, []);
+
+  const approveTask = useCallback(async (id: string) => {
+    const r = await fetch(`/api/tasks/${id}/approve`, { method: 'POST' });
+    if (!r.ok) throw new Error(`Approve task failed: ${r.status}`);
+  }, []);
+
+  const rejectTask = useCallback(async (id: string, feedback: string) => {
+    const r = await fetch(`/api/tasks/${id}/reject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ feedback }),
+    });
+    if (!r.ok) throw new Error(`Reject task failed: ${r.status}`);
+  }, []);
+
+  const approveSpec = useCallback(async () => {
+    const r = await fetch('/api/loop/spec/approve', { method: 'POST' });
+    if (!r.ok) throw new Error(`Approve spec failed: ${r.status}`);
+  }, []);
+
+  const rejectSpec = useCallback(async () => {
+    const r = await fetch('/api/loop/spec/reject', { method: 'POST' });
+    if (!r.ok) throw new Error(`Reject spec failed: ${r.status}`);
+  }, []);
+
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
 
-  return { loading, tasks, createTask, updateTask, deleteTask, refresh };
+  return {
+    loading,
+    tasks,
+    loopStatus,
+    createTask,
+    updateTask,
+    deleteTask,
+    startLoop,
+    pauseLoop,
+    resumeLoop,
+    stopLoop,
+    approveTask,
+    rejectTask,
+    approveSpec,
+    rejectSpec,
+    refresh,
+  };
 }

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -2,12 +2,29 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TaskNode } from '../components/TaskNode';
 import { TaskCreateForm } from '../components/TaskCreateForm';
+import { LoopControls } from '../components/LoopControls';
 import { useTaskBoard } from '../hooks/useTaskBoard';
 import type { TaskStatus } from '../types/task';
 
 export function TaskBoard() {
   const navigate = useNavigate();
-  const { loading, tasks, createTask, updateTask, deleteTask, refresh } = useTaskBoard();
+  const {
+    loading,
+    tasks,
+    loopStatus,
+    createTask,
+    updateTask,
+    deleteTask,
+    startLoop,
+    pauseLoop,
+    resumeLoop,
+    stopLoop,
+    approveTask,
+    rejectTask,
+    approveSpec,
+    rejectSpec,
+    refresh,
+  } = useTaskBoard();
   const [creating, setCreating] = useState<{ parentId?: string } | null>(null);
 
   function handleStatusChange(id: string, status: TaskStatus) {
@@ -26,6 +43,9 @@ export function TaskBoard() {
     createTask({ title, parentId });
     setCreating(null);
   }
+
+  // Root tasks with no parent serve as potential goals
+  const goals = tasks.filter((t) => !t.parentId);
 
   return (
     <div className="task-board-page">
@@ -47,6 +67,17 @@ export function TaskBoard() {
           &#x21bb;
         </button>
       </header>
+
+      <LoopControls
+        loopStatus={loopStatus}
+        goals={goals}
+        onStart={startLoop}
+        onPause={pauseLoop}
+        onResume={resumeLoop}
+        onStop={stopLoop}
+        onApproveSpec={approveSpec}
+        onRejectSpec={rejectSpec}
+      />
 
       {creating && (
         <TaskCreateForm
@@ -72,9 +103,12 @@ export function TaskBoard() {
             key={task.id}
             task={task}
             depth={0}
+            active={loopStatus.activeTaskId === task.id}
             onStatusChange={handleStatusChange}
             onDelete={handleDelete}
             onAddChild={handleAddChild}
+            onApprove={approveTask}
+            onReject={rejectTask}
           />
         ))}
       </div>

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -103,7 +103,7 @@ export function TaskBoard() {
             key={task.id}
             task={task}
             depth={0}
-            active={loopStatus.activeTaskId === task.id}
+            activeTaskId={loopStatus.activeTaskId}
             onStatusChange={handleStatusChange}
             onDelete={handleDelete}
             onAddChild={handleAddChild}

--- a/frontend/src/pages/__tests__/TaskBoard.test.tsx
+++ b/frontend/src/pages/__tests__/TaskBoard.test.tsx
@@ -39,6 +39,14 @@ const mockRefresh = vi.fn();
 const mockCreateTask = vi.fn();
 const mockUpdateTask = vi.fn();
 const mockDeleteTask = vi.fn();
+const mockStartLoop = vi.fn();
+const mockPauseLoop = vi.fn();
+const mockResumeLoop = vi.fn();
+const mockStopLoop = vi.fn();
+const mockApproveTask = vi.fn();
+const mockRejectTask = vi.fn();
+const mockApproveSpec = vi.fn();
+const mockRejectSpec = vi.fn();
 let mockLoading = false;
 let mockTasks: Task[] = [];
 
@@ -46,9 +54,25 @@ vi.mock('../../hooks/useTaskBoard', () => ({
   useTaskBoard: () => ({
     loading: mockLoading,
     tasks: mockTasks,
+    loopStatus: {
+      state: 'idle',
+      goalId: null,
+      activeTaskId: null,
+      progress: null,
+      specMode: false,
+      awaitingApproval: false,
+    },
     createTask: mockCreateTask,
     updateTask: mockUpdateTask,
     deleteTask: mockDeleteTask,
+    startLoop: mockStartLoop,
+    pauseLoop: mockPauseLoop,
+    resumeLoop: mockResumeLoop,
+    stopLoop: mockStopLoop,
+    approveTask: mockApproveTask,
+    rejectTask: mockRejectTask,
+    approveSpec: mockApproveSpec,
+    rejectSpec: mockRejectSpec,
     refresh: mockRefresh,
   }),
 }));
@@ -81,8 +105,8 @@ describe('TaskBoard', () => {
     mockLoading = false;
     mockTasks = [makeTask({ title: 'Task A' }), makeTask({ id: 'task-2', title: 'Task B' })];
     renderBoard();
-    expect(screen.getByText('Task A')).toBeTruthy();
-    expect(screen.getByText('Task B')).toBeTruthy();
+    expect(screen.getAllByText('Task A').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Task B').length).toBeGreaterThan(0);
   });
 
   it('add button toggles create form', () => {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -3483,6 +3483,14 @@ textarea:focus {
   padding: 4px 0;
 }
 
+.task-node--active > .task-node-row {
+  border-left: 3px solid var(--accent);
+}
+
+.task-node-action--approve:hover {
+  color: var(--success);
+}
+
 .task-node-row {
   display: flex;
   align-items: center;
@@ -3655,4 +3663,268 @@ textarea:focus {
 .task-create-cancel:hover {
   color: var(--text);
   border-color: var(--text-dim);
+}
+
+/* ── Loop Controls ────────────────────────────────────── */
+
+.loop-controls {
+  padding: 8px 0;
+  margin-bottom: 8px;
+}
+
+.loop-controls-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.loop-controls-pill {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.loop-controls-pill--idle {
+  background: var(--border);
+  color: var(--text-dim);
+}
+
+.loop-controls-pill--running {
+  background: var(--success);
+  color: var(--bg);
+}
+
+.loop-controls-pill--paused {
+  background: #ff9800;
+  color: var(--bg);
+}
+
+.loop-controls-progress {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.loop-controls-start {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.loop-controls-select {
+  flex: 1;
+  min-width: 120px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.loop-controls-spec-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.loop-controls-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.loop-controls-btn {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.loop-controls-btn:hover {
+  background: var(--border);
+}
+
+.loop-controls-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.loop-controls-btn--start {
+  background: var(--success);
+  color: var(--bg);
+  border-color: var(--success);
+}
+
+.loop-controls-btn--start:hover {
+  opacity: 0.9;
+}
+
+.loop-controls-btn--danger {
+  background: var(--danger);
+  color: white;
+  border-color: var(--danger);
+}
+
+.loop-controls-btn--danger:hover {
+  opacity: 0.9;
+}
+
+.loop-controls-approval {
+  margin-top: 8px;
+}
+
+.loop-controls-approval-msg {
+  font-size: 0.85rem;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.loop-controls-bar {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 8px;
+  overflow: hidden;
+}
+
+.loop-controls-bar-fill {
+  height: 100%;
+  background: var(--success);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* ── Task Sidebar ─────────────────────────────────────── */
+
+.task-sidebar {
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+}
+
+.task-sidebar--collapsed {
+  padding: 8px 12px;
+}
+
+.task-sidebar-toggle {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 6px;
+}
+
+.task-sidebar--collapsed .task-sidebar-toggle {
+  margin-bottom: 0;
+}
+
+.task-sidebar-current {
+  margin-bottom: 8px;
+}
+
+.task-sidebar-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.task-sidebar-desc {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  margin: 0;
+}
+
+.task-sidebar-annotations {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0;
+}
+
+.task-sidebar-annotations li {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  padding: 2px 0;
+}
+
+.task-sidebar-review {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.task-sidebar-reject-form {
+  display: flex;
+  gap: 4px;
+}
+
+.task-sidebar-reject-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  color: var(--text);
+  font-size: 0.8rem;
+  outline: none;
+  width: 120px;
+}
+
+.task-sidebar-reject-input:focus {
+  border-color: var(--accent);
+}
+
+.task-sidebar-siblings h4 {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  margin: 0 0 4px;
+}
+
+.task-sidebar-siblings ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.task-sidebar-sibling {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  padding: 3px 0;
+}
+
+.task-sidebar-sibling--active {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.task-sidebar-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.task-sidebar-progress .loop-controls-bar {
+  flex: 1;
+  margin-top: 0;
+}
+
+.task-sidebar-progress-label {
+  font-size: 0.75rem;
+  color: var(--text-dim);
 }

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -9,6 +9,15 @@ export type TaskStatus =
 
 export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
 
+export interface LoopStatus {
+  state: 'idle' | 'running' | 'paused';
+  goalId: string | null;
+  activeTaskId: string | null;
+  progress: { done: number; total: number } | null;
+  specMode: boolean;
+  awaitingApproval: boolean;
+}
+
 export interface Task {
   id: string;
   parentId: string | null;

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -220,7 +220,8 @@ export type ServerMessage =
   | TaskStateMsg
   | TaskUpdatedMsg
   | TaskDeletedMsg
-  | TokenUpdateMsg;
+  | TokenUpdateMsg
+  | LoopStatusMsg;
 
 export interface InboxUpdatedMsg {
   type: 'inbox_updated';
@@ -234,4 +235,12 @@ export interface TokenUpdateMsg {
   costUsd?: number;
   numTurns?: number;
   turnIndex: number;
+}
+
+export interface LoopStatusMsg {
+  type: 'loop_status';
+  state: 'idle' | 'running' | 'paused';
+  goalId: string | null;
+  activeTaskId: string | null;
+  progress: { done: number; total: number } | null;
 }

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -243,4 +243,6 @@ export interface LoopStatusMsg {
   goalId: string | null;
   activeTaskId: string | null;
   progress: { done: number; total: number } | null;
+  specMode: boolean;
+  awaitingApproval: boolean;
 }

--- a/server/__tests__/loop-routes.test.ts
+++ b/server/__tests__/loop-routes.test.ts
@@ -98,4 +98,42 @@ describe('loop orchestrator API (unit)', () => {
     const status = orchestrator.start(goal.id);
     expect(status.state).toBe('running');
   });
+
+  it('spec mode start + approve flow', () => {
+    const goal = store.create({ title: 'Goal' });
+    const status = orchestrator.start(goal.id, { specMode: true });
+    expect(status.specMode).toBe(true);
+
+    store.create({ title: 'Sub', parentId: goal.id });
+    orchestrator.onSpecDecomposed();
+    expect(orchestrator.getStatus().awaitingApproval).toBe(true);
+
+    const approved = orchestrator.approveSpec();
+    expect(approved.state).toBe('running');
+    expect(approved.specMode).toBe(false);
+  });
+
+  it('spec mode start + reject flow', () => {
+    const goal = store.create({ title: 'Goal' });
+    orchestrator.start(goal.id, { specMode: true });
+
+    const child = store.create({ title: 'Sub', parentId: goal.id });
+    orchestrator.onSpecDecomposed();
+
+    const rejected = orchestrator.rejectSpec();
+    expect(rejected.state).toBe('idle');
+    expect(store.get(child.id)).toBeNull();
+  });
+
+  it('approveTask + rejectTask', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'T1', parentId: goal.id });
+    store.create({ title: 'T2', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    store.update(c1.id, { status: 'pending_review' });
+
+    expect(orchestrator.approveTask(c1.id)).toBe(true);
+    expect(store.get(c1.id)!.status).toBe('done');
+  });
 });

--- a/server/__tests__/loop-routes.test.ts
+++ b/server/__tests__/loop-routes.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+import { TaskOrchestrator } from '../task-orchestrator.js';
+import type { OrchestratorDeps } from '../task-orchestrator.js';
+
+// Mock sendToChat
+vi.mock('../chat.js', () => ({
+  sendToChat: vi.fn(() => true),
+}));
+
+const TEST_DIR = join(tmpdir(), `mitzo-loop-routes-test-${process.pid}`);
+
+let store: TaskStore;
+let orchestrator: TaskOrchestrator;
+
+function createTestDeps(store: TaskStore): OrchestratorDeps {
+  return {
+    store,
+    getClientId: () => 'test-client',
+    setTaskContext: vi.fn(),
+    clearTaskContext: vi.fn(),
+    broadcastStatus: vi.fn(),
+    broadcastTasks: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+  orchestrator = new TaskOrchestrator(createTestDeps(store));
+});
+
+afterEach(() => {
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('loop orchestrator API (unit)', () => {
+  it('getStatus returns idle by default', () => {
+    expect(orchestrator.getStatus().state).toBe('idle');
+  });
+
+  it('start transitions to running', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    const status = orchestrator.start(goal.id);
+    expect(status.state).toBe('running');
+    expect(status.goalId).toBe(goal.id);
+  });
+
+  it('start with nonexistent goalId stays idle', () => {
+    const status = orchestrator.start('bad-id');
+    expect(status.state).toBe('idle');
+  });
+
+  it('pause returns paused', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    const status = orchestrator.pause();
+    expect(status.state).toBe('paused');
+  });
+
+  it('resume returns running', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'T1', parentId: goal.id });
+    store.create({ title: 'T2', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    orchestrator.pause();
+    const status = orchestrator.resume();
+    expect(status.state).toBe('running');
+  });
+
+  it('stop returns idle', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    const status = orchestrator.stop();
+    expect(status.state).toBe('idle');
+  });
+
+  it('start while running returns current state', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    const status = orchestrator.start(goal.id);
+    expect(status.state).toBe('running');
+  });
+});

--- a/server/__tests__/task-context.test.ts
+++ b/server/__tests__/task-context.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+import { buildTaskContextPrompt, buildTaskSystemPrompt } from '../task-context.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-task-context-test-${process.pid}`);
+
+let store: TaskStore;
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+});
+
+afterEach(() => {
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('buildTaskContextPrompt', () => {
+  it('returns null for nonexistent task', () => {
+    expect(buildTaskContextPrompt(store, 'bad-id')).toBeNull();
+  });
+
+  it('builds context for a root task', () => {
+    const task = store.create({ title: 'My Goal' });
+    const ctx = buildTaskContextPrompt(store, task.id)!;
+
+    expect(ctx).toContain('<task-context>');
+    expect(ctx).toContain(`id="${task.id}"`);
+    expect(ctx).toContain('depth="0"');
+    expect(ctx).toContain('<title>My Goal</title>');
+    expect(ctx).not.toContain('<parent');
+    expect(ctx).not.toContain('<siblings');
+  });
+
+  it('includes parent and sibling context for child task', () => {
+    const parent = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Step 1', parentId: parent.id });
+    const c2 = store.create({ title: 'Step 2', parentId: parent.id });
+    store.update(c1.id, { status: 'done' });
+
+    const ctx = buildTaskContextPrompt(store, c2.id)!;
+
+    expect(ctx).toContain('<parent title="Goal"');
+    expect(ctx).toContain('<siblings>');
+    expect(ctx).toContain('current="true"');
+    expect(ctx).toContain('status="done"');
+  });
+
+  it('includes completed sibling summaries', () => {
+    const parent = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Done task', parentId: parent.id });
+    const c2 = store.create({ title: 'Current', parentId: parent.id });
+    store.update(c1.id, { status: 'done', summary: 'Did the thing' });
+
+    const ctx = buildTaskContextPrompt(store, c2.id)!;
+
+    expect(ctx).toContain('<completed-siblings>');
+    expect(ctx).toContain('Did the thing');
+  });
+
+  it('truncates long summaries', () => {
+    const parent = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Verbose', parentId: parent.id });
+    const c2 = store.create({ title: 'Current', parentId: parent.id });
+    const longSummary = 'x'.repeat(2500);
+    store.update(c1.id, { status: 'done', summary: longSummary });
+
+    const ctx = buildTaskContextPrompt(store, c2.id)!;
+
+    expect(ctx).toContain('...');
+    expect(ctx.length).toBeLessThan(3000);
+  });
+
+  it('returns depth error for tasks at max depth', () => {
+    let parentId: string | undefined;
+    for (let i = 0; i < 5; i++) {
+      const t = store.create({ title: `Level ${i}`, parentId });
+      parentId = t.id;
+    }
+    const deep = store.create({ title: 'Too deep', parentId });
+
+    const ctx = buildTaskContextPrompt(store, deep.id)!;
+    expect(ctx).toContain('<error>');
+    expect(ctx).toContain('exceeds maximum');
+  });
+
+  it('escapes XML special characters', () => {
+    const task = store.create({ title: 'Fix <script> & "quotes"' });
+    const ctx = buildTaskContextPrompt(store, task.id)!;
+
+    expect(ctx).toContain('&lt;script&gt;');
+    expect(ctx).toContain('&amp;');
+    expect(ctx).toContain('&quot;quotes&quot;');
+  });
+});
+
+describe('buildTaskSystemPrompt', () => {
+  it('includes task board instructions and context', () => {
+    const task = store.create({ title: 'Build feature' });
+    const prompt = buildTaskSystemPrompt(store, task.id);
+
+    expect(prompt).toContain('Task Board');
+    expect(prompt).toContain('TaskSet');
+    expect(prompt).toContain('TaskComplete');
+    expect(prompt).toContain('<task-context>');
+  });
+
+  it('returns empty string for nonexistent task', () => {
+    expect(buildTaskSystemPrompt(store, 'bad-id')).toBe('');
+  });
+});

--- a/server/__tests__/task-mcp-server.test.ts
+++ b/server/__tests__/task-mcp-server.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getToolTier } from '../tool-tiers.js';
+import { summarizeToolInput } from '../tool-summary.js';
+
+describe('task-board MCP integration', () => {
+  // --- Tool tiers ---
+
+  it('classifies mcp__task-board__ tools as safe', () => {
+    expect(getToolTier('mcp__task-board__TaskSet')).toBe('safe');
+    expect(getToolTier('mcp__task-board__TaskComplete')).toBe('safe');
+    expect(getToolTier('mcp__task-board__TaskStatus')).toBe('safe');
+    expect(getToolTier('mcp__task-board__TaskBlock')).toBe('safe');
+  });
+
+  it('does not affect other MCP tools', () => {
+    expect(getToolTier('mcp__other__SomeTool')).toBe('unknown');
+  });
+
+  // --- Tool summaries ---
+
+  it('summarizes TaskSet input', () => {
+    const summary = summarizeToolInput('mcp__task-board__TaskSet', {
+      tasks: [{ title: 'A' }, { title: 'B' }],
+    });
+    expect(summary).toBe('2 subtasks');
+  });
+
+  it('summarizes TaskComplete input', () => {
+    const summary = summarizeToolInput('mcp__task-board__TaskComplete', {
+      summary: 'Implemented the feature',
+    });
+    expect(summary).toBe('Implemented the feature');
+  });
+
+  it('summarizes TaskStatus input', () => {
+    const summary = summarizeToolInput('mcp__task-board__TaskStatus', {});
+    expect(summary).toBe('get status');
+  });
+
+  it('summarizes TaskBlock input', () => {
+    const summary = summarizeToolInput('mcp__task-board__TaskBlock', {
+      reason: 'Missing API key',
+    });
+    expect(summary).toBe('Missing API key');
+  });
+});

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -340,7 +340,7 @@ describe('TaskOrchestrator', () => {
 
       const goal = store.create({ title: 'Goal' });
       const c1 = store.create({ title: 'Active', parentId: goal.id });
-      store.create({ title: 'Next', parentId: goal.id });
+      const c2 = store.create({ title: 'Next', parentId: goal.id });
 
       store.update(c1.id, { status: 'active' });
       store.setSessionId(c1.id, 'alive-session');

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+import { TaskOrchestrator } from '../task-orchestrator.js';
+import type { OrchestratorDeps, LoopStatus } from '../task-orchestrator.js';
+
+// Mock sendToChat
+vi.mock('../chat.js', () => ({
+  sendToChat: vi.fn(() => true),
+}));
+
+const TEST_DIR = join(tmpdir(), `mitzo-orchestrator-test-${process.pid}`);
+
+let store: TaskStore;
+let orchestrator: TaskOrchestrator;
+let mockDeps: OrchestratorDeps;
+let broadcastedStatuses: LoopStatus[];
+
+function createTestDeps(store: TaskStore): OrchestratorDeps {
+  broadcastedStatuses = [];
+  return {
+    store,
+    getClientId: () => 'test-client',
+    setTaskContext: vi.fn(),
+    clearTaskContext: vi.fn(),
+    broadcastStatus: (s) => broadcastedStatuses.push(s),
+    broadcastTasks: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+  mockDeps = createTestDeps(store);
+  orchestrator = new TaskOrchestrator(mockDeps);
+});
+
+afterEach(() => {
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('TaskOrchestrator', () => {
+  it('starts in idle state', () => {
+    const status = orchestrator.getStatus();
+    expect(status.state).toBe('idle');
+    expect(status.goalId).toBeNull();
+  });
+
+  it('start() transitions to running and assigns first task', () => {
+    const goal = store.create({ title: 'Goal' });
+    const child = store.create({ title: 'First task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+
+    const status = orchestrator.getStatus();
+    expect(status.state).toBe('running');
+    expect(status.goalId).toBe(goal.id);
+    expect(status.activeTaskId).toBe(child.id);
+    expect(store.get(child.id)!.status).toBe('active');
+  });
+
+  it('pause() transitions from running to paused', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    orchestrator.pause();
+
+    expect(orchestrator.getStatus().state).toBe('paused');
+  });
+
+  it('resume() transitions from paused to running', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task 1', parentId: goal.id });
+    store.create({ title: 'Task 2', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    orchestrator.pause();
+    orchestrator.resume();
+
+    expect(orchestrator.getStatus().state).toBe('running');
+  });
+
+  it('stop() transitions to idle and clears state', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    orchestrator.stop();
+
+    const status = orchestrator.getStatus();
+    expect(status.state).toBe('idle');
+    expect(status.goalId).toBeNull();
+    expect(status.activeTaskId).toBeNull();
+    expect(mockDeps.clearTaskContext).toHaveBeenCalled();
+  });
+
+  it('tick assigns deepest-left pending leaf (DFS)', () => {
+    const goal = store.create({ title: 'Goal' });
+    const parent = store.create({ title: 'Parent', parentId: goal.id });
+    const leaf = store.create({ title: 'Leaf', parentId: parent.id });
+    store.create({ title: 'Sibling', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+
+    expect(orchestrator.getStatus().activeTaskId).toBe(leaf.id);
+    expect(store.get(leaf.id)!.status).toBe('active');
+  });
+
+  it('tick does nothing when paused', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    orchestrator.pause();
+
+    const activeId = orchestrator.getStatus().activeTaskId;
+    // Manually call tick — should not change anything
+    orchestrator.tick();
+    expect(orchestrator.getStatus().activeTaskId).toBe(activeId);
+  });
+
+  it('tick transitions to idle when all tasks done', () => {
+    const goal = store.create({ title: 'Goal' });
+    const child = store.create({ title: 'Only task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+
+    // Simulate task completion
+    store.update(child.id, { status: 'done' });
+    store.cascadeStatus(child.id);
+    orchestrator.onTaskCompleted(child.id);
+
+    expect(orchestrator.getStatus().state).toBe('idle');
+  });
+
+  it('tick skips blocked tasks and finds next', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Blocked', parentId: goal.id });
+    const c2 = store.create({ title: 'Available', parentId: goal.id });
+    store.update(c1.id, { status: 'blocked' });
+
+    orchestrator.start(goal.id);
+
+    expect(orchestrator.getStatus().activeTaskId).toBe(c2.id);
+  });
+
+  it('onTaskCompleted triggers tick and assigns next', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Task 1', parentId: goal.id });
+    const c2 = store.create({ title: 'Task 2', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    expect(orchestrator.getStatus().activeTaskId).toBe(c1.id);
+
+    // Complete first task
+    store.update(c1.id, { status: 'done' });
+    store.cascadeStatus(c1.id);
+    orchestrator.onTaskCompleted(c1.id);
+
+    expect(orchestrator.getStatus().activeTaskId).toBe(c2.id);
+  });
+
+  it('onTaskBlocked triggers tick', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Task 1', parentId: goal.id });
+    const c2 = store.create({ title: 'Task 2', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+
+    store.update(c1.id, { status: 'blocked' });
+    store.cascadeStatus(c1.id);
+    orchestrator.onTaskBlocked(c1.id);
+
+    expect(orchestrator.getStatus().activeTaskId).toBe(c2.id);
+  });
+
+  it('broadcasts status on state changes', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+    expect(broadcastedStatuses.length).toBeGreaterThan(0);
+    expect(broadcastedStatuses[0].state).toBe('running');
+  });
+
+  it('sets task context on session when assigning', () => {
+    const goal = store.create({ title: 'Goal' });
+    const child = store.create({ title: 'Task', parentId: goal.id });
+
+    orchestrator.start(goal.id);
+
+    expect(mockDeps.setTaskContext).toHaveBeenCalledWith(child.id, goal.id);
+  });
+
+  it('computes progress correctly', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Task 1', parentId: goal.id });
+    store.create({ title: 'Task 2', parentId: goal.id });
+    store.create({ title: 'Task 3', parentId: goal.id });
+    store.update(c1.id, { status: 'done' });
+
+    orchestrator.start(goal.id);
+
+    const status = orchestrator.getStatus();
+    expect(status.progress).toEqual({ done: 1, total: 3 });
+  });
+
+  it('pauses when no executable tasks (all blocked)', () => {
+    const goal = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'Task', parentId: goal.id });
+    store.update(c1.id, { status: 'blocked' });
+
+    orchestrator.start(goal.id);
+
+    expect(orchestrator.getStatus().state).toBe('paused');
+  });
+});

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -222,4 +222,197 @@ describe('TaskOrchestrator', () => {
 
     expect(orchestrator.getStatus().state).toBe('paused');
   });
+
+  describe('spec mode', () => {
+    it('start with specMode assigns goal directly', () => {
+      const goal = store.create({ title: 'Goal' });
+      const status = orchestrator.start(goal.id, { specMode: true });
+
+      expect(status.state).toBe('running');
+      expect(status.specMode).toBe(true);
+      expect(status.activeTaskId).toBe(goal.id);
+      expect(store.get(goal.id)!.status).toBe('active');
+    });
+
+    it('onSpecDecomposed pauses and sets awaitingApproval', () => {
+      const goal = store.create({ title: 'Goal' });
+      orchestrator.start(goal.id, { specMode: true });
+
+      orchestrator.onSpecDecomposed();
+
+      const status = orchestrator.getStatus();
+      expect(status.state).toBe('paused');
+      expect(status.awaitingApproval).toBe(true);
+    });
+
+    it('onSpecDecomposed is no-op when not in spec mode', () => {
+      const goal = store.create({ title: 'Goal' });
+      store.create({ title: 'Task', parentId: goal.id });
+      orchestrator.start(goal.id);
+
+      orchestrator.onSpecDecomposed();
+
+      expect(orchestrator.getStatus().state).toBe('running');
+      expect(orchestrator.getStatus().awaitingApproval).toBe(false);
+    });
+
+    it('approveSpec transitions to execution mode', () => {
+      const goal = store.create({ title: 'Goal' });
+      orchestrator.start(goal.id, { specMode: true });
+      // Simulate agent creating children
+      store.create({ title: 'Sub 1', parentId: goal.id });
+      store.create({ title: 'Sub 2', parentId: goal.id });
+      orchestrator.onSpecDecomposed();
+
+      const status = orchestrator.approveSpec();
+
+      expect(status.state).toBe('running');
+      expect(status.specMode).toBe(false);
+      expect(status.awaitingApproval).toBe(false);
+    });
+
+    it('rejectSpec deletes children and stops', () => {
+      const goal = store.create({ title: 'Goal' });
+      orchestrator.start(goal.id, { specMode: true });
+      const c1 = store.create({ title: 'Sub 1', parentId: goal.id });
+      const c2 = store.create({ title: 'Sub 2', parentId: goal.id });
+      orchestrator.onSpecDecomposed();
+
+      const status = orchestrator.rejectSpec();
+
+      expect(status.state).toBe('idle');
+      expect(store.get(c1.id)).toBeNull();
+      expect(store.get(c2.id)).toBeNull();
+      expect(store.get(goal.id)!.status).toBe('pending');
+    });
+
+    it('approveSpec is no-op when not awaiting approval', () => {
+      const goal = store.create({ title: 'Goal' });
+      store.create({ title: 'Task', parentId: goal.id });
+      orchestrator.start(goal.id);
+
+      const before = orchestrator.getStatus();
+      orchestrator.approveSpec();
+      const after = orchestrator.getStatus();
+
+      expect(after.state).toBe(before.state);
+    });
+
+    it('rejectSpec is no-op when not awaiting approval', () => {
+      const goal = store.create({ title: 'Goal' });
+      store.create({ title: 'Task', parentId: goal.id });
+      orchestrator.start(goal.id);
+
+      const before = orchestrator.getStatus();
+      orchestrator.rejectSpec();
+
+      expect(orchestrator.getStatus().state).toBe(before.state);
+    });
+  });
+
+  describe('orphan detection', () => {
+    it('reclaims orphaned tasks during tick', () => {
+      // Create deps with getActiveSessionIds
+      const depsWithOrphan = createTestDeps(store);
+      depsWithOrphan.getActiveSessionIds = () => new Set(['alive-session']);
+      const orch = new TaskOrchestrator(depsWithOrphan);
+
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Orphan', parentId: goal.id });
+      store.create({ title: 'Next', parentId: goal.id });
+
+      // Simulate c1 assigned to dead session
+      store.update(c1.id, { status: 'active' });
+      store.setSessionId(c1.id, 'dead-session');
+
+      orch.start(goal.id);
+
+      // c1 should have been reclaimed to pending, then re-assigned
+      // The tick should have picked c1 (first pending) since it was reclaimed
+      expect(store.get(c1.id)!.status).toBe('active');
+      expect(orch.getStatus().activeTaskId).toBe(c1.id);
+    });
+
+    it('does not reclaim tasks with alive sessions', () => {
+      const depsWithOrphan = createTestDeps(store);
+      depsWithOrphan.getActiveSessionIds = () => new Set(['alive-session']);
+      const orch = new TaskOrchestrator(depsWithOrphan);
+
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Active', parentId: goal.id });
+      store.create({ title: 'Next', parentId: goal.id });
+
+      store.update(c1.id, { status: 'active' });
+      store.setSessionId(c1.id, 'alive-session');
+
+      orch.start(goal.id);
+
+      // c1 is alive, so tick should skip it and pick c2
+      expect(orch.getStatus().activeTaskId).toBe(c2.id);
+    });
+  });
+
+  describe('task approval', () => {
+    it('approveTask moves pending_review to done', () => {
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Task 1', parentId: goal.id });
+      store.create({ title: 'Task 2', parentId: goal.id });
+
+      orchestrator.start(goal.id);
+      store.update(c1.id, { status: 'pending_review' });
+
+      const ok = orchestrator.approveTask(c1.id);
+
+      expect(ok).toBe(true);
+      expect(store.get(c1.id)!.status).toBe('done');
+    });
+
+    it('approveTask returns false for non-pending_review', () => {
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Task', parentId: goal.id });
+
+      orchestrator.start(goal.id);
+
+      expect(orchestrator.approveTask(c1.id)).toBe(false);
+    });
+
+    it('approveTask triggers tick when running', () => {
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Task 1', parentId: goal.id });
+      const c2 = store.create({ title: 'Task 2', parentId: goal.id });
+
+      orchestrator.start(goal.id);
+      store.update(c1.id, { status: 'pending_review' });
+
+      orchestrator.approveTask(c1.id);
+
+      // After approval + tick, c2 should be active
+      expect(orchestrator.getStatus().activeTaskId).toBe(c2.id);
+    });
+
+    it('rejectTask moves pending_review to active with feedback', () => {
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Task', parentId: goal.id });
+      store.create({ title: 'Task 2', parentId: goal.id });
+
+      orchestrator.start(goal.id);
+      store.update(c1.id, { status: 'pending_review' });
+
+      const ok = orchestrator.rejectTask(c1.id, 'needs more tests');
+
+      expect(ok).toBe(true);
+      const task = store.get(c1.id)!;
+      expect(task.status).toBe('active');
+      expect(task.annotations).toContain('review_feedback: needs more tests');
+    });
+
+    it('rejectTask returns false for non-pending_review', () => {
+      const goal = store.create({ title: 'Goal' });
+      const c1 = store.create({ title: 'Task', parentId: goal.id });
+
+      orchestrator.start(goal.id);
+
+      expect(orchestrator.rejectTask(c1.id, 'nope')).toBe(false);
+    });
+  });
 });

--- a/server/__tests__/task-store.test.ts
+++ b/server/__tests__/task-store.test.ts
@@ -219,6 +219,205 @@ describe('TaskStore', () => {
     expect(store.getSubtree('nonexistent')).toEqual([]);
   });
 
+  // --- deriveParentStatus ---
+
+  it('derives failed when any child is failed', () => {
+    const parent = store.create({ title: 'Parent' });
+    store.create({ title: 'C1', parentId: parent.id });
+    const c2 = store.create({ title: 'C2', parentId: parent.id });
+    store.update(c2.id, { status: 'failed' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('failed');
+  });
+
+  it('derives blocked when any child is blocked (no failed)', () => {
+    const parent = store.create({ title: 'Parent' });
+    store.create({ title: 'C1', parentId: parent.id });
+    const c2 = store.create({ title: 'C2', parentId: parent.id });
+    store.update(c2.id, { status: 'blocked' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('blocked');
+  });
+
+  it('derives active when any child is active', () => {
+    const parent = store.create({ title: 'Parent' });
+    const c1 = store.create({ title: 'C1', parentId: parent.id });
+    store.create({ title: 'C2', parentId: parent.id });
+    store.update(c1.id, { status: 'active' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('active');
+  });
+
+  it('derives pending_review when any child is pending_review', () => {
+    const parent = store.create({ title: 'Parent' });
+    const c1 = store.create({ title: 'C1', parentId: parent.id });
+    const c2 = store.create({ title: 'C2', parentId: parent.id });
+    store.update(c1.id, { status: 'done' });
+    store.update(c2.id, { status: 'pending_review' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('pending_review');
+  });
+
+  it('derives done when all children are done or skipped', () => {
+    const parent = store.create({ title: 'Parent' });
+    const c1 = store.create({ title: 'C1', parentId: parent.id });
+    const c2 = store.create({ title: 'C2', parentId: parent.id });
+    store.update(c1.id, { status: 'done' });
+    store.update(c2.id, { status: 'skipped' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('done');
+  });
+
+  it('derives pending when children are mixed pending', () => {
+    const parent = store.create({ title: 'Parent' });
+    const c1 = store.create({ title: 'C1', parentId: parent.id });
+    store.create({ title: 'C2', parentId: parent.id });
+    store.update(c1.id, { status: 'done' });
+
+    expect(store.deriveParentStatus(parent.id)).toBe('pending');
+  });
+
+  it('returns own status when task has no children', () => {
+    const leaf = store.create({ title: 'Leaf' });
+    store.update(leaf.id, { status: 'active' });
+
+    expect(store.deriveParentStatus(leaf.id)).toBe('active');
+  });
+
+  // --- cascadeStatus ---
+
+  it('cascades status up the parent chain', () => {
+    const root = store.create({ title: 'Root' });
+    const mid = store.create({ title: 'Mid', parentId: root.id });
+    const leaf = store.create({ title: 'Leaf', parentId: mid.id });
+    store.update(leaf.id, { status: 'done' });
+
+    store.cascadeStatus(leaf.id);
+
+    expect(store.get(mid.id)!.status).toBe('done');
+    expect(store.get(root.id)!.status).toBe('done');
+  });
+
+  it('cascade stops when status unchanged', () => {
+    const root = store.create({ title: 'Root' });
+    const mid = store.create({ title: 'Mid', parentId: root.id });
+    store.create({ title: 'Sibling', parentId: root.id }); // pending sibling keeps root pending
+    const leaf = store.create({ title: 'Leaf', parentId: mid.id });
+    store.update(leaf.id, { status: 'done' });
+
+    store.cascadeStatus(leaf.id);
+
+    expect(store.get(mid.id)!.status).toBe('done');
+    // Root stays pending because of the pending sibling
+    expect(store.get(root.id)!.status).toBe('pending');
+  });
+
+  // --- getBySession ---
+
+  it('returns tasks assigned to a session', () => {
+    const t1 = store.create({ title: 'T1' });
+    store.create({ title: 'T2' });
+    store.setSessionId(t1.id, 'session-abc');
+
+    const result = store.getBySession('session-abc');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(t1.id);
+  });
+
+  it('returns empty array for unknown session', () => {
+    expect(store.getBySession('nonexistent')).toEqual([]);
+  });
+
+  // --- setSessionId ---
+
+  it('assigns a session to a task', () => {
+    const task = store.create({ title: 'Assignable' });
+    const updated = store.setSessionId(task.id, 'session-xyz');
+    expect(updated!.sessionId).toBe('session-xyz');
+    expect(updated!.claimedBy).toBe('session-xyz');
+    expect(updated!.claimedAt).toBeGreaterThan(0);
+  });
+
+  it('unassigns a session from a task', () => {
+    const task = store.create({ title: 'Unassignable' });
+    store.setSessionId(task.id, 'session-xyz');
+    const cleared = store.setSessionId(task.id, null);
+    expect(cleared!.sessionId).toBeNull();
+    expect(cleared!.claimedAt).toBeNull();
+  });
+
+  // --- getNextExecutable ---
+
+  it('returns the deepest-left pending leaf (DFS)', () => {
+    const root = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'C1', parentId: root.id });
+    const c1a = store.create({ title: 'C1a', parentId: c1.id });
+    store.create({ title: 'C2', parentId: root.id });
+
+    const next = store.getNextExecutable();
+    expect(next!.id).toBe(c1a.id);
+  });
+
+  it('skips done subtrees and finds next pending', () => {
+    const root = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'C1', parentId: root.id });
+    const c2 = store.create({ title: 'C2', parentId: root.id });
+    store.update(c1.id, { status: 'done' });
+
+    const next = store.getNextExecutable();
+    expect(next!.id).toBe(c2.id);
+  });
+
+  it('skips blocked subtrees', () => {
+    const root = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'C1', parentId: root.id });
+    const c2 = store.create({ title: 'C2', parentId: root.id });
+    store.update(c1.id, { status: 'blocked' });
+
+    const next = store.getNextExecutable();
+    expect(next!.id).toBe(c2.id);
+  });
+
+  it('returns null when all tasks are done', () => {
+    const root = store.create({ title: 'Goal' });
+    const c1 = store.create({ title: 'C1', parentId: root.id });
+    store.update(c1.id, { status: 'done' });
+    store.update(root.id, { status: 'done' });
+
+    expect(store.getNextExecutable()).toBeNull();
+  });
+
+  it('searches within a specific parent subtree', () => {
+    const g1 = store.create({ title: 'Goal 1' });
+    const g2 = store.create({ title: 'Goal 2' });
+    store.create({ title: 'G1-child', parentId: g1.id });
+    const g2child = store.create({ title: 'G2-child', parentId: g2.id });
+
+    const next = store.getNextExecutable(g2.id);
+    expect(next!.id).toBe(g2child.id);
+  });
+
+  // --- getOrphaned ---
+
+  it('finds active tasks with dead sessions', () => {
+    const t1 = store.create({ title: 'Active' });
+    store.update(t1.id, { status: 'active' });
+    store.setSessionId(t1.id, 'dead-session');
+
+    const orphans = store.getOrphaned(new Set(['alive-session']));
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0].id).toBe(t1.id);
+  });
+
+  it('does not include tasks with alive sessions', () => {
+    const t1 = store.create({ title: 'Active' });
+    store.update(t1.id, { status: 'active' });
+    store.setSessionId(t1.id, 'alive-session');
+
+    const orphans = store.getOrphaned(new Set(['alive-session']));
+    expect(orphans).toHaveLength(0);
+  });
+
   // --- close ---
 
   it('can close and reopen', () => {

--- a/server/__tests__/task-tools.test.ts
+++ b/server/__tests__/task-tools.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+import {
+  handleTaskSet,
+  handleTaskComplete,
+  handleTaskStatus,
+  handleTaskBlock,
+} from '../task-tools.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-task-tools-test-${process.pid}`);
+
+let store: TaskStore;
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+});
+
+afterEach(() => {
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('handleTaskSet', () => {
+  it('creates subtasks under the current task', () => {
+    const goal = store.create({ title: 'Goal' });
+    const result = handleTaskSet(store, goal.id, [
+      { title: 'Step 1' },
+      { title: 'Step 2', description: 'Details', priority: 5 },
+    ]);
+
+    expect(result).toContain('Created 2 subtask(s)');
+    const children = store.getChildren(goal.id);
+    expect(children).toHaveLength(2);
+    expect(children[0].title).toBe('Step 2'); // priority 5 first
+    expect(children[1].title).toBe('Step 1');
+  });
+
+  it('replaces existing children', () => {
+    const goal = store.create({ title: 'Goal' });
+    store.create({ title: 'Old child', parentId: goal.id });
+
+    handleTaskSet(store, goal.id, [{ title: 'New child' }]);
+
+    const children = store.getChildren(goal.id);
+    expect(children).toHaveLength(1);
+    expect(children[0].title).toBe('New child');
+  });
+
+  it('returns error for nonexistent task', () => {
+    const result = handleTaskSet(store, 'bad-id', [{ title: 'X' }]);
+    expect(result).toContain('Error');
+  });
+
+  it('returns error for empty task list', () => {
+    const goal = store.create({ title: 'Goal' });
+    const result = handleTaskSet(store, goal.id, []);
+    expect(result).toContain('Error');
+  });
+});
+
+describe('handleTaskComplete', () => {
+  it('marks task as done with summary', () => {
+    const goal = store.create({ title: 'Goal' });
+    const child = store.create({ title: 'Task', parentId: goal.id });
+
+    const result = handleTaskComplete(store, child.id, 'All done');
+
+    expect(result).toContain('completed');
+    const updated = store.get(child.id)!;
+    expect(updated.status).toBe('done');
+    expect(updated.summary).toBe('All done');
+  });
+
+  it('marks task as pending_review when requiresApproval', () => {
+    const task = store.create({ title: 'Reviewable' });
+    store.update(task.id, { requiresApproval: true });
+
+    const result = handleTaskComplete(store, task.id, 'Please review');
+
+    expect(result).toContain('pending_review');
+    expect(store.get(task.id)!.status).toBe('pending_review');
+  });
+
+  it('cascades status to parent', () => {
+    const parent = store.create({ title: 'Parent' });
+    const child = store.create({ title: 'Only child', parentId: parent.id });
+
+    handleTaskComplete(store, child.id, 'Done');
+
+    expect(store.get(parent.id)!.status).toBe('done');
+  });
+
+  it('returns error for empty summary', () => {
+    const task = store.create({ title: 'Task' });
+    const result = handleTaskComplete(store, task.id, '  ');
+    expect(result).toContain('Error');
+  });
+});
+
+describe('handleTaskStatus', () => {
+  it('returns formatted status with siblings', () => {
+    const parent = store.create({ title: 'Parent' });
+    const c1 = store.create({ title: 'Task A', parentId: parent.id });
+    const c2 = store.create({ title: 'Task B', parentId: parent.id });
+    store.update(c1.id, { status: 'done' });
+
+    const result = handleTaskStatus(store, c2.id);
+
+    expect(result).toContain('Task B');
+    expect(result).toContain('[pending]');
+    expect(result).toContain('1/2 siblings complete');
+    expect(result).toContain('[done] Task A');
+  });
+
+  it('returns status for root task without siblings', () => {
+    const root = store.create({ title: 'Solo' });
+    const result = handleTaskStatus(store, root.id);
+    expect(result).toContain('Solo');
+    expect(result).not.toContain('Siblings');
+  });
+
+  it('returns error for nonexistent task', () => {
+    const result = handleTaskStatus(store, 'bad-id');
+    expect(result).toContain('Error');
+  });
+});
+
+describe('handleTaskBlock', () => {
+  it('sets status to blocked with reason annotation', () => {
+    const parent = store.create({ title: 'Parent' });
+    const task = store.create({ title: 'Blockable', parentId: parent.id });
+
+    const result = handleTaskBlock(store, task.id, 'Missing API key');
+
+    expect(result).toContain('blocked');
+    expect(result).toContain('Missing API key');
+
+    const updated = store.get(task.id)!;
+    expect(updated.status).toBe('blocked');
+    expect(updated.annotations).toContain('blocked: Missing API key');
+  });
+
+  it('cascades blocked status to parent', () => {
+    const parent = store.create({ title: 'Parent' });
+    const task = store.create({ title: 'Blockable', parentId: parent.id });
+
+    handleTaskBlock(store, task.id, 'Stuck');
+
+    expect(store.get(parent.id)!.status).toBe('blocked');
+  });
+
+  it('returns error for empty reason', () => {
+    const task = store.create({ title: 'Task' });
+    const result = handleTaskBlock(store, task.id, '  ');
+    expect(result).toContain('Error');
+  });
+});

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -132,3 +132,8 @@ export const TaskUpdateBody = z.object({
   summary: z.string().optional(),
   requiresApproval: z.boolean().optional(),
 });
+
+export const LoopStartBody = z.object({
+  goalId: z.string().min(1),
+  specMode: z.boolean().optional(),
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -462,7 +462,14 @@ app.post('/api/internal/task-tools/block', (req, res) => {
 
 app.get('/api/loop/status', (req, res) => {
   if (!orchestrator) {
-    res.json({ state: 'idle', goalId: null, activeTaskId: null, progress: null });
+    res.json({
+      state: 'idle',
+      goalId: null,
+      activeTaskId: null,
+      progress: null,
+      specMode: false,
+      awaitingApproval: false,
+    });
     return;
   }
   res.json(orchestrator.getStatus());

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,12 @@ import { getLocalCommit, isUpdateAvailable } from './git-version.js';
 import { resolvePending } from './permissions.js';
 import { createLogger } from './logger.js';
 import {
+  handleTaskSet,
+  handleTaskComplete,
+  handleTaskStatus,
+  handleTaskBlock,
+} from './task-tools.js';
+import {
   LoginBody,
   FileWriteBody,
   PermissionDecision,
@@ -364,6 +370,83 @@ app.delete('/api/tasks/:id', (req, res) => {
   }
   res.json({ ok: true });
   onTaskBroadcast?.({ type: 'task_deleted', taskId: req.params.id });
+});
+
+// --- Internal task-tool endpoints (MCP server callback) ---
+
+function resolveTaskContext(req: express.Request): string | null {
+  const clientId = req.headers['x-client-id'] as string | undefined;
+  if (!clientId) return null;
+  const session = registry.get(clientId);
+  return session?.taskContext?.currentTaskId ?? null;
+}
+
+app.post('/api/internal/task-tools/set', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  const taskId = resolveTaskContext(req);
+  if (!taskId) {
+    res.status(400).json({ error: 'No active task context' });
+    return;
+  }
+  const result = handleTaskSet(taskStore, taskId, req.body.tasks ?? []);
+  res.json({ result });
+  onTaskBroadcast?.({
+    type: 'task_state',
+    tasks: taskStore.getTree(),
+  });
+});
+
+app.post('/api/internal/task-tools/complete', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  const taskId = resolveTaskContext(req);
+  if (!taskId) {
+    res.status(400).json({ error: 'No active task context' });
+    return;
+  }
+  const result = handleTaskComplete(taskStore, taskId, req.body.summary ?? '');
+  res.json({ result });
+  onTaskBroadcast?.({
+    type: 'task_state',
+    tasks: taskStore.getTree(),
+  });
+});
+
+app.get('/api/internal/task-tools/status', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  const taskId = resolveTaskContext(req);
+  if (!taskId) {
+    res.status(400).json({ error: 'No active task context' });
+    return;
+  }
+  const result = handleTaskStatus(taskStore, taskId);
+  res.json({ result });
+});
+
+app.post('/api/internal/task-tools/block', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  const taskId = resolveTaskContext(req);
+  if (!taskId) {
+    res.status(400).json({ error: 'No active task context' });
+    return;
+  }
+  const result = handleTaskBlock(taskStore, taskId, req.body.reason ?? '');
+  res.json({ result });
+  onTaskBroadcast?.({
+    type: 'task_state',
+    tasks: taskStore.getTree(),
+  });
 });
 
 app.post('/api/auth/login', loginLimiter, async (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -511,6 +511,48 @@ app.post('/api/loop/stop', (_req, res) => {
   res.json(orchestrator.stop());
 });
 
+app.post('/api/tasks/:id/approve', (req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  const ok = orchestrator.approveTask(req.params.id);
+  if (!ok) {
+    res.status(400).json({ error: 'Task not in pending_review state' });
+    return;
+  }
+  res.json({ ok: true });
+});
+
+app.post('/api/tasks/:id/reject', (req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  const ok = orchestrator.rejectTask(req.params.id, req.body.feedback ?? '');
+  if (!ok) {
+    res.status(400).json({ error: 'Task not in pending_review state' });
+    return;
+  }
+  res.json({ ok: true });
+});
+
+app.post('/api/loop/spec/approve', (_req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  res.json(orchestrator.approveSpec());
+});
+
+app.post('/api/loop/spec/reject', (_req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  res.json(orchestrator.rejectSpec());
+});
+
 app.post('/api/auth/login', loginLimiter, async (req, res) => {
   const body = LoginBody.safeParse(req.body);
   if (!body.success) {

--- a/server/app.ts
+++ b/server/app.ts
@@ -35,6 +35,7 @@ import {
   handleTaskStatus,
   handleTaskBlock,
 } from './task-tools.js';
+import { setTaskStore } from './chat.js';
 import {
   LoginBody,
   FileWriteBody,
@@ -171,6 +172,7 @@ try {
   // may already exist
 }
 export const taskStore = new TaskStore(join(mitzoDir, 'tasks.db'));
+setTaskStore(taskStore);
 
 export function setUpdateBroadcast(fn: () => void) {
   onUpdateAvailable = fn;

--- a/server/app.ts
+++ b/server/app.ts
@@ -483,7 +483,9 @@ app.post('/api/loop/start', (req, res) => {
     res.status(409).json({ error: 'Loop already running' });
     return;
   }
-  const result = orchestrator.start(body.data.goalId);
+  const result = orchestrator.start(body.data.goalId, {
+    specMode: body.data.specMode,
+  });
   res.json(result);
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -47,7 +47,9 @@ import {
   TodoActionResponse,
   TaskCreateBody,
   TaskUpdateBody,
+  LoopStartBody,
 } from './api-schemas.js';
+import type { TaskOrchestrator } from './task-orchestrator.js';
 import {
   listInboxItems,
   readInboxItem,
@@ -162,6 +164,11 @@ let updateAvailable = false;
 let onUpdateAvailable: (() => void) | null = null;
 let onInboxUpdated: (() => void) | null = null;
 let onTaskBroadcast: ((event: Record<string, unknown>) => void) | null = null;
+let orchestrator: TaskOrchestrator | null = null;
+
+export function setOrchestrator(o: TaskOrchestrator): void {
+  orchestrator = o;
+}
 
 // --- Task store ---
 
@@ -449,6 +456,59 @@ app.post('/api/internal/task-tools/block', (req, res) => {
     type: 'task_state',
     tasks: taskStore.getTree(),
   });
+});
+
+// --- Loop orchestrator API ---
+
+app.get('/api/loop/status', (req, res) => {
+  if (!orchestrator) {
+    res.json({ state: 'idle', goalId: null, activeTaskId: null, progress: null });
+    return;
+  }
+  res.json(orchestrator.getStatus());
+});
+
+app.post('/api/loop/start', (req, res) => {
+  const body = LoopStartBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: 'goalId is required' });
+    return;
+  }
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  const status = orchestrator.getStatus();
+  if (status.state === 'running') {
+    res.status(409).json({ error: 'Loop already running' });
+    return;
+  }
+  const result = orchestrator.start(body.data.goalId);
+  res.json(result);
+});
+
+app.post('/api/loop/pause', (_req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  res.json(orchestrator.pause());
+});
+
+app.post('/api/loop/resume', (_req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  res.json(orchestrator.resume());
+});
+
+app.post('/api/loop/stop', (_req, res) => {
+  if (!orchestrator) {
+    res.status(503).json({ error: 'Orchestrator not initialized' });
+    return;
+  }
+  res.json(orchestrator.stop());
 });
 
 app.post('/api/auth/login', loginLimiter, async (req, res) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -23,6 +23,13 @@ import { runQueryLoop, createWsMessageHandler, broadcastToObservers } from './qu
 import { AsyncQueue } from './async-queue.js';
 import { GIT_BRANCH_TIMEOUT_MS, SESSION_LIST_LIMIT, SESSION_MESSAGES_LIMIT } from './constants.js';
 import { INTERNAL_TOKEN } from './internal-token.js';
+import { buildTaskSystemPrompt } from './task-context.js';
+import type { TaskStore } from './task-store.js';
+
+let _taskStore: TaskStore | null = null;
+export function setTaskStore(store: TaskStore): void {
+  _taskStore = store;
+}
 import { EventStore } from './event-store.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
 import { createLogger } from './logger.js';
@@ -187,6 +194,13 @@ function buildTaskMcpServer(clientId: string): Record<string, McpServerConfig> |
       env: { MITZO_INTERNAL_TOKEN: INTERNAL_TOKEN },
     },
   };
+}
+
+function buildTaskPromptForSession(clientId: string): string {
+  if (!_taskStore) return '';
+  const session = registry.get(clientId);
+  if (!session?.taskContext) return '';
+  return buildTaskSystemPrompt(_taskStore, session.taskContext.currentTaskId);
 }
 
 function buildRepoSystemPrompt(): string {
@@ -403,7 +417,8 @@ export async function startChat(
             '- Read operations are fine without asking.\n' +
             '- Keep responses concise — small screen.\n' +
             '- Read CLAUDE.md and .cursor/rules/ for project context before doing substantive work.' +
-            buildRepoSystemPrompt(),
+            buildRepoSystemPrompt() +
+            buildTaskPromptForSession(clientId),
         },
         permissionMode: MODE_TO_SDK[mode] as 'plan' | 'default' | 'bypassPermissions',
         allowedTools: [...modeAllowed, ...mcpAllowed, ...extraTools],

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -130,10 +130,16 @@ function getBranch(cwd: string): string {
   }
 }
 
-function buildMcpAllowedTools(): string[] {
+function buildMcpAllowedTools(clientId?: string): string[] {
   const patterns = Object.keys(mcpServers).map((name) => `mcp__${name}__*`);
   if (Object.keys(getRepoConfig().repos).length > 0) {
     patterns.push('mcp__mitzo_repos__*');
+  }
+  if (clientId) {
+    const session = registry.get(clientId);
+    if (session?.taskContext) {
+      patterns.push('mcp__task-board__*');
+    }
   }
   return patterns;
 }
@@ -150,6 +156,29 @@ function buildRepoMcpServer(clientId: string): Record<string, McpServerConfig> |
         '--import',
         'tsx',
         join(__dirname, 'repo-mcp-server.ts'),
+        '--base-url',
+        `http://localhost:${port}`,
+        '--client-id',
+        clientId,
+      ],
+      env: { MITZO_INTERNAL_TOKEN: INTERNAL_TOKEN },
+    },
+  };
+}
+
+const TASK_MCP_SERVER_NAME = 'task-board';
+
+function buildTaskMcpServer(clientId: string): Record<string, McpServerConfig> | null {
+  const session = registry.get(clientId);
+  if (!session?.taskContext) return null;
+  const port = process.env.PORT || '3100';
+  return {
+    [TASK_MCP_SERVER_NAME]: {
+      command: 'node',
+      args: [
+        '--import',
+        'tsx',
+        join(__dirname, 'task-mcp-server.ts'),
         '--base-url',
         `http://localhost:${port}`,
         '--client-id',
@@ -325,7 +354,7 @@ export async function startChat(
   applyTierOverrides(currentConfig.toolTierOverrides);
 
   const modeAllowed = getAllowedToolsForMode(mode);
-  const mcpAllowed = buildMcpAllowedTools();
+  const mcpAllowed = buildMcpAllowedTools(clientId);
   const extraTools = options.extraTools ? options.extraTools.split(',').map((t) => t.trim()) : [];
 
   // Streaming-input queue — kept open for the session lifetime.
@@ -347,9 +376,10 @@ export async function startChat(
   const branch = getBranch(cwd);
   send(ws, { type: 'session_info', branch, cwd, worktree: !!worktreePath });
 
-  // Merge repo MCP server if repos are configured (works with or without sandbox mode)
+  // Merge dynamic MCP servers (repo + task board if active)
   const repoMcp = buildRepoMcpServer(clientId);
-  const allMcpServers = { ...mcpServers, ...repoMcp };
+  const taskMcp = buildTaskMcpServer(clientId);
+  const allMcpServers = { ...mcpServers, ...repoMcp, ...taskMcp };
 
   // Load project hooks from .claude/settings.json (e.g. SessionStart boot context)
   const hooks = loadProjectHooks(cwd);

--- a/server/index.ts
+++ b/server/index.ts
@@ -93,14 +93,12 @@ const orchestrator = new TaskOrchestrator({
     return null;
   },
   setTaskContext: (taskId, goalId) => {
-    // Find attached client and set task context on its session
-    for (const [clientId] of registry.entries()) {
-      if (registry.isAttached(clientId)) {
-        const session = registry.get(clientId);
-        if (session) {
-          session.taskContext = { currentTaskId: taskId, goalId };
-        }
-        break;
+    // Set task context on the pinned client's session
+    const clientId = orchestrator.getPinnedClientId();
+    if (clientId) {
+      const session = registry.get(clientId);
+      if (session) {
+        session.taskContext = { currentTaskId: taskId, goalId };
       }
     }
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
   setUpdateBroadcast,
   setInboxBroadcast,
   setTaskBroadcast,
+  setOrchestrator,
   runUpdateCheck,
   buildSkillRegistry,
   NATIVE_COMMAND_NAMES,
@@ -35,6 +36,7 @@ import {
   yapperWsProxy,
   taskStore,
 } from './app.js';
+import { TaskOrchestrator } from './task-orchestrator.js';
 import { IncomingWsMessage } from './ws-schemas.js';
 import { resolveSlashCommand } from './slash-commands.js';
 import { NativeCommandRegistry } from './native-commands.js';
@@ -79,6 +81,58 @@ setTaskBroadcast((event) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
 });
+
+// --- Task Orchestrator ---
+const orchestrator = new TaskOrchestrator({
+  store: taskStore,
+  getClientId: () => {
+    // Find the first registered client (reuse-only for Phase 2)
+    for (const [clientId] of registry.entries()) {
+      if (registry.isAttached(clientId)) return clientId;
+    }
+    return null;
+  },
+  setTaskContext: (taskId, goalId) => {
+    // Find attached client and set task context on its session
+    for (const [clientId] of registry.entries()) {
+      if (registry.isAttached(clientId)) {
+        const session = registry.get(clientId);
+        if (session) {
+          session.taskContext = { currentTaskId: taskId, goalId };
+        }
+        break;
+      }
+    }
+  },
+  clearTaskContext: () => {
+    for (const [clientId] of registry.entries()) {
+      const session = registry.get(clientId);
+      if (session) session.taskContext = null;
+    }
+  },
+  broadcastStatus: (status) => {
+    const msg = JSON.stringify({ type: 'loop_status', ...status });
+    wss.clients.forEach((client) => {
+      if (client.readyState === client.OPEN) client.send(msg);
+    });
+  },
+  broadcastTasks: () => {
+    const tree = taskStore.getTree();
+    const msg = JSON.stringify({ type: 'task_state', tasks: tree });
+    wss.clients.forEach((client) => {
+      if (client.readyState === client.OPEN) client.send(msg);
+    });
+  },
+  getActiveSessionIds: () => {
+    const ids = new Set<string>();
+    for (const [clientId] of registry.entries()) {
+      const session = registry.get(clientId);
+      if (session?.sessionId) ids.add(session.sessionId);
+    }
+    return ids;
+  },
+});
+setOrchestrator(orchestrator);
 
 server.on('upgrade', async (req, socket, head) => {
   const url = new URL(req.url || '', `http://${req.headers.host}`);

--- a/server/session-registry.ts
+++ b/server/session-registry.ts
@@ -40,6 +40,7 @@ export interface ManagedSession {
   /** Accumulates token totals across multiple query() calls in a session */
   cumulativeSessionTokens: number;
   cumulativeCostUsd: number;
+  taskContext: { currentTaskId: string; goalId: string } | null;
 }
 
 export class SessionRegistry {
@@ -59,6 +60,7 @@ export class SessionRegistry {
       | 'observers'
       | 'cumulativeSessionTokens'
       | 'cumulativeCostUsd'
+      | 'taskContext'
     > & {
       sessionId?: string;
     },
@@ -71,6 +73,7 @@ export class SessionRegistry {
       observers: new Set(),
       cumulativeSessionTokens: 0,
       cumulativeCostUsd: 0,
+      taskContext: null,
     });
     this.attached.add(clientId);
   }

--- a/server/session-registry.ts
+++ b/server/session-registry.ts
@@ -82,6 +82,10 @@ export class SessionRegistry {
     return this.sessions.get(clientId);
   }
 
+  entries(): IterableIterator<[string, ManagedSession]> {
+    return this.sessions.entries();
+  }
+
   isActive(clientId: string): boolean {
     return this.sessions.has(clientId);
   }

--- a/server/task-context.ts
+++ b/server/task-context.ts
@@ -1,0 +1,111 @@
+import type { TaskStore } from './task-store.js';
+
+const SUMMARY_MAX_CHARS = 2000;
+const MAX_DEPTH = 5;
+
+/**
+ * Build an XML task context block for injection into the system prompt.
+ * Per design doc §8.1.
+ */
+export function buildTaskContextPrompt(store: TaskStore, taskId: string): string | null {
+  const task = store.get(taskId);
+  if (!task) return null;
+
+  if (task.depth >= MAX_DEPTH) {
+    return `<task-context>\n<error>Task depth ${task.depth} exceeds maximum ${MAX_DEPTH}</error>\n</task-context>`;
+  }
+
+  const lines: string[] = [];
+  lines.push('<task-context>');
+  lines.push(`<task id="${task.id}" depth="${task.depth}">`);
+
+  // Parent context
+  if (task.parentId) {
+    const parent = store.get(task.parentId);
+    if (parent) {
+      lines.push(`  <parent title="${escapeXml(parent.title)}" />`);
+    }
+  }
+
+  lines.push(`  <title>${escapeXml(task.title)}</title>`);
+
+  if (task.description) {
+    lines.push(`  <description>${escapeXml(task.description)}</description>`);
+  }
+
+  if (task.annotations.length > 0) {
+    lines.push('  <annotations>');
+    for (const a of task.annotations) {
+      lines.push(`    <annotation>${escapeXml(a)}</annotation>`);
+    }
+    lines.push('  </annotations>');
+  }
+
+  // Sibling context
+  if (task.parentId) {
+    const siblings = store.getChildren(task.parentId);
+    if (siblings.length > 1) {
+      lines.push('  <siblings>');
+      for (const s of siblings) {
+        const marker = s.id === task.id ? ' current="true"' : '';
+        lines.push(
+          `    <sibling id="${s.id}" status="${s.status}"${marker}>${escapeXml(s.title)}</sibling>`,
+        );
+      }
+      lines.push('  </siblings>');
+
+      // Completed sibling summaries
+      const completed = siblings.filter(
+        (s) => s.id !== task.id && (s.status === 'done' || s.status === 'skipped') && s.summary,
+      );
+      if (completed.length > 0) {
+        lines.push('  <completed-siblings>');
+        for (const s of completed) {
+          const summary = truncate(s.summary!, SUMMARY_MAX_CHARS);
+          lines.push(`    <summary task="${escapeXml(s.title)}">`);
+          lines.push(`      ${escapeXml(summary)}`);
+          lines.push('    </summary>');
+        }
+        lines.push('  </completed-siblings>');
+      }
+    }
+  }
+
+  lines.push('</task>');
+  lines.push('</task-context>');
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the task board system prompt addition (§8.2).
+ */
+export function buildTaskSystemPrompt(store: TaskStore, taskId: string): string {
+  const context = buildTaskContextPrompt(store, taskId);
+  if (!context) return '';
+
+  return (
+    '\n\n## Task Board\n\n' +
+    'You are working on a task from the task board. ' +
+    'Use the TaskSet, TaskComplete, TaskStatus, and TaskBlock tools ' +
+    'to manage your work.\n\n' +
+    '- Call TaskSet to decompose your task into subtasks\n' +
+    '- Call TaskComplete with a summary when done\n' +
+    '- Call TaskStatus to check progress\n' +
+    '- Call TaskBlock if you encounter a blocker\n\n' +
+    context
+  );
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 3) + '...';
+}

--- a/server/task-mcp-server.ts
+++ b/server/task-mcp-server.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Task Board MCP Server — exposes TaskSet, TaskComplete, TaskStatus,
+ * TaskBlock tools to the Agent SDK.
+ *
+ * Launched as a child process by Mitzo's chat.ts. Calls back to the
+ * Mitzo HTTP API for all operations. Receives config as CLI args + env:
+ *   --base-url <url>  --client-id <id>  env MITZO_INTERNAL_TOKEN
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+function parseArgs(argv: string[]): {
+  baseUrl: string;
+  clientId: string;
+  token: string;
+} {
+  let baseUrl = '';
+  let clientId = '';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--base-url' && argv[i + 1]) baseUrl = argv[++i];
+    else if (argv[i] === '--client-id' && argv[i + 1]) clientId = argv[++i];
+  }
+  const token = process.env.MITZO_INTERNAL_TOKEN || '';
+  if (!baseUrl || !clientId || !token) {
+    throw new Error('Missing required args: --base-url, --client-id; env: MITZO_INTERNAL_TOKEN');
+  }
+  return { baseUrl, clientId, token };
+}
+
+const config = parseArgs(process.argv.slice(2));
+
+async function apiCall(method: string, path: string, body?: unknown): Promise<unknown> {
+  const res = await fetch(`${config.baseUrl}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Token': config.token,
+      'X-Client-Id': config.clientId,
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error((data as { error?: string }).error || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
+const server = new McpServer({ name: 'task-board', version: '1.0.0' });
+
+server.registerTool(
+  'TaskSet',
+  {
+    description:
+      "Replace the current task's subtasks with a new decomposition. " +
+      'Deletes existing children and creates new ones.',
+    inputSchema: {
+      tasks: z
+        .array(
+          z.object({
+            title: z.string().describe('Subtask title'),
+            description: z.string().optional().describe('Optional details'),
+            priority: z.number().optional().describe('Priority (higher = first)'),
+          }),
+        )
+        .min(1)
+        .describe('List of subtasks to create'),
+    },
+  },
+  async ({ tasks }) => {
+    try {
+      const data = (await apiCall('POST', '/api/internal/task-tools/set', { tasks })) as {
+        result: string;
+      };
+      return { content: [{ type: 'text' as const, text: data.result }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] };
+    }
+  },
+);
+
+server.registerTool(
+  'TaskComplete',
+  {
+    description: 'Mark the current task as completed with a summary of what was done.',
+    inputSchema: {
+      summary: z.string().min(1).describe('Summary of what was accomplished'),
+    },
+  },
+  async ({ summary }) => {
+    try {
+      const data = (await apiCall('POST', '/api/internal/task-tools/complete', { summary })) as {
+        result: string;
+      };
+      return { content: [{ type: 'text' as const, text: data.result }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] };
+    }
+  },
+);
+
+server.registerTool(
+  'TaskStatus',
+  {
+    description: 'Get the status of the current task, its siblings, and progress.',
+    inputSchema: {},
+  },
+  async () => {
+    try {
+      const data = (await apiCall('GET', '/api/internal/task-tools/status')) as { result: string };
+      return { content: [{ type: 'text' as const, text: data.result }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] };
+    }
+  },
+);
+
+server.registerTool(
+  'TaskBlock',
+  {
+    description: 'Mark the current task as blocked with a reason.',
+    inputSchema: {
+      reason: z.string().min(1).describe('Why this task is blocked'),
+    },
+  },
+  async ({ reason }) => {
+    try {
+      const data = (await apiCall('POST', '/api/internal/task-tools/block', { reason })) as {
+        result: string;
+      };
+      return { content: [{ type: 'text' as const, text: data.result }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] };
+    }
+  },
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`task-mcp-server fatal: ${err}\n`);
+  process.exit(1);
+});

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -1,0 +1,192 @@
+import type { TaskStore, Task } from './task-store.js';
+import { sendToChat } from './chat.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('task-orchestrator');
+
+export type LoopState = 'idle' | 'running' | 'paused';
+
+export interface LoopStatus {
+  state: LoopState;
+  goalId: string | null;
+  activeTaskId: string | null;
+  progress: { done: number; total: number } | null;
+}
+
+export interface OrchestratorDeps {
+  store: TaskStore;
+  /** Resolve session's clientId for the reuse session */
+  getClientId: () => string | null;
+  /** Set task context on the session */
+  setTaskContext: (taskId: string, goalId: string) => void;
+  /** Clear task context on the session */
+  clearTaskContext: () => void;
+  /** Broadcast loop status change */
+  broadcastStatus: (status: LoopStatus) => void;
+  /** Broadcast task tree change */
+  broadcastTasks: () => void;
+}
+
+export class TaskOrchestrator {
+  private state: LoopState = 'idle';
+  private goalId: string | null = null;
+  private activeTaskId: string | null = null;
+  private deps: OrchestratorDeps;
+
+  constructor(deps: OrchestratorDeps) {
+    this.deps = deps;
+  }
+
+  getStatus(): LoopStatus {
+    const progress = this.goalId ? this.computeProgress(this.goalId) : null;
+    return {
+      state: this.state,
+      goalId: this.goalId,
+      activeTaskId: this.activeTaskId,
+      progress,
+    };
+  }
+
+  start(goalId: string): LoopStatus {
+    if (this.state === 'running') {
+      log.warn('start() called while already running');
+      return this.getStatus();
+    }
+
+    const goal = this.deps.store.get(goalId);
+    if (!goal) {
+      log.error('start() with nonexistent goalId', { goalId });
+      return this.getStatus();
+    }
+
+    this.state = 'running';
+    this.goalId = goalId;
+    this.activeTaskId = null;
+
+    log.info('orchestrator started', { goalId, title: goal.title });
+    this.broadcastAndTick();
+
+    return this.getStatus();
+  }
+
+  pause(): LoopStatus {
+    if (this.state !== 'running') return this.getStatus();
+    this.state = 'paused';
+    log.info('orchestrator paused');
+    this.deps.broadcastStatus(this.getStatus());
+    return this.getStatus();
+  }
+
+  resume(): LoopStatus {
+    if (this.state !== 'paused') return this.getStatus();
+    this.state = 'running';
+    log.info('orchestrator resumed');
+    this.broadcastAndTick();
+    return this.getStatus();
+  }
+
+  stop(): LoopStatus {
+    if (this.state === 'idle') return this.getStatus();
+    this.state = 'idle';
+    this.goalId = null;
+    this.activeTaskId = null;
+    this.deps.clearTaskContext();
+    log.info('orchestrator stopped');
+    this.deps.broadcastStatus(this.getStatus());
+    return this.getStatus();
+  }
+
+  /** Called when a task completes (from tool interception). */
+  onTaskCompleted(taskId: string): void {
+    if (this.state !== 'running') return;
+    log.info('task completed, triggering tick', { taskId });
+    this.tick();
+  }
+
+  /** Called when a task is blocked (from tool interception). */
+  onTaskBlocked(taskId: string): void {
+    if (this.state !== 'running') return;
+    log.info('task blocked, triggering tick', { taskId });
+    this.tick();
+  }
+
+  /**
+   * Core loop iteration. Stateless — re-reads state from SQLite.
+   * 1. Find next executable task (DFS)
+   * 2. Assign it to the session
+   * 3. Inject task context
+   * 4. Send prompt to agent
+   */
+  tick(): void {
+    if (this.state !== 'running' || !this.goalId) return;
+
+    // Re-read goal state (statelessness invariant)
+    const goal = this.deps.store.get(this.goalId);
+    if (!goal) {
+      log.error('goal disappeared during tick', { goalId: this.goalId });
+      this.stop();
+      return;
+    }
+
+    // Check if goal is complete
+    const goalStatus = this.deps.store.deriveParentStatus(this.goalId);
+    if (goalStatus === 'done' || goalStatus === 'failed') {
+      log.info('goal reached terminal state', {
+        goalId: this.goalId,
+        status: goalStatus,
+      });
+      this.stop();
+      return;
+    }
+
+    // Find next executable task
+    const next = this.deps.store.getNextExecutable(this.goalId);
+    if (!next) {
+      // No executable tasks — could be all blocked or pending_review
+      log.info('no executable tasks found', { goalId: this.goalId });
+      this.state = 'paused';
+      this.deps.broadcastStatus(this.getStatus());
+      return;
+    }
+
+    // Assign task
+    this.activeTaskId = next.id;
+    this.deps.store.update(next.id, { status: 'active' });
+    this.deps.store.cascadeStatus(next.id);
+
+    // Set task context on session
+    this.deps.setTaskContext(next.id, this.goalId);
+
+    // Broadcast updates
+    this.deps.broadcastTasks();
+    this.deps.broadcastStatus(this.getStatus());
+
+    // Send prompt to agent session
+    const clientId = this.deps.getClientId();
+    if (clientId) {
+      const prompt = this.buildTaskPrompt(next);
+      sendToChat(clientId, prompt);
+    }
+  }
+
+  private broadcastAndTick(): void {
+    this.deps.broadcastStatus(this.getStatus());
+    this.tick();
+  }
+
+  private buildTaskPrompt(task: Task): string {
+    return (
+      `Work on this task: "${task.title}"\n` +
+      (task.description ? `\nDetails: ${task.description}\n` : '') +
+      '\nUse TaskStatus to see your context, TaskSet to decompose, ' +
+      'and TaskComplete when done.'
+    );
+  }
+
+  private computeProgress(goalId: string): { done: number; total: number } {
+    const children = this.deps.store.getChildren(goalId);
+    if (children.length === 0) return { done: 0, total: 0 };
+    const done = children.filter((c) => c.status === 'done' || c.status === 'skipped').length;
+    return { done, total: children.length };
+  }
+}

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -11,6 +11,12 @@ export interface LoopStatus {
   goalId: string | null;
   activeTaskId: string | null;
   progress: { done: number; total: number } | null;
+  specMode: boolean;
+  awaitingApproval: boolean;
+}
+
+export interface StartOptions {
+  specMode?: boolean;
 }
 
 export interface OrchestratorDeps {
@@ -25,12 +31,16 @@ export interface OrchestratorDeps {
   broadcastStatus: (status: LoopStatus) => void;
   /** Broadcast task tree change */
   broadcastTasks: () => void;
+  /** Get active session IDs for orphan detection */
+  getActiveSessionIds?: () => Set<string>;
 }
 
 export class TaskOrchestrator {
   private state: LoopState = 'idle';
   private goalId: string | null = null;
   private activeTaskId: string | null = null;
+  private specMode = false;
+  private awaitingApproval = false;
   private deps: OrchestratorDeps;
 
   constructor(deps: OrchestratorDeps) {
@@ -44,10 +54,12 @@ export class TaskOrchestrator {
       goalId: this.goalId,
       activeTaskId: this.activeTaskId,
       progress,
+      specMode: this.specMode,
+      awaitingApproval: this.awaitingApproval,
     };
   }
 
-  start(goalId: string): LoopStatus {
+  start(goalId: string, opts?: StartOptions): LoopStatus {
     if (this.state === 'running') {
       log.warn('start() called while already running');
       return this.getStatus();
@@ -62,9 +74,36 @@ export class TaskOrchestrator {
     this.state = 'running';
     this.goalId = goalId;
     this.activeTaskId = null;
+    this.specMode = opts?.specMode ?? false;
+    this.awaitingApproval = false;
 
-    log.info('orchestrator started', { goalId, title: goal.title });
-    this.broadcastAndTick();
+    log.info('orchestrator started', {
+      goalId,
+      title: goal.title,
+      specMode: this.specMode,
+    });
+
+    if (this.specMode) {
+      // In spec mode, assign goal directly for decomposition
+      this.activeTaskId = goalId;
+      this.deps.store.update(goalId, { status: 'active' });
+      this.deps.setTaskContext(goalId, goalId);
+      this.deps.broadcastTasks();
+      this.deps.broadcastStatus(this.getStatus());
+
+      const clientId = this.deps.getClientId();
+      if (clientId) {
+        sendToChat(
+          clientId,
+          `Decompose this goal into subtasks: "${goal.title}"\n` +
+            (goal.description ? `\nDetails: ${goal.description}\n` : '') +
+            '\nUse TaskSet to create a task breakdown. ' +
+            'Do NOT start working yet — just plan.',
+        );
+      }
+    } else {
+      this.broadcastAndTick();
+    }
 
     return this.getStatus();
   }
@@ -90,10 +129,48 @@ export class TaskOrchestrator {
     this.state = 'idle';
     this.goalId = null;
     this.activeTaskId = null;
+    this.specMode = false;
+    this.awaitingApproval = false;
     this.deps.clearTaskContext();
     log.info('orchestrator stopped');
     this.deps.broadcastStatus(this.getStatus());
     return this.getStatus();
+  }
+
+  /** Called when TaskSet is used in spec mode — pause for approval. */
+  onSpecDecomposed(): void {
+    if (!this.specMode || this.state !== 'running') return;
+    this.awaitingApproval = true;
+    this.state = 'paused';
+    log.info('spec mode: awaiting approval');
+    this.deps.broadcastStatus(this.getStatus());
+  }
+
+  /** Approve the spec mode decomposition — begin execution. */
+  approveSpec(): LoopStatus {
+    if (!this.awaitingApproval) return this.getStatus();
+    this.awaitingApproval = false;
+    this.specMode = false;
+    this.state = 'running';
+    log.info('spec mode: approved, beginning execution');
+    this.broadcastAndTick();
+    return this.getStatus();
+  }
+
+  /** Reject the spec mode decomposition — delete children and stop. */
+  rejectSpec(): LoopStatus {
+    if (!this.awaitingApproval || !this.goalId) return this.getStatus();
+    // Delete proposed children
+    const children = this.deps.store.getChildren(this.goalId);
+    for (const child of children) {
+      this.deps.store.delete(child.id);
+    }
+    this.deps.store.update(this.goalId, { status: 'pending' });
+    this.awaitingApproval = false;
+    this.specMode = false;
+    log.info('spec mode: rejected, children deleted');
+    this.deps.broadcastTasks();
+    return this.stop();
   }
 
   /** Called when a task completes (from tool interception). */
@@ -110,6 +187,37 @@ export class TaskOrchestrator {
     this.tick();
   }
 
+  /** Approve a pending_review task → done + cascade + tick. */
+  approveTask(taskId: string): boolean {
+    const task = this.deps.store.get(taskId);
+    if (!task || task.status !== 'pending_review') return false;
+
+    this.deps.store.update(taskId, { status: 'done' });
+    this.deps.store.cascadeStatus(taskId);
+    this.deps.broadcastTasks();
+
+    log.info('task approved', { taskId });
+    if (this.state === 'running') this.tick();
+    return true;
+  }
+
+  /** Reject a pending_review task → active + feedback + tick. */
+  rejectTask(taskId: string, feedback: string): boolean {
+    const task = this.deps.store.get(taskId);
+    if (!task || task.status !== 'pending_review') return false;
+
+    const annotations = [...task.annotations, `review_feedback: ${feedback}`];
+    this.deps.store.update(taskId, {
+      status: 'active',
+      annotations,
+    });
+    this.deps.store.cascadeStatus(taskId);
+    this.deps.broadcastTasks();
+
+    log.info('task rejected', { taskId, feedback });
+    return true;
+  }
+
   /**
    * Core loop iteration. Stateless — re-reads state from SQLite.
    * 1. Find next executable task (DFS)
@@ -119,6 +227,17 @@ export class TaskOrchestrator {
    */
   tick(): void {
     if (this.state !== 'running' || !this.goalId) return;
+
+    // Reclaim orphaned tasks
+    if (this.deps.getActiveSessionIds) {
+      const activeIds = this.deps.getActiveSessionIds();
+      const orphans = this.deps.store.getOrphaned(activeIds);
+      for (const orphan of orphans) {
+        log.info('reclaiming orphaned task', { taskId: orphan.id });
+        this.deps.store.update(orphan.id, { status: 'pending' });
+        this.deps.store.setSessionId(orphan.id, null);
+      }
+    }
 
     // Re-read goal state (statelessness invariant)
     const goal = this.deps.store.get(this.goalId);

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -41,10 +41,15 @@ export class TaskOrchestrator {
   private activeTaskId: string | null = null;
   private specMode = false;
   private awaitingApproval = false;
+  private pinnedClientId: string | null = null;
   private deps: OrchestratorDeps;
 
   constructor(deps: OrchestratorDeps) {
     this.deps = deps;
+  }
+
+  getPinnedClientId(): string | null {
+    return this.pinnedClientId;
   }
 
   getStatus(): LoopStatus {
@@ -76,6 +81,7 @@ export class TaskOrchestrator {
     this.activeTaskId = null;
     this.specMode = opts?.specMode ?? false;
     this.awaitingApproval = false;
+    this.pinnedClientId = this.deps.getClientId();
 
     log.info('orchestrator started', {
       goalId,
@@ -91,10 +97,9 @@ export class TaskOrchestrator {
       this.deps.broadcastTasks();
       this.deps.broadcastStatus(this.getStatus());
 
-      const clientId = this.deps.getClientId();
-      if (clientId) {
+      if (this.pinnedClientId) {
         sendToChat(
-          clientId,
+          this.pinnedClientId,
           `Decompose this goal into subtasks: "${goal.title}"\n` +
             (goal.description ? `\nDetails: ${goal.description}\n` : '') +
             '\nUse TaskSet to create a task breakdown. ' +
@@ -131,6 +136,7 @@ export class TaskOrchestrator {
     this.activeTaskId = null;
     this.specMode = false;
     this.awaitingApproval = false;
+    this.pinnedClientId = null;
     this.deps.clearTaskContext();
     log.info('orchestrator stopped');
     this.deps.broadcastStatus(this.getStatus());
@@ -215,6 +221,18 @@ export class TaskOrchestrator {
     this.deps.broadcastTasks();
 
     log.info('task rejected', { taskId, feedback });
+
+    // Notify agent session so it retries with feedback
+    if (this.state === 'running') {
+      if (this.pinnedClientId) {
+        sendToChat(
+          this.pinnedClientId,
+          `Your previous work on "${task.title}" was rejected.\n` +
+            (feedback ? `Feedback: ${feedback}\n` : '') +
+            '\nPlease re-attempt this task addressing the feedback.',
+        );
+      }
+    }
     return true;
   }
 
@@ -280,11 +298,10 @@ export class TaskOrchestrator {
     this.deps.broadcastTasks();
     this.deps.broadcastStatus(this.getStatus());
 
-    // Send prompt to agent session
-    const clientId = this.deps.getClientId();
-    if (clientId) {
+    // Send prompt to pinned agent session
+    if (this.pinnedClientId) {
       const prompt = this.buildTaskPrompt(next);
-      sendToChat(clientId, prompt);
+      sendToChat(this.pinnedClientId, prompt);
     }
   }
 

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -325,6 +325,93 @@ export class TaskStore {
     return [buildSubtree(rootTask)];
   }
 
+  /** Derive a parent's status from its children per §2.3 cascade rules. */
+  deriveParentStatus(parentId: string): TaskStatus {
+    const children = this.getChildren(parentId);
+    if (children.length === 0) return this.get(parentId)?.status ?? 'pending';
+
+    if (children.some((c) => c.status === 'failed')) return 'failed';
+    if (children.some((c) => c.status === 'blocked')) return 'blocked';
+    if (children.some((c) => c.status === 'active')) return 'active';
+    if (children.some((c) => c.status === 'pending_review')) return 'pending_review';
+    if (children.every((c) => c.status === 'done' || c.status === 'skipped')) return 'done';
+    return 'pending';
+  }
+
+  /** Walk up the parent chain applying deriveParentStatus. Stops when status unchanged. */
+  cascadeStatus(taskId: string): void {
+    const task = this.get(taskId);
+    if (!task?.parentId) return;
+
+    let currentId: string | null = task.parentId;
+    while (currentId) {
+      const derived = this.deriveParentStatus(currentId);
+      const parent = this.get(currentId);
+      if (!parent) break;
+      if (parent.status === derived) break;
+      this.update(currentId, { status: derived });
+      currentId = parent.parentId;
+    }
+  }
+
+  /** All tasks assigned to a given session. */
+  getBySession(sessionId: string): Task[] {
+    const rows = this.getDb()
+      .prepare('SELECT * FROM tasks WHERE session_id = ? ORDER BY priority DESC, created_at ASC')
+      .all(sessionId) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  /** Assign or unassign a session to a task. */
+  setSessionId(taskId: string, sessionId: string | null): Task | null {
+    const existing = this.get(taskId);
+    if (!existing) return null;
+
+    const now = Date.now();
+    this.getDb()
+      .prepare(
+        'UPDATE tasks SET session_id = ?, claimed_by = ?, claimed_at = ?, updated_at = ? WHERE id = ?',
+      )
+      .run(sessionId, sessionId, sessionId ? now : null, now, taskId);
+
+    return this.get(taskId);
+  }
+
+  /**
+   * DFS: find the deepest-left pending leaf task.
+   * Skips subtrees rooted at blocked/failed ancestors.
+   * If parentId given, searches within that subtree; otherwise searches all roots.
+   */
+  getNextExecutable(parentId?: string): Task | null {
+    const candidates = parentId ? this.getChildren(parentId) : this.listRoots();
+
+    for (const task of candidates) {
+      // Skip terminal or blocked subtrees
+      if (TERMINAL_STATUSES.has(task.status) || task.status === 'blocked') continue;
+
+      // Check children first (DFS — go deeper before returning this node)
+      const children = this.getChildren(task.id);
+      if (children.length > 0) {
+        const deeperResult = this.getNextExecutable(task.id);
+        if (deeperResult) return deeperResult;
+        continue; // Parent with children is not itself executable
+      }
+
+      // Leaf node — only pending leaves are executable
+      if (task.status === 'pending') return task;
+    }
+
+    return null;
+  }
+
+  /** Find active tasks whose session_id is not in the set of active sessions. */
+  getOrphaned(activeSessionIds: Set<string>): Task[] {
+    const rows = this.getDb()
+      .prepare("SELECT * FROM tasks WHERE status = 'active' AND session_id IS NOT NULL")
+      .all() as TaskRow[];
+    return rows.map(rowToTask).filter((t) => !activeSessionIds.has(t.sessionId!));
+  }
+
   private assembleTree(rows: TaskRow[]): Task[] {
     const tasks = rows.map(rowToTask);
     const taskMap = new Map<string, Task>();

--- a/server/task-tools.ts
+++ b/server/task-tools.ts
@@ -1,0 +1,123 @@
+import type { TaskStore, Task, TaskStatus } from './task-store.js';
+
+/**
+ * Pure handler functions for task board tools.
+ * Each takes a TaskStore + context, returns a result string.
+ * Never throws for invalid input — returns error strings.
+ */
+
+export interface TaskSetItem {
+  title: string;
+  description?: string;
+  priority?: number;
+}
+
+/**
+ * Replace current task's children with a new set.
+ * Deletes existing children first, then creates new ones.
+ */
+export function handleTaskSet(
+  store: TaskStore,
+  currentTaskId: string,
+  tasks: TaskSetItem[],
+): string {
+  const current = store.get(currentTaskId);
+  if (!current) return `Error: task ${currentTaskId} not found`;
+
+  if (tasks.length === 0) return 'Error: at least one subtask is required';
+
+  // Delete existing children
+  const existingChildren = store.getChildren(currentTaskId);
+  for (const child of existingChildren) {
+    store.delete(child.id);
+  }
+
+  // Create new children
+  const created: Task[] = [];
+  for (const item of tasks) {
+    const task = store.create({
+      title: item.title,
+      description: item.description,
+      parentId: currentTaskId,
+      priority: item.priority ?? 0,
+    });
+    created.push(task);
+  }
+
+  return `Created ${created.length} subtask(s) under "${current.title}":\n${created.map((t, i) => `  ${i + 1}. ${t.title}`).join('\n')}`;
+}
+
+/**
+ * Mark the current task as done (or pending_review if requiresApproval).
+ * Stores the summary and cascades status up the tree.
+ */
+export function handleTaskComplete(
+  store: TaskStore,
+  currentTaskId: string,
+  summary: string,
+): string {
+  const current = store.get(currentTaskId);
+  if (!current) return `Error: task ${currentTaskId} not found`;
+
+  if (!summary.trim()) return 'Error: summary is required';
+
+  const targetStatus: TaskStatus = current.requiresApproval ? 'pending_review' : 'done';
+
+  store.update(currentTaskId, { status: targetStatus, summary });
+  store.cascadeStatus(currentTaskId);
+
+  if (targetStatus === 'pending_review') {
+    return `Task "${current.title}" marked as pending_review — awaiting approval.`;
+  }
+  return `Task "${current.title}" completed.`;
+}
+
+/**
+ * Get formatted status of the current task, siblings, and progress.
+ */
+export function handleTaskStatus(store: TaskStore, currentTaskId: string): string {
+  const current = store.get(currentTaskId);
+  if (!current) return `Error: task ${currentTaskId} not found`;
+
+  const lines: string[] = [];
+  lines.push(`Current: "${current.title}" [${current.status}]`);
+
+  if (current.description) {
+    lines.push(`Description: ${current.description}`);
+  }
+
+  if (current.annotations.length > 0) {
+    lines.push(`Annotations: ${current.annotations.join(', ')}`);
+  }
+
+  // Sibling context
+  if (current.parentId) {
+    const siblings = store.getChildren(current.parentId);
+    const total = siblings.length;
+    const done = siblings.filter((s) => s.status === 'done' || s.status === 'skipped').length;
+    lines.push(`\nProgress: ${done}/${total} siblings complete`);
+    lines.push('Siblings:');
+    for (const s of siblings) {
+      const marker = s.id === currentTaskId ? '→' : ' ';
+      lines.push(`  ${marker} [${s.status}] ${s.title}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Mark the current task as blocked with a reason annotation.
+ */
+export function handleTaskBlock(store: TaskStore, currentTaskId: string, reason: string): string {
+  const current = store.get(currentTaskId);
+  if (!current) return `Error: task ${currentTaskId} not found`;
+
+  if (!reason.trim()) return 'Error: reason is required';
+
+  const annotations = [...current.annotations, `blocked: ${reason}`];
+  store.update(currentTaskId, { status: 'blocked', annotations });
+  store.cascadeStatus(currentTaskId);
+
+  return `Task "${current.title}" blocked: ${reason}`;
+}

--- a/server/tool-summary.ts
+++ b/server/tool-summary.ts
@@ -58,6 +58,14 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
       return `${input.search_term || ''}`;
     case 'WebFetch':
       return `${input.url || ''}`;
+    case 'mcp__task-board__TaskSet':
+      return `${(input.tasks as unknown[])?.length ?? 0} subtasks`;
+    case 'mcp__task-board__TaskComplete':
+      return `${String(input.summary || '').slice(0, 60)}`;
+    case 'mcp__task-board__TaskStatus':
+      return 'get status';
+    case 'mcp__task-board__TaskBlock':
+      return `${String(input.reason || '').slice(0, 60)}`;
     default:
       return JSON.stringify(input).slice(0, TOOL_SUMMARY_MAX_CHARS);
   }

--- a/server/tool-tiers.ts
+++ b/server/tool-tiers.ts
@@ -28,6 +28,8 @@ export function applyTierOverrides(overrides: Record<string, ToolTier>): void {
 
 export function getToolTier(toolName: string): ToolTier {
   if (activeTiers[toolName]) return activeTiers[toolName];
+  // Task board tools are always safe
+  if (toolName.startsWith('mcp__task-board__')) return 'safe';
   if (toolName.startsWith('mcp__')) return 'unknown';
   return 'unknown';
 }


### PR DESCRIPTION
## Summary

- **Task orchestrator**: DFS sequential loop that auto-assigns tasks from SQLite, with event-driven tick (no polling). Stateless between ticks — always re-reads from DB.
- **Agent tools via MCP**: TaskSet, TaskComplete, TaskStatus, TaskBlock delivered as `mcp__task-board__*` tools. Task context injected as XML system prompt per §8.1.
- **Spec mode**: Agent decomposes goals into subtasks for human review before execution begins. Approve/reject flow with child cleanup on reject.
- **Orphan detection**: Active tasks whose sessions have died get reclaimed to pending during tick.
- **Frontend**: LoopControls (start/pause/resume/stop + spec mode toggle), TaskSidebar (current task context + approve/reject), progress bars, active task highlighting. `useTaskBoard` extended with loop status hydration via REST + WS.
- **143 tests** across 7 test files covering all new server + frontend functionality.

## Test plan

- [ ] `npm test` passes (143 task-related tests + existing suite)
- [ ] `npm run typecheck` clean
- [ ] Manual: create goal → start loop → orchestrator assigns first pending task
- [ ] Manual: agent calls TaskComplete → next task auto-assigned
- [ ] Manual: pause/resume/stop controls work from TaskBoard UI
- [ ] Manual: spec mode — create goal → start with spec → approve/reject decomposition
- [ ] Manual: LoopControls reflect orchestrator state across browser tabs via WS

🤖 Generated with [Claude Code](https://claude.com/claude-code)