### PR TITLE
feat(sessions): persistent context strip + session hash display

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -28,6 +28,7 @@ interface Props {
   branch?: string;
   isWorktree?: boolean;
   wtId?: string;
+  sessionId?: string;
   /** When provided, uses these context blocks instead of internal state. Hides @ picker. */
   externalContextBlocks?: string[];
   tokenState?: TokenState;
@@ -44,6 +45,7 @@ export function ChatInput({
   branch,
   isWorktree,
   wtId,
+  sessionId,
   externalContextBlocks,
   tokenState,
 }: Props) {
@@ -295,6 +297,11 @@ export function ChatInput({
           onChange={handleFileChange}
           className="sr-only"
         />
+        {sessionId && (
+          <span className="chat-input-session-hash" title={`session: ${sessionId}`}>
+            {sessionId.slice(-5)}
+          </span>
+        )}
         {(branch || wtId) && (
           <span
             className={`chat-input-branch${isWorktree ? ' chat-input-branch--wt' : ''}`}

--- a/frontend/src/components/TokenBar.tsx
+++ b/frontend/src/components/TokenBar.tsx
@@ -1,11 +1,6 @@
 import { useState } from 'react';
 import type { TokenState } from '../hooks/useTokenState';
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
-  return String(n);
-}
+import { formatTokens } from '../lib/formatTokens';
 
 function getContextColor(ratio: number): string {
   if (ratio >= 0.95) return 'flashing';

--- a/frontend/src/components/TokenBar.tsx
+++ b/frontend/src/components/TokenBar.tsx
@@ -27,27 +27,32 @@ export function TokenBar({ tokenState }: Props) {
   const ceiling = tokenState.contextCeiling;
   const ratio = ceiling > 0 ? tokenState.agentContext / ceiling : 0;
   const color = getContextColor(ratio);
+  // Completed sessions have agentContext=0 but sessionTotal>0 (hydrated from event store).
+  // Show only session total in that case — the agent context bar is meaningless.
+  const isCompleted = tokenState.agentContext === 0 && tokenState.sessionTotal > 0;
 
   return (
     <>
       <button
-        className={`token-bar token-bar--${color}`}
+        className={`token-bar token-bar--${isCompleted ? 'green' : color}`}
         onClick={() => setExpanded((v) => !v)}
         aria-label="Token usage"
         title="Token usage — tap for details"
       >
-        <span className="token-bar-agent">
-          <svg
-            className="token-bar-icon"
-            viewBox="0 0 24 24"
-            width="12"
-            height="12"
-            fill="currentColor"
-          >
-            <path d="M12 2a9 9 0 0 0-9 9c0 3.1 1.6 5.8 4 7.4V21h2v-2h6v2h2v-2.6c2.4-1.6 4-4.3 4-7.4a9 9 0 0 0-9-9zm-1 14h-1v-4h1v4zm1-6H9.5V8.5a2.5 2.5 0 0 1 5 0V10H12zm3 6h-1v-4h1v4z" />
-          </svg>
-          {formatTokens(tokenState.agentContext)}/{formatTokens(ceiling)}
-        </span>
+        {!isCompleted && (
+          <span className="token-bar-agent">
+            <svg
+              className="token-bar-icon"
+              viewBox="0 0 24 24"
+              width="12"
+              height="12"
+              fill="currentColor"
+            >
+              <path d="M12 2a9 9 0 0 0-9 9c0 3.1 1.6 5.8 4 7.4V21h2v-2h6v2h2v-2.6c2.4-1.6 4-4.3 4-7.4a9 9 0 0 0-9-9zm-1 14h-1v-4h1v4zm1-6H9.5V8.5a2.5 2.5 0 0 1 5 0V10H12zm3 6h-1v-4h1v4z" />
+            </svg>
+            {formatTokens(tokenState.agentContext)}/{formatTokens(ceiling)}
+          </span>
+        )}
         {tokenState.sessionTotal > 0 && (
           <span className="token-bar-session">
             <span className="token-bar-sigma">Σ</span>

--- a/frontend/src/components/__tests__/ChatInputCommandStrip.test.tsx
+++ b/frontend/src/components/__tests__/ChatInputCommandStrip.test.tsx
@@ -101,6 +101,20 @@ describe('ChatInput command strip', () => {
     expect(container.querySelectorAll('.mic-btn')).toHaveLength(1);
   });
 
+  it('renders session hash badge when sessionId is provided', () => {
+    const { container } = render(
+      <ChatInput onSend={noop} onStop={noopVoid} running={false} sessionId="abc123def456ghi789" />,
+    );
+    const badge = container.querySelector('.chat-input-session-hash');
+    expect(badge).toBeTruthy();
+    expect(badge?.textContent).toBe('hi789');
+  });
+
+  it('does not render session hash badge when sessionId is undefined', () => {
+    const { container } = render(<ChatInput onSend={noop} onStop={noopVoid} running={false} />);
+    expect(container.querySelector('.chat-input-session-hash')).toBeNull();
+  });
+
   it('opens slash picker when / button is clicked', () => {
     const { container } = render(<ChatInput onSend={noop} onStop={noopVoid} running={false} />);
     fireEvent.click(screen.getByTitle('Skills'));

--- a/frontend/src/components/__tests__/TokenBar.test.tsx
+++ b/frontend/src/components/__tests__/TokenBar.test.tsx
@@ -69,6 +69,25 @@ describe('TokenBar', () => {
     expect(container.querySelector('.token-bar--flashing')).toBeTruthy();
   });
 
+  it('renders session total for completed sessions (agentContext=0)', () => {
+    const { container } = render(
+      <TokenBar
+        tokenState={makeState({
+          agentContext: 0,
+          sessionTotal: 50000,
+          numTurns: 5,
+          turnIndex: 5,
+        })}
+      />,
+    );
+    // Should render (not return null)
+    expect(container.querySelector('.token-bar')).toBeTruthy();
+    // Should show session total
+    expect(screen.getByText(/50k/)).toBeTruthy();
+    // Should NOT show agent context bar (0/200k is meaningless for completed sessions)
+    expect(screen.queryByText(/0\/200k/)).toBeNull();
+  });
+
   it('expands detail panel on tap', () => {
     render(
       <TokenBar

--- a/frontend/src/hooks/__tests__/useSessionMeta.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionMeta.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSessionMeta } from '../useSessionMeta.js';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const META_RESPONSE = {
+  sessionId: 'sess-abc123',
+  branch: 'feat/my-feature',
+  wtId: 'wt-xyz',
+  cwd: '/tmp/repo',
+  mode: 'agent',
+  isActive: false,
+  inputTokens: 5000,
+  outputTokens: 3000,
+  cacheReadTokens: 1000,
+  cacheCreationTokens: 500,
+  totalCostUsd: 0.05,
+  numTurns: 4,
+};
+
+describe('useSessionMeta', () => {
+  const dispatch = vi.fn();
+  const tokenDispatch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches metadata and dispatches SESSION_INFO', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(META_RESPONSE),
+    });
+
+    renderHook(() => useSessionMeta('sess-abc123', dispatch, tokenDispatch));
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SESSION_INFO',
+        branch: 'feat/my-feature',
+        isWorktree: true,
+        wtId: 'wt-xyz',
+      });
+    });
+  });
+
+  it('dispatches TOKEN_UPDATE when numTurns > 0', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(META_RESPONSE),
+    });
+
+    renderHook(() => useSessionMeta('sess-abc123', dispatch, tokenDispatch));
+
+    await waitFor(() => {
+      expect(tokenDispatch).toHaveBeenCalledWith({
+        type: 'TOKEN_UPDATE',
+        agentContext: 0,
+        sessionTotal: 9500,
+        numTurns: 4,
+        turnIndex: 4,
+      });
+    });
+  });
+
+  it('does not fetch when sessionId is undefined', () => {
+    renderHook(() => useSessionMeta(undefined, dispatch, tokenDispatch));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch on 404', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    renderHook(() => useSessionMeta('unknown', dispatch, tokenDispatch));
+
+    // Wait a tick to ensure no dispatches
+    await new Promise((r) => setTimeout(r, 50));
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(tokenDispatch).not.toHaveBeenCalled();
+  });
+
+  it('sets isWorktree false when wtId is null', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...META_RESPONSE, wtId: null }),
+    });
+
+    renderHook(() => useSessionMeta('sess-abc123', dispatch, tokenDispatch));
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ isWorktree: false, wtId: null }),
+      );
+    });
+  });
+
+  it('skips TOKEN_UPDATE when numTurns is 0', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...META_RESPONSE, numTurns: 0 }),
+    });
+
+    renderHook(() => useSessionMeta('sess-abc123', dispatch, tokenDispatch));
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalled();
+    });
+    expect(tokenDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/__tests__/useSessionMeta.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionMeta.test.ts
@@ -13,10 +13,7 @@ const META_RESPONSE = {
   cwd: '/tmp/repo',
   mode: 'agent',
   isActive: false,
-  inputTokens: 5000,
-  outputTokens: 3000,
-  cacheReadTokens: 1000,
-  cacheCreationTokens: 500,
+  totalTokens: 9500,
   totalCostUsd: 0.05,
   numTurns: 4,
 };
@@ -99,6 +96,22 @@ describe('useSessionMeta', () => {
         expect.objectContaining({ isWorktree: false, wtId: undefined }),
       );
     });
