### PR TITLE
refactor(css): standardize spacing and typography with design tokens

### DIFF
--- a/frontend/src/styles/__tests__/tokens.test.ts
+++ b/frontend/src/styles/__tests__/tokens.test.ts
@@ -35,7 +35,17 @@ describe('design tokens', () => {
   });
 
   describe('type scale variables', () => {
-    const typeVars = ['--text-xs', '--text-sm', '--text-base', '--text-lg', '--text-xl'];
+    const typeVars = [
+      '--text-2xs',
+      '--text-xxs',
+      '--text-xs',
+      '--text-s',
+      '--text-sm',
+      '--text-md',
+      '--text-base',
+      '--text-lg',
+      '--text-xl',
+    ];
 
     for (const v of typeVars) {
       it(`defines ${v}`, () => {
@@ -47,6 +57,7 @@ describe('design tokens', () => {
   describe('spacing scale variables', () => {
     const spaceVars = [
       '--space-1',
+      '--space-1h',
       '--space-2',
       '--space-3',
       '--space-4',

--- a/frontend/src/styles/calendar.css
+++ b/frontend/src/styles/calendar.css
@@ -13,8 +13,8 @@
 .cal-header {
   display: flex;
   align-items: center;
-  padding: 12px 16px;
-  gap: 8px;
+  padding: var(--space-3) var(--space-4);
+  gap: var(--space-2);
   border-bottom: 1px solid var(--border);
   background: var(--surface);
   flex-shrink: 0;
@@ -24,8 +24,8 @@
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 24px;
-  padding: 0 8px;
+  font-size: var(--text-xl);
+  padding: 0 var(--space-2);
   cursor: pointer;
   line-height: 1;
 }
@@ -33,7 +33,7 @@
 .cal-header-center {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   flex: 1;
   justify-content: center;
 }
@@ -45,7 +45,7 @@
   font-size: 15px;
   font-weight: 600;
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 6px;
 }
 
@@ -60,7 +60,7 @@
   color: var(--text-dim);
   font-size: 20px;
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   border-radius: 6px;
   line-height: 1;
 }
@@ -80,14 +80,14 @@
 }
 
 .cal-filter-toggle {
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 .cal-view-btn {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 12px;
+  font-size: var(--text-xs);
   padding: 4px 10px;
   border-radius: 4px;
   cursor: pointer;
@@ -106,10 +106,10 @@
 /* Sprint bar */
 
 .cal-sprints {
-  padding: 8px 16px;
+  padding: var(--space-2) var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   border-bottom: 1px solid var(--border);
 }
 
@@ -119,9 +119,9 @@
   justify-content: space-between;
   background: rgba(108, 99, 255, 0.1);
   border-left: 3px solid var(--accent);
-  padding: 6px 12px;
+  padding: var(--space-1h) var(--space-3);
   border-radius: 0 6px 6px 0;
-  font-size: 12px;
+  font-size: var(--text-xs);
 }
 
 .cal-sprint-label {
@@ -167,14 +167,14 @@
 }
 
 .cal-day {
-  padding: 0 16px;
+  padding: 0 var(--space-4);
 }
 
 .cal-day-header {
   position: sticky;
   top: 0;
   background: var(--bg);
-  padding: 12px 0 6px;
+  padding: var(--space-3) 0 var(--space-1h);
   font-size: 13px;
   font-weight: 600;
   color: var(--text-dim);
@@ -183,7 +183,7 @@
 }
 
 .cal-day-empty {
-  padding: 12px 0;
+  padding: var(--space-3) 0;
   font-size: 13px;
   color: var(--text-dim);
   font-style: italic;
@@ -194,7 +194,7 @@
 .cal-event {
   padding: 10px 12px;
   border-radius: 8px;
-  margin: 6px 0;
+  margin: var(--space-1h) 0;
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -224,11 +224,11 @@
 .cal-event-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .cal-event-time {
-  font-size: 12px;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   white-space: nowrap;
   min-width: 80px;
@@ -271,8 +271,8 @@
 /* Event detail (expanded) */
 
 .cal-event-detail {
-  margin-top: 8px;
-  padding-top: 8px;
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
   border-top: 1px solid var(--border);
   font-size: 13px;
 }
@@ -285,7 +285,7 @@
 .cal-detail-attendees {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .cal-attendee {
@@ -302,9 +302,9 @@
 
 .cal-detail-link {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: var(--space-1h);
   color: var(--accent);
-  font-size: 12px;
+  font-size: var(--text-xs);
   text-decoration: none;
 }
 

--- a/frontend/src/styles/desktop.css
+++ b/frontend/src/styles/desktop.css
@@ -48,7 +48,7 @@
     width: 100%;
     height: 32px;
     padding: 0;
-    font-size: 0.625rem;
+    font-size: var(--text-2xs);
     color: var(--text-dim);
     background: transparent;
     border-radius: 0;
@@ -85,15 +85,15 @@
   .desktop-chat-header {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem 0.75rem;
+    gap: var(--space-2);
+    padding: var(--space-1h) var(--space-3);
     border-bottom: 1px solid var(--border);
     background: var(--surface);
     flex-shrink: 0;
   }
 
   .desktop-chat-header .chat-model-select {
-    font-size: 0.8125rem;
+    font-size: var(--text-s);
   }
 
   .desktop-chat-header .mode-pills {
@@ -119,9 +119,9 @@
   .desktop-status-bar {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.25rem 0.75rem;
-    font-size: 0.75rem;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
     color: var(--text-dim);
   }
 
@@ -141,29 +141,29 @@
   }
 
   .status-label {
-    margin-right: 0.5rem;
+    margin-right: var(--space-2);
   }
 
   .status-session {
     font-family: var(--code-font);
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
     opacity: 0.7;
   }
 
   .status-branch {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: var(--space-1);
     margin-left: auto;
     font-family: var(--code-font);
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
   }
 
   .status-wt-badge {
     background: var(--accent);
     color: #fff;
     font-size: 0.5625rem;
-    padding: 0 0.25rem;
+    padding: 0 var(--space-1);
     border-radius: 3px;
     font-weight: 600;
   }
@@ -173,16 +173,16 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding: 0.5rem;
-    gap: 0.5rem;
+    padding: var(--space-2);
+    gap: var(--space-2);
   }
 
   .session-panel-new {
     background: var(--accent);
     color: #fff;
-    padding: 0.5rem;
+    padding: var(--space-2);
     border-radius: 6px;
-    font-size: 0.8125rem;
+    font-size: var(--text-s);
     font-weight: 500;
     width: 100%;
   }
@@ -193,7 +193,7 @@
 
   .session-panel-empty {
     color: var(--text-dim);
-    font-size: 0.8125rem;
+    font-size: var(--text-s);
     text-align: center;
     padding: 1rem 0;
   }
@@ -210,10 +210,10 @@
   .session-panel-item {
     display: flex;
     align-items: center;
-    padding: 0.5rem;
+    padding: var(--space-2);
     border-radius: 6px;
     cursor: pointer;
-    gap: 0.5rem;
+    gap: var(--space-2);
   }
 
   .session-panel-item:hover {
@@ -231,7 +231,7 @@
   }
 
   .session-panel-item-summary {
-    font-size: 0.8125rem;
+    font-size: var(--text-s);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -239,8 +239,8 @@
 
   .session-panel-item-meta {
     display: flex;
-    gap: 0.5rem;
-    font-size: 0.6875rem;
+    gap: var(--space-2);
+    font-size: var(--text-xxs);
     color: var(--text-dim);
     margin-top: 0.125rem;
   }
@@ -252,7 +252,7 @@
   .session-panel-delete {
     opacity: 0;
     padding: 0.125rem 0.375rem;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
     color: var(--text-dim);
     border-radius: 4px;
     flex-shrink: 0;
@@ -271,23 +271,23 @@
   .context-panel {
     display: flex;
     flex-direction: column;
-    padding: 0.5rem;
+    padding: var(--space-2);
   }
 
   .context-panel-header {
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--text-dim);
-    padding: 0.25rem 0.5rem;
-    margin-bottom: 0.25rem;
+    padding: var(--space-1) var(--space-2);
+    margin-bottom: var(--space-1);
   }
 
   .context-panel-empty {
     color: var(--text-dim);
-    font-size: 0.8125rem;
-    padding: 0.5rem;
+    font-size: var(--text-s);
+    padding: var(--space-2);
   }
 
   .context-panel-list {
@@ -299,10 +299,10 @@
   .context-panel-item {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.375rem 0.5rem;
+    gap: var(--space-2);
+    padding: var(--space-1h) var(--space-2);
     border-radius: 4px;
-    font-size: 0.8125rem;
+    font-size: var(--text-s);
     text-align: left;
     width: 100%;
   }
@@ -323,7 +323,7 @@
     width: 1rem;
     text-align: center;
     color: var(--accent);
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     flex-shrink: 0;
   }
 
@@ -336,7 +336,7 @@
   }
 
   .context-panel-size {
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
     color: var(--text-dim);
     font-family: var(--code-font);
     flex-shrink: 0;
@@ -346,32 +346,32 @@
   .file-browser-panel {
     display: flex;
     flex-direction: column;
-    padding: 0.5rem;
+    padding: var(--space-2);
     border-top: 1px solid var(--border);
     flex: 1;
     min-height: 0;
   }
 
   .file-browser-header {
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--text-dim);
-    padding: 0.25rem 0.5rem;
-    margin-bottom: 0.25rem;
+    padding: var(--space-1) var(--space-2);
+    margin-bottom: var(--space-1);
   }
 
   .file-browser-roots {
     display: flex;
-    gap: 0.25rem;
-    padding: 0 0.25rem;
-    margin-bottom: 0.5rem;
+    gap: var(--space-1);
+    padding: 0 var(--space-1);
+    margin-bottom: var(--space-2);
     flex-wrap: wrap;
   }
 
   .file-browser-root {
-    font-size: 0.6875rem;
+    font-size: var(--text-xxs);
     padding: 0.125rem 0.5rem;
     border-radius: 4px;
     background: var(--border);
@@ -399,8 +399,8 @@
     display: block;
     width: 100%;
     text-align: left;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.8125rem;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-s);
     border-radius: 4px;
     white-space: nowrap;
     overflow: hidden;
@@ -417,13 +417,13 @@
 
   .file-browser-empty {
     color: var(--text-dim);
-    font-size: 0.8125rem;
-    padding: 0.5rem;
+    font-size: var(--text-s);
+    padding: var(--space-2);
   }
 
   .file-browser-back {
-    font-size: 0.8125rem;
-    padding: 0.25rem 0.5rem;
+    font-size: var(--text-s);
+    padding: var(--space-1) var(--space-2);
     color: var(--text-dim);
     text-align: left;
     width: 100%;
@@ -444,9 +444,9 @@
     flex: 1;
     overflow: auto;
     font-family: var(--code-font);
-    font-size: 0.75rem;
+    font-size: var(--text-xs);
     line-height: 1.5;
-    padding: 0.5rem;
+    padding: var(--space-2);
     background: var(--code-bg);
     border-radius: 4px;
     white-space: pre-wrap;
@@ -474,15 +474,15 @@
 
   .cal-day {
     background: var(--bg);
-    padding: 0 8px;
+    padding: 0 var(--space-2);
     min-height: 150px;
   }
 
   .cal-day-header {
     position: static;
     text-align: center;
-    padding: 8px 0 4px;
-    font-size: 12px;
+    padding: var(--space-2) 0 var(--space-1);
+    font-size: var(--text-xs);
     border-bottom: none;
   }
 
@@ -492,9 +492,9 @@
   }
 
   .cal-event {
-    padding: 6px 8px;
+    padding: var(--space-1h) var(--space-2);
     margin: 3px 0;
-    font-size: 12px;
+    font-size: var(--text-xs);
   }
 
   .cal-event-time {
@@ -503,16 +503,16 @@
   }
 
   .cal-event-title {
-    font-size: 12px;
+    font-size: var(--text-xs);
   }
 
   .cal-event-row {
-    gap: 4px;
+    gap: var(--space-1);
   }
 
   .cal-sprints {
     flex-direction: row;
-    gap: 8px;
+    gap: var(--space-2);
     flex-wrap: wrap;
   }
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -71,7 +71,7 @@ a:hover {
 button {
   cursor: pointer;
   border: none;
-  padding: 0.5rem 1rem;
+  padding: var(--space-2) var(--space-4);
   border-radius: 6px;
   font-size: 0.875rem;
   background: transparent;
@@ -99,7 +99,7 @@ input,
 select,
 textarea {
   width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg);
@@ -348,16 +348,16 @@ textarea:focus {
   align-items: center;
   justify-content: center;
   min-height: 100dvh;
-  padding: 1rem;
+  padding: var(--space-4);
 }
 
 .login-form {
   background: var(--surface);
-  padding: 2rem;
+  padding: var(--space-6);
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--space-4);
   width: 320px;
   max-width: 100%;
 }
@@ -375,14 +375,14 @@ textarea:focus {
   min-height: 100dvh;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 var(--space-4);
 }
 
 .session-list-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 0 1rem;
+  padding: var(--space-5) 0 var(--space-4);
   position: sticky;
   top: 0;
   background: var(--bg);
@@ -456,14 +456,14 @@ textarea:focus {
 
 .hero-chat-btn {
   width: 100%;
-  padding: 1rem;
+  padding: var(--space-4);
   font-size: var(--text-base);
   font-weight: 600;
   border-radius: 14px;
   background: var(--accent);
   color: #fff;
   border: none;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   transition: background 0.15s;
@@ -479,13 +479,13 @@ textarea:focus {
   background: var(--surface);
   border-radius: 12px;
   overflow: hidden;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
 }
 
 .quick-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--space-3);
   padding: 0.9rem 1rem;
   background: transparent;
   border: none;
@@ -540,7 +540,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 0 0.5rem;
+  padding: var(--space-3) 0 var(--space-2);
 }
 
 .session-list-section-title {
@@ -595,8 +595,8 @@ textarea:focus {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 0;
+  gap: var(--space-3);
+  padding: var(--space-4) 0;
   border-bottom: 1px solid var(--border);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
@@ -639,7 +639,7 @@ textarea:focus {
 .session-item-meta {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
   margin-top: 0.2rem;
 }
 
@@ -702,13 +702,13 @@ textarea:focus {
 .inbox-nav-btn {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--space-3);
   width: 100%;
   padding: 0.9rem 1rem;
   background: var(--surface);
   border: none;
   border-radius: 12px;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-5);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
@@ -747,14 +747,14 @@ textarea:focus {
   min-height: 100dvh;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 1rem;
+  padding: 0 var(--space-4);
 }
 
 .inbox-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 1.5rem 0 1rem;
+  gap: var(--space-2);
+  padding: var(--space-5) 0 var(--space-4);
   position: sticky;
   top: 0;
   background: var(--bg);
@@ -767,7 +767,7 @@ textarea:focus {
   letter-spacing: -0.02em;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
 }
 
 .inbox-back {
@@ -800,14 +800,14 @@ textarea:focus {
 
 .inbox-empty-icon {
   font-size: 2.5rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
   color: var(--success);
 }
 
 .inbox-filters {
   display: flex;
-  gap: 0.5rem;
-  padding: 0 1rem 0.75rem;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-3);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
@@ -846,15 +846,15 @@ textarea:focus {
   text-align: center;
   font-size: 0.72rem;
   color: var(--text-dim);
-  padding: 0 0 0.75rem;
+  padding: 0 0 var(--space-3);
   opacity: 0.7;
 }
 
 .inbox-list {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding-bottom: 2rem;
+  gap: var(--space-3);
+  padding-bottom: var(--space-6);
 }
 
 .inbox-card-wrapper {
@@ -869,7 +869,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 1.5rem;
+  padding: 0 var(--space-5);
 }
 
 .inbox-action-label {
@@ -891,7 +891,7 @@ textarea:focus {
   position: relative;
   background: var(--surface);
   border-radius: 12px;
-  padding: 1rem;
+  padding: var(--space-4);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: pan-y;
@@ -952,9 +952,9 @@ textarea:focus {
 }
 
 .inbox-card-body {
-  margin-top: 0.75rem;
+  margin-top: var(--space-3);
   border-top: 1px solid var(--border);
-  padding-top: 0.75rem;
+  padding-top: var(--space-3);
 }
 
 .inbox-card-body-text {
@@ -968,8 +968,8 @@ textarea:focus {
 
 .inbox-card-buttons {
   display: flex;
-  gap: 0.75rem;
-  margin-top: 0.75rem;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
 }
 
 .inbox-btn {
@@ -1012,7 +1012,7 @@ textarea:focus {
 .chat-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--space-3);
   padding: 0.6rem 0.75rem;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
@@ -1158,10 +1158,10 @@ textarea:focus {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: 1rem 0.75rem;
+  padding: var(--space-4) var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: var(--space-3);
   min-height: 0;
   overscroll-behavior-y: contain;
 }
@@ -1205,7 +1205,7 @@ textarea:focus {
   max-width: 100%;
   font-size: var(--text-sm);
   border-left: 2px solid var(--border);
-  padding-left: 0.75rem;
+  padding-left: var(--space-3);
   opacity: 0.7;
 }
 
@@ -1244,7 +1244,7 @@ textarea:focus {
 .msg-meta {
   font-size: var(--text-2xs);
   color: var(--text-dim);
-  margin-top: 0.25rem;
+  margin-top: var(--space-1);
   padding: 0 0.2rem;
 }
 
@@ -1325,7 +1325,7 @@ textarea:focus {
 
 .msg-bubble--assistant pre {
   margin: 0.5em 0;
-  padding: 0.75rem;
+  padding: var(--space-3);
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -1550,7 +1550,7 @@ textarea:focus {
   padding: 0.4rem;
   border-radius: 4px;
   border-left: 3px solid rgba(244, 67, 54, 0.4);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .tool-pill-new {
@@ -1642,7 +1642,7 @@ textarea:focus {
 .tool-group-header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
   touch-action: manipulation;
   padding: 0.4rem 0.6rem;
   width: 100%;
@@ -1681,7 +1681,7 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 0 0 0.25rem;
+  padding: 0 0 var(--space-1);
   background: var(--surface);
   border-radius: 0 0 6px 6px;
   max-height: 40vh;
@@ -1705,7 +1705,7 @@ textarea:focus {
   right: 0;
   background: var(--surface);
   border-top: 1px solid var(--border);
-  padding: 1rem;
+  padding: var(--space-4);
   padding-bottom: max(1rem, env(safe-area-inset-bottom));
   z-index: 200;
   transform: translateY(100%);
@@ -1742,14 +1742,14 @@ textarea:focus {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text);
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
 }
 
 .perm-banner-desc {
   font-size: var(--text-s);
   color: var(--text-dim);
   line-height: 1.4;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
 }
 
 .perm-banner-info {
@@ -1758,7 +1758,7 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: var(--space-3);
   min-height: 0;
 }
 
@@ -1790,7 +1790,7 @@ textarea:focus {
 
 .perm-banner-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-2);
   flex-shrink: 0;
 }
 
@@ -1863,7 +1863,7 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
   background: var(--bg);
   flex-shrink: 0;
@@ -1872,8 +1872,8 @@ textarea:focus {
 .chat-input-command-strip {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.25rem;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-1);
   position: relative;
 }
 
@@ -1882,7 +1882,7 @@ textarea:focus {
   font-size: 0.6rem;
   color: var(--text-dim);
   opacity: 0.5;
-  margin-left: 0.5rem;
+  margin-left: var(--space-2);
 }
 
 .chat-input-branch {
@@ -1897,7 +1897,7 @@ textarea:focus {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-left: 0.5rem;
+  margin-left: var(--space-2);
 }
 
 .chat-input-branch--wt {
@@ -1987,11 +1987,11 @@ textarea:focus {
   position: absolute;
   bottom: 100%;
   right: 0;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   font-family: var(--code-font);
   font-size: var(--text-xxs);
   color: var(--text);
@@ -2004,7 +2004,7 @@ textarea:focus {
   display: flex;
   justify-content: space-between;
   padding: 0.2rem 0;
-  gap: 1rem;
+  gap: var(--space-4);
 }
 
 .token-bar-detail-row span:first-child {
@@ -2014,7 +2014,7 @@ textarea:focus {
 .chat-input-row {
   display: flex;
   align-items: flex-end;
-  gap: 0.5rem;
+  gap: var(--space-2);
   width: 100%;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -2255,7 +2255,7 @@ textarea:focus {
 /* Voice partial transcript overlay */
 
 .voice-partial {
-  padding: 0.375rem 0.75rem;
+  padding: var(--space-1h) var(--space-3);
   font-size: var(--text-sm);
   color: var(--text-secondary);
   font-style: italic;
@@ -2269,7 +2269,7 @@ textarea:focus {
 .voice-settings {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
 }
 
 .voice-toggle {
@@ -2332,7 +2332,7 @@ textarea:focus {
   border-radius: 12px;
   max-height: 240px;
   overflow-y: auto;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
   -webkit-overflow-scrolling: touch;
 }
 
@@ -2344,7 +2344,7 @@ textarea:focus {
 .slash-picker-item {
   display: flex;
   align-items: baseline;
-  gap: 0.5rem;
+  gap: var(--space-2);
   padding: 0.6rem 0.75rem;
   background: transparent;
   border: none;
@@ -2397,7 +2397,7 @@ textarea:focus {
 }
 
 .slash-picker-empty {
-  padding: 0.75rem;
+  padding: var(--space-3);
   color: var(--text-dim);
   font-size: var(--text-sm);
   text-align: center;
@@ -2412,7 +2412,7 @@ textarea:focus {
   border-radius: 12px;
   max-height: 240px;
   overflow-y: auto;
-  margin-bottom: 0.25rem;
+  margin-bottom: var(--space-1);
   -webkit-overflow-scrolling: touch;
 }
 
@@ -2424,7 +2424,7 @@ textarea:focus {
 .context-picker-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-2);
   padding: 0.6rem 0.75rem;
   background: transparent;
   border: none;
@@ -2467,7 +2467,7 @@ textarea:focus {
 }
 
 .context-picker-empty {
-  padding: 0.75rem;
+  padding: var(--space-3);
   color: var(--text-dim);
   font-size: var(--text-sm);
   text-align: center;
@@ -2478,14 +2478,14 @@ textarea:focus {
 .chat-input-context-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.25rem 0.5rem;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
 }
 
 .chat-input-context-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
   font-size: var(--text-xxs);
   color: var(--accent);
   background: rgba(108, 99, 255, 0.1);
@@ -2517,8 +2517,8 @@ textarea:focus {
 
 .chat-input-previews {
   display: flex;
-  gap: 0.5rem;
-  padding: 0.25rem 0;
+  gap: var(--space-2);
+  padding: var(--space-1) 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -2583,7 +2583,7 @@ textarea:focus {
 .chat-input-thinking {
   font-size: var(--text-xs);
   color: var(--text-dim);
-  padding: 0 0.25rem;
+  padding: 0 var(--space-1);
 }
 
 .chat-input-thinking::after {
@@ -2621,7 +2621,7 @@ textarea:focus {
 .viewer-header {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: var(--space-3);
   padding: 0.6rem 0.75rem;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
@@ -2661,7 +2661,7 @@ textarea:focus {
 .viewer-status {
   text-align: center;
   color: var(--text-dim);
-  padding: 2rem 1rem;
+  padding: var(--space-6) var(--space-4);
   font-size: var(--text-md);
 }
 
@@ -2677,8 +2677,8 @@ textarea:focus {
 .viewer-entry {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
@@ -2724,7 +2724,7 @@ textarea:focus {
 }
 
 .viewer-markdown {
-  padding: 1rem;
+  padding: var(--space-4);
   font-size: var(--text-md);
   line-height: 1.6;
   color: var(--text);
@@ -2782,7 +2782,7 @@ textarea:focus {
 
 .viewer-markdown pre {
   margin: 0.6em 0;
-  padding: 0.75rem;
+  padding: var(--space-3);
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -2843,7 +2843,7 @@ textarea:focus {
 }
 
 .viewer-code {
-  padding: 1rem;
+  padding: var(--space-4);
   font-family: var(--code-font);
   font-size: var(--text-s);
   line-height: 1.5;
@@ -2902,7 +2902,7 @@ textarea:focus {
 .viewer-root-bar {
   display: flex;
   gap: 0.35rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-2) var(--space-3);
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
@@ -2947,7 +2947,7 @@ textarea:focus {
   height: 100%;
   min-height: 0;
   flex: 1;
-  padding: 1rem;
+  padding: var(--space-4);
   font-family: var(--code-font);
   font-size: var(--text-s);
   line-height: 1.5;
@@ -2985,11 +2985,11 @@ textarea:focus {
 @media (min-width: 768px) {
   .session-list-page {
     max-width: 720px;
-    padding: 0 2rem;
+    padding: 0 var(--space-6);
   }
 
   .session-list-header {
-    padding: 1.5rem 0;
+    padding: var(--space-5) 0;
   }
 
   .quick-list {
@@ -2997,11 +2997,11 @@ textarea:focus {
   }
 
   .chat-messages {
-    padding: 1.5rem 2rem;
+    padding: var(--space-5) var(--space-6);
   }
 
   .chat-input {
-    padding: 0.75rem 2rem;
+    padding: var(--space-3) var(--space-6);
   }
 
   .msg-bubble {
@@ -3013,7 +3013,7 @@ textarea:focus {
   }
 
   .session-item {
-    padding: 1rem 0.5rem;
+    padding: var(--space-4) var(--space-2);
     border-radius: 8px;
   }
 
@@ -3082,7 +3082,7 @@ textarea:focus {
   min-height: 100dvh;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 16px 32px;
+  padding: 0 var(--space-4) var(--space-6);
   background: var(--bg);
   color: var(--text);
 }
@@ -3090,8 +3090,8 @@ textarea:focus {
 .todo-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 16px 0 8px;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
 }
 
 .todo-header h1 {
@@ -3108,7 +3108,7 @@ textarea:focus {
   color: var(--accent);
   font-size: var(--text-xl);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .todo-count {
@@ -3118,13 +3118,13 @@ textarea:focus {
   padding: 2px 8px;
   border-radius: 10px;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 .todo-filters {
   display: flex;
-  gap: 6px;
-  padding: 8px 0;
+  gap: var(--space-1h);
+  padding: var(--space-2) 0;
   overflow-x: auto;
 }
 
@@ -3148,7 +3148,7 @@ textarea:focus {
 .todo-hint {
   font-size: var(--text-xs);
   color: var(--text-dim);
-  padding: 4px 0 8px;
+  padding: var(--space-1) 0 var(--space-2);
 }
 
 .todo-empty {
@@ -3159,12 +3159,12 @@ textarea:focus {
 
 .todo-empty-icon {
   font-size: 2rem;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .todo-empty-hint {
   font-size: var(--text-s);
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .todo-empty-hint code {
@@ -3177,7 +3177,7 @@ textarea:focus {
 .todo-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .todo-card-wrapper {
@@ -3220,8 +3220,8 @@ textarea:focus {
 .todo-card-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 4px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1);
   font-size: var(--text-xs);
 }
 
@@ -3255,7 +3255,7 @@ textarea:focus {
 }
 
 .todo-card-meta {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   font-size: var(--text-xxs);
   color: var(--text-dim);
 }
@@ -3269,7 +3269,7 @@ textarea:focus {
 .todo-card-tree-node--child {
   margin-left: 20px;
   border-left: 2px solid var(--border);
-  padding-left: 8px;
+  padding-left: var(--space-2);
 }
 
 .todo-card-expand {
@@ -3310,7 +3310,7 @@ textarea:focus {
   padding: 2px 8px;
   border-radius: 10px;
   cursor: pointer;
-  margin-top: 4px;
+  margin-top: var(--space-1);
   opacity: 0.4;
   transition: opacity 0.15s;
 }
@@ -3322,7 +3322,7 @@ textarea:focus {
 }
 
 .todo-card-children {
-  margin-top: 4px;
+  margin-top: var(--space-1);
 }
 
 /* --- Add button in header --- */
@@ -3346,18 +3346,18 @@ textarea:focus {
 /* --- Create form --- */
 
 .todo-create-form {
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .todo-create-input {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   color: var(--text);
   font-size: var(--text-sm);
   width: 100%;
@@ -3374,7 +3374,7 @@ textarea:focus {
 
 .todo-create-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .todo-create-submit {
@@ -3382,7 +3382,7 @@ textarea:focus {
   color: var(--bg);
   border: none;
   border-radius: 8px;
-  padding: 6px 16px;
+  padding: var(--space-1h) var(--space-4);
   font-size: var(--text-s);
   font-weight: 600;
   cursor: pointer;
@@ -3398,7 +3398,7 @@ textarea:focus {
   border: 1px solid var(--border);
   color: var(--text-dim);
   border-radius: 8px;
-  padding: 6px 16px;
+  padding: var(--space-1h) var(--space-4);
   font-size: var(--text-s);
   cursor: pointer;
 }
@@ -3411,7 +3411,7 @@ textarea:focus {
   min-height: 100dvh;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 16px 32px;
+  padding: 0 var(--space-4) var(--space-6);
   background: var(--bg);
   color: var(--text);
 }
@@ -3419,8 +3419,8 @@ textarea:focus {
 .todo-detail-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 16px 0 8px;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
 }
 
 .todo-detail-header h1 {
@@ -3436,7 +3436,7 @@ textarea:focus {
   color: var(--accent);
   font-size: var(--text-xl);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .todo-detail-chat-btn {
@@ -3455,14 +3455,14 @@ textarea:focus {
   font-size: 1.1rem;
   font-weight: 600;
   line-height: 1.4;
-  padding: 8px 0 12px;
+  padding: var(--space-2) 0 var(--space-3);
 }
 
 .todo-detail-meta {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 0 16px;
+  gap: var(--space-2);
+  padding: var(--space-2) 0 var(--space-4);
   flex-wrap: wrap;
 }
 
@@ -3509,7 +3509,7 @@ textarea:focus {
 /* --- Sources --- */
 
 .todo-detail-sources {
-  padding: 8px 0;
+  padding: var(--space-2) 0;
 }
 
 .todo-detail-sources h2,
@@ -3520,7 +3520,7 @@ textarea:focus {
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-2);
 }
 
 .todo-detail-source-row {
@@ -3529,7 +3529,7 @@ textarea:focus {
   padding: 10px 12px;
   background: var(--surface);
   border-radius: 8px;
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1h);
   cursor: pointer;
   transition: background 0.15s;
 }
@@ -3578,7 +3578,7 @@ textarea:focus {
 .todo-detail-source-snippet {
   font-size: var(--text-xs);
   color: var(--text-dim);
-  margin-top: 4px;
+  margin-top: var(--space-1);
   line-height: 1.3;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -3589,7 +3589,7 @@ textarea:focus {
 /* --- Task Hint --- */
 
 .todo-detail-task-hint {
-  padding: 12px 0;
+  padding: var(--space-3) 0;
 }
 
 .todo-detail-task-hint p {
@@ -3606,25 +3606,25 @@ textarea:focus {
 /* --- Context --- */
 
 .todo-detail-context {
-  padding: 8px 0;
+  padding: var(--space-2) 0;
 }
 
 .todo-detail-context-group {
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 .todo-detail-context-group h3 {
   font-size: var(--text-xxs);
   font-weight: 600;
   color: var(--text-dim);
-  margin: 0 0 6px;
+  margin: 0 0 var(--space-1h);
   text-transform: uppercase;
 }
 
 .todo-detail-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--space-1h);
 }
 
 .todo-detail-chip {
@@ -3657,7 +3657,7 @@ textarea:focus {
   min-height: 100dvh;
   max-width: 600px;
   margin: 0 auto;
-  padding: 0 16px 32px;
+  padding: 0 var(--space-4) var(--space-6);
   background: var(--bg);
   color: var(--text);
 }
@@ -3665,8 +3665,8 @@ textarea:focus {
 .task-board-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 16px 0 8px;
+  gap: var(--space-2);
+  padding: var(--space-4) 0 var(--space-2);
 }
 
 .task-board-header h1 {
@@ -3683,7 +3683,7 @@ textarea:focus {
   color: var(--accent);
   font-size: var(--text-xl);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .task-board-count {
@@ -3693,7 +3693,7 @@ textarea:focus {
   padding: 2px 8px;
   border-radius: 10px;
   vertical-align: middle;
-  margin-left: 4px;
+  margin-left: var(--space-1);
 }
 
 .task-board-add-btn {
@@ -3702,7 +3702,7 @@ textarea:focus {
   color: var(--accent);
   font-size: var(--text-xl);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
 }
 
 .task-board-list {
@@ -3719,18 +3719,18 @@ textarea:focus {
 
 .task-board-empty-icon {
   font-size: 2rem;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .task-board-empty-hint {
   font-size: var(--text-s);
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 /* ── Task Node ──────────────────────────────────────────── */
 
 .task-node {
-  padding: 4px 0;
+  padding: var(--space-1) 0;
 }
 
 .task-node--active > .task-node-row {
@@ -3744,8 +3744,8 @@ textarea:focus {
 .task-node-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
+  gap: var(--space-1h);
+  padding: var(--space-1h) var(--space-2);
   border-radius: 6px;
   background: var(--surface);
 }
@@ -3815,7 +3815,7 @@ textarea:focus {
 
 .task-node-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
   opacity: 0;
   transition: opacity 0.15s;
 }
@@ -3844,7 +3844,7 @@ textarea:focus {
 }
 
 .task-node-children {
-  margin-left: 8px;
+  margin-left: var(--space-2);
   border-left: 1px solid var(--border);
 }
 
@@ -3853,9 +3853,9 @@ textarea:focus {
 .task-create-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  margin: 8px 0;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  margin: var(--space-2) 0;
   background: var(--surface);
   border-radius: 8px;
   border: 1px solid var(--border);
@@ -3865,7 +3865,7 @@ textarea:focus {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
   color: var(--text);
   font-size: var(--text-md);
   outline: none;
@@ -3877,7 +3877,7 @@ textarea:focus {
 
 .task-create-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   justify-content: flex-end;
 }
 
@@ -3886,7 +3886,7 @@ textarea:focus {
   color: var(--bg);
   border: none;
   border-radius: 6px;
-  padding: 6px 16px;
+  padding: var(--space-1h) var(--space-4);
   font-size: var(--text-sm);
   cursor: pointer;
 }
@@ -3904,7 +3904,7 @@ textarea:focus {
   background: none;
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 6px 16px;
+  padding: var(--space-1h) var(--space-4);
   font-size: var(--text-sm);
   color: var(--text-dim);
   cursor: pointer;
@@ -3918,15 +3918,15 @@ textarea:focus {
 /* ── Loop Controls ────────────────────────────────────── */
 
 .loop-controls {
-  padding: 8px 0;
-  margin-bottom: 8px;
+  padding: var(--space-2) 0;
+  margin-bottom: var(--space-2);
 }
 
 .loop-controls-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-1h);
 }
 
 .loop-controls-pill {
@@ -3984,7 +3984,7 @@ textarea:focus {
 .loop-controls-spec-toggle {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   font-size: var(--text-s);
   color: var(--text-dim);
   cursor: pointer;
@@ -3992,7 +3992,7 @@ textarea:focus {
 
 .loop-controls-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .loop-controls-btn {
@@ -4035,20 +4035,20 @@ textarea:focus {
 }
 
 .loop-controls-approval {
-  margin-top: 8px;
+  margin-top: var(--space-2);
 }
 
 .loop-controls-approval-msg {
   font-size: var(--text-sm);
   color: var(--accent);
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1h);
 }
 
 .loop-controls-bar {
   height: 4px;
   background: var(--border);
   border-radius: 2px;
-  margin-top: 8px;
+  margin-top: var(--space-2);
   overflow: hidden;
 }
 
@@ -4064,13 +4064,13 @@ textarea:focus {
 .task-sidebar {
   background: var(--surface);
   border-radius: 8px;
-  padding: 12px;
-  margin-bottom: 8px;
+  padding: var(--space-3);
+  margin-bottom: var(--space-2);
   border: 1px solid var(--border);
 }
 
 .task-sidebar--collapsed {
-  padding: 8px 12px;
+  padding: var(--space-2) var(--space-3);
 }
 
 .task-sidebar-toggle {
@@ -4080,7 +4080,7 @@ textarea:focus {
   font-size: var(--text-s);
   cursor: pointer;
   padding: 0;
-  margin-bottom: 6px;
+  margin-bottom: var(--space-1h);
 }
 
 .task-sidebar--collapsed .task-sidebar-toggle {
@@ -4088,13 +4088,13 @@ textarea:focus {
 }
 
 .task-sidebar-current {
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .task-sidebar-title {
   font-size: 0.95rem;
   font-weight: 600;
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-1);
 }
 
 .task-sidebar-desc {
@@ -4106,7 +4106,7 @@ textarea:focus {
 .task-sidebar-annotations {
   list-style: none;
   padding: 0;
-  margin: 6px 0 0;
+  margin: var(--space-1h) 0 0;
 }
 
 .task-sidebar-annotations li {
@@ -4117,21 +4117,21 @@ textarea:focus {
 
 .task-sidebar-review {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-2);
 }
 
 .task-sidebar-reject-form {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .task-sidebar-reject-input {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 4px;
-  padding: 4px 8px;
+  padding: var(--space-1) var(--space-2);
   color: var(--text);
   font-size: var(--text-s);
   outline: none;
@@ -4145,7 +4145,7 @@ textarea:focus {
 .task-sidebar-siblings h4 {
   font-size: var(--text-s);
   color: var(--text-dim);
-  margin: 0 0 4px;
+  margin: 0 0 var(--space-1);
 }
 
 .task-sidebar-siblings ul {
@@ -4157,7 +4157,7 @@ textarea:focus {
 .task-sidebar-sibling {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1h);
   font-size: var(--text-s);
   padding: 3px 0;
 }
@@ -4170,8 +4170,8 @@ textarea:focus {
 .task-sidebar-progress {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
 }
 
 .task-sidebar-progress .loop-controls-bar {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -254,7 +254,7 @@ textarea:focus {
   right: calc(50% - 20px);
   background: var(--danger);
   color: #fff;
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   min-width: 16px;
   height: 16px;
   border-radius: 8px;
@@ -363,7 +363,7 @@ textarea:focus {
 }
 
 .login-form h1 {
-  font-size: 1.25rem;
+  font-size: var(--text-lg);
   text-align: center;
 }
 
@@ -390,13 +390,13 @@ textarea:focus {
 }
 
 .session-list-header h1 {
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 
 .check-update-btn {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   padding: 0.35rem 0.55rem;
   border-radius: 8px;
   background: transparent;
@@ -424,7 +424,7 @@ textarea:focus {
   padding: 0.55rem 1rem;
   background: var(--accent);
   color: #fff;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 500;
   text-align: center;
   border: none;
@@ -457,7 +457,7 @@ textarea:focus {
 .hero-chat-btn {
   width: 100%;
   padding: 1rem;
-  font-size: 1rem;
+  font-size: var(--text-base);
   font-weight: 600;
   border-radius: 14px;
   background: var(--accent);
@@ -508,7 +508,7 @@ textarea:focus {
 }
 
 .quick-row-label {
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text);
   white-space: nowrap;
@@ -544,7 +544,7 @@ textarea:focus {
 }
 
 .session-list-section-title {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   color: var(--text-dim);
   text-transform: uppercase;
@@ -552,7 +552,7 @@ textarea:focus {
 }
 
 .session-list-clear {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   padding: 0.25rem 0.6rem;
   background: transparent;
   color: var(--text-dim);
@@ -583,7 +583,7 @@ textarea:focus {
   justify-content: center;
   background: var(--danger);
   color: #fff;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   letter-spacing: 0.02em;
   cursor: pointer;
@@ -616,7 +616,7 @@ textarea:focus {
 }
 
 .session-item-summary {
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text);
   overflow: hidden;
@@ -625,7 +625,7 @@ textarea:focus {
 }
 
 .session-rename-input {
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text);
   background: var(--bg-secondary);
@@ -644,12 +644,12 @@ textarea:focus {
 }
 
 .session-item-time {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
 }
 
 .session-item-branch {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-family: var(--code-font);
   color: var(--accent);
   background: rgba(108, 99, 255, 0.12);
@@ -662,14 +662,14 @@ textarea:focus {
 }
 
 .session-item-hash {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-family: var(--code-font);
   color: var(--text-dim);
   opacity: 0.6;
 }
 
 .session-item-tokens {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-family: var(--code-font);
   color: var(--text-dim);
 }
@@ -693,7 +693,7 @@ textarea:focus {
 
 .session-item-chevron {
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   flex-shrink: 0;
 }
 
@@ -720,7 +720,7 @@ textarea:focus {
 }
 
 .inbox-nav-label {
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text);
   flex: 1;
@@ -728,7 +728,7 @@ textarea:focus {
 }
 
 .inbox-nav-badge {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-weight: 700;
   color: #fff;
   background: var(--accent);
@@ -762,7 +762,7 @@ textarea:focus {
 }
 
 .inbox-header h1 {
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   font-weight: 700;
   letter-spacing: -0.02em;
   display: flex;
@@ -781,7 +781,7 @@ textarea:focus {
 }
 
 .inbox-count {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 700;
   color: #fff;
   background: var(--accent);
@@ -795,7 +795,7 @@ textarea:focus {
   text-align: center;
   color: var(--text-dim);
   padding: 3rem 1rem;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
 }
 
 .inbox-empty-icon {
@@ -873,7 +873,7 @@ textarea:focus {
 }
 
 .inbox-action-label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -905,7 +905,7 @@ textarea:focus {
 }
 
 .inbox-card-agent {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-family: var(--code-font);
   color: var(--accent);
   background: rgba(108, 99, 255, 0.12);
@@ -915,12 +915,12 @@ textarea:focus {
 }
 
 .inbox-card-time {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text-dim);
 }
 
 .inbox-card-title {
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   font-weight: 500;
   color: var(--text);
   margin-bottom: 0.35rem;
@@ -975,7 +975,7 @@ textarea:focus {
 .inbox-btn {
   flex: 1;
   padding: 0.55rem 0.75rem;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   border-radius: 8px;
   border: none;
@@ -1029,7 +1029,7 @@ textarea:focus {
 }
 
 .chat-header-status {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text-dim);
 }
 
@@ -1038,7 +1038,7 @@ textarea:focus {
   flex: 0 1 auto;
   max-width: 6.5rem;
   padding: 0.4rem 1.4rem 0.4rem 0.5rem;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   background: var(--bg);
   color: var(--text);
   border: 1px solid var(--border);
@@ -1066,7 +1066,7 @@ textarea:focus {
 
 .mode-pill {
   padding: 0.35rem 0.55rem;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-weight: 600;
   background: transparent;
   color: var(--text-dim);
@@ -1102,7 +1102,7 @@ textarea:focus {
 
 .chat-header-branch {
   font-family: var(--code-font);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   color: var(--text-dim);
   background: var(--bg);
   padding: 0.2rem 0.45rem;
@@ -1131,7 +1131,7 @@ textarea:focus {
   border-radius: 50%;
   background: var(--danger);
   color: #fff;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-weight: 700;
   flex-shrink: 0;
   animation: pulse-offline 1.5s ease-in-out infinite;
@@ -1151,7 +1151,7 @@ textarea:focus {
   text-align: center;
   color: var(--text-dim);
   padding: 3rem 1rem;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
 }
 
 .chat-messages {
@@ -1173,7 +1173,7 @@ textarea:focus {
   padding: 0.7rem 0.9rem;
   border-radius: 14px;
   line-height: 1.5;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   word-break: break-word;
   overflow-wrap: break-word;
 }
@@ -1203,7 +1203,7 @@ textarea:focus {
   color: var(--text-dim);
   border-bottom-left-radius: 4px;
   max-width: 100%;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   border-left: 2px solid var(--border);
   padding-left: 0.75rem;
   opacity: 0.7;
@@ -1242,7 +1242,7 @@ textarea:focus {
 }
 
 .msg-meta {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   color: var(--text-dim);
   margin-top: 0.25rem;
   padding: 0 0.2rem;
@@ -1336,7 +1336,7 @@ textarea:focus {
 .msg-bubble--assistant pre code {
   background: transparent;
   padding: 0;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   line-height: 1.5;
   color: var(--text);
 }
@@ -1409,7 +1409,7 @@ textarea:focus {
   align-self: flex-start;
   width: 100%;
   border-radius: 6px;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   overflow: hidden;
 }
 
@@ -1425,7 +1425,7 @@ textarea:focus {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: inherit;
   min-width: 0;
 }
@@ -1472,7 +1472,7 @@ textarea:focus {
   min-width: 0;
   color: var(--text-dim);
   font-family: var(--code-font);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1480,7 +1480,7 @@ textarea:focus {
 
 .tool-pill-status {
   color: var(--text-dim);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   flex-shrink: 0;
   opacity: 0.7;
 }
@@ -1525,7 +1525,7 @@ textarea:focus {
 
 .tool-pill-pre {
   font-family: var(--code-font);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   line-height: 1.4;
   color: var(--text-dim);
   white-space: pre-wrap;
@@ -1583,7 +1583,7 @@ textarea:focus {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: inherit;
   font-style: italic;
   min-width: 0;
@@ -1595,7 +1595,7 @@ textarea:focus {
 
 .thinking-block-label {
   color: var(--text-dim);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-style: italic;
 }
 
@@ -1618,7 +1618,7 @@ textarea:focus {
 
 .thinking-block-text {
   font-family: var(--code-font);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   line-height: 1.4;
   color: var(--text-dim);
   white-space: pre-wrap;
@@ -1652,7 +1652,7 @@ textarea:focus {
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: inherit;
 }
 
@@ -1667,7 +1667,7 @@ textarea:focus {
 }
 
 .tool-group-label {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text-dim);
 }
 
@@ -1739,14 +1739,14 @@ textarea:focus {
 }
 
 .perm-banner-title {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   color: var(--text);
   margin-bottom: 0.25rem;
 }
 
 .perm-banner-desc {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   color: var(--text-dim);
   line-height: 1.4;
   margin-bottom: 0.75rem;
@@ -1783,7 +1783,7 @@ textarea:focus {
 }
 
 .perm-banner-timer {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   text-align: center;
 }
@@ -1797,7 +1797,7 @@ textarea:focus {
 .perm-banner-btn {
   flex: 1;
   padding: 0.7rem 0.5rem;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
   border-radius: 10px;
   border: none;
@@ -1831,7 +1831,7 @@ textarea:focus {
 
 .perm-banner-tier {
   display: inline-block;
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -1887,7 +1887,7 @@ textarea:focus {
 
 .chat-input-branch {
   font-family: var(--code-font);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   color: var(--text-dim);
   background: var(--surface);
   padding: 0.15rem 0.4rem;
@@ -1915,7 +1915,7 @@ textarea:focus {
   margin-left: auto;
   padding: 0.15rem 0.5rem;
   font-family: var(--code-font);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   border-radius: 4px;
   border: 1px solid var(--border);
   background: var(--surface);
@@ -1980,7 +1980,7 @@ textarea:focus {
 
 .token-bar-sigma {
   font-weight: 600;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
 }
 
 .token-bar-detail {
@@ -1993,7 +1993,7 @@ textarea:focus {
   border-radius: 8px;
   padding: 0.5rem 0.75rem;
   font-family: var(--code-font);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text);
   min-width: 14rem;
   z-index: 10;
@@ -2086,7 +2086,7 @@ textarea:focus {
   height: 3rem;
   border-radius: 50%;
   padding: 0;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   background: var(--danger);
   color: #fff;
   display: flex;
@@ -2107,7 +2107,7 @@ textarea:focus {
   height: 1.7rem;
   border-radius: 50%;
   padding: 0;
-  font-size: 1rem;
+  font-size: var(--text-base);
   font-weight: 600;
   background: transparent;
   color: var(--text-dim);
@@ -2134,7 +2134,7 @@ textarea:focus {
   height: 1.7rem;
   border-radius: 50%;
   padding: 0;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 700;
   background: transparent;
   color: var(--text-dim);
@@ -2256,7 +2256,7 @@ textarea:focus {
 
 .voice-partial {
   padding: 0.375rem 0.75rem;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--text-secondary);
   font-style: italic;
   border-bottom: 1px solid var(--border);
@@ -2275,7 +2275,7 @@ textarea:focus {
 .voice-toggle {
   background: none;
   border: none;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   cursor: pointer;
   padding: 0.15rem 0.3rem;
   border-radius: 4px;
@@ -2309,7 +2309,7 @@ textarea:focus {
 }
 
 .voice-picker {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border);
@@ -2350,7 +2350,7 @@ textarea:focus {
   border: none;
   border-bottom: 1px solid var(--border);
   text-align: left;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--text);
   cursor: pointer;
   min-width: 0;
@@ -2371,7 +2371,7 @@ textarea:focus {
 
 .slash-picker-scope {
   flex-shrink: 0;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
 }
 
 .slash-picker-name {
@@ -2382,7 +2382,7 @@ textarea:focus {
 
 .slash-picker-desc {
   color: var(--text-dim);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2391,7 +2391,7 @@ textarea:focus {
 
 .slash-picker-collision {
   width: 100%;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--warning, #e65100);
   margin-top: 0.15rem;
 }
@@ -2399,7 +2399,7 @@ textarea:focus {
 .slash-picker-empty {
   padding: 0.75rem;
   color: var(--text-dim);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   text-align: center;
 }
 
@@ -2430,7 +2430,7 @@ textarea:focus {
   border: none;
   border-bottom: 1px solid var(--border);
   text-align: left;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--text);
   cursor: pointer;
 }
@@ -2462,14 +2462,14 @@ textarea:focus {
 
 .context-picker-size {
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   margin-left: auto;
 }
 
 .context-picker-empty {
   padding: 0.75rem;
   color: var(--text-dim);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   text-align: center;
 }
 
@@ -2486,7 +2486,7 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--accent);
   background: rgba(108, 99, 255, 0.1);
   border: 1px solid var(--accent);
@@ -2498,14 +2498,14 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   cursor: pointer;
   padding: 0;
   line-height: 1;
 }
 
 .chat-input-btn--context {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 600;
 }
 
@@ -2546,7 +2546,7 @@ textarea:focus {
   width: 1.2rem;
   height: 1.2rem;
   padding: 0;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   line-height: 1;
   border-radius: 50%;
   background: rgba(0, 0, 0, 0.7);
@@ -2560,7 +2560,7 @@ textarea:focus {
 /* Images in message bubbles */
 
 .msg-bubble-context {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--accent);
   margin-bottom: 0.3rem;
   opacity: 0.8;
@@ -2581,7 +2581,7 @@ textarea:focus {
 }
 
 .chat-input-thinking {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   padding: 0 0.25rem;
 }
@@ -2630,7 +2630,7 @@ textarea:focus {
 }
 
 .viewer-header-back {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   padding: 0.35rem 0.6rem;
   background: transparent;
   color: var(--text);
@@ -2662,7 +2662,7 @@ textarea:focus {
   text-align: center;
   color: var(--text-dim);
   padding: 2rem 1rem;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
 }
 
 .viewer-status--error {
@@ -2682,7 +2682,7 @@ textarea:focus {
   border-bottom: 1px solid var(--border);
   background: transparent;
   color: var(--text);
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   text-align: left;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
@@ -2701,7 +2701,7 @@ textarea:focus {
 
 .viewer-entry-icon {
   font-family: var(--code-font);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--accent);
   width: 1rem;
   text-align: center;
@@ -2725,7 +2725,7 @@ textarea:focus {
 
 .viewer-markdown {
   padding: 1rem;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   line-height: 1.6;
   color: var(--text);
   -webkit-user-select: text;
@@ -2793,7 +2793,7 @@ textarea:focus {
 .viewer-markdown pre code {
   background: transparent;
   padding: 0;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   line-height: 1.5;
   color: var(--text);
 }
@@ -2845,7 +2845,7 @@ textarea:focus {
 .viewer-code {
   padding: 1rem;
   font-family: var(--code-font);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   line-height: 1.5;
   color: var(--text);
   white-space: pre-wrap;
@@ -2854,7 +2854,7 @@ textarea:focus {
 }
 
 .viewer-header-branch {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-family: var(--code-font);
   color: var(--accent);
   background: rgba(108, 99, 255, 0.12);
@@ -2868,7 +2868,7 @@ textarea:focus {
 }
 
 .viewer-header-action {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   padding: 0.3rem 0.7rem;
   border-radius: 6px;
@@ -2915,7 +2915,7 @@ textarea:focus {
 }
 
 .viewer-root-btn {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-family: var(--code-font);
   font-weight: 600;
   padding: 0.3rem 0.6rem;
@@ -2949,7 +2949,7 @@ textarea:focus {
   flex: 1;
   padding: 1rem;
   font-family: var(--code-font);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   line-height: 1.5;
   color: var(--text);
   background: var(--bg);
@@ -3096,7 +3096,7 @@ textarea:focus {
 
 .todo-header h1 {
   flex: 1;
-  font-size: 1.25rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   margin: 0;
 }
@@ -3106,7 +3106,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   cursor: pointer;
   padding: 4px 8px;
 }
@@ -3114,7 +3114,7 @@ textarea:focus {
 .todo-count {
   background: var(--accent);
   color: var(--bg);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   padding: 2px 8px;
   border-radius: 10px;
   vertical-align: middle;
@@ -3134,7 +3134,7 @@ textarea:focus {
   color: var(--text-dim);
   border-radius: 16px;
   padding: 4px 14px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   cursor: pointer;
   white-space: nowrap;
 }
@@ -3146,7 +3146,7 @@ textarea:focus {
 }
 
 .todo-hint {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   padding: 4px 0 8px;
 }
@@ -3163,7 +3163,7 @@ textarea:focus {
 }
 
 .todo-empty-hint {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   margin-top: 8px;
 }
 
@@ -3171,7 +3171,7 @@ textarea:focus {
   background: var(--surface);
   padding: 2px 6px;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
 }
 
 .todo-list {
@@ -3196,7 +3196,7 @@ textarea:focus {
 }
 
 .todo-action-label {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   text-transform: uppercase;
 }
@@ -3222,7 +3222,7 @@ textarea:focus {
   align-items: center;
   gap: 8px;
   margin-bottom: 4px;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
 }
 
 .todo-card-status {
@@ -3239,7 +3239,7 @@ textarea:focus {
   background: var(--bg);
   padding: 1px 6px;
   border-radius: 4px;
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-dim);
 }
@@ -3250,13 +3250,13 @@ textarea:focus {
 }
 
 .todo-card-summary {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   line-height: 1.35;
 }
 
 .todo-card-meta {
   margin-top: 4px;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text-dim);
 }
 
@@ -3276,14 +3276,14 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   padding: 2px 6px;
   cursor: pointer;
   flex-shrink: 0;
 }
 
 .todo-card-progress {
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   color: var(--accent);
   margin-left: auto;
   font-weight: 600;
@@ -3298,7 +3298,7 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-weight: bold;
 }
 
@@ -3306,7 +3306,7 @@ textarea:focus {
   background: none;
   border: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   padding: 2px 8px;
   border-radius: 10px;
   cursor: pointer;
@@ -3359,7 +3359,7 @@ textarea:focus {
   border-radius: 8px;
   padding: 8px 12px;
   color: var(--text);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   width: 100%;
 }
 
@@ -3369,7 +3369,7 @@ textarea:focus {
   border-radius: 8px;
   padding: 6px 10px;
   color: var(--text);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
 }
 
 .todo-create-actions {
@@ -3383,7 +3383,7 @@ textarea:focus {
   border: none;
   border-radius: 8px;
   padding: 6px 16px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   cursor: pointer;
 }
@@ -3399,7 +3399,7 @@ textarea:focus {
   color: var(--text-dim);
   border-radius: 8px;
   padding: 6px 16px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   cursor: pointer;
 }
 
@@ -3425,7 +3425,7 @@ textarea:focus {
 
 .todo-detail-header h1 {
   flex: 1;
-  font-size: 1.25rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   margin: 0;
 }
@@ -3434,7 +3434,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   cursor: pointer;
   padding: 4px 8px;
 }
@@ -3445,7 +3445,7 @@ textarea:focus {
   border: none;
   border-radius: 8px;
   padding: 6px 14px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
@@ -3467,7 +3467,7 @@ textarea:focus {
 }
 
 .todo-detail-status {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   padding: 2px 10px;
   border-radius: 10px;
@@ -3488,7 +3488,7 @@ textarea:focus {
 }
 
 .todo-detail-urgency {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   background: var(--surface);
   padding: 2px 10px;
@@ -3496,12 +3496,12 @@ textarea:focus {
 }
 
 .todo-detail-age {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
 }
 
 .todo-detail-profile {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--accent);
   margin-left: auto;
 }
@@ -3515,7 +3515,7 @@ textarea:focus {
 .todo-detail-sources h2,
 .todo-detail-task-hint h2,
 .todo-detail-context h2 {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   font-weight: 600;
   color: var(--text-dim);
   text-transform: uppercase;
@@ -3550,7 +3550,7 @@ textarea:focus {
   background: var(--bg);
   padding: 2px 8px;
   border-radius: 4px;
-  font-size: 0.65rem;
+  font-size: var(--text-2xs);
   font-weight: 600;
   color: var(--text-dim);
   align-self: flex-start;
@@ -3564,19 +3564,19 @@ textarea:focus {
 }
 
 .todo-detail-source-title {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   font-weight: 500;
   line-height: 1.3;
 }
 
 .todo-detail-source-author {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   color: var(--text-dim);
   margin-top: 2px;
 }
 
 .todo-detail-source-snippet {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   margin-top: 4px;
   line-height: 1.3;
@@ -3593,7 +3593,7 @@ textarea:focus {
 }
 
 .todo-detail-task-hint p {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   line-height: 1.4;
   color: var(--text);
   background: var(--surface);
@@ -3614,7 +3614,7 @@ textarea:focus {
 }
 
 .todo-detail-context-group h3 {
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   font-weight: 600;
   color: var(--text-dim);
   margin: 0 0 6px;
@@ -3633,7 +3633,7 @@ textarea:focus {
   color: var(--text);
   border-radius: 6px;
   padding: 4px 10px;
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-family: inherit;
 }
 
@@ -3671,7 +3671,7 @@ textarea:focus {
 
 .task-board-header h1 {
   flex: 1;
-  font-size: 1.25rem;
+  font-size: var(--text-lg);
   font-weight: 600;
   margin: 0;
 }
@@ -3681,7 +3681,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   cursor: pointer;
   padding: 4px 8px;
 }
@@ -3689,7 +3689,7 @@ textarea:focus {
 .task-board-count {
   background: var(--accent);
   color: var(--bg);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   padding: 2px 8px;
   border-radius: 10px;
   vertical-align: middle;
@@ -3700,7 +3700,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--accent);
-  font-size: 1.5rem;
+  font-size: var(--text-xl);
   cursor: pointer;
   padding: 4px 8px;
 }
@@ -3723,7 +3723,7 @@ textarea:focus {
 }
 
 .task-board-empty-hint {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   margin-top: 8px;
 }
 
@@ -3758,7 +3758,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 0.7rem;
+  font-size: var(--text-xxs);
   cursor: pointer;
   padding: 2px 4px;
   min-width: 20px;
@@ -3767,7 +3767,7 @@ textarea:focus {
 .task-node-status {
   background: none;
   border: none;
-  font-size: 1rem;
+  font-size: var(--text-base);
   cursor: pointer;
   padding: 2px;
   min-width: 20px;
@@ -3804,7 +3804,7 @@ textarea:focus {
 
 .task-node-title {
   flex: 1;
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   line-height: 1.3;
 }
 
@@ -3828,7 +3828,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 1rem;
+  font-size: var(--text-base);
   cursor: pointer;
   padding: 2px 6px;
   border-radius: 4px;
@@ -3867,7 +3867,7 @@ textarea:focus {
   border-radius: 6px;
   padding: 8px 12px;
   color: var(--text);
-  font-size: 0.9rem;
+  font-size: var(--text-md);
   outline: none;
 }
 
@@ -3887,7 +3887,7 @@ textarea:focus {
   border: none;
   border-radius: 6px;
   padding: 6px 16px;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   cursor: pointer;
 }
 
@@ -3905,7 +3905,7 @@ textarea:focus {
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 6px 16px;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--text-dim);
   cursor: pointer;
 }
@@ -3930,7 +3930,7 @@ textarea:focus {
 }
 
 .loop-controls-pill {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   font-weight: 600;
   padding: 2px 10px;
   border-radius: 10px;
@@ -3954,7 +3954,7 @@ textarea:focus {
 }
 
 .loop-controls-progress {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   color: var(--text-dim);
 }
 
@@ -3978,14 +3978,14 @@ textarea:focus {
   border-radius: 6px;
   padding: 6px 10px;
   color: var(--text);
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
 }
 
 .loop-controls-spec-toggle {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   color: var(--text-dim);
   cursor: pointer;
 }
@@ -4000,7 +4000,7 @@ textarea:focus {
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 6px 14px;
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--text);
   cursor: pointer;
 }
@@ -4039,7 +4039,7 @@ textarea:focus {
 }
 
 .loop-controls-approval-msg {
-  font-size: 0.85rem;
+  font-size: var(--text-sm);
   color: var(--accent);
   margin-bottom: 6px;
 }
@@ -4077,7 +4077,7 @@ textarea:focus {
   background: none;
   border: none;
   color: var(--text-dim);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   cursor: pointer;
   padding: 0;
   margin-bottom: 6px;
@@ -4098,7 +4098,7 @@ textarea:focus {
 }
 
 .task-sidebar-desc {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   color: var(--text-dim);
   margin: 0;
 }
@@ -4110,7 +4110,7 @@ textarea:focus {
 }
 
 .task-sidebar-annotations li {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   padding: 2px 0;
 }
@@ -4133,7 +4133,7 @@ textarea:focus {
   border-radius: 4px;
   padding: 4px 8px;
   color: var(--text);
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   outline: none;
   width: 120px;
 }
@@ -4143,7 +4143,7 @@ textarea:focus {
 }
 
 .task-sidebar-siblings h4 {
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   color: var(--text-dim);
   margin: 0 0 4px;
 }
@@ -4158,7 +4158,7 @@ textarea:focus {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.8rem;
+  font-size: var(--text-s);
   padding: 3px 0;
 }
 
@@ -4180,6 +4180,6 @@ textarea:focus {
 }
 
 .task-sidebar-progress-label {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -25,14 +25,19 @@
   --warning: #ff9800;
 
   /* Type scale */
+  --text-2xs: 0.65rem;
+  --text-xxs: 0.7rem;
   --text-xs: 0.75rem;
+  --text-s: 0.8rem;
   --text-sm: 0.85rem;
+  --text-md: 0.9rem;
   --text-base: 1rem;
   --text-lg: 1.25rem;
   --text-xl: 1.5rem;
 
   /* Spacing scale */
   --space-1: 0.25rem;
+  --space-1h: 0.375rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;


### PR DESCRIPTION
## Summary

- **Expand token scales**: Added 4 type tokens (`--text-2xs`, `--text-xxs`, `--text-s`, `--text-md`) and 1 spacing token (`--space-1h`) to fill gaps in the design system where 0.7rem, 0.8rem, 0.9rem had no tokens
- **Replace 147 raw font-size declarations** in global.css with `var(--text-*)` references
- **Replace 167 raw spacing declarations** in global.css with `var(--space-N)` references
- **Tokenize desktop.css** (24 font, 34 spacing) and **calendar.css** (5 font, 19 spacing)

## What's preserved (not tokenized)

- `em`-based markdown renderer sizes (relative sizing, intentional)
- `16px` on inputs (iOS zoom prevention)
- Animation/keyframe values
- Sub-token precision values (<4px)
- Values between tokens (0.3rem, 0.4rem, etc.)
- Compound shorthands where not all values map to tokens

## Related

- Follow-up to PR #190 (mobile UI overhaul)
- Issues #195 (FileViewer header migration) and #196 (dead CSS cleanup) remain open

## Test plan

- [x] All 294 frontend test files pass (2937 tests)
- [x] All 35 desktop tests pass
- [x] Token test validates new tokens exist in `:root`
- [x] Pre-commit hooks (eslint + prettier) pass on all commits
- [ ] Manual visual check on mobile recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)