### PR TITLE
fix(sessions): paginate session list and fix worktree discovery

### DIFF
--- a/frontend/src/components/__tests__/SessionPanel.test.tsx
+++ b/frontend/src/components/__tests__/SessionPanel.test.tsx
@@ -17,12 +17,15 @@ function makeDefaultReturn(overrides = {}) {
     sessions: [],
     quickActions: [],
     loading: false,
+    loadingMore: false,
+    hasMore: false,
     updateAvailable: false,
     checking: false,
     dismissSession: vi.fn(),
     clearAll: vi.fn(),
     handleRename: vi.fn(),
     checkForUpdates: vi.fn(),
+    loadMore: vi.fn(),
     ...overrides,
   };
 }

--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Session } from '../types/chat';
 import { renameSession as renameSessionApi } from '../lib/rename-session';
 
@@ -40,8 +40,6 @@ export interface UseSessionListReturn {
   loadMore: () => void;
 }
 
-const PAGE_SIZE = 20;
-
 function parseSessionsResponse(data: unknown): { sessions: Session[]; hasMore: boolean } {
   // Handle both new paginated shape and legacy array shape
   if (Array.isArray(data)) return { sessions: data, hasMore: false };
@@ -57,11 +55,12 @@ export function useSessionList(): UseSessionListReturn {
   const [hasMore, setHasMore] = useState(false);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [checking, setChecking] = useState(false);
+  const nextOffset = useRef(0);
 
   useEffect(() => {
     const loadAll = () =>
       Promise.all([
-        fetch(`/api/sessions?offset=0&limit=${PAGE_SIZE}`)
+        fetch('/api/sessions')
           .then((r) => r.json())
           .catch(() => ({ sessions: [], hasMore: false })),
         fetch('/api/config')
@@ -74,6 +73,7 @@ export function useSessionList(): UseSessionListReturn {
         const { sessions: page, hasMore: more } = parseSessionsResponse(sessData);
         setSessions(page);
         setHasMore(more);
+        nextOffset.current = page.length;
         setQuickActions(buildQuickActions(config.quickActions));
         if (version?.updateAvailable) setUpdateAvailable(true);
       });
@@ -93,17 +93,17 @@ export function useSessionList(): UseSessionListReturn {
   const loadMore = useCallback(() => {
     if (loadingMore || !hasMore) return;
     setLoadingMore(true);
-    const offset = sessions.length;
-    fetch(`/api/sessions?offset=${offset}&limit=${PAGE_SIZE}`)
+    fetch(`/api/sessions?offset=${nextOffset.current}`)
       .then((r) => r.json())
       .then((data) => {
         const { sessions: page, hasMore: more } = parseSessionsResponse(data);
         setSessions((prev) => [...prev, ...page]);
         setHasMore(more);
+        nextOffset.current += page.length;
       })
       .catch(() => {})
       .finally(() => setLoadingMore(false));
-  }, [loadingMore, hasMore, sessions.length]);
+  }, [loadingMore, hasMore]);
 
   const dismissSession = useCallback((id: string) => {
     setSessions((prev) => prev.filter((s) => s.id !== id));
@@ -113,18 +113,20 @@ export function useSessionList(): UseSessionListReturn {
   const clearAll = useCallback(() => {
     setSessions([]);
     setHasMore(false);
+    nextOffset.current = 0;
     fetch('/api/sessions', { method: 'DELETE' }).catch(() => {});
   }, []);
 
   const handleRename = useCallback((id: string, title: string) => {
     setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, summary: title } : s)));
     renameSessionApi(id, title).catch(() => {
-      fetch(`/api/sessions?offset=0&limit=${PAGE_SIZE}`)
+      fetch('/api/sessions')
         .then((r) => r.json())
         .then((data) => {
           const { sessions: page, hasMore: more } = parseSessionsResponse(data);
           setSessions(page);
           setHasMore(more);
+          nextOffset.current = page.length;
         })
         .catch(() => {});
     });

--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -29,27 +29,41 @@ export interface UseSessionListReturn {
   sessions: Session[];
   quickActions: QuickAction[];
   loading: boolean;
+  loadingMore: boolean;
+  hasMore: boolean;
   updateAvailable: boolean;
   checking: boolean;
   dismissSession: (id: string) => void;
   clearAll: () => void;
   handleRename: (id: string, title: string) => void;
   checkForUpdates: () => Promise<void>;
+  loadMore: () => void;
+}
+
+const PAGE_SIZE = 20;
+
+function parseSessionsResponse(data: unknown): { sessions: Session[]; hasMore: boolean } {
+  // Handle both new paginated shape and legacy array shape
+  if (Array.isArray(data)) return { sessions: data, hasMore: false };
+  const obj = data as { sessions?: Session[]; hasMore?: boolean };
+  return { sessions: obj.sessions ?? [], hasMore: obj.hasMore ?? false };
 }
 
 export function useSessionList(): UseSessionListReturn {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [quickActions, setQuickActions] = useState<QuickAction[]>(DEFAULT_ACTIONS);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [checking, setChecking] = useState(false);
 
   useEffect(() => {
     const loadAll = () =>
       Promise.all([
-        fetch('/api/sessions')
+        fetch(`/api/sessions?offset=0&limit=${PAGE_SIZE}`)
           .then((r) => r.json())
-          .catch(() => []),
+          .catch(() => ({ sessions: [], hasMore: false })),
         fetch('/api/config')
           .then((r) => r.json())
           .catch(() => ({})),
@@ -57,7 +71,9 @@ export function useSessionList(): UseSessionListReturn {
           .then((r) => r.json())
           .catch(() => ({})),
       ]).then(([sessData, config, version]) => {
-        setSessions(sessData);
+        const { sessions: page, hasMore: more } = parseSessionsResponse(sessData);
+        setSessions(page);
+        setHasMore(more);
         setQuickActions(buildQuickActions(config.quickActions));
         if (version?.updateAvailable) setUpdateAvailable(true);
       });
@@ -74,6 +90,21 @@ export function useSessionList(): UseSessionListReturn {
     };
   }, []);
 
+  const loadMore = useCallback(() => {
+    if (loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    const offset = sessions.length;
+    fetch(`/api/sessions?offset=${offset}&limit=${PAGE_SIZE}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const { sessions: page, hasMore: more } = parseSessionsResponse(data);
+        setSessions((prev) => [...prev, ...page]);
+        setHasMore(more);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingMore(false));
+  }, [loadingMore, hasMore, sessions.length]);
+
   const dismissSession = useCallback((id: string) => {
     setSessions((prev) => prev.filter((s) => s.id !== id));
     fetch(`/api/sessions/${id}`, { method: 'DELETE' }).catch(() => {});
@@ -81,15 +112,20 @@ export function useSessionList(): UseSessionListReturn {
 
   const clearAll = useCallback(() => {
     setSessions([]);
+    setHasMore(false);
     fetch('/api/sessions', { method: 'DELETE' }).catch(() => {});
   }, []);
 
   const handleRename = useCallback((id: string, title: string) => {
     setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, summary: title } : s)));
     renameSessionApi(id, title).catch(() => {
-      fetch('/api/sessions')
+      fetch(`/api/sessions?offset=0&limit=${PAGE_SIZE}`)
         .then((r) => r.json())
-        .then(setSessions)
+        .then((data) => {
+          const { sessions: page, hasMore: more } = parseSessionsResponse(data);
+          setSessions(page);
+          setHasMore(more);
+        })
         .catch(() => {});
     });
   }, []);
@@ -111,11 +147,14 @@ export function useSessionList(): UseSessionListReturn {
     sessions,
     quickActions,
     loading,
+    loadingMore,
+    hasMore,
     updateAvailable,
     checking,
     dismissSession,
     clearAll,
     handleRename,
     checkForUpdates,
+    loadMore,
   };
 }

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -204,12 +204,15 @@ export function SessionList() {
     sessions,
     quickActions,
     loading,
+    loadingMore,
+    hasMore,
     updateAvailable,
     checking,
     dismissSession,
     clearAll,
     handleRename,
     checkForUpdates,
+    loadMore,
   } = useSessionList();
 
   function handleDeployAction() {
@@ -296,6 +299,11 @@ export function SessionList() {
               onRename={handleRename}
             />
           ))}
+          {hasMore && (
+            <button className="session-load-more" onClick={loadMore} disabled={loadingMore}>
+              {loadingMore ? 'Loading...' : 'Load More'}
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -692,6 +692,24 @@ textarea:focus {
   flex-shrink: 0;
 }
 
+.session-load-more {
+  display: block;
+  width: 100%;
+  padding: 0.75rem;
+  background: transparent;
+  color: var(--accent);
+  border: none;
+  border-top: 1px solid var(--border);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.session-load-more:disabled {
+  color: var(--text-dim);
+  cursor: default;
+}
+
 /* ===== Inbox Navigation (Home Screen) ===== */
 
 .inbox-nav-btn {

--- a/server/__tests__/calendar.test.ts
+++ b/server/__tests__/calendar.test.ts
@@ -14,7 +14,7 @@ vi.mock('../chat.js', () => {
   const { tmpdir: ptmpdir } = require('os');
   const repo = pjoin(ptmpdir(), `mitzo-test-repo-${process.pid}`);
   return {
-    getSessions: vi.fn().mockResolvedValue([]),
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
     getMessages: vi.fn().mockResolvedValue([]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -28,13 +28,14 @@ describe('chat module exports', () => {
 describe('getSessions', () => {
   it('returns an array', async () => {
     const { getSessions } = await import('../chat.js');
-    const sessions = await getSessions();
-    expect(Array.isArray(sessions)).toBe(true);
+    const result = await getSessions();
+    expect(Array.isArray(result.sessions)).toBe(true);
+    expect(typeof result.hasMore).toBe('boolean');
   });
 
   it('session objects have expected shape', async () => {
     const { getSessions } = await import('../chat.js');
-    const sessions = await getSessions();
+    const { sessions } = await getSessions();
     for (const s of sessions) {
       expect(s).toHaveProperty('id');
       expect(s).toHaveProperty('summary');

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -301,6 +301,24 @@ describe('session routes', () => {
     expect(typeof res.body.hasMore).toBe('boolean');
   });
 
+  it('GET /api/sessions — passes offset and limit query params', async () => {
+    const { getSessions } = await import('../chat.js');
+    await request(app).get('/api/sessions?offset=5&limit=10').set('Cookie', authCookie);
+    expect(getSessions).toHaveBeenCalledWith(5, 10);
+  });
+
+  it('GET /api/sessions — clamps invalid offset and limit', async () => {
+    const { getSessions } = await import('../chat.js');
+    await request(app).get('/api/sessions?offset=-1&limit=999').set('Cookie', authCookie);
+    expect(getSessions).toHaveBeenCalledWith(0, 100);
+  });
+
+  it('GET /api/sessions — uses defaults when no params', async () => {
+    const { getSessions } = await import('../chat.js');
+    await request(app).get('/api/sessions').set('Cookie', authCookie);
+    expect(getSessions).toHaveBeenCalledWith(0, 20);
+  });
+
   it('GET /api/sessions — unauthenticated returns 401', async () => {
     const res = await request(app).get('/api/sessions');
     expect(res.status).toBe(401);

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -14,12 +14,10 @@ vi.mock('../chat.js', () => {
   const { tmpdir: ptmpdir } = require('os');
   const repo = pjoin(ptmpdir(), `mitzo-test-repo-${process.pid}`);
   return {
-    getSessions: vi
-      .fn()
-      .mockResolvedValue({
-        sessions: [{ id: 's1', summary: 'Test', lastModified: 1 }],
-        hasMore: false,
-      }),
+    getSessions: vi.fn().mockResolvedValue({
+      sessions: [{ id: 's1', summary: 'Test', lastModified: 1 }],
+      hasMore: false,
+    }),
     getMessages: vi.fn().mockResolvedValue([{ messageId: 'm1', role: 'assistant', blocks: [] }]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -14,7 +14,12 @@ vi.mock('../chat.js', () => {
   const { tmpdir: ptmpdir } = require('os');
   const repo = pjoin(ptmpdir(), `mitzo-test-repo-${process.pid}`);
   return {
-    getSessions: vi.fn().mockResolvedValue([{ id: 's1', summary: 'Test', lastModified: 1 }]),
+    getSessions: vi
+      .fn()
+      .mockResolvedValue({
+        sessions: [{ id: 's1', summary: 'Test', lastModified: 1 }],
+        hasMore: false,
+      }),
     getMessages: vi.fn().mockResolvedValue([{ messageId: 'm1', role: 'assistant', blocks: [] }]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),
@@ -283,7 +288,7 @@ describe('session routes', () => {
   it('GET /api/sessions — annotates sessions with active status and token data', async () => {
     const res = await request(app).get('/api/sessions').set('Cookie', authCookie);
     expect(res.status).toBe(200);
-    const s1 = res.body.find((s: any) => s.id === 's1');
+    const s1 = res.body.sessions.find((s: { id: string }) => s.id === 's1');
     expect(s1).toBeDefined();
     expect(s1.isActive).toBe(true);
     expect(s1.isAttached).toBe(true);
@@ -291,10 +296,11 @@ describe('session routes', () => {
     expect(s1.numTurns).toBe(3);
   });
 
-  it('GET /api/sessions — authenticated returns array', async () => {
+  it('GET /api/sessions — authenticated returns paginated shape', async () => {
     const res = await request(app).get('/api/sessions').set('Cookie', authCookie);
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
+    expect(Array.isArray(res.body.sessions)).toBe(true);
+    expect(typeof res.body.hasMore).toBe('boolean');
   });
 
   it('GET /api/sessions — unauthenticated returns 401', async () => {

--- a/server/__tests__/task-routes.test.ts
+++ b/server/__tests__/task-routes.test.ts
@@ -14,7 +14,7 @@ vi.mock('../chat.js', () => {
   const { tmpdir: ptmpdir } = require('os');
   const repo = pjoin(ptmpdir(), `mitzo-task-routes-test-${process.pid}`);
   return {
-    getSessions: vi.fn().mockResolvedValue([]),
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
     getMessages: vi.fn().mockResolvedValue([]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),

--- a/server/__tests__/todos.test.ts
+++ b/server/__tests__/todos.test.ts
@@ -15,7 +15,7 @@ vi.mock('../chat.js', () => {
   const { tmpdir: ptmpdir } = require('os');
   const repo = pjoin(ptmpdir(), `mitzo-test-repo-${process.pid}`);
   return {
-    getSessions: vi.fn().mockResolvedValue([]),
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
     getMessages: vi.fn().mockResolvedValue([]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),

--- a/server/__tests__/yapper-proxy.test.ts
+++ b/server/__tests__/yapper-proxy.test.ts
@@ -18,7 +18,7 @@ vi.mock('../chat.js', () => {
   const { tmpdir } = require('os');
   const repo = join(tmpdir(), `mitzo-yapper-test-${process.pid}`);
   return {
-    getSessions: vi.fn().mockResolvedValue([]),
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
     getMessages: vi.fn().mockResolvedValue([]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),

--- a/server/app.ts
+++ b/server/app.ts
@@ -631,8 +631,10 @@ app.get('/api/sessions/active', (_req, res) => {
   res.json(registry.getActiveSessions());
 });
 
-app.get('/api/sessions', async (_req, res) => {
-  const sessions = await getSessions();
+app.get('/api/sessions', async (req, res) => {
+  const offset = Math.max(0, parseInt(req.query.offset as string) || 0);
+  const limit = Math.min(Math.max(1, parseInt(req.query.limit as string) || 20), 100);
+  const { sessions, hasMore } = await getSessions(offset, limit);
   const activeMap = new Map<string, { attached: boolean }>();
   for (const s of registry.getActiveSessions()) {
     if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
@@ -650,7 +652,7 @@ app.get('/api/sessions', async (_req, res) => {
       numTurns: meta?.numTurns,
     };
   });
-  res.json(annotated);
+  res.json({ sessions: annotated, hasMore });
 });
 
 app.get('/api/sessions/:id/messages', async (req, res) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -9,7 +9,6 @@ import type { WebSocket } from 'ws';
 import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 import { createWorktree, removeWorktree } from './worktree.js';
 import { SessionRegistry, type MitzoMode } from './session-registry.js';
@@ -21,7 +20,7 @@ import { loadProjectHooks } from './hook-bridge.js';
 import { buildPermissionHandler } from './permission-handler.js';
 import { runQueryLoop, createWsMessageHandler, broadcastToObservers } from './query-loop.js';
 import { AsyncQueue } from './async-queue.js';
-import { GIT_BRANCH_TIMEOUT_MS, SESSION_LIST_LIMIT, SESSION_MESSAGES_LIMIT } from './constants.js';
+import { GIT_BRANCH_TIMEOUT_MS, SESSION_PAGE_SIZE, SESSION_MESSAGES_LIMIT } from './constants.js';
 import { INTERNAL_TOKEN } from './internal-token.js';
 import { buildTaskSystemPrompt } from './task-context.js';
 import type { TaskStore } from './task-store.js';
@@ -659,17 +658,6 @@ export function isActive(clientId: string): boolean {
 function getSessionDirs(): string[] {
   const dirs = [BASE_REPO];
 
-  // New location: .claude/worktrees/ inside the repo
-  const worktreeDir = join(BASE_REPO, '.claude', 'worktrees');
-  try {
-    const entries = readdirSync(worktreeDir);
-    for (const e of entries) {
-      dirs.push(join(worktreeDir, e));
-    }
-  } catch {
-    // Expected when worktrees dir doesn't exist yet
-  }
-
   // Legacy location: <repo>-sessions/ sibling directory
   const sessionsDir = `${BASE_REPO}-sessions`;
   try {
@@ -680,19 +668,9 @@ function getSessionDirs(): string[] {
   } catch {
     // Expected when sessions dir doesn't exist yet
   }
-  const claudeProjects = join(homedir(), '.claude', 'projects');
-  const prefix = BASE_REPO.replace(/\//g, '-').replace(/^-/, '-');
-  const sessionsPrefix = `${prefix}-sessions-session-`;
-  try {
-    for (const entry of readdirSync(claudeProjects)) {
-      if (entry.startsWith(sessionsPrefix)) {
-        const originalPath = entry.replace(/^-/, '/').replace(/-/g, '/');
-        if (!dirs.includes(originalPath)) dirs.push(originalPath);
-      }
-    }
-  } catch {
-    // Expected when ~/.claude/projects doesn't exist yet
-  }
+
+  // SDK's listSessions with includeWorktrees: true (the default) handles
+  // worktree-based sessions automatically — no manual scanning needed.
   return dirs;
 }
 
@@ -726,14 +704,17 @@ export async function renameSessionById(
   throw new Error('Session not found');
 }
 
-export async function getSessions() {
+export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
   const seen = new Map<
     string,
     { id: string; summary: string; lastModified: number; branch?: string }
   >();
+  // Fetch enough from each dir to cover the requested window after dedup.
+  // The SDK handles worktree discovery via includeWorktrees (default true).
+  const fetchLimit = offset + limit + 50; // buffer for dedup losses
   for (const dir of getSessionDirs()) {
     try {
-      const sessions = await listSessions({ dir, limit: SESSION_LIST_LIMIT });
+      const sessions = await listSessions({ dir, limit: fetchLimit, includeWorktrees: true });
       for (const s of sessions) {
         if (hiddenSessionIds.has(s.sessionId)) continue;
         const existing = seen.get(s.sessionId);
@@ -752,7 +733,9 @@ export async function getSessions() {
   }
   const deduped = Array.from(seen.values());
   deduped.sort((a, b) => b.lastModified - a.lastModified);
-  return deduped.slice(0, SESSION_LIST_LIMIT);
+  const page = deduped.slice(offset, offset + limit);
+  const hasMore = deduped.length > offset + limit;
+  return { sessions: page, hasMore };
 }
 
 export interface RestoredMessage {

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -25,7 +25,7 @@ export const WORKTREE_PRUNE_TIMEOUT_MS = 5_000;
 export const GIT_BRANCH_TIMEOUT_MS = 5_000;
 
 // --- Session listing ---
-export const SESSION_LIST_LIMIT = 20;
+export const SESSION_PAGE_SIZE = 20;
 export const SESSION_MESSAGES_LIMIT = 100;
 
 // --- Observers ---


### PR DESCRIPTION
## Summary

- **Worktree sessions invisible**: `getSessionDirs()` manually scanned `.claude/worktrees/` and `~/.claude/projects/` with a broken prefix pattern that never matched worktree-path-based project hashes. Now relies on the SDK's `includeWorktrees: true` (the default), which handles discovery automatically.
- **Hard cap of 20**: `SESSION_LIST_LIMIT` truncated all sessions to 20 with no way to see older ones. Replaced with offset/limit pagination — `GET /api/sessions?offset=N&limit=N` returns `{ sessions, hasMore }`. Frontend shows a "Load More" button.

## Test plan

- [ ] Verify worktree sessions appear in session list (previously invisible)
- [ ] Verify older sessions (beyond first 20) load via "Load More"
- [ ] Verify session dismiss, rename, and clear still work
- [ ] Verify visibility-change refresh resets to page 1
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` — session-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)