+  });
+
+  it('hydrates tokens but skips SESSION_INFO when branch is null', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ...META_RESPONSE, branch: null, wtId: null }),
+    });
+
+    renderHook(() => useSessionMeta('sess-abc123', dispatch, tokenDispatch));
+
+    await waitFor(() => {
+      expect(tokenDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'TOKEN_UPDATE', sessionTotal: 9500 }),
+      );
+    });
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it('skips TOKEN_UPDATE when numTurns is 0', async () => {

--- a/frontend/src/hooks/__tests__/useSessionMeta.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionMeta.test.ts
@@ -96,7 +96,7 @@ describe('useSessionMeta', () => {
 
     await waitFor(() => {
       expect(dispatch).toHaveBeenCalledWith(
-        expect.objectContaining({ isWorktree: false, wtId: null }),
+        expect.objectContaining({ isWorktree: false, wtId: undefined }),
       );
     });
   });

--- a/frontend/src/hooks/useSessionMeta.ts
+++ b/frontend/src/hooks/useSessionMeta.ts
@@ -20,7 +20,7 @@ type MessageDispatch = (action: {
   type: 'SESSION_INFO';
   branch: string;
   isWorktree: boolean;
-  wtId: string | null | undefined;
+  wtId?: string;
 }) => void;
 
 /**
@@ -51,7 +51,7 @@ export function useSessionMeta(
             type: 'SESSION_INFO',
             branch: meta.branch,
             isWorktree: !!meta.wtId,
-            wtId: meta.wtId,
+            wtId: meta.wtId ?? undefined,
           });
         }
 

--- a/frontend/src/hooks/useSessionMeta.ts
+++ b/frontend/src/hooks/useSessionMeta.ts
@@ -1,0 +1,76 @@
+import { useEffect } from 'react';
+import type { TokenAction } from './useTokenState.js';
+
+interface SessionMetaResponse {
+  sessionId: string;
+  branch: string | null;
+  wtId: string | null;
+  cwd: string | null;
+  mode: string;
+  isActive: boolean;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  totalCostUsd: number;
+  numTurns: number;
+}
+
+type MessageDispatch = (action: {
+  type: 'SESSION_INFO';
+  branch: string;
+  isWorktree: boolean;
+  wtId: string | null | undefined;
+}) => void;
+
+/**
+ * Hydrates branch/worktree and token state from persisted session metadata.
+ * Runs on mount when sessionId is defined, providing immediate context strip
+ * data without waiting for live WebSocket messages.
+ */
+export function useSessionMeta(
+  sessionId: string | undefined,
+  dispatch: MessageDispatch,
+  tokenDispatch: React.Dispatch<TokenAction>,
+): void {
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const controller = new AbortController();
+
+    fetch(`/api/sessions/${sessionId}/meta`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((meta: SessionMetaResponse | null) => {
+        if (controller.signal.aborted || !meta) return;
+
+        if (meta.branch) {
+          dispatch({
+            type: 'SESSION_INFO',
+            branch: meta.branch,
+            isWorktree: !!meta.wtId,
+            wtId: meta.wtId,
+          });
+        }
+
+        if (meta.numTurns > 0) {
+          tokenDispatch({
+            type: 'TOKEN_UPDATE',
+            agentContext: 0,
+            sessionTotal:
+              meta.inputTokens +
+              meta.outputTokens +
+              meta.cacheReadTokens +
+              meta.cacheCreationTokens,
+            numTurns: meta.numTurns,
+            turnIndex: meta.numTurns,
+          });
+        }
+      })
+      .catch(() => {});
+
+    return () => controller.abort();
+  }, [sessionId, dispatch, tokenDispatch]);
+}

--- a/frontend/src/hooks/useSessionMeta.ts
+++ b/frontend/src/hooks/useSessionMeta.ts
@@ -8,10 +8,7 @@ interface SessionMetaResponse {
   cwd: string | null;
   mode: string;
   isActive: boolean;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadTokens: number;
-  cacheCreationTokens: number;
+  totalTokens: number;
   totalCostUsd: number;
   numTurns: number;
 }
@@ -59,11 +56,7 @@ export function useSessionMeta(
           tokenDispatch({
             type: 'TOKEN_UPDATE',
             agentContext: 0,
-            sessionTotal:
-              meta.inputTokens +
-              meta.outputTokens +
-              meta.cacheReadTokens +
-              meta.cacheCreationTokens,
+            sessionTotal: meta.totalTokens,
             numTurns: meta.numTurns,
             turnIndex: meta.numTurns,
           });

--- a/frontend/src/hooks/useTokenState.ts
+++ b/frontend/src/hooks/useTokenState.ts
@@ -77,5 +77,5 @@ export function useTokenState(sessionId?: string) {
     }
   }, []);
 
-  return { tokenState, tokenDispatch, handleTokenMessage };
+  return { tokenState, tokenDispatch, handleTokenMessage } as const;
 }

--- a/frontend/src/lib/formatTokens.ts
+++ b/frontend/src/lib/formatTokens.ts
@@ -1,0 +1,6 @@
+/** Format a token count for compact display (e.g. 1500 → "2k", 1200000 → "1.2M"). */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -14,6 +14,7 @@ import { usePermission } from '../hooks/usePermission';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
 import { useTokenState } from '../hooks/useTokenState';
+import { useSessionMeta } from '../hooks/useSessionMeta';
 
 export function ChatView() {
   const { sessionId } = useParams<{ sessionId?: string }>();
@@ -26,7 +27,9 @@ export function ChatView() {
   );
 
   const voice = useVoice();
-  const { tokenState, handleTokenMessage } = useTokenState(sessionState.currentSessionId);
+  const { tokenState, tokenDispatch, handleTokenMessage } = useTokenState(
+    sessionState.currentSessionId,
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const forceScrollToBottom = useCallback(() => {
@@ -105,6 +108,10 @@ export function ChatView() {
 
     return () => controller.abort();
   }, [sessionId, dispatch, forceScrollToBottom]);
+
+  // Hydrate branch/worktree and token state from persisted metadata.
+  // Runs alongside message restore so the context strip is visible immediately.
+  useSessionMeta(sessionId, dispatch, tokenDispatch);
 
   const { connected } = useChatConnection(poolKey, handleWsMessage, handleTokenMessage);
 

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -210,6 +210,7 @@ export function ChatView() {
         branch={msgState.branch || undefined}
         isWorktree={msgState.isWorktree}
         wtId={msgState.wtId || undefined}
+        sessionId={sessionState.currentSessionId}
         tokenState={tokenState}
       />
     </div>

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -18,6 +18,7 @@ import { usePermission } from '../hooks/usePermission';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
 import { useTokenState } from '../hooks/useTokenState';
+import { useSessionMeta } from '../hooks/useSessionMeta';
 import type { FileRoot } from '../components/FileBrowserPanel';
 import type { ContextBlockEntry } from '../components/ContextPicker';
 
@@ -60,7 +61,9 @@ export function DesktopChatView() {
   );
 
   const voice = useVoice();
-  const { tokenState, handleTokenMessage } = useTokenState(sessionState.currentSessionId);
+  const { tokenState, tokenDispatch, handleTokenMessage } = useTokenState(
+    sessionState.currentSessionId,
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const forceScrollToBottom = useCallback(() => {
@@ -127,6 +130,8 @@ export function DesktopChatView() {
       .catch(() => {});
     return () => controller.abort();
   }, [sessionId, dispatch, forceScrollToBottom]);
+
+  useSessionMeta(sessionId, dispatch, tokenDispatch);
 
   const { connected } = useChatConnection(poolKey, handleWsMessage, handleTokenMessage);
 

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -244,6 +244,7 @@ export function DesktopChatView() {
             branch={msgState.branch || undefined}
             isWorktree={msgState.isWorktree}
             wtId={msgState.wtId || undefined}
+            sessionId={sessionState.currentSessionId}
             externalContextBlocks={contextBlocks}
             tokenState={tokenState}
           />

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -8,6 +8,12 @@ import { EmptyState } from '../components/EmptyState';
 import { useSessionList } from '../hooks/useSessionList';
 import type { QuickAction } from '../hooks/useSessionList';
 
+function formatTokensShort(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
 function SwipeableSession({
   session,
   onDismiss,
@@ -175,8 +181,12 @@ function SwipeableSession({
             <div className="session-item-summary">{session.summary || 'Untitled session'}</div>
           )}
           <div className="session-item-meta">
+            <span className="session-item-hash">{session.id.slice(-6)}</span>
             <span className="session-item-time">{formatRelativeTime(session.lastModified)}</span>
             {session.branch && <span className="session-item-branch">{session.branch}</span>}
+            {session.totalTokens != null && session.totalTokens > 0 && (
+              <span className="session-item-tokens">{formatTokensShort(session.totalTokens)}</span>
+            )}
           </div>
         </div>
         {!editing && <span className="session-item-chevron">&rsaquo;</span>}

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -7,12 +7,7 @@ import { computeSwipeState, REVEAL_WIDTH } from '../lib/swipe-reveal';
 import { EmptyState } from '../components/EmptyState';
 import { useSessionList } from '../hooks/useSessionList';
 import type { QuickAction } from '../hooks/useSessionList';
-
-function formatTokensShort(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
-  return String(n);
-}
+import { formatTokens } from '../lib/formatTokens';
 
 function SwipeableSession({
   session,
@@ -185,7 +180,7 @@ function SwipeableSession({
             <span className="session-item-time">{formatRelativeTime(session.lastModified)}</span>
             {session.branch && <span className="session-item-branch">{session.branch}</span>}
             {session.totalTokens != null && session.totalTokens > 0 && (
-              <span className="session-item-tokens">{formatTokensShort(session.totalTokens)}</span>
+              <span className="session-item-tokens">{formatTokens(session.totalTokens)}</span>
             )}
           </div>
         </div>

--- a/frontend/src/pages/__tests__/SessionList.test.tsx
+++ b/frontend/src/pages/__tests__/SessionList.test.tsx
@@ -109,6 +109,57 @@ describe('SessionList status dot', () => {
   });
 });
 
+describe('SessionList hash and tokens', () => {
+  it('renders session hash (last 6 chars) in session item', async () => {
+    mockFetchResponses({
+      '/api/sessions': [{ id: 'abc123def456', summary: 'Test', lastModified: 1 }],
+    });
+
+    renderSessionList();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const hash = container.querySelector('.session-item-hash');
+    expect(hash).not.toBeNull();
+    expect(hash!.textContent).toBe('def456');
+  });
+
+  it('renders token count when totalTokens is present', async () => {
+    mockFetchResponses({
+      '/api/sessions': [
+        { id: 'abc123def456', summary: 'Test', lastModified: 1, totalTokens: 42500 },
+      ],
+    });
+
+    renderSessionList();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const tokens = container.querySelector('.session-item-tokens');
+    expect(tokens).not.toBeNull();
+    expect(tokens!.textContent).toMatch(/43k/);
+  });
+
+  it('does not render token count when totalTokens is undefined', async () => {
+    mockFetchResponses({
+      '/api/sessions': [{ id: 'abc123def456', summary: 'Test', lastModified: 1 }],
+    });
+
+    renderSessionList();
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const tokens = container.querySelector('.session-item-tokens');
+    expect(tokens).toBeNull();
+  });
+});
+
 describe('SessionList', () => {
   it('does not render inline inbox/todo nav buttons (tab bar handles navigation)', async () => {
     mockFetchResponses({

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1872,6 +1872,14 @@ textarea:focus {
   position: relative;
 }
 
+.chat-input-session-hash {
+  font-family: var(--code-font);
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  opacity: 0.5;
+  margin-left: 0.5rem;
+}
+
 .chat-input-branch {
   font-family: var(--code-font);
   font-size: 0.65rem;

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -656,6 +656,19 @@ textarea:focus {
   white-space: nowrap;
 }
 
+.session-item-hash {
+  font-size: 0.65rem;
+  font-family: var(--code-font);
+  color: var(--text-dim);
+  opacity: 0.6;
+}
+
+.session-item-tokens {
+  font-size: 0.65rem;
+  font-family: var(--code-font);
+  color: var(--text-dim);
+}
+
 .session-status-dot {
   width: 8px;
   height: 8px;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -92,4 +92,6 @@ export interface Session {
   branch?: string;
   isActive?: boolean;
   isAttached?: boolean;
+  totalTokens?: number;
+  numTurns?: number;
 }

--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -165,6 +165,36 @@ describe('EventStore', () => {
       expect(session!.branch).toBe('main');
       expect(session!.mode).toBe('agent');
     });
+
+    it('persists and retrieves wtId', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test', wtId: 'wt-abc123' });
+
+      const session = store.getSession('sess-1');
+      expect(session).not.toBeNull();
+      expect(session!.wtId).toBe('wt-abc123');
+    });
+
+    it('updates wtId on existing session', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      expect(store.getSession('sess-1')!.wtId).toBeNull();
+
+      store.upsertSession({ sessionId: 'sess-1', wtId: 'wt-xyz789' });
+      expect(store.getSession('sess-1')!.wtId).toBe('wt-xyz789');
+    });
+
+    it('persists branch and wtId together on insert', () => {
+      store.upsertSession({
+        sessionId: 'sess-1',
+        branch: 'feat/my-feature',
+        wtId: 'wt-session-123',
+        mode: 'agent',
+      });
+
+      const session = store.getSession('sess-1');
+      expect(session!.branch).toBe('feat/my-feature');
+      expect(session!.wtId).toBe('wt-session-123');
+      expect(session!.mode).toBe('agent');
+    });
   });
 
   describe('getSession', () => {

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -280,13 +280,15 @@ describe('session routes', () => {
     expect(res.status).toBe(401);
   });
 
-  it('GET /api/sessions — annotates sessions with active status', async () => {
+  it('GET /api/sessions — annotates sessions with active status and token data', async () => {
     const res = await request(app).get('/api/sessions').set('Cookie', authCookie);
     expect(res.status).toBe(200);
     const s1 = res.body.find((s: any) => s.id === 's1');
     expect(s1).toBeDefined();
     expect(s1.isActive).toBe(true);
     expect(s1.isAttached).toBe(true);
+    expect(s1.totalTokens).toBe(9500); // 5000 + 3000 + 1000 + 500
+    expect(s1.numTurns).toBe(3);
   });
 
   it('GET /api/sessions — authenticated returns array', async () => {

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -363,10 +363,7 @@ describe('session routes', () => {
       cwd: '/tmp/repo',
       mode: 'agent',
       isActive: true,
-      inputTokens: 5000,
-      outputTokens: 3000,
-      cacheReadTokens: 1000,
-      cacheCreationTokens: 500,
+      totalTokens: 9500,
       totalCostUsd: 0.05,
       numTurns: 3,
     });

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -54,7 +54,39 @@ vi.mock('../chat.js', () => {
       ]),
     },
     setTaskStore: vi.fn(),
-    eventStore: { append: vi.fn(), getEventsAfter: vi.fn().mockReturnValue([]) },
+    eventStore: {
+      append: vi.fn(),
+      getEventsAfter: vi.fn().mockReturnValue([]),
+      getSession: vi.fn().mockImplementation((id: string) => {
+        if (id === 's1') {
+          return {
+            sessionId: 's1',
+            summary: 'Test',
+            branch: 'main',
+            cwd: '/tmp/repo',
+            mode: 'agent',
+            wtId: null,
+            isActive: true,
+            isHidden: false,
+            promptCount: 0,
+            manuallyRenamed: false,
+            initialPrompt: null,
+            inputTokens: 5000,
+            outputTokens: 3000,
+            cacheReadTokens: 1000,
+            cacheCreationTokens: 500,
+            totalCostUsd: 0.05,
+            numTurns: 3,
+            durationMs: 10000,
+            durationApiMs: 8000,
+            goalId: null,
+            createdAt: 1000,
+            updatedAt: 2000,
+          };
+        }
+        return null;
+      }),
+    },
   };
 });
 
@@ -316,6 +348,35 @@ describe('session routes', () => {
 
   it('PUT /api/sessions/:id/rename — unauthenticated returns 401', async () => {
     const res = await request(app).put('/api/sessions/s1/rename').send({ title: 'Name' });
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /api/sessions/:id/meta — returns session metadata', async () => {
+    const res = await request(app).get('/api/sessions/s1/meta').set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      sessionId: 's1',
+      branch: 'main',
+      wtId: null,
+      cwd: '/tmp/repo',
+      mode: 'agent',
+      isActive: true,
+      inputTokens: 5000,
+      outputTokens: 3000,
+      cacheReadTokens: 1000,
+      cacheCreationTokens: 500,
+      totalCostUsd: 0.05,
+      numTurns: 3,
+    });
+  });
+
+  it('GET /api/sessions/:id/meta — unknown session returns 404', async () => {
+    const res = await request(app).get('/api/sessions/unknown/meta').set('Cookie', authCookie);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/sessions/:id/meta — unauthenticated returns 401', async () => {
+    const res = await request(app).get('/api/sessions/s1/meta');
     expect(res.status).toBe(401);
   });
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -668,6 +668,8 @@ app.get('/api/sessions/:id/meta', (req, res) => {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
+  const totalTokens =
+    meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens;
   res.json({
     sessionId: meta.sessionId,
     branch: meta.branch,
@@ -675,10 +677,7 @@ app.get('/api/sessions/:id/meta', (req, res) => {
     cwd: meta.cwd,
     mode: meta.mode,
     isActive: meta.isActive,
-    inputTokens: meta.inputTokens,
-    outputTokens: meta.outputTokens,
-    cacheReadTokens: meta.cacheReadTokens,
-    cacheCreationTokens: meta.cacheCreationTokens,
+    totalTokens,
     totalCostUsd: meta.totalCostUsd,
     numTurns: meta.numTurns,
   });

--- a/server/app.ts
+++ b/server/app.ts
@@ -639,7 +639,16 @@ app.get('/api/sessions', async (_req, res) => {
   }
   const annotated = sessions.map((s) => {
     const live = activeMap.get(s.id);
-    return { ...s, isActive: !!live, isAttached: live?.attached ?? false };
+    const meta = eventStore.getSession(s.id);
+    return {
+      ...s,
+      isActive: !!live,
+      isAttached: live?.attached ?? false,
+      totalTokens: meta
+        ? meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens
+        : undefined,
+      numTurns: meta?.numTurns,
+    };
   });
   res.json(annotated);
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -653,6 +653,28 @@ app.delete('/api/sessions/:id', (req, res) => {
   res.json({ ok: true });
 });
 
+app.get('/api/sessions/:id/meta', (req, res) => {
+  const meta = eventStore.getSession(req.params.id);
+  if (!meta) {
+    res.status(404).json({ error: 'Session not found' });
+    return;
+  }
+  res.json({
+    sessionId: meta.sessionId,
+    branch: meta.branch,
+    wtId: meta.wtId,
+    cwd: meta.cwd,
+    mode: meta.mode,
+    isActive: meta.isActive,
+    inputTokens: meta.inputTokens,
+    outputTokens: meta.outputTokens,
+    cacheReadTokens: meta.cacheReadTokens,
+    cacheCreationTokens: meta.cacheCreationTokens,
+    totalCostUsd: meta.totalCostUsd,
+    numTurns: meta.numTurns,
+  });
+});
+
 app.get('/api/sessions/:id/events', (req, res) => {
   const afterSeq = parseInt(req.query.after as string, 10);
   if (isNaN(afterSeq)) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -430,6 +430,7 @@ export async function startChat(
   }
 
   const branch = getBranch(cwd);
+  session.branch = branch;
   send(ws, { type: 'session_info', branch, cwd, worktree: !!worktreePath, wtId });
 
   // Build session env with worktree paths for the agent

--- a/server/event-store.ts
+++ b/server/event-store.ts
@@ -22,6 +22,7 @@ export interface SessionMeta {
   promptCount: number;
   manuallyRenamed: boolean;
   initialPrompt: string | null;
+  wtId: string | null;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
@@ -54,6 +55,7 @@ interface SessionRow {
   prompt_count: number;
   manually_renamed: number;
   initial_prompt: string | null;
+  wt_id: string | null;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
@@ -119,6 +121,7 @@ export class EventStore {
     // Migrate existing databases that lack the new columns
     this.migratePromptTracking(db);
     this.migrateUsageTracking(db);
+    this.migrateWorktreeTracking(db);
 
     this.stmts = {
       append: db.prepare('INSERT INTO events (session_id, type, payload) VALUES (?, ?, ?)'),
@@ -212,6 +215,16 @@ export class EventStore {
     }
   }
 
+  /** Add worktree tracking column if it doesn't exist yet. */
+  private migrateWorktreeTracking(db: Database.Database): void {
+    const columns = db.prepare("PRAGMA table_info('sessions')").all() as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((c) => c.name));
+    if (!columnNames.has('wt_id')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN wt_id TEXT');
+      log.info('migrated sessions table: added wt_id');
+    }
+  }
+
   close(): void {
     if (this.db) {
       this.db.close();
@@ -270,6 +283,10 @@ export class EventStore {
         fields.push('goal_id = ?');
         values.push(meta.goalId);
       }
+      if (meta.wtId !== undefined) {
+        fields.push('wt_id = ?');
+        values.push(meta.wtId);
+      }
       fields.push("updated_at = unixepoch('now', 'subsec') * 1000");
       values.push(meta.sessionId);
       this.db!.prepare(`UPDATE sessions SET ${fields.join(', ')} WHERE session_id = ?`).run(
@@ -277,7 +294,7 @@ export class EventStore {
       );
     } else {
       this.db!.prepare(
-        'INSERT INTO sessions (session_id, summary, branch, cwd, mode, initial_prompt) VALUES (?, ?, ?, ?, ?, ?)',
+        'INSERT INTO sessions (session_id, summary, branch, cwd, mode, initial_prompt, wt_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
       ).run(
         meta.sessionId,
         meta.summary ?? null,
@@ -285,6 +302,7 @@ export class EventStore {
         meta.cwd ?? null,
         meta.mode ?? 'agent',
         meta.initialPrompt ?? null,
+        meta.wtId ?? null,
       );
     }
   }
@@ -388,6 +406,7 @@ function rowToSession(row: SessionRow): SessionMeta {
     promptCount: row.prompt_count ?? 0,
     manuallyRenamed: (row.manually_renamed ?? 0) === 1,
     initialPrompt: row.initial_prompt ?? null,
+    wtId: row.wt_id ?? null,
     inputTokens: row.input_tokens ?? 0,
     outputTokens: row.output_tokens ?? 0,
     cacheReadTokens: row.cache_read_tokens ?? 0,

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -267,6 +267,8 @@ export async function runQueryLoop(
               sessionId: resolvedSessionId,
               cwd: currentSession.cwd,
               mode: currentSession.mode,
+              branch: currentSession.branch,
+              wtId: currentSession.wtId,
               ...(initialPrompt ? { initialPrompt } : {}),
             });
             if (initialPrompt) {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -268,7 +268,7 @@ export async function runQueryLoop(
               cwd: currentSession.cwd,
               mode: currentSession.mode,
               branch: currentSession.branch,
-              wtId: currentSession.wtId,
+              ...(currentSession.worktreePath ? { wtId: currentSession.wtId } : {}),
               ...(initialPrompt ? { initialPrompt } : {}),
             });
             if (initialPrompt) {

--- a/server/session-registry.ts
+++ b/server/session-registry.ts
@@ -30,6 +30,8 @@ export interface ManagedSession {
   sessionAllowList: Set<string>;
   mode: MitzoMode;
   cwd?: string;
+  /** Git branch at session start. */
+  branch?: string;
   /** Session-scoped worktree identifier, shared across all repos. */
   wtId?: string;
   worktreePath?: string;


### PR DESCRIPTION
## Summary

- **Persist branch + wtId to event store** — previously only sent via WS, lost on navigation
- **New `/api/sessions/:id/meta` endpoint** — serves persisted session metadata  
- **Enrich `/api/sessions`** with token totals from event store
- **Frontend hydration** — `useSessionMeta` hook fetches metadata on session load, populates branch badge + token bar before WS data arrives
- **TokenBar** — shows session total for completed sessions (was returning null when agentContext=0)
- **Session list** — each item shows session hash (last 6 chars) + token count
- **Chat toolbar** — always shows session hash badge (last 5 chars) alongside branch pill

## Root cause

`session_info` and `token_update` are raw WebSocket messages, never persisted to the event store, never replayed on reattach. When navigating away and returning to a session, the context strip (branch badge + token bar) disappeared because the frontend had no way to recover this data.

## Test plan

- [x] Event store: branch + wtId round-trip (3 new tests)
- [x] Routes: `/meta` endpoint returns data / 404 (3 new tests)  
- [x] Routes: `/api/sessions` includes totalTokens + numTurns
- [x] useSessionMeta: dispatches SESSION_INFO + TOKEN_UPDATE from API (6 new tests)
- [x] TokenBar: renders session total when agentContext=0 (1 new test)
- [x] SessionList: shows hash + token count (3 new tests)
- [x] ChatInput: renders session hash badge (2 new tests)
- [x] Full suite: 8540 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)