### PR TITLE
fix(sessions): fix session reattachment for multi-client and expiry

### DIFF
--- a/frontend/src/hooks/__tests__/useChatMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useChatMessages.test.ts
@@ -506,6 +506,42 @@ describe('USER_MESSAGE_RECEIVED deduplication', () => {
   });
 });
 
+describe('useChatMessages — session expiry error', () => {
+  it('calls onSessionExpired with current session ID on "No conversation found"', () => {
+    const onSessionExpired = vi.fn();
+
+    const { result } = renderHook(() =>
+      useChatMessages('session:test', 'test-session-id', vi.fn(), onSessionExpired),
+    );
+
+    act(() => {
+      result.current.handleWsMessage({ type: 'error', error: 'No conversation found' });
+    });
+
+    expect(onSessionExpired).toHaveBeenCalledWith('test-session-id');
+    // Error is rendered as a message, not a state field
+    const lastMsg = result.current.state.messages.at(-1);
+    expect(lastMsg?.blocks[0].content).toContain('Session expired');
+    expect(result.current.state.running).toBe(false);
+  });
+
+  it('does not call onSessionExpired for other errors', () => {
+    const onSessionExpired = vi.fn();
+
+    const { result } = renderHook(() =>
+      useChatMessages('session:test', 'test-session-id', vi.fn(), onSessionExpired),
+    );
+
+    act(() => {
+      result.current.handleWsMessage({ type: 'error', error: 'Something else went wrong' });
+    });
+
+    expect(onSessionExpired).not.toHaveBeenCalled();
+    const lastMsg = result.current.state.messages.at(-1);
+    expect(lastMsg?.blocks[0].content).toContain('Something else went wrong');
+  });
+});
+
 describe('useChatMessages — reattach_failed handler', () => {
   it('restores messages from API array response on reattach_failed', async () => {
     const apiMessages = [

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
 import { VoiceSettings } from '../components/VoiceSettings';
@@ -19,8 +19,6 @@ import { useSessionMeta } from '../hooks/useSessionMeta';
 export function ChatView() {
   const { sessionId } = useParams<{ sessionId?: string }>();
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
-
   const [sessionState, sessionActions, poolKey] = useChatSession(
     sessionId,
     searchParams.get('extraTools') ? 'auto' : 'agent',
@@ -38,18 +36,12 @@ export function ChatView() {
     });
   }, []);
 
-  const handleSessionExpired = useCallback(
-    (staleId: string | undefined) => {
-      sessionActions.setCurrentSessionId(undefined);
-      if (staleId) {
-        localStorage.removeItem(LAST_SESSION_KEY);
-      }
-      if (sessionId) {
-        navigate('/chat', { replace: true });
-      }
-    },
-    [sessionId, navigate, sessionActions],
-  );
+  const handleSessionExpired = useCallback((staleId: string | undefined) => {
+    // Clear from localStorage so fresh page loads don't auto-resume an expired session.
+    // Keep currentSessionId so the next send includes `resume` and the SDK can
+    // attempt to pick up the conversation.
+    if (staleId) localStorage.removeItem(LAST_SESSION_KEY);
+  }, []);
 
   // When a session ID is assigned mid-conversation (started from /chat),
   // update the URL so refreshes and back-navigation land on /chat/:id

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -72,14 +72,12 @@ export function DesktopChatView() {
     });
   }, []);
 
-  const handleSessionExpired = useCallback(
-    (staleId: string | undefined) => {
-      sessionActions.setCurrentSessionId(undefined);
-      if (staleId) localStorage.removeItem(LAST_SESSION_KEY);
-      if (sessionId) navigate('/chat', { replace: true });
-    },
-    [sessionId, navigate, sessionActions],
-  );
+  const handleSessionExpired = useCallback((staleId: string | undefined) => {
+    // Clear from localStorage so fresh page loads don't auto-resume an expired session.
+    // Keep currentSessionId so the next send includes `resume` and the SDK can
+    // attempt to pick up the conversation.
+    if (staleId) localStorage.removeItem(LAST_SESSION_KEY);
+  }, []);
 
   const handleSessionAssigned = useCallback(
     (id: string) => {

--- a/server/__tests__/multi-client-sessions.test.ts
+++ b/server/__tests__/multi-client-sessions.test.ts
@@ -200,7 +200,7 @@ describe('tryRouteToActiveSession gating', () => {
     registry.dispose();
   });
 
-  it('findBySessionId returns detached sessions but isAttached filters them', () => {
+  it('findBySessionId returns detached sessions (still routable)', () => {
     const ws = mockWs();
     registry.register('c1', {
       ws,
@@ -217,13 +217,28 @@ describe('tryRouteToActiveSession gating', () => {
     registry.detach('c1');
     expect(registry.isAttached('c1')).toBe(false);
 
-    // findBySessionId still finds it
+    // findBySessionId still finds it — detached sessions remain routable
     const found = registry.findBySessionId('sess-1');
     expect(found).not.toBeNull();
     expect(found!.clientId).toBe('c1');
+  });
 
-    // But isAttached returns false — tryRouteToActiveSession should bail
-    expect(registry.isAttached(found!.clientId)).toBe(false);
+  it('addObserver succeeds when driver is detached', () => {
+    const ws = mockWs();
+    const obsWs = mockWs();
+    registry.register('c1', {
+      ws,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+      sessionId: 'sess-1',
+    });
+
+    registry.detach('c1');
+
+    const result = registry.addObserver('sess-1', obsWs);
+    expect(result).toBe('c1');
+    expect(registry.get('c1')!.observers.size).toBe(1);
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -176,8 +176,6 @@ function tryRouteToActiveSession(
   if (!resume) return null;
   const found = registry.findBySessionId(resume);
   if (!found) return null;
-  // Only route to the session if the driver is still attached
-  if (!registry.isAttached(found.clientId)) return null;
   // Session is active — subscribe as observer instead of starting a duplicate query
   const driverId = registry.addObserver(resume, ws);
   if (!driverId) return null; // observer cap reached


### PR DESCRIPTION
## Summary

- **Multi-client fix**: Removed the `isAttached` gate in `tryRouteToActiveSession()` — observers (e.g. phone) can now send messages when the driver (e.g. laptop) has disconnected. The SDK query is still running and downstream code (`sendOrBuffer`, `broadcastToObservers`) already handles detached drivers correctly.
- **Resume fix**: `handleSessionExpired` no longer clears `currentSessionId` — the next send includes `resume` so the SDK can pick up the conversation instead of starting fresh. Only localStorage is cleared to prevent stale auto-restore on fresh page loads.

## Test plan

- [x] Added test: observer can be added to detached session
- [x] Added test: `onSessionExpired` called on "No conversation found" error
- [x] Added test: other errors don't trigger session expiry
- [x] All 291 targeted tests pass
- [ ] Manual: open session on two devices, sleep one, send from the other — should route to existing session
- [ ] Manual: let session expire, resend — should resume not start fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)