### PR TITLE
fix(sessions): address PR #201 review — restore tests, use options param

### DIFF
--- a/server/__tests__/session-dirs.test.ts
+++ b/server/__tests__/session-dirs.test.ts
@@ -212,12 +212,13 @@ describe('getSessionDirs', () => {
 
   it('does not include non-worktree dirs from ~/.claude/projects/', () => {
     const encoded = BASE_REPO.replace(/\//g, '-');
+    // Base repo dir and unrelated repo — neither should add entries
     mkdirSync(join(TEST_CLAUDE_PROJECTS, encoded), { recursive: true });
     mkdirSync(join(TEST_CLAUDE_PROJECTS, '-Users-someone-other-repo'), { recursive: true });
 
     const dirs = getSessionDirs({ claudeProjectsRoot: TEST_CLAUDE_PROJECTS });
-    const worktreeDirs = dirs.filter((d) => d.includes('worktrees'));
-    expect(worktreeDirs).toHaveLength(0);
+    const dirsWithoutBaseAndLegacy = dirs.filter((d) => d !== BASE_REPO);
+    expect(dirsWithoutBaseAndLegacy).toHaveLength(0);
   });
 
   it('deduplicates worktree dirs already found via other methods', () => {

--- a/server/__tests__/session-dirs.test.ts
+++ b/server/__tests__/session-dirs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { RepoConfig } from '../repo-config.js';
@@ -26,21 +26,19 @@ vi.mock('../repo-config.js', () => ({
   loadRepoConfig: (repoPath: string) => mockLoadRepoConfig(repoPath),
 }));
 
-import { getSessionDirs, BASE_REPO, setClaudeProjectsRoot } from '../chat.js';
+import { getSessionDirs, BASE_REPO } from '../chat.js';
 
 let fakeTime = 100_000;
 beforeEach(() => {
   mkdirSync(TEST_PROJECTS, { recursive: true });
   mkdirSync(TEST_CLAUDE_PROJECTS, { recursive: true });
   mockLoadRepoConfig.mockReturnValue({ ...mockConfig });
-  setClaudeProjectsRoot(TEST_CLAUDE_PROJECTS);
   fakeTime += 10_000;
   vi.useFakeTimers({ now: fakeTime });
 });
 
 afterEach(() => {
   vi.useRealTimers();
-  setClaudeProjectsRoot(null);
   rmSync(TEST_BASE, { recursive: true, force: true });
   mockLoadRepoConfig.mockReset();
 });
@@ -77,6 +75,78 @@ describe('getSessionDirs', () => {
     expect(dirs).toContain(projA);
   });
 
+  it('discovers sibling dirs with .claude (no .git)', () => {
+    const projB = join(TEST_PROJECTS, 'proj-b');
+    mkdirSync(join(projB, '.claude'), { recursive: true });
+
+    const otherProj = join(TEST_PROJECTS, 'other');
+    mkdirSync(otherProj, { recursive: true });
+
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [{ label: 'Other', path: otherProj }],
+    });
+
+    const dirs = getSessionDirs();
+    expect(dirs).toContain(projB);
+  });
+
+  it('skips non-directory entries in parent dirs', () => {
+    writeFileSync(join(TEST_PROJECTS, 'not-a-dir'), 'hello');
+
+    const projDir = join(TEST_PROJECTS, 'proj');
+    mkdirSync(projDir, { recursive: true });
+
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [{ label: 'Proj', path: projDir }],
+    });
+
+    const dirs = getSessionDirs();
+    expect(dirs).not.toContain(join(TEST_PROJECTS, 'not-a-dir'));
+  });
+
+  it('skips directories without .git or .claude', () => {
+    const plainDir = join(TEST_PROJECTS, 'no-markers');
+    mkdirSync(plainDir, { recursive: true });
+
+    const rootDir = join(TEST_PROJECTS, 'root');
+    mkdirSync(rootDir, { recursive: true });
+
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [{ label: 'Root', path: rootDir }],
+    });
+
+    const dirs = getSessionDirs();
+    expect(dirs).not.toContain(plainDir);
+  });
+
+  it('deduplicates repos that appear in both repos and root siblings', () => {
+    const projA = join(TEST_PROJECTS, 'proj-a');
+    mkdirSync(join(projA, '.git'), { recursive: true });
+
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [{ label: 'ProjA', path: projA }],
+      repos: { 'proj-a': projA },
+    });
+
+    const dirs = getSessionDirs();
+    const count = dirs.filter((d) => d === projA).length;
+    expect(count).toBe(1);
+  });
+
+  it('handles missing parent dirs gracefully', () => {
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [{ label: 'Missing', path: '/nonexistent/path/xyz/child' }],
+    });
+
+    const dirs = getSessionDirs();
+    expect(dirs[0]).toBe(BASE_REPO);
+  });
+
   it('handles config load failure gracefully', () => {
     mockLoadRepoConfig.mockImplementation(() => {
       throw new Error('config not loaded');
@@ -103,6 +173,31 @@ describe('getSessionDirs', () => {
     }
   });
 
+  it('multiple roots sharing the same parent only scan parent once', () => {
+    const projA = join(TEST_PROJECTS, 'proj-a');
+    const projB = join(TEST_PROJECTS, 'proj-b');
+    const projC = join(TEST_PROJECTS, 'proj-c');
+    mkdirSync(join(projA, '.git'), { recursive: true });
+    mkdirSync(join(projB, '.git'), { recursive: true });
+    mkdirSync(join(projC, '.claude'), { recursive: true });
+
+    mockLoadRepoConfig.mockReturnValue({
+      ...mockConfig,
+      roots: [
+        { label: 'A', path: projA },
+        { label: 'B', path: projB },
+      ],
+    });
+
+    const dirs = getSessionDirs();
+    expect(dirs).toContain(projA);
+    expect(dirs).toContain(projB);
+    expect(dirs).toContain(projC);
+    expect(dirs.filter((d) => d === projA).length).toBe(1);
+    expect(dirs.filter((d) => d === projB).length).toBe(1);
+    expect(dirs.filter((d) => d === projC).length).toBe(1);
+  });
+
   it('discovers worktree sessions from ~/.claude/projects/', () => {
     const encoded = BASE_REPO.replace(/\//g, '-');
     const wtDir1 = `${encoded}--claude-worktrees-2026-04-15-abc123`;
@@ -110,21 +205,19 @@ describe('getSessionDirs', () => {
     mkdirSync(join(TEST_CLAUDE_PROJECTS, wtDir1), { recursive: true });
     mkdirSync(join(TEST_CLAUDE_PROJECTS, wtDir2), { recursive: true });
 
-    const dirs = getSessionDirs();
+    const dirs = getSessionDirs({ claudeProjectsRoot: TEST_CLAUDE_PROJECTS });
     expect(dirs).toContain(`${BASE_REPO}/.claude/worktrees/2026-04-15-abc123`);
     expect(dirs).toContain(`${BASE_REPO}/.claude/worktrees/2026-04-14-def456`);
   });
 
   it('does not include non-worktree dirs from ~/.claude/projects/', () => {
     const encoded = BASE_REPO.replace(/\//g, '-');
-    // Base repo dir — already covered by BASE_REPO
     mkdirSync(join(TEST_CLAUDE_PROJECTS, encoded), { recursive: true });
-    // Unrelated repo
     mkdirSync(join(TEST_CLAUDE_PROJECTS, '-Users-someone-other-repo'), { recursive: true });
 
-    const dirs = getSessionDirs();
-    expect(dirs).toHaveLength(1);
-    expect(dirs[0]).toBe(BASE_REPO);
+    const dirs = getSessionDirs({ claudeProjectsRoot: TEST_CLAUDE_PROJECTS });
+    const worktreeDirs = dirs.filter((d) => d.includes('worktrees'));
+    expect(worktreeDirs).toHaveLength(0);
   });
 
   it('deduplicates worktree dirs already found via other methods', () => {
@@ -132,15 +225,13 @@ describe('getSessionDirs', () => {
     const wtDir = `${encoded}--claude-worktrees-2026-04-15-abc123`;
     mkdirSync(join(TEST_CLAUDE_PROJECTS, wtDir), { recursive: true });
 
-    const dirs = getSessionDirs();
+    const dirs = getSessionDirs({ claudeProjectsRoot: TEST_CLAUDE_PROJECTS });
     const wtPath = `${BASE_REPO}/.claude/worktrees/2026-04-15-abc123`;
     expect(dirs.filter((d) => d === wtPath)).toHaveLength(1);
   });
 
   it('handles missing ~/.claude/projects/ gracefully', () => {
-    rmSync(TEST_CLAUDE_PROJECTS, { recursive: true, force: true });
-
-    const dirs = getSessionDirs();
+    const dirs = getSessionDirs({ claudeProjectsRoot: '/nonexistent/path' });
     expect(dirs[0]).toBe(BASE_REPO);
   });
 });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -670,16 +670,7 @@ export function isActive(clientId: string): boolean {
  *
  * This keeps all paths configurable (no hardcoded machine-specific paths).
  */
-let _claudeProjectsRoot: string | null = null;
-/** Override ~/.claude/projects root for testing. */
-export function setClaudeProjectsRoot(root: string | null): void {
-  _claudeProjectsRoot = root;
-}
-function getClaudeProjectsRoot(): string {
-  return _claudeProjectsRoot ?? join(homedir(), '.claude', 'projects');
-}
-
-export function getSessionDirs(): string[] {
+export function getSessionDirs(options?: { claudeProjectsRoot?: string }): string[] {
   const dirs = [BASE_REPO];
   const seen = new Set([BASE_REPO]);
 
@@ -739,7 +730,8 @@ export function getSessionDirs(): string[] {
   const encodedBase = BASE_REPO.replace(/\//g, '-');
   const wtPrefix = `${encodedBase}--claude-worktrees-`;
   try {
-    for (const entry of readdirSync(getClaudeProjectsRoot())) {
+    const claudeProjects = options?.claudeProjectsRoot ?? join(homedir(), '.claude', 'projects');
+    for (const entry of readdirSync(claudeProjects)) {
       if (!entry.startsWith(wtPrefix)) continue;
       const wtId = entry.slice(wtPrefix.length);
       if (!wtId) continue;


### PR DESCRIPTION
## Summary

Follow-up to #201. Addresses Centaur review feedback:

- **Restore all 6 sibling-discovery tests** that were incorrectly deleted (RED: test coverage regression)
- **Replace module-level `_claudeProjectsRoot` mutable** with an explicit `options.claudeProjectsRoot` param on `getSessionDirs()` (BLUE: style)
- 15 tests total (11 original + 4 new worktree discovery), all passing

## Test plan

- [x] All original sibling-discovery tests restored and passing
- [x] New worktree discovery tests use options param
- [x] No shared mutable state for test injection

Made with [Cursor](https://cursor.com)