### PR TITLE
feat(ui): mobile UI overhaul — tab bar, design tokens, layout fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { TodoView } from './pages/TodoView';
 import { TodoDetailView } from './pages/TodoDetailView';
 import { TaskBoard } from './pages/TaskBoard';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { MobileShell } from './components/MobileShell';
 import { useIsDesktop } from './hooks/useMediaQuery';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -41,89 +42,91 @@ export function App() {
   return (
     <ErrorBoundary>
       <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route
-            path="/"
-            element={
-              <ProtectedRoute>
-                <ErrorBoundary>
-                  <HomeRoute />
-                </ErrorBoundary>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/chat"
-            element={
-              <ProtectedRoute>
-                <ErrorBoundary>
-                  <ChatRoute />
-                </ErrorBoundary>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/chat/:sessionId"
-            element={
-              <ProtectedRoute>
-                <ErrorBoundary>
-                  <ChatRoute />
-                </ErrorBoundary>
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/inbox"
-            element={
-              <ProtectedRoute>
-                <InboxView />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/calendar"
-            element={
-              <ProtectedRoute>
-                <CalendarView />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/todos"
-            element={
-              <ProtectedRoute>
-                <TodoView />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/todos/:id"
-            element={
-              <ProtectedRoute>
-                <TodoDetailView />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/tasks"
-            element={
-              <ProtectedRoute>
-                <TaskBoard />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/files"
-            element={
-              <ProtectedRoute>
-                <ErrorBoundary>
-                  <FileViewer />
-                </ErrorBoundary>
-              </ProtectedRoute>
-            }
-          />
-        </Routes>
+        <MobileShell>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <ErrorBoundary>
+                    <HomeRoute />
+                  </ErrorBoundary>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/chat"
+              element={
+                <ProtectedRoute>
+                  <ErrorBoundary>
+                    <ChatRoute />
+                  </ErrorBoundary>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/chat/:sessionId"
+              element={
+                <ProtectedRoute>
+                  <ErrorBoundary>
+                    <ChatRoute />
+                  </ErrorBoundary>
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/inbox"
+              element={
+                <ProtectedRoute>
+                  <InboxView />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/calendar"
+              element={
+                <ProtectedRoute>
+                  <CalendarView />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/todos"
+              element={
+                <ProtectedRoute>
+                  <TodoView />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/todos/:id"
+              element={
+                <ProtectedRoute>
+                  <TodoDetailView />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/tasks"
+              element={
+                <ProtectedRoute>
+                  <TaskBoard />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/files"
+              element={
+                <ProtectedRoute>
+                  <ErrorBoundary>
+                    <FileViewer />
+                  </ErrorBoundary>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </MobileShell>
       </BrowserRouter>
     </ErrorBoundary>
   );

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  icon: string;
+  title: string;
+  subtitle?: ReactNode;
+}
+
+export function EmptyState({ icon, title, subtitle }: EmptyStateProps) {
+  return (
+    <div className="empty-state">
+      <div className="empty-state-icon">{icon}</div>
+      <p className="empty-state-title">{title}</p>
+      {subtitle && <p className="empty-state-subtitle">{subtitle}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/LoopControls.tsx
+++ b/frontend/src/components/LoopControls.tsx
@@ -61,21 +61,23 @@ export function LoopControls({
               </option>
             ))}
           </select>
-          <label className="loop-controls-spec-toggle">
-            <input
-              type="checkbox"
-              checked={specMode}
-              onChange={(e) => setSpecMode(e.target.checked)}
-            />
-            Spec mode
-          </label>
-          <button
-            className="loop-controls-btn loop-controls-btn--start"
-            disabled={!selectedGoalId}
-            onClick={() => onStart(selectedGoalId, specMode || undefined)}
-          >
-            Start
-          </button>
+          <div className="loop-controls-start-row">
+            <label className="loop-controls-spec-toggle">
+              <input
+                type="checkbox"
+                checked={specMode}
+                onChange={(e) => setSpecMode(e.target.checked)}
+              />
+              Spec mode
+            </label>
+            <button
+              className="loop-controls-btn loop-controls-btn--start"
+              disabled={!selectedGoalId}
+              onClick={() => onStart(selectedGoalId, specMode || undefined)}
+            >
+              Start
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/MobileShell.tsx
+++ b/frontend/src/components/MobileShell.tsx
@@ -1,0 +1,22 @@
+import { useLocation } from 'react-router-dom';
+import { useIsDesktop } from '../hooks/useMediaQuery';
+import { TabBar } from './TabBar';
+
+const HIDE_TAB_BAR = ['/login', '/chat'];
+
+function shouldHideTabBar(pathname: string): boolean {
+  return HIDE_TAB_BAR.some((p) => pathname === p || pathname.startsWith(p + '/'));
+}
+
+export function MobileShell({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+  const isDesktop = useIsDesktop();
+  const showTabBar = !isDesktop && !shouldHideTabBar(location.pathname);
+
+  return (
+    <>
+      {children}
+      {showTabBar && <TabBar />}
+    </>
+  );
+}

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+
+interface PageHeaderProps {
+  title: string;
+  onBack?: () => void;
+  badge?: number;
+  center?: ReactNode;
+  children?: ReactNode;
+}
+
+export function PageHeader({ title, onBack, badge, center, children }: PageHeaderProps) {
+  return (
+    <header className="page-header">
+      {onBack && (
+        <button className="page-header-back" onClick={onBack} title="Back">
+          {'\u2039'}
+        </button>
+      )}
+      {center ? (
+        <div className="page-header-center">{center}</div>
+      ) : (
+        <h1>
+          {title}
+          {badge ? <span className="page-header-badge">{badge}</span> : null}
+        </h1>
+      )}
+      {children && <div className="page-header-actions">{children}</div>}
+    </header>
+  );
+}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,0 +1,86 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTabBadges } from '../hooks/useTabBadges';
+import { useIsDesktop } from '../hooks/useMediaQuery';
+import { useState } from 'react';
+
+interface Tab {
+  label: string;
+  path: string;
+  match: (pathname: string) => boolean;
+  badge?: number;
+}
+
+export function TabBar() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { inboxCount, todoCount } = useTabBadges();
+  const isDesktop = useIsDesktop();
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  if (isDesktop) return null;
+
+  const tabs: Tab[] = [
+    {
+      label: 'Chat',
+      path: '/',
+      match: (p) => p === '/' || p === '/chat' || p.startsWith('/chat/'),
+    },
+    { label: 'Tasks', path: '/tasks', match: (p) => p === '/tasks' },
+    { label: 'Inbox', path: '/inbox', match: (p) => p === '/inbox', badge: inboxCount },
+    {
+      label: 'Todos',
+      path: '/todos',
+      match: (p) => p === '/todos' || p.startsWith('/todos/'),
+      badge: todoCount,
+    },
+  ];
+
+  const isMoreActive = ['/calendar', '/files'].some((p) => location.pathname.startsWith(p));
+
+  return (
+    <>
+      {moreOpen && (
+        <div className="tab-bar-more-overlay" onClick={() => setMoreOpen(false)}>
+          <div className="tab-bar-more-menu" onClick={(e) => e.stopPropagation()}>
+            <button
+              className="tab-bar-more-item"
+              onClick={() => {
+                navigate('/calendar');
+                setMoreOpen(false);
+              }}
+            >
+              Calendar
+            </button>
+            <button
+              className="tab-bar-more-item"
+              onClick={() => {
+                navigate('/files');
+                setMoreOpen(false);
+              }}
+            >
+              Files
+            </button>
+          </div>
+        </div>
+      )}
+      <nav className="tab-bar">
+        {tabs.map((tab) => (
+          <button
+            key={tab.label}
+            className={`tab-bar-item ${tab.match(location.pathname) ? 'tab-bar-item--active' : ''}`}
+            onClick={() => navigate(tab.path)}
+          >
+            <span className="tab-bar-label">{tab.label}</span>
+            {tab.badge ? <span className="tab-bar-badge">{tab.badge}</span> : null}
+          </button>
+        ))}
+        <button
+          className={`tab-bar-item ${isMoreActive ? 'tab-bar-item--active' : ''}`}
+          onClick={() => setMoreOpen((o) => !o)}
+        >
+          <span className="tab-bar-label">More</span>
+        </button>
+      </nav>
+    </>
+  );
+}

--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { EmptyState } from '../EmptyState';
+
+afterEach(cleanup);
+
+describe('EmptyState', () => {
+  it('renders icon, title, and subtitle', () => {
+    render(<EmptyState icon="!" title="All done" subtitle="Nothing left" />);
+    expect(screen.getByText('!')).toBeTruthy();
+    expect(screen.getByText('All done')).toBeTruthy();
+    expect(screen.getByText('Nothing left')).toBeTruthy();
+  });
+
+  it('renders without subtitle', () => {
+    render(<EmptyState icon="\u2610" title="No tasks yet" />);
+    expect(screen.getByText('No tasks yet')).toBeTruthy();
+  });
+
+  it('uses the empty-state CSS class', () => {
+    const { container } = render(<EmptyState icon="!" title="Empty" />);
+    expect(container.querySelector('.empty-state')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/__tests__/PageHeader.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PageHeader } from '../PageHeader';
+
+afterEach(cleanup);
+
+describe('PageHeader', () => {
+  it('renders the title', () => {
+    render(<PageHeader title="Tasks" />);
+    expect(screen.getByText('Tasks')).toBeTruthy();
+  });
+
+  it('renders a back button when onBack is provided', () => {
+    const onBack = vi.fn();
+    render(<PageHeader title="Inbox" onBack={onBack} />);
+    const btn = screen.getByTitle('Back');
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('does not render a back button when onBack is omitted', () => {
+    render(<PageHeader title="Home" />);
+    expect(screen.queryByTitle('Back')).toBeNull();
+  });
+
+  it('renders a badge when provided', () => {
+    render(<PageHeader title="Inbox" badge={5} />);
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('does not render a badge when count is 0', () => {
+    render(<PageHeader title="Inbox" badge={0} />);
+    // badge should not render for 0
+    expect(screen.queryByText('0')).toBeNull();
+  });
+
+  it('renders children in the right slot', () => {
+    render(
+      <PageHeader title="Tasks">
+        <button data-testid="add-btn">+</button>
+        <button data-testid="refresh-btn">refresh</button>
+      </PageHeader>,
+    );
+    expect(screen.getByTestId('add-btn')).toBeTruthy();
+    expect(screen.getByTestId('refresh-btn')).toBeTruthy();
+  });
+
+  it('renders custom center content when center prop is provided', () => {
+    render(<PageHeader title="Calendar" center={<div data-testid="date-nav">Apr 2026</div>} />);
+    expect(screen.getByTestId('date-nav')).toBeTruthy();
+    // title should not render when center is provided
+    expect(screen.queryByText('Calendar')).toBeNull();
+  });
+
+  it('uses the page-header CSS class', () => {
+    const { container } = render(<PageHeader title="Test" />);
+    expect(container.querySelector('.page-header')).toBeTruthy();
+  });
+
+  it('uses lsaquo character for back button', () => {
+    render(<PageHeader title="Test" onBack={() => {}} />);
+    const btn = screen.getByTitle('Back');
+    expect(btn.textContent).toBe('\u2039');
+  });
+});

--- a/frontend/src/components/__tests__/SessionPanel.test.tsx
+++ b/frontend/src/components/__tests__/SessionPanel.test.tsx
@@ -17,8 +17,6 @@ function makeDefaultReturn(overrides = {}) {
     sessions: [],
     quickActions: [],
     loading: false,
-    inboxCount: 0,
-    todoCount: 0,
     updateAvailable: false,
     checking: false,
     dismissSession: vi.fn(),

--- a/frontend/src/components/__tests__/TabBar.test.tsx
+++ b/frontend/src/components/__tests__/TabBar.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../hooks/useTabBadges', () => ({
+  useTabBadges: () => ({ inboxCount: 3, todoCount: 0 }),
+}));
+
+vi.mock('../../hooks/useMediaQuery', () => ({
+  useIsDesktop: () => false,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+import { TabBar } from '../TabBar';
+
+afterEach(() => {
+  cleanup();
+  mockNavigate.mockClear();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <TabBar />
+    </MemoryRouter>,
+  );
+}
+
+describe('TabBar', () => {
+  it('renders five tab items', () => {
+    renderAt('/');
+    const tabs = screen.getAllByRole('button');
+    expect(tabs.length).toBe(5);
+  });
+
+  it('shows tab labels', () => {
+    renderAt('/');
+    expect(screen.getByText('Chat')).toBeTruthy();
+    expect(screen.getByText('Tasks')).toBeTruthy();
+    expect(screen.getByText('Inbox')).toBeTruthy();
+    expect(screen.getByText('Todos')).toBeTruthy();
+    expect(screen.getByText('More')).toBeTruthy();
+  });
+
+  it('highlights Chat tab on home route', () => {
+    renderAt('/');
+    const chatTab = screen.getByText('Chat').closest('button');
+    expect(chatTab?.className).toContain('tab-bar-item--active');
+  });
+
+  it('highlights Tasks tab on /tasks route', () => {
+    renderAt('/tasks');
+    const tasksTab = screen.getByText('Tasks').closest('button');
+    expect(tasksTab?.className).toContain('tab-bar-item--active');
+  });
+
+  it('shows badge on Inbox tab when count > 0', () => {
+    renderAt('/');
+    const badge = screen.getByText('3');
+    expect(badge.className).toContain('tab-bar-badge');
+  });
+
+  it('does not show badge on Todos tab when count is 0', () => {
+    renderAt('/');
+    const todosTab = screen.getByText('Todos').closest('button');
+    expect(todosTab?.querySelector('.tab-bar-badge')).toBeNull();
+  });
+
+  it('navigates when tab is clicked', () => {
+    renderAt('/');
+    fireEvent.click(screen.getByText('Tasks'));
+    expect(mockNavigate).toHaveBeenCalledWith('/tasks');
+  });
+
+  it('uses the tab-bar CSS class', () => {
+    const { container } = renderAt('/');
+    expect(container.querySelector('.tab-bar')).toBeTruthy();
+  });
+});
+
+// Desktop rendering is guarded by useIsDesktop() in TabBar.
+// Verified via the useIsDesktop mock returning false above — if it returned true,
+// all tests would fail because the component wouldn't render.

--- a/frontend/src/hooks/__tests__/useSessionList.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionList.test.ts
@@ -26,7 +26,6 @@ beforeEach(() => {
     if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
     if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
     if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-    if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
     return Promise.resolve({ json: () => Promise.resolve({}) });
   });
 });
@@ -48,7 +47,6 @@ describe('useSessionList', () => {
         return Promise.resolve({ json: () => Promise.resolve(sessions) });
       if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
       if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 
@@ -71,7 +69,6 @@ describe('useSessionList', () => {
         return Promise.resolve({ json: () => Promise.resolve(sessions) });
       if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
       if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 
@@ -94,7 +91,6 @@ describe('useSessionList', () => {
         return Promise.resolve({ json: () => Promise.resolve(sessions) });
       if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
       if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 
@@ -116,7 +112,6 @@ describe('useSessionList', () => {
         return Promise.resolve({ json: () => Promise.resolve(sessions) });
       if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
       if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 
@@ -130,11 +125,6 @@ describe('useSessionList', () => {
     expect(result.current.sessions[0].summary).toBe('New Name');
   });
 
-  it('subscribes to WS for inbox updates', () => {
-    renderHook(() => useSessionList());
-    expect(mockWsSubscribe).toHaveBeenCalledWith('global:system', expect.any(Function));
-  });
-
   it('builds quick actions from config', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
@@ -143,7 +133,6 @@ describe('useSessionList', () => {
           json: () => Promise.resolve({ quickActions: [{ label: 'Test', desc: 'Test action' }] }),
         });
       if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/inbox') return Promise.resolve({ json: () => Promise.resolve([]) });
       return Promise.resolve({ json: () => Promise.resolve({}) });
     });
 

--- a/frontend/src/hooks/__tests__/useTabBadges.test.ts
+++ b/frontend/src/hooks/__tests__/useTabBadges.test.ts
@@ -20,7 +20,14 @@ beforeEach(() => {
       if (url === '/api/todos') {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ items: [{ id: 'a' }, { id: 'b' }] }),
+          json: () =>
+            Promise.resolve({
+              items: [
+                { id: 'a', status: 'active' },
+                { id: 'b', status: 'completed' },
+                { id: 'c', status: 'acknowledged' },
+              ],
+            }),
         });
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
@@ -42,6 +49,7 @@ describe('useTabBadges', () => {
     });
 
     expect(result.current.inboxCount).toBe(1);
+    // Only non-completed items (active + acknowledged) should be counted
     expect(result.current.todoCount).toBe(2);
   });
 

--- a/frontend/src/hooks/__tests__/useTabBadges.test.ts
+++ b/frontend/src/hooks/__tests__/useTabBadges.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+
+const mockWsSubscribe = vi.fn().mockReturnValue(vi.fn());
+
+vi.mock('../../lib/ws-pool', () => ({
+  wsSubscribe: (...args: unknown[]) => mockWsSubscribe(...args),
+}));
+
+import { useTabBadges } from '../useTabBadges';
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      if (url === '/api/inbox') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: '1' }]) });
+      }
+      if (url === '/api/todos') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ items: [{ id: 'a' }, { id: 'b' }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('useTabBadges', () => {
+  it('fetches inbox and todo counts on mount', async () => {
+    const { result } = renderHook(() => useTabBadges());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(result.current.inboxCount).toBe(1);
+    expect(result.current.todoCount).toBe(2);
+  });
+
+  it('returns 0 when APIs fail', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network'))),
+    );
+
+    const { result } = renderHook(() => useTabBadges());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(result.current.inboxCount).toBe(0);
+    expect(result.current.todoCount).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Session } from '../types/chat';
 import { renameSession as renameSessionApi } from '../lib/rename-session';
-import { wsSubscribe } from '../lib/ws-pool';
 
 export interface QuickAction {
   label: string;
@@ -30,8 +29,6 @@ export interface UseSessionListReturn {
   sessions: Session[];
   quickActions: QuickAction[];
   loading: boolean;
-  inboxCount: number;
-  todoCount: number;
   updateAvailable: boolean;
   checking: boolean;
   dismissSession: (id: string) => void;
@@ -44,8 +41,6 @@ export function useSessionList(): UseSessionListReturn {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [quickActions, setQuickActions] = useState<QuickAction[]>(DEFAULT_ACTIONS);
   const [loading, setLoading] = useState(true);
-  const [inboxCount, setInboxCount] = useState(0);
-  const [todoCount, setTodoCount] = useState(0);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [checking, setChecking] = useState(false);
 
@@ -61,18 +56,10 @@ export function useSessionList(): UseSessionListReturn {
         fetch('/api/version')
           .then((r) => r.json())
           .catch(() => ({})),
-        fetch('/api/inbox')
-          .then((r) => r.json())
-          .catch(() => []),
-        fetch('/api/todos')
-          .then((r) => r.json())
-          .catch(() => ({ items: [] })),
-      ]).then(([sessData, config, version, inboxData, todoData]) => {
+      ]).then(([sessData, config, version]) => {
         setSessions(sessData);
         setQuickActions(buildQuickActions(config.quickActions));
         if (version?.updateAvailable) setUpdateAvailable(true);
-        if (Array.isArray(inboxData)) setInboxCount(inboxData.length);
-        if (todoData?.items) setTodoCount(todoData.items.length);
       });
 
     loadAll().finally(() => setLoading(false));
@@ -82,25 +69,8 @@ export function useSessionList(): UseSessionListReturn {
     };
     document.addEventListener('visibilitychange', onVisible);
 
-    let inboxFetchTimer: ReturnType<typeof setTimeout> | null = null;
-    const unsub = wsSubscribe('global:system', (msg) => {
-      if (msg.type === 'inbox_updated') {
-        if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
-        inboxFetchTimer = setTimeout(() => {
-          fetch('/api/inbox')
-            .then((r) => r.json())
-            .then((data) => {
-              if (Array.isArray(data)) setInboxCount(data.length);
-            })
-            .catch(() => {});
-        }, 300);
-      }
-    });
-
     return () => {
       document.removeEventListener('visibilitychange', onVisible);
-      if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
-      unsub();
     };
   }, []);
 
@@ -141,8 +111,6 @@ export function useSessionList(): UseSessionListReturn {
     sessions,
     quickActions,
     loading,
-    inboxCount,
-    todoCount,
     updateAvailable,
     checking,
     dismissSession,

--- a/frontend/src/hooks/useTabBadges.ts
+++ b/frontend/src/hooks/useTabBadges.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { wsSubscribe } from '../lib/ws-pool';
+
+export interface TabBadges {
+  inboxCount: number;
+  todoCount: number;
+}
+
+export function useTabBadges(): TabBadges {
+  const [inboxCount, setInboxCount] = useState(0);
+  const [todoCount, setTodoCount] = useState(0);
+
+  useEffect(() => {
+    const fetchCounts = () =>
+      Promise.all([
+        fetch('/api/inbox')
+          .then((r) => r.json())
+          .catch(() => []),
+        fetch('/api/todos')
+          .then((r) => r.json())
+          .catch(() => ({ items: [] })),
+      ]).then(([inboxData, todoData]) => {
+        if (Array.isArray(inboxData)) setInboxCount(inboxData.length);
+        if (todoData?.items) setTodoCount(todoData.items.length);
+      });
+
+    fetchCounts();
+
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') fetchCounts();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
+    let inboxFetchTimer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = wsSubscribe('global:system', (msg) => {
+      if (msg.type === 'inbox_updated') {
+        if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
+        inboxFetchTimer = setTimeout(() => {
+          fetch('/api/inbox')
+            .then((r) => r.json())
+            .then((data) => {
+              if (Array.isArray(data)) setInboxCount(data.length);
+            })
+            .catch(() => {});
+        }, 300);
+      }
+    });
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      if (inboxFetchTimer) clearTimeout(inboxFetchTimer);
+      unsub();
+    };
+  }, []);
+
+  return { inboxCount, todoCount };
+}

--- a/frontend/src/hooks/useTabBadges.ts
+++ b/frontend/src/hooks/useTabBadges.ts
@@ -21,7 +21,12 @@ export function useTabBadges(): TabBadges {
           .catch(() => ({ items: [] })),
       ]).then(([inboxData, todoData]) => {
         if (Array.isArray(inboxData)) setInboxCount(inboxData.length);
-        if (todoData?.items) setTodoCount(todoData.items.length);
+        if (todoData?.items) {
+          const pending = todoData.items.filter(
+            (item: { status?: string }) => item.status !== 'completed',
+          );
+          setTodoCount(pending.length);
+        }
       });
 
     fetchCounts();

--- a/frontend/src/pages/InboxView.tsx
+++ b/frontend/src/pages/InboxView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { wsSubscribe } from '../lib/ws-pool';
+import { EmptyState } from '../components/EmptyState';
 
 interface InboxItem {
   filename: string;
@@ -228,12 +229,7 @@ export function InboxView() {
 
       {loading && <p className="inbox-empty">Loading...</p>}
 
-      {!loading && items.length === 0 && (
-        <div className="inbox-empty">
-          <div className="inbox-empty-icon">&#10003;</div>
-          <p>No pending items</p>
-        </div>
-      )}
+      {!loading && items.length === 0 && <EmptyState icon={'\u2713'} title="No pending items" />}
 
       {sources.length > 1 && (
         <div className="inbox-filters">

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -4,6 +4,7 @@ import type { Session } from '../types/chat';
 import { formatRelativeTime } from '../lib/formatTime';
 import { useLongPress } from '../hooks/useLongPress';
 import { computeSwipeState, REVEAL_WIDTH } from '../lib/swipe-reveal';
+import { EmptyState } from '../components/EmptyState';
 import { useSessionList } from '../hooks/useSessionList';
 import type { QuickAction } from '../hooks/useSessionList';
 
@@ -269,7 +270,9 @@ export function SessionList() {
 
       {loading && <p className="session-list-empty">Loading...</p>}
 
-      {!loading && sessions.length === 0 && <p className="session-list-empty">No past sessions</p>}
+      {!loading && sessions.length === 0 && (
+        <EmptyState icon={'\uD83D\uDCAC'} title="No past sessions" />
+      )}
 
       {!loading && sessions.length > 0 && (
         <div className="session-list">

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -198,8 +198,6 @@ export function SessionList() {
     sessions,
     quickActions,
     loading,
-    inboxCount,
-    todoCount,
     updateAvailable,
     checking,
     dismissSession,
@@ -250,18 +248,6 @@ export function SessionList() {
 
       <button className="hero-chat-btn" onClick={() => navigate('/chat')}>
         New Chat
-      </button>
-
-      <button className="inbox-nav-btn" onClick={() => navigate('/inbox')}>
-        <span className="inbox-nav-label">Inbox</span>
-        {inboxCount > 0 && <span className="inbox-nav-badge">{inboxCount}</span>}
-        <span className="quick-row-chevron">&rsaquo;</span>
-      </button>
-
-      <button className="inbox-nav-btn" onClick={() => navigate('/todos')}>
-        <span className="inbox-nav-label">Todos</span>
-        {todoCount > 0 && <span className="inbox-nav-badge">{todoCount}</span>}
-        <span className="quick-row-chevron">&rsaquo;</span>
       </button>
 
       {quickActions.length > 0 && (

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { TaskNode } from '../components/TaskNode';
 import { TaskCreateForm } from '../components/TaskCreateForm';
 import { LoopControls } from '../components/LoopControls';
+import { EmptyState } from '../components/EmptyState';
 import { useTaskBoard } from '../hooks/useTaskBoard';
 import type { TaskStatus } from '../types/task';
 
@@ -90,11 +91,7 @@ export function TaskBoard() {
       {loading && <p className="task-board-empty">Loading...</p>}
 
       {!loading && tasks.length === 0 && (
-        <div className="task-board-empty">
-          <div className="task-board-empty-icon">&#x2610;</div>
-          <p>No tasks yet</p>
-          <p className="task-board-empty-hint">Add a task to get started</p>
-        </div>
+        <EmptyState icon={'\u2610'} title="No tasks yet" subtitle="Add a task to get started" />
       )}
 
       <div className="task-board-list">

--- a/frontend/src/pages/TodoView.tsx
+++ b/frontend/src/pages/TodoView.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TodoCard } from '../components/TodoCard';
+import { EmptyState } from '../components/EmptyState';
 import { useTodoData } from '../hooks/useTodoData';
 import type { TodoItem } from '../types/todo';
 
@@ -137,13 +138,15 @@ export function TodoView() {
       {loading && <p className="todo-empty">Loading...</p>}
 
       {!loading && items.length === 0 && (
-        <div className="todo-empty">
-          <div className="todo-empty-icon">&#10003;</div>
-          <p>No active items</p>
-          <p className="todo-empty-hint">
-            Run <code>./mgmt todo --refresh</code> to fetch from sources
-          </p>
-        </div>
+        <EmptyState
+          icon={'\u2713'}
+          title="No active items"
+          subtitle={
+            <>
+              Run <code>./mgmt todo --refresh</code> to fetch from sources
+            </>
+          }
+        />
       )}
 
       <div className="todo-hint">

--- a/frontend/src/pages/__tests__/SessionList.test.tsx
+++ b/frontend/src/pages/__tests__/SessionList.test.tsx
@@ -11,6 +11,7 @@ function mockFetchResponses(overrides: Record<string, unknown> = {}) {
     '/api/config': { quickActions: [] },
     '/api/inbox': [],
     '/api/version': {},
+    '/api/todos': { items: [] },
     ...overrides,
   };
 
@@ -108,26 +109,11 @@ describe('SessionList status dot', () => {
   });
 });
 
-describe('SessionList inbox badge', () => {
-  it('renders badge with correct count when inbox has items', async () => {
+describe('SessionList', () => {
+  it('does not render inline inbox/todo nav buttons (tab bar handles navigation)', async () => {
     mockFetchResponses({
-      '/api/inbox': [{ id: '1' }, { id: '2' }, { id: '3' }],
+      '/api/inbox': [{ id: '1' }, { id: '2' }],
     });
-
-    renderSessionList();
-
-    // Wait for async fetch + state update
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 10));
-    });
-
-    const badge = container.querySelector('.inbox-nav-badge');
-    expect(badge).not.toBeNull();
-    expect(badge!.textContent).toBe('3');
-  });
-
-  it('does not render badge when inbox is empty', async () => {
-    mockFetchResponses({ '/api/inbox': [] });
 
     renderSessionList();
 
@@ -135,8 +121,9 @@ describe('SessionList inbox badge', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    const badge = container.querySelector('.inbox-nav-badge');
-    expect(badge).toBeNull();
+    // Old inbox-nav-btn should be gone — tab bar handles navigation now
+    const inboxBtn = container.querySelector('.inbox-nav-btn');
+    expect(inboxBtn).toBeNull();
   });
 
   it('renders update banner when version endpoint reports update', async () => {
@@ -153,5 +140,18 @@ describe('SessionList inbox badge', () => {
     const banner = container.querySelector('.update-banner');
     expect(banner).not.toBeNull();
     expect(banner!.textContent).toMatch(/Update available/);
+  });
+
+  it('renders the hero New Chat button', async () => {
+    mockFetchResponses();
+
+    renderSessionList();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const heroBtn = container.querySelector('.hero-chat-btn');
+    expect(heroBtn).not.toBeNull();
   });
 });

--- a/frontend/src/styles/__tests__/tokens.test.ts
+++ b/frontend/src/styles/__tests__/tokens.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const css = readFileSync(resolve(__dirname, '../global.css'), 'utf-8');
+
+// Extract :root block content
+const rootMatch = css.match(/:root\s*\{([^}]+)\}/);
+const rootBlock = rootMatch?.[1] ?? '';
+
+describe('design tokens', () => {
+  describe('required CSS variables are defined in :root', () => {
+    const requiredVars = [
+      '--bg',
+      '--surface',
+      '--border',
+      '--text',
+      '--text-dim',
+      '--text-secondary',
+      '--accent',
+      '--accent-hover',
+      '--danger',
+      '--success',
+      '--warning',
+      '--bg-secondary',
+      '--hover',
+      '--active',
+    ];
+
+    for (const v of requiredVars) {
+      it(`defines ${v}`, () => {
+        expect(rootBlock).toContain(`${v}:`);
+      });
+    }
+  });
+
+  describe('type scale variables', () => {
+    const typeVars = ['--text-xs', '--text-sm', '--text-base', '--text-lg', '--text-xl'];
+
+    for (const v of typeVars) {
+      it(`defines ${v}`, () => {
+        expect(rootBlock).toContain(`${v}:`);
+      });
+    }
+  });
+
+  describe('spacing scale variables', () => {
+    const spaceVars = [
+      '--space-1',
+      '--space-2',
+      '--space-3',
+      '--space-4',
+      '--space-5',
+      '--space-6',
+    ];
+
+    for (const v of spaceVars) {
+      it(`defines ${v}`, () => {
+        expect(rootBlock).toContain(`${v}:`);
+      });
+    }
+  });
+
+  describe('no hardcoded colors for themed values', () => {
+    // These specific hex values should use CSS vars instead
+    const bannedColors = [
+      { hex: '#e53935', replacement: 'var(--danger)' },
+      { hex: '#ff9800', replacement: 'var(--warning)' },
+    ];
+
+    for (const { hex, replacement } of bannedColors) {
+      it(`does not use hardcoded ${hex} (use ${replacement})`, () => {
+        // Strip the :root block — definitions there are fine
+        const withoutRoot = css.replace(/:root\s*\{[^}]+\}/, '');
+        expect(withoutRoot).not.toContain(hex);
+      });
+    }
+  });
+});

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -16,6 +16,28 @@
   --success: #4caf50;
   --code-bg: #141425;
   --code-font: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
+
+  /* Previously undefined — now explicit */
+  --bg-secondary: #161628;
+  --text-secondary: #8888aa;
+  --hover: rgba(108, 99, 255, 0.1);
+  --active: rgba(108, 99, 255, 0.2);
+  --warning: #ff9800;
+
+  /* Type scale */
+  --text-xs: 0.75rem;
+  --text-sm: 0.85rem;
+  --text-base: 1rem;
+  --text-lg: 1.25rem;
+  --text-xl: 1.5rem;
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
 }
 
 html {
@@ -369,7 +391,7 @@ textarea:focus {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #e53935;
+  background: var(--danger);
   color: #fff;
   font-size: 0.8rem;
   font-weight: 600;
@@ -1597,7 +1619,7 @@ textarea:focus {
 }
 
 .perm-banner--elevated {
-  border-top-color: #ff9800;
+  border-top-color: var(--warning);
 }
 
 .perm-banner--unknown {
@@ -1619,7 +1641,7 @@ textarea:focus {
 
 .perm-banner-tier--elevated {
   background: rgba(255, 152, 0, 0.15);
-  color: #ff9800;
+  color: var(--warning);
 }
 
 .perm-banner-tier--unknown {
@@ -1984,7 +2006,7 @@ textarea:focus {
 }
 
 .mic-btn--recording {
-  background: #e53935;
+  background: var(--danger);
   color: #fff;
   animation: mic-pulse 1s ease-in-out infinite;
 }
@@ -3558,7 +3580,7 @@ textarea:focus {
 }
 
 .task-node-status--blocked {
-  color: #ff9800;
+  color: var(--warning);
 }
 
 .task-node-status--skipped {
@@ -3716,7 +3738,7 @@ textarea:focus {
 }
 
 .loop-controls-pill--paused {
-  background: #ff9800;
+  background: var(--warning);
   color: var(--bg);
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -202,6 +202,112 @@ textarea:focus {
   gap: var(--space-1);
 }
 
+/* ── TabBar ─────────────────────────────────────────────── */
+
+.tab-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 100;
+}
+
+.tab-bar-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: var(--space-2) 0;
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  background: none;
+  border: none;
+  border-radius: 0;
+  gap: 2px;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.tab-bar-item--active {
+  color: var(--accent);
+}
+
+.tab-bar-label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+}
+
+.tab-bar-badge {
+  position: absolute;
+  top: 4px;
+  right: calc(50% - 20px);
+  background: var(--danger);
+  color: #fff;
+  font-size: 0.65rem;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.tab-bar-more-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 99;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.tab-bar-more-menu {
+  background: var(--surface);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  padding: var(--space-4) var(--space-4) calc(var(--space-6) + env(safe-area-inset-bottom));
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.tab-bar-more-item {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: var(--text-sm);
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.tab-bar-more-item:active {
+  background: var(--hover);
+}
+
+/* Pages with tab bar need bottom padding to clear fixed nav */
+.session-list-page,
+.inbox-page,
+.todo-page,
+.task-board-page,
+.cal-page,
+.viewer-page {
+  padding-bottom: 72px;
+}
+
 /* ===== Login ===== */
 
 .login-page {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -151,6 +151,57 @@ textarea:focus {
   transform: scale(0.95);
 }
 
+/* ── PageHeader ─────────────────────────────────────────── */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 10;
+}
+
+.page-header-back {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: var(--text-xl);
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.page-header h1 {
+  flex: 1;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin: 0;
+}
+
+.page-header-center {
+  flex: 1;
+}
+
+.page-header-badge {
+  background: var(--accent);
+  color: var(--bg);
+  font-size: var(--text-xs);
+  padding: 2px 8px;
+  border-radius: 10px;
+  vertical-align: middle;
+  margin-left: var(--space-1);
+}
+
+.page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
 /* ===== Login ===== */
 
 .login-page {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -298,6 +298,34 @@ textarea:focus {
   background: var(--hover);
 }
 
+/* ── EmptyState ─────────────────────────────────────────── */
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6) var(--space-4);
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.empty-state-icon {
+  font-size: 2.5rem;
+  margin-bottom: var(--space-2);
+  opacity: 0.6;
+}
+
+.empty-state-title {
+  font-size: var(--text-base);
+  margin-bottom: var(--space-1);
+}
+
+.empty-state-subtitle {
+  font-size: var(--text-sm);
+  opacity: 0.7;
+}
+
 /* Pages with tab bar need bottom padding to clear fixed nav */
 .session-list-page,
 .inbox-page,
@@ -3906,9 +3934,14 @@ textarea:focus {
 
 .loop-controls-start {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.loop-controls-start-row {
+  display: flex;
   align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+  gap: var(--space-2);
 }
 
 .loop-controls-select {


### PR DESCRIPTION
## Summary

- **Bottom tab bar** — persistent navigation with Chat, Tasks, Inbox, Todos, More tabs. Badge counts on Inbox/Todos. "More" opens a slide-up menu for Calendar and Files. Hidden on desktop and chat routes.
- **Design tokens** — defined 5 previously-undefined CSS vars (`--bg-secondary`, `--text-secondary`, `--hover`, `--active`, `--warning`), added type scale (`--text-xs` through `--text-xl`) and spacing scale (`--space-1` through `--space-6`). Replaced all hardcoded `#e53935` and `#ff9800` with CSS var refs.
- **PageHeader component** — reusable header with back button, title, badge, center slot, and action slot. Ready for adoption across all pages.
- **LoopControls fix** — stacked vertically on mobile so goal select, spec toggle, and Start button no longer overlap.
- **EmptyState component** — consistent empty state pattern (icon + title + subtitle) adopted in TaskBoard, InboxView, TodoView, SessionList.
- **Removed old nav** — inline Inbox/Todos buttons removed from SessionList (tab bar handles navigation).

## Remaining (follow-up PRs)

- Adopt PageHeader in InboxView, TodoView, TaskBoard, CalendarView, FileViewer (replace per-page headers)
- Spacing/typography standardization (replace raw px with `var(--space-N)`, map font sizes to type scale)
- Desktop regression verification

## Test plan

- [x] 581 frontend tests pass (59 test files)
- [x] Pre-commit hooks (eslint + prettier) pass
- [ ] Manual check on mobile — tab bar renders, navigation works, badges show
- [ ] Verify tab bar does NOT appear on /chat routes
- [ ] Verify loop controls no longer overlap on task board
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)