### PR TITLE
feat(client): @mitzo/client reactive store package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2006,6 +2006,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mitzo/client": {
+      "resolved": "packages/client",
+      "link": true
+    },
     "node_modules/@mitzo/harness": {
       "resolved": "packages/harness",
       "link": true
@@ -10929,6 +10933,35 @@
         "zod": "^3.25.28 || ^4"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -10937,6 +10970,26 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/client": {
+      "name": "@mitzo/client",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mitzo/protocol": "*",
+        "zustand": "^5.0.0"
+      },
+      "devDependencies": {
+        "react": "^19.0.0",
+        "typescript": "^5.6.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "packages/harness": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier": "^3.8.1",
     "supertest": "^7.2.2",
     "tsx": "^4.19.0",
-    "typescript": "^5.6.0",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.2"
   }

--- a/packages/client/__tests__/api-client.test.ts
+++ b/packages/client/__tests__/api-client.test.ts
@@ -232,4 +232,30 @@ describe('MitzoApiClient', () => {
       }),
     );
   });
+
+  // ── Error handling ──────────────────────────────────────────────────────
+
+  it('throws on non-ok response', async () => {
+    const errorFetch: ApiFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: () => Promise.resolve('Session not found'),
+      json: () => Promise.resolve({ error: 'Session not found' }),
+    });
+    const errorClient = new MitzoApiClient(errorFetch);
+    await expect(errorClient.getSessionMessages('bad-id')).rejects.toThrow('API 404: Session not found');
+  });
+
+  it('throws on 500 with empty body', async () => {
+    const errorFetch: ApiFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    });
+    const errorClient = new MitzoApiClient(errorFetch);
+    await expect(errorClient.checkAuth()).rejects.toThrow('API 500: Internal Server Error');
+  });
 });

--- a/packages/client/__tests__/api-client.test.ts
+++ b/packages/client/__tests__/api-client.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MitzoApiClient } from '../src/api-client.js';
+import type { ApiFetch } from '../src/api-client.js';
+
+function mockFetch(data: unknown = {}, text?: string): ApiFetch {
+  return vi.fn().mockResolvedValue({
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(text ?? JSON.stringify(data)),
+    ok: true,
+  });
+}
+
+describe('MitzoApiClient', () => {
+  let fetchFn: ReturnType<typeof vi.fn>;
+  let client: MitzoApiClient;
+
+  beforeEach(() => {
+    fetchFn = mockFetch() as ReturnType<typeof vi.fn>;
+    client = new MitzoApiClient(fetchFn);
+  });
+
+  // ── Auth ─────────────────────────────────────────────────────────────────
+
+  it('checkAuth calls /api/auth/check', async () => {
+    await client.checkAuth();
+    expect(fetchFn).toHaveBeenCalledWith('/api/auth/check', expect.objectContaining({ credentials: 'include' }));
+  });
+
+  it('login sends passphrase', async () => {
+    await client.login('secret');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ passphrase: 'secret' }),
+      }),
+    );
+  });
+
+  // ── Sessions ─────────────────────────────────────────────────────────────
+
+  it('listSessions without offset', async () => {
+    await client.listSessions();
+    expect(fetchFn).toHaveBeenCalledWith('/api/sessions', expect.any(Object));
+  });
+
+  it('listSessions with offset', async () => {
+    await client.listSessions(10);
+    expect(fetchFn).toHaveBeenCalledWith('/api/sessions?offset=10', expect.any(Object));
+  });
+
+  it('getSessionMessages with abort signal', async () => {
+    const controller = new AbortController();
+    await client.getSessionMessages('sid-1', controller.signal);
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/sessions/sid-1/messages',
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('deleteSession sends DELETE', async () => {
+    await client.deleteSession('sid-1');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/sessions/sid-1',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('renameSession sends PUT with title', async () => {
+    await client.renameSession('sid-1', 'New Name');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/sessions/sid-1/rename',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ title: 'New Name' }),
+      }),
+    );
+  });
+
+  // ── Tasks ────────────────────────────────────────────────────────────────
+
+  it('createTask sends POST with body', async () => {
+    await client.createTask({ title: 'Test task' });
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/tasks',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ title: 'Test task' }),
+      }),
+    );
+  });
+
+  it('updateTask sends PATCH', async () => {
+    await client.updateTask('t1', { title: 'Updated' });
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/tasks/t1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ title: 'Updated' }),
+      }),
+    );
+  });
+
+  it('approveTask sends POST', async () => {
+    await client.approveTask('t1');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/tasks/t1/approve',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('rejectTask sends feedback', async () => {
+    await client.rejectTask('t1', 'Not good enough');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/tasks/t1/reject',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ feedback: 'Not good enough' }),
+      }),
+    );
+  });
+
+  it('startLoop sends goalId and specMode', async () => {
+    await client.startLoop('g1', true);
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/loop/start',
+      expect.objectContaining({
+        body: JSON.stringify({ goalId: 'g1', specMode: true }),
+      }),
+    );
+  });
+
+  // ── Todos ────────────────────────────────────────────────────────────────
+
+  it('getTodos without profile', async () => {
+    await client.getTodos();
+    expect(fetchFn).toHaveBeenCalledWith('/api/todos', expect.any(Object));
+  });
+
+  it('getTodos with profile', async () => {
+    await client.getTodos('work');
+    expect(fetchFn).toHaveBeenCalledWith('/api/todos?profile=work', expect.any(Object));
+  });
+
+  it('createTodo sends summary, profile, parentId', async () => {
+    await client.createTodo('Fix bug', 'work', 'parent-1');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/todos',
+      expect.objectContaining({
+        body: JSON.stringify({ summary: 'Fix bug', profile: 'work', parentId: 'parent-1' }),
+      }),
+    );
+  });
+
+  it('todoAction sends action and optional days', async () => {
+    await client.todoAction('td-1', 'snooze', 3);
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/todos/td-1/action',
+      expect.objectContaining({
+        body: JSON.stringify({ action: 'snooze', days: 3 }),
+      }),
+    );
+  });
+
+  // ── Calendar ─────────────────────────────────────────────────────────────
+
+  it('getCalendar passes date and days params', async () => {
+    await client.getCalendar('2026-04-16', 7);
+    expect(fetchFn).toHaveBeenCalledWith(
+      expect.stringContaining('/api/calendar?'),
+      expect.any(Object),
+    );
+    const url = fetchFn.mock.calls[0][0] as string;
+    expect(url).toContain('date=2026-04-16');
+    expect(url).toContain('days=7');
+  });
+
+  // ── Inbox ────────────────────────────────────────────────────────────────
+
+  it('getInbox calls /api/inbox', async () => {
+    await client.getInbox();
+    expect(fetchFn).toHaveBeenCalledWith('/api/inbox', expect.any(Object));
+  });
+
+  it('approveInboxItem sends POST', async () => {
+    await client.approveInboxItem('item.md');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/inbox/item.md/approve',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('deleteInboxItem sends DELETE', async () => {
+    await client.deleteInboxItem('item.md');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/inbox/item.md',
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  // ── Skills ───────────────────────────────────────────────────────────────
+
+  it('getSkills without cwd', async () => {
+    await client.getSkills();
+    expect(fetchFn).toHaveBeenCalledWith('/api/skills', expect.any(Object));
+  });
+
+  it('getSkills with cwd', async () => {
+    await client.getSkills('/tmp/project');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/skills?cwd=%2Ftmp%2Fproject',
+      expect.any(Object),
+    );
+  });
+
+  // ── Files ────────────────────────────────────────────────────────────────
+
+  it('listDirectory with root param', async () => {
+    await client.listDirectory('/src', '/project');
+    const url = fetchFn.mock.calls[0][0] as string;
+    expect(url).toContain('dir=%2Fsrc');
+    expect(url).toContain('root=%2Fproject');
+  });
+
+  it('writeFile sends path and content', async () => {
+    await client.writeFile('/tmp/test.ts', 'console.log("hi")');
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/files/write',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ path: '/tmp/test.ts', content: 'console.log("hi")' }),
+      }),
+    );
+  });
+});

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1,0 +1,1044 @@
+import { describe, it, expect } from 'vitest';
+import {
+  messagesReducer,
+  INITIAL_MESSAGES_STATE,
+} from '../src/slices/messages.js';
+import type { MessagesState } from '../src/slices/messages.js';
+import type { FinishedBlock } from '@mitzo/protocol';
+
+const INITIAL = INITIAL_MESSAGES_STATE;
+
+// ─── MESSAGE_START ────────────────────────────────────────────────────────────
+
+describe('MESSAGE_START', () => {
+  it('creates an empty streaming message', () => {
+    const state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    expect(state.current).not.toBeNull();
+    expect(state.current!.messageId).toBe('msg-1');
+    expect(state.current!.blockOrder).toHaveLength(0);
+    expect(state.current!.blocks.size).toBe(0);
+  });
+
+  it('finalizes orphaned current into messages when a new message starts', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'orphaned content',
+    });
+    state = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-2' });
+    expect(state.current!.messageId).toBe('msg-2');
+    expect(state.current!.blockOrder).toHaveLength(0);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-1');
+    expect(state.messages[0].blocks[0].content).toBe('orphaned content');
+  });
+
+  it('creates new current cleanly when no prior current exists', () => {
+    const state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-2' });
+    expect(state.current!.messageId).toBe('msg-2');
+    expect(state.current!.blockOrder).toHaveLength(0);
+    expect(state.messages).toHaveLength(0);
+  });
+});
+
+// ─── BLOCK_START ──────────────────────────────────────────────────────────────
+
+describe('BLOCK_START', () => {
+  it('adds a block to current message', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    expect(state.current!.blockOrder).toEqual(['b1']);
+    expect(state.current!.blocks.get('b1')).toMatchObject({
+      blockId: 'b1',
+      blockType: 'text',
+      content: '',
+      done: false,
+    });
+  });
+
+  it('preserves block order across multiple BLOCK_START calls', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'thinking',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b3',
+      blockType: 'tool_use',
+    });
+    expect(state.current!.blockOrder).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  it('sets toolName on tool_use block when provided', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Bash',
+    });
+    expect(state.current!.blocks.get('b1')!.toolName).toBe('Bash');
+  });
+
+  it('is a no-op when current is null', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    expect(state.current).toBeNull();
+  });
+});
+
+// ─── BLOCK_DELTA ──────────────────────────────────────────────────────────────
+
+describe('BLOCK_DELTA', () => {
+  it('accumulates content on text blocks', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'Hello',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: ' world',
+    });
+    expect(state.current!.blocks.get('b1')!.content).toBe('Hello world');
+  });
+
+  it('accumulates thinking content', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'thinking',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'thinking',
+      delta: 'Let me think',
+    });
+    expect(state.current!.blocks.get('b1')!.content).toBe('Let me think');
+  });
+
+  it('is a no-op for unknown blockId', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    const before = state.current!.blocks.get('b1')!.content;
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'unknown',
+      blockType: 'text',
+      delta: 'xyz',
+    });
+    expect(state.current!.blocks.get('b1')!.content).toBe(before);
+  });
+});
+
+// ─── BLOCK_END ────────────────────────────────────────────────────────────────
+
+describe('BLOCK_END', () => {
+  it('marks block as done', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    expect(state.current!.blocks.get('b1')!.done).toBe(true);
+  });
+
+  it('attaches toolName, toolId, and input for tool_use blocks', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Bash',
+      toolId: 'tool-1',
+      input: 'echo hi',
+    });
+    const block = state.current!.blocks.get('b1')!;
+    expect(block.done).toBe(true);
+    expect(block.toolName).toBe('Bash');
+    expect(block.toolId).toBe('tool-1');
+    expect(block.toolInput).toBe('echo hi');
+  });
+});
+
+// ─── TOOL_RESULT ──────────────────────────────────────────────────────────────
+
+describe('TOOL_RESULT', () => {
+  it('patches toolResult onto the matching block in current', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 'tool-1',
+    });
+    state = messagesReducer(state, {
+      type: 'TOOL_RESULT',
+      toolId: 'tool-1',
+      result: 'file contents',
+      isError: false,
+    });
+    expect(state.current!.blocks.get('b1')!.toolResult).toBe('file contents');
+    expect(state.current!.blocks.get('b1')!.toolError).toBe(false);
+  });
+
+  it('patches toolResult onto a finished message when tool is in messages[]', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Bash',
+      toolId: 'tool-2',
+    });
+    state = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'TOOL_RESULT',
+      toolId: 'tool-2',
+      result: 'output',
+      isError: false,
+    });
+    const msg = state.messages[0];
+    expect(msg.blocks[0].toolResult).toBe('output');
+  });
+
+  it('sets toolError=true on error results', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Bash',
+      toolId: 'tool-err',
+    });
+    state = messagesReducer(state, {
+      type: 'TOOL_RESULT',
+      toolId: 'tool-err',
+      result: 'Error!',
+      isError: true,
+    });
+    expect(state.current!.blocks.get('b1')!.toolError).toBe(true);
+  });
+});
+
+// ─── MESSAGE_END ──────────────────────────────────────────────────────────────
+
+describe('MESSAGE_END', () => {
+  it('moves current to messages[] and clears current', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'hi',
+    });
+    state = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-1' });
+
+    expect(state.current).toBeNull();
+    expect(state.messages).toHaveLength(1);
+    const msg = state.messages[0];
+    expect(msg.messageId).toBe('msg-1');
+    expect(msg.role).toBe('assistant');
+    expect(msg.blocks[0].content).toBe('hi');
+  });
+
+  it('preserves block order in finished message', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'thinking',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-1' });
+
+    expect(state.messages[0].blocks.map((b) => b.blockId)).toEqual(['b1', 'b2']);
+  });
+
+  it('is a no-op when current is null', () => {
+    const state = messagesReducer(INITIAL, { type: 'MESSAGE_END', messageId: 'msg-1' });
+    expect(state.messages).toHaveLength(0);
+  });
+});
+
+// ─── SESSION_END ──────────────────────────────────────────────────────────────
+
+describe('SESSION_END', () => {
+  it('sets running=false', () => {
+    const running = { ...INITIAL, running: true };
+    const state = messagesReducer(running, { type: 'SESSION_END' });
+    expect(state.running).toBe(false);
+  });
+
+  it('force-finalizes current into messages if session ends with in-flight message', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-orphan' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-orphan',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'msg-orphan',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'partial text',
+    });
+    state = messagesReducer(state, { type: 'SESSION_END' });
+    expect(state.current).toBeNull();
+    expect(state.running).toBe(false);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-orphan');
+    expect(state.messages[0].blocks[0].content).toBe('partial text');
+  });
+});
+
+// ─── MESSAGE_SNAPSHOT ─────────────────────────────────────────────────────────
+
+describe('MESSAGE_SNAPSHOT', () => {
+  it('reconstructs current from snapshot on reattach', () => {
+    const blocks: FinishedBlock[] = [
+      { blockId: 'b1', blockType: 'text', content: 'partial text' },
+      {
+        blockId: 'b2',
+        blockType: 'tool_use',
+        content: '',
+        toolName: 'Read',
+        toolId: 'tool-1',
+        toolInput: 'somefile',
+      },
+    ];
+
+    const state = messagesReducer(INITIAL, {
+      type: 'MESSAGE_SNAPSHOT',
+      messageId: 'msg-snap',
+      blocks,
+    });
+
+    expect(state.current).not.toBeNull();
+    expect(state.current!.messageId).toBe('msg-snap');
+    expect(state.current!.blockOrder).toEqual(['b1', 'b2']);
+    expect(state.current!.blocks.get('b1')!.content).toBe('partial text');
+    expect(state.current!.blocks.get('b2')!.toolName).toBe('Read');
+  });
+
+  it('is a no-op when blocks is undefined', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'MESSAGE_SNAPSHOT',
+      messageId: 'msg-snap',
+      blocks: undefined as unknown as FinishedBlock[],
+    });
+    expect(state.current).toBeNull();
+  });
+
+  it('is a no-op when blocks is null', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'MESSAGE_SNAPSHOT',
+      messageId: 'msg-snap',
+      blocks: null as unknown as FinishedBlock[],
+    });
+    expect(state.current).toBeNull();
+  });
+
+  it('replaces existing current on snapshot', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-old' });
+    state = messagesReducer(state, {
+      type: 'MESSAGE_SNAPSHOT',
+      messageId: 'msg-snap',
+      blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
+    });
+    expect(state.current!.messageId).toBe('msg-snap');
+  });
+});
+
+// ─── USER_SEND ────────────────────────────────────────────────────────────────
+
+describe('USER_SEND', () => {
+  it('adds user message and sets running=true', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-1-abc',
+    });
+    expect(state.running).toBe(true);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].role).toBe('user');
+    expect(state.messages[0].blocks[0].content).toBe('hello');
+  });
+
+  it('appends user message when already running', () => {
+    const running = { ...INITIAL, running: true };
+    const state = messagesReducer(running, {
+      type: 'USER_SEND',
+      text: 'follow-up',
+      clientMsgId: 'user-2-def',
+    });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].role).toBe('user');
+    expect(state.messages[0].blocks[0].content).toBe('follow-up');
+    expect(state.running).toBe(true);
+  });
+
+  it('stores image previews on the user message', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: 'look',
+      clientMsgId: 'user-3-ghi',
+      images: ['data:image/png;base64,...'],
+    });
+    expect(state.messages[0].images).toEqual(['data:image/png;base64,...']);
+  });
+});
+
+// ─── RESTORE ──────────────────────────────────────────────────────────────────
+
+describe('RESTORE', () => {
+  it('restores valid v2 messages', () => {
+    const messages = [
+      {
+        messageId: 'msg-1',
+        role: 'user' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hello' }],
+      },
+    ];
+    const state = messagesReducer(INITIAL, { type: 'RESTORE', messages });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-1');
+  });
+
+  it('filters out v1-format messages missing messageId and blocks', () => {
+    const legacyMessages = [
+      { role: 'user', text: 'hello' },
+      { role: 'assistant', text: 'hi' },
+    ] as unknown as import('@mitzo/protocol').FinishedMessage[];
+    const state = messagesReducer(INITIAL, { type: 'RESTORE', messages: legacyMessages });
+    expect(state.messages).toHaveLength(0);
+  });
+
+  it('keeps valid messages and drops invalid ones in a mixed array', () => {
+    const mixed = [
+      { role: 'user', text: 'old format' },
+      {
+        messageId: 'msg-2',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'valid' }],
+      },
+    ] as unknown as import('@mitzo/protocol').FinishedMessage[];
+    const state = messagesReducer(INITIAL, { type: 'RESTORE', messages: mixed });
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('msg-2');
+  });
+
+  it('with interrupted flag appends a notice message', () => {
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hi' }],
+      },
+    ];
+    const result = messagesReducer(INITIAL, {
+      type: 'RESTORE',
+      messages: msgs,
+      interrupted: true,
+    });
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].messageId).toBe('m1');
+    const notice = result.messages[1];
+    expect(notice.role).toBe('assistant');
+    expect(notice.blocks[0].content).toContain('interrupted');
+  });
+
+  it('without interrupted flag does not append notice', () => {
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hi' }],
+      },
+    ];
+    const result = messagesReducer(INITIAL, { type: 'RESTORE', messages: msgs });
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('does not replace when state already has all incoming messages', () => {
+    const existing: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'first' }],
+        },
+        {
+          messageId: 'm2',
+          role: 'user',
+          blocks: [{ blockId: 'b2', blockType: 'text', content: 'second' }],
+        },
+        {
+          messageId: 'm3',
+          role: 'assistant',
+          blocks: [{ blockId: 'b3', blockType: 'text', content: 'third' }],
+        },
+      ],
+    };
+    const apiMsgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'first' }],
+      },
+    ];
+    const result = messagesReducer(existing, { type: 'RESTORE', messages: apiMsgs });
+    expect(result.messages).toHaveLength(3);
+  });
+
+  it('replaces when incoming has new messages', () => {
+    const existing: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'first' }],
+        },
+      ],
+    };
+    const apiMsgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'first' }],
+      },
+      {
+        messageId: 'm2',
+        role: 'user' as const,
+        blocks: [{ blockId: 'b2', blockType: 'text' as const, content: 'second' }],
+      },
+    ];
+    const result = messagesReducer(existing, { type: 'RESTORE', messages: apiMsgs });
+    expect(result.messages).toHaveLength(2);
+  });
+});
+
+// ─── RESTORE with interrupted — optimistic message preservation ──────────────
+
+describe('RESTORE with interrupted preserves optimistic user messages', () => {
+  it('merges optimistic user sends not present in restored set', () => {
+    const stateWithOptimistic: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'user-1234',
+          role: 'user',
+          blocks: [{ blockId: 'user-text-1234', blockType: 'text', content: 'my question' }],
+        },
+        {
+          messageId: 'a1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'response' }],
+        },
+        {
+          messageId: 'user-5678',
+          role: 'user',
+          blocks: [{ blockId: 'user-text-5678', blockType: 'text', content: 'follow-up' }],
+        },
+      ],
+    };
+
+    const restoredMsgs = [
+      {
+        messageId: 'user-1234' as string,
+        role: 'user' as const,
+        blocks: [{ blockId: 'user-text-1234', blockType: 'text' as const, content: 'my question' }],
+      },
+      {
+        messageId: 'a1' as string,
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'response' }],
+      },
+    ];
+
+    const result = messagesReducer(stateWithOptimistic, {
+      type: 'RESTORE',
+      messages: restoredMsgs,
+      interrupted: true,
+    });
+
+    const userMsgs = result.messages.filter((m) => m.role === 'user');
+    expect(userMsgs).toHaveLength(2);
+    expect(userMsgs.some((m) => m.messageId === 'user-5678')).toBe(true);
+
+    const ids = result.messages.map((m) => m.messageId);
+    const optimisticIdx = ids.indexOf('user-5678');
+    const a1Idx = ids.indexOf('a1');
+    expect(optimisticIdx).toBeGreaterThan(a1Idx);
+
+    const lastMsg = result.messages[result.messages.length - 1];
+    expect(lastMsg.role).toBe('assistant');
+    expect(lastMsg.blocks[0].content).toContain('interrupted');
+    expect(result.messages).toHaveLength(4);
+  });
+
+  it('does not duplicate user messages already in restored set', () => {
+    const stateWithOptimistic: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'user-1234',
+          role: 'user',
+          blocks: [{ blockId: 'user-text-1234', blockType: 'text', content: 'question' }],
+        },
+      ],
+    };
+
+    const restoredMsgs = [
+      {
+        messageId: 'user-1234' as string,
+        role: 'user' as const,
+        blocks: [{ blockId: 'user-text-1234', blockType: 'text' as const, content: 'question' }],
+      },
+      {
+        messageId: 'a1' as string,
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'answer' }],
+      },
+    ];
+
+    const result = messagesReducer(stateWithOptimistic, {
+      type: 'RESTORE',
+      messages: restoredMsgs,
+      interrupted: true,
+    });
+
+    const user1234 = result.messages.filter((m) => m.messageId === 'user-1234');
+    expect(user1234).toHaveLength(1);
+  });
+
+  it('does not merge assistant messages as optimistic', () => {
+    const stateWithOrphan: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'orphan-assistant',
+          role: 'assistant',
+          blocks: [{ blockId: 'ob1', blockType: 'text', content: 'stale' }],
+        },
+      ],
+    };
+
+    const restoredMsgs = [
+      {
+        messageId: 'a1' as string,
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'fresh' }],
+      },
+    ];
+
+    const result = messagesReducer(stateWithOrphan, {
+      type: 'RESTORE',
+      messages: restoredMsgs,
+      interrupted: true,
+    });
+
+    const nonNoticeAssistantMsgs = result.messages.filter(
+      (m) => m.role === 'assistant' && m.messageId === 'a1',
+    );
+    expect(nonNoticeAssistantMsgs).toHaveLength(1);
+    expect(result.messages.some((m) => m.messageId === 'orphan-assistant')).toBe(false);
+  });
+});
+
+// ─── USER_MESSAGE_RECEIVED deduplication ─────────────────────────────────────
+
+describe('USER_MESSAGE_RECEIVED deduplication', () => {
+  it('adds user message when not already present', () => {
+    const result = messagesReducer(INITIAL, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-100',
+      text: 'hello',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].messageId).toBe('umsg-100');
+    expect(result.messages[0].role).toBe('user');
+  });
+
+  it('skips duplicate when message with same ID already exists', () => {
+    const stateWithMsg: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'umsg-100',
+          role: 'user',
+          blocks: [{ blockId: 'ut', blockType: 'text', content: 'hello' }],
+        },
+      ],
+    };
+    const result = messagesReducer(stateWithMsg, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-100',
+      text: 'hello',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result).toBe(stateWithMsg);
+  });
+
+  it('skips duplicate when ID collides with an existing assistant message', () => {
+    const stateWithAssistant: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'shared-id',
+          role: 'assistant',
+          blocks: [{ blockId: 'ab1', blockType: 'text', content: 'response' }],
+        },
+      ],
+    };
+    const result = messagesReducer(stateWithAssistant, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'shared-id',
+      text: 'hello',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result).toBe(stateWithAssistant);
+  });
+
+  it('adds message with different ID even if text is identical', () => {
+    const stateWithMsg: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'umsg-100',
+          role: 'user',
+          blocks: [{ blockId: 'ut', blockType: 'text', content: 'hello' }],
+        },
+      ],
+    };
+    const result = messagesReducer(stateWithMsg, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'umsg-200',
+      text: 'hello',
+    });
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1].messageId).toBe('umsg-200');
+  });
+
+  it('deduplicates when server echoes back the same clientMsgId', () => {
+    const clientMsgId = 'user-1234-abc';
+    const afterSend = messagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: "Yep. Let's go",
+      clientMsgId,
+    });
+    expect(afterSend.messages).toHaveLength(1);
+    expect(afterSend.messages[0].messageId).toBe(clientMsgId);
+
+    const afterEcho = messagesReducer(afterSend, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: clientMsgId,
+      text: "Yep. Let's go",
+    });
+    expect(afterEcho.messages).toHaveLength(1);
+    expect(afterEcho).toBe(afterSend);
+  });
+
+  it('handles duplicate text sent twice with different clientMsgIds', () => {
+    const afterSend1 = messagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-1-aaa',
+    });
+    const afterSend2 = messagesReducer(afterSend1, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-2-bbb',
+    });
+    expect(afterSend2.messages).toHaveLength(2);
+
+    const afterEcho1 = messagesReducer(afterSend2, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'user-1-aaa',
+      text: 'hello',
+    });
+    expect(afterEcho1.messages).toHaveLength(2);
+    const afterEcho2 = messagesReducer(afterEcho1, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'user-2-bbb',
+      text: 'hello',
+    });
+    expect(afterEcho2.messages).toHaveLength(2);
+  });
+
+  it('adds server message when no optimistic message exists (reconnect)', () => {
+    const result = messagesReducer(INITIAL, {
+      type: 'USER_MESSAGE_RECEIVED',
+      messageId: 'user-500-xyz',
+      text: 'reconnected message',
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].messageId).toBe('user-500-xyz');
+  });
+});
+
+// ─── SESSION_INFO ────────────────────────────────────────────────────────────
+
+describe('SESSION_INFO', () => {
+  it('sets branch, isWorktree, and wtId', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'SESSION_INFO',
+      branch: 'session/2026-04-13-a3f2b1',
+      isWorktree: true,
+      wtId: '2026-04-13-a3f2b1',
+    });
+    expect(state.branch).toBe('session/2026-04-13-a3f2b1');
+    expect(state.isWorktree).toBe(true);
+    expect(state.wtId).toBe('2026-04-13-a3f2b1');
+  });
+
+  it('preserves existing wtId when new action omits it', () => {
+    let state = messagesReducer(INITIAL, {
+      type: 'SESSION_INFO',
+      branch: 'session/2026-04-13-a3f2b1',
+      isWorktree: true,
+      wtId: '2026-04-13-a3f2b1',
+    });
+    state = messagesReducer(state, {
+      type: 'SESSION_INFO',
+      branch: 'session/2026-04-13-a3f2b1',
+      isWorktree: true,
+    });
+    expect(state.wtId).toBe('2026-04-13-a3f2b1');
+  });
+
+  it('sets branch without wtId for non-worktree sessions', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'SESSION_INFO',
+      branch: 'main',
+      isWorktree: false,
+    });
+    expect(state.branch).toBe('main');
+    expect(state.isWorktree).toBe(false);
+    expect(state.wtId).toBeNull();
+  });
+});
+
+// ─── WORKTREE_OPENED ────────────────────────────────────────────────────────
+
+describe('WORKTREE_OPENED', () => {
+  it('adds a new worktree to activeWorktrees', () => {
+    const result = messagesReducer(INITIAL, {
+      type: 'WORKTREE_OPENED',
+      repoName: 'team_home',
+      path: '/tmp/team_home-sessions/session-wt-123',
+    });
+    expect(result.activeWorktrees).toHaveLength(1);
+    expect(result.activeWorktrees[0]).toEqual({
+      repoName: 'team_home',
+      path: '/tmp/team_home-sessions/session-wt-123',
+    });
+  });
+
+  it('ignores duplicate repo (first-write-wins)', () => {
+    const state1 = messagesReducer(INITIAL, {
+      type: 'WORKTREE_OPENED',
+      repoName: 'team_home',
+      path: '/tmp/team_home-sessions/session-wt-123',
+    });
+    const state2 = messagesReducer(state1, {
+      type: 'WORKTREE_OPENED',
+      repoName: 'team_home',
+      path: '/tmp/team_home-sessions/session-wt-456',
+    });
+    expect(state2.activeWorktrees).toHaveLength(1);
+    expect(state2.activeWorktrees[0].path).toBe('/tmp/team_home-sessions/session-wt-123');
+    expect(state2).toBe(state1);
+  });
+
+  it('tracks multiple repos', () => {
+    const state1 = messagesReducer(INITIAL, {
+      type: 'WORKTREE_OPENED',
+      repoName: 'mgmt',
+      path: '/tmp/mgmt-sessions/session-wt-1',
+    });
+    const state2 = messagesReducer(state1, {
+      type: 'WORKTREE_OPENED',
+      repoName: 'team_home',
+      path: '/tmp/team_home-sessions/session-wt-2',
+    });
+    expect(state2.activeWorktrees).toHaveLength(2);
+  });
+});
+
+// ─── CLEAR ──────────────────────────────────────────────────────────────────
+
+describe('CLEAR', () => {
+  it('resets state to initial', () => {
+    const populated: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'm1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'hello' }],
+        },
+      ],
+      running: true,
+      branch: 'main',
+    };
+    const result = messagesReducer(populated, { type: 'CLEAR' });
+    expect(result.messages).toHaveLength(0);
+    expect(result.current).toBeNull();
+    expect(result.running).toBe(false);
+    expect(result.branch).toBeNull();
+  });
+});
+
+// ─── Full turn sequence ──────────────────────────────────────────────────────
+
+describe('full turn sequence', () => {
+  it('handles user -> assistant turn with tool call correctly', () => {
+    let state = INITIAL;
+
+    state = messagesReducer(state, {
+      type: 'USER_SEND',
+      text: 'list files',
+      clientMsgId: 'user-4-jkl',
+    });
+
+    state = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-a' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-a',
+      blockId: 'b1',
+      blockType: 'tool_use',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-a',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Bash',
+      toolId: 'tool-ls',
+    });
+    state = messagesReducer(state, {
+      type: 'TOOL_RESULT',
+      toolId: 'tool-ls',
+      result: 'file1\nfile2',
+      isError: false,
+    });
+
+    expect(state.current!.blocks.get('b1')!.toolResult).toBe('file1\nfile2');
+
+    state = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-a' });
+    expect(state.current).toBeNull();
+    expect(state.messages).toHaveLength(2);
+
+    state = messagesReducer(state, { type: 'SESSION_END' });
+    expect(state.running).toBe(false);
+
+    const assistantMsg = state.messages[1];
+    expect(assistantMsg.blocks[0].toolResult).toBe('file1\nfile2');
+  });
+});

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1042,3 +1042,57 @@ describe('full turn sequence', () => {
     expect(assistantMsg.blocks[0].toolResult).toBe('file1\nfile2');
   });
 });
+
+// ─── ERROR ──────────────────────────────────────────────────────────────────
+
+describe('ERROR', () => {
+  it('clears running and current state', () => {
+    let state = messagesReducer(INITIAL, { type: 'USER_SEND', text: 'hello', clientMsgId: 'c1' });
+    expect(state.running).toBe(true);
+
+    state = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    expect(state.current).not.toBeNull();
+
+    state = messagesReducer(state, { type: 'ERROR', error: 'Something went wrong' });
+    expect(state.running).toBe(false);
+    expect(state.current).toBeNull();
+  });
+
+  it('appends an error message to the list', () => {
+    let state = messagesReducer(INITIAL, { type: 'USER_SEND', text: 'hello', clientMsgId: 'c1' });
+    const msgCount = state.messages.length;
+    state = messagesReducer(state, { type: 'ERROR', error: 'fail' });
+    expect(state.messages.length).toBe(msgCount + 1);
+    expect(state.messages[state.messages.length - 1].blocks[0].content).toContain('fail');
+  });
+});
+
+// ─── CONNECTION_LOST ────────────────────────────────────────────────────────
+
+describe('CONNECTION_LOST', () => {
+  it('appends a connection lost message without clearing running', () => {
+    let state = messagesReducer(INITIAL, { type: 'USER_SEND', text: 'hello', clientMsgId: 'c1' });
+    const msgCount = state.messages.length;
+
+    state = messagesReducer(state, { type: 'CONNECTION_LOST' });
+    expect(state.messages.length).toBe(msgCount + 1);
+    expect(state.messages[state.messages.length - 1].blocks[0].content).toContain('Connection lost');
+  });
+});
+
+// ─── NATIVE_COMMAND_RESULT ──────────────────────────────────────────────────
+
+describe('NATIVE_COMMAND_RESULT', () => {
+  it('appends a native command result message', () => {
+    const state = messagesReducer(INITIAL, {
+      type: 'NATIVE_COMMAND_RESULT',
+      command: 'skills',
+      content: 'Available skills: none',
+    });
+    expect(state.messages.length).toBe(1);
+    const msg = state.messages[0];
+    expect(msg.role).toBe('assistant');
+    expect(msg.blocks.length).toBe(1);
+    expect(msg.blocks[0].content).toContain('Available skills');
+  });
+});

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseServerMessage } from '../src/protocol-parser.js';
+import type { ProtocolCallbacks, ProtocolParserState } from '../src/protocol-parser.js';
+import type { WsMsg } from '../src/server-messages.js';
+
+function makeState(overrides?: Partial<ProtocolParserState>): ProtocolParserState {
+  return {
+    currentSessionId: undefined,
+    pendingSend: null,
+    ...overrides,
+  };
+}
+
+function makeCallbacks(overrides?: Partial<ProtocolCallbacks>): ProtocolCallbacks {
+  return {
+    onSessionAssigned: vi.fn(),
+    onSessionExpired: vi.fn(),
+    onMessagesRestored: vi.fn(),
+    onSessionRenamed: vi.fn(),
+    setWsRunning: vi.fn(),
+    sendQueued: vi.fn(),
+    ...overrides,
+  };
+}
+
+const POOL_KEY = 'session:test';
+
+// ─── Lifecycle events ─────────────────────────────────────────────────────────
+
+describe('pool lifecycle events', () => {
+  it('_open and _close produce no actions', () => {
+    const state = makeState();
+    const cb = makeCallbacks();
+    const r1 = parseServerMessage({ type: '_open' }, state, cb, POOL_KEY);
+    const r2 = parseServerMessage({ type: '_close' }, state, cb, POOL_KEY);
+    expect(r1.messagesActions).toHaveLength(0);
+    expect(r2.messagesActions).toHaveLength(0);
+  });
+});
+
+// ─── Reattach ─────────────────────────────────────────────────────────────────
+
+describe('reattach', () => {
+  it('reattached sets running and calls onSessionAssigned', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'reattached', clientId: 'c1', sessionId: 'sid-1', running: true },
+      makeState(),
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'SET_RUNNING', running: true }]);
+    expect(cb.onSessionAssigned).toHaveBeenCalledWith('sid-1');
+    expect(cb.setWsRunning).toHaveBeenCalledWith(POOL_KEY, true);
+  });
+
+  it('reattach_failed sets running=false', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'reattach_failed', clientId: 'old' },
+      makeState(),
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'SET_RUNNING', running: false }]);
+    expect(cb.setWsRunning).toHaveBeenCalledWith(POOL_KEY, false);
+  });
+});
+
+// ─── Session lifecycle ────────────────────────────────────────────────────────
+
+describe('session lifecycle', () => {
+  it('session_id calls onSessionAssigned', () => {
+    const cb = makeCallbacks();
+    parseServerMessage({ type: 'session_id', sessionId: 'new-sid' }, makeState(), cb, POOL_KEY);
+    expect(cb.onSessionAssigned).toHaveBeenCalledWith('new-sid');
+  });
+
+  it('session_renamed calls onSessionRenamed', () => {
+    const cb = makeCallbacks();
+    parseServerMessage(
+      { type: 'session_renamed', sessionId: 'sid', name: 'New Name' },
+      makeState(),
+      cb,
+      POOL_KEY,
+    );
+    expect(cb.onSessionRenamed).toHaveBeenCalledWith('New Name');
+  });
+
+  it('session_info dispatches SESSION_INFO action', () => {
+    const r = parseServerMessage(
+      { type: 'session_info', branch: 'main', cwd: '/tmp', worktree: false },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'SESSION_INFO', branch: 'main', isWorktree: false, wtId: undefined },
+    ]);
+  });
+
+  it('session_end clears pending send and queues it', () => {
+    const state = makeState({ pendingSend: { type: 'send', prompt: 'follow-up' } });
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'session_end', sessionId: 'sid' },
+      state,
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toContainEqual({ type: 'SESSION_END', sessionId: 'sid' });
+    expect(r.messagesActions).toContainEqual({ type: 'SET_RUNNING', running: true });
+    expect(cb.sendQueued).toHaveBeenCalledWith(POOL_KEY, { type: 'send', prompt: 'follow-up' });
+    expect(state.pendingSend).toBeNull();
+  });
+});
+
+// ─── V2 content events ───────────────────────────────────────────────────────
+
+describe('v2 content events', () => {
+  it('message_start dispatches MESSAGE_START', () => {
+    const r = parseServerMessage(
+      { type: 'message_start', v: 2, messageId: 'msg-1' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'MESSAGE_START', messageId: 'msg-1' }]);
+  });
+
+  it('block_start dispatches BLOCK_START with toolName', () => {
+    const r = parseServerMessage(
+      { type: 'block_start', v: 2, messageId: 'msg-1', blockId: 'b1', blockType: 'tool_use', toolName: 'Bash' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'BLOCK_START', messageId: 'msg-1', blockId: 'b1', blockType: 'tool_use', toolName: 'Bash' },
+    ]);
+  });
+
+  it('block_delta dispatches BLOCK_DELTA', () => {
+    const r = parseServerMessage(
+      { type: 'block_delta', v: 2, messageId: 'msg-1', blockId: 'b1', blockType: 'text', delta: 'hi' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'BLOCK_DELTA', messageId: 'msg-1', blockId: 'b1', blockType: 'text', delta: 'hi' },
+    ]);
+  });
+
+  it('block_end dispatches BLOCK_END with tool fields', () => {
+    const r = parseServerMessage(
+      {
+        type: 'block_end',
+        v: 2,
+        messageId: 'msg-1',
+        blockId: 'b1',
+        blockType: 'tool_use',
+        toolName: 'Read',
+        toolId: 'tool-1',
+        input: 'file.ts',
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'BLOCK_END',
+      toolName: 'Read',
+      toolId: 'tool-1',
+      input: 'file.ts',
+    });
+  });
+
+  it('tool_result dispatches TOOL_RESULT', () => {
+    const r = parseServerMessage(
+      { type: 'tool_result', v: 2, messageId: 'msg-1', toolId: 'tool-1', result: 'output', isError: false },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'TOOL_RESULT', toolId: 'tool-1', result: 'output', isError: false },
+    ]);
+  });
+
+  it('message_end dispatches MESSAGE_END and assigns session if new', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'message_end', v: 2, messageId: 'msg-1', sessionId: 'new-sid' },
+      makeState(), // no currentSessionId
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'MESSAGE_END', messageId: 'msg-1', sessionId: 'new-sid' },
+    ]);
+    expect(cb.onSessionAssigned).toHaveBeenCalledWith('new-sid');
+  });
+
+  it('message_end does not reassign when session already known', () => {
+    const cb = makeCallbacks();
+    parseServerMessage(
+      { type: 'message_end', v: 2, messageId: 'msg-1', sessionId: 'sid' },
+      makeState({ currentSessionId: 'sid' }),
+      cb,
+      POOL_KEY,
+    );
+    expect(cb.onSessionAssigned).not.toHaveBeenCalled();
+  });
+
+  it('message_snapshot dispatches MESSAGE_SNAPSHOT', () => {
+    const blocks = [{ blockId: 'b1', blockType: 'text', content: 'hello' }];
+    const r = parseServerMessage(
+      { type: 'message_snapshot', v: 2, messageId: 'msg-snap', blocks },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'MESSAGE_SNAPSHOT',
+      messageId: 'msg-snap',
+    });
+  });
+});
+
+// ─── Permission events ───────────────────────────────────────────────────────
+
+describe('permission events', () => {
+  it('permission_request dispatches PERMISSION_REQUEST', () => {
+    const r = parseServerMessage(
+      {
+        type: 'permission_request',
+        permId: 'p1',
+        toolName: 'Bash',
+        toolInput: 'rm -rf /',
+        tier: 'elevated',
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'PERMISSION_REQUEST',
+      payload: { permId: 'p1', toolName: 'Bash', tier: 'elevated' },
+    });
+  });
+
+  it('permission_timeout dispatches PERMISSION_TIMEOUT', () => {
+    const r = parseServerMessage(
+      { type: 'permission_timeout', permId: 'p1' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'PERMISSION_TIMEOUT', permId: 'p1' }]);
+  });
+});
+
+// ─── Error handling ──────────────────────────────────────────────────────────
+
+describe('error handling', () => {
+  it('error with "No conversation found" calls onSessionExpired', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'error', error: 'No conversation found' },
+      makeState({ currentSessionId: 'expired-sid' }),
+      cb,
+      POOL_KEY,
+    );
+    expect(cb.onSessionExpired).toHaveBeenCalledWith('expired-sid');
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'ERROR',
+      error: 'Session expired. Send your message again to start fresh.',
+    });
+    expect(cb.setWsRunning).toHaveBeenCalledWith(POOL_KEY, false);
+  });
+
+  it('generic error dispatches ERROR action', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'error', error: 'Something broke' },
+      makeState(),
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'ERROR', error: 'Something broke' }]);
+  });
+
+  it('error clears pendingSend', () => {
+    const state = makeState({ pendingSend: { type: 'send', prompt: 'test' } });
+    parseServerMessage({ type: 'error', error: 'fail' }, state, makeCallbacks(), POOL_KEY);
+    expect(state.pendingSend).toBeNull();
+  });
+});
+
+// ─── Subscribed ──────────────────────────────────────────────────────────────
+
+describe('subscribed', () => {
+  it('subscribed with running=true sets running', () => {
+    const cb = makeCallbacks();
+    const r = parseServerMessage(
+      { type: 'subscribed', sessionId: 'sid', running: true },
+      makeState(),
+      cb,
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([{ type: 'SET_RUNNING', running: true }]);
+    expect(cb.setWsRunning).toHaveBeenCalledWith(POOL_KEY, true);
+  });
+
+  it('subscribed with running=false produces no actions', () => {
+    const r = parseServerMessage(
+      { type: 'subscribed', sessionId: 'sid', running: false },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toHaveLength(0);
+  });
+});
+
+// ─── User message dedup ──────────────────────────────────────────────────────
+
+describe('user_message', () => {
+  it('dispatches USER_MESSAGE_RECEIVED', () => {
+    const r = parseServerMessage(
+      { type: 'user_message', v: 2, messageId: 'umsg-1', text: 'hello' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'USER_MESSAGE_RECEIVED', messageId: 'umsg-1', text: 'hello' },
+    ]);
+  });
+});
+
+// ─── Task system messages ─────────────────────────────────────────────────────
+
+describe('task system messages', () => {
+  it('task_state produces tasksUpdate', () => {
+    const tasks = [{ id: 't1', title: 'Task 1' }];
+    const r = parseServerMessage(
+      { type: 'task_state', tasks },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tasksUpdate).toEqual({ type: 'task_state', tasks });
+  });
+
+  it('task_updated produces tasksUpdate', () => {
+    const task = { id: 't1', title: 'Updated' };
+    const r = parseServerMessage(
+      { type: 'task_updated', task },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tasksUpdate).toEqual({ type: 'task_updated', task });
+  });
+
+  it('task_deleted produces tasksUpdate', () => {
+    const r = parseServerMessage(
+      { type: 'task_deleted', taskId: 't1' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tasksUpdate).toEqual({ type: 'task_deleted', taskId: 't1' });
+  });
+
+  it('loop_status produces tasksUpdate', () => {
+    const r = parseServerMessage(
+      { type: 'loop_status', state: 'running', goalId: 'g1', activeTaskId: 't1', progress: { done: 2, total: 5 }, specMode: false, awaitingApproval: false },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tasksUpdate).toMatchObject({
+      type: 'loop_status',
+      status: { state: 'running', goalId: 'g1' },
+    });
+  });
+});
+
+// ─── Inbox ────────────────────────────────────────────────────────────────────
+
+describe('inbox', () => {
+  it('inbox_updated signals refresh', () => {
+    const r = parseServerMessage(
+      { type: 'inbox_updated' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.inboxRefresh).toBe(true);
+  });
+});
+
+// ─── Misc ─────────────────────────────────────────────────────────────────────
+
+describe('misc', () => {
+  it('worktree_opened dispatches WORKTREE_OPENED', () => {
+    const r = parseServerMessage(
+      { type: 'worktree_opened', repoName: 'mgmt', path: '/tmp/wt' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'WORKTREE_OPENED', repoName: 'mgmt', path: '/tmp/wt' },
+    ]);
+  });
+
+  it('native_command_result dispatches NATIVE_COMMAND_RESULT', () => {
+    const r = parseServerMessage(
+      { type: 'native_command_result', v: 2, command: 'status', content: 'ok' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toEqual([
+      { type: 'NATIVE_COMMAND_RESULT', command: 'status', content: 'ok' },
+    ]);
+  });
+
+  it('skill_invoked produces no actions', () => {
+    const r = parseServerMessage(
+      { type: 'skill_invoked', v: 2, name: 'commit', source: 'repo', arguments: '' },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toHaveLength(0);
+  });
+
+  it('unknown message type produces no actions', () => {
+    const r = parseServerMessage(
+      { type: 'some_future_event', data: 123 },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toHaveLength(0);
+  });
+});

--- a/packages/client/__tests__/ws-connection.test.ts
+++ b/packages/client/__tests__/ws-connection.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { WsPool } from '../src/ws-connection.js';
+import type { WebSocketLike, MsgListener } from '../src/ws-connection.js';
+import type { WsMsg } from '../src/server-messages.js';
+
+// ─── Mock WebSocket ──────────────────────────────────────────────────────────
+
+class MockWebSocket implements WebSocketLike {
+  readyState = 0; // CONNECTING
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+
+  simulateOpen() {
+    this.readyState = 1; // OPEN
+    this.onopen?.(null);
+  }
+
+  simulateMessage(data: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateClose() {
+    this.readyState = 3; // CLOSED
+    this.onclose?.();
+  }
+}
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+let lastCreatedWs: MockWebSocket | null = null;
+
+function createPool(): WsPool {
+  lastCreatedWs = null;
+  return new WsPool({
+    buildUrl: () => 'ws://localhost:3100/ws/chat',
+    createWebSocket: () => {
+      const ws = new MockWebSocket();
+      lastCreatedWs = ws;
+      return ws;
+    },
+    reconnectDelayMs: 50,
+    reconnectPollMs: 60_000, // disable in tests
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('WsPool message delivery', () => {
+  let pool: WsPool;
+
+  beforeEach(() => {
+    pool = createPool();
+  });
+
+  it('delivers messages directly to listeners', () => {
+    const received: WsMsg[] = [];
+    pool.subscribe('test-deliver-1', (msg) => received.push(msg));
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+
+    ws.simulateMessage({ type: 'block_delta', blockId: 'b1', delta: 'live' });
+
+    expect(received.some((m) => m.type === 'block_delta')).toBe(true);
+  });
+
+  it('drops messages when no listeners are subscribed', () => {
+    const unsub = pool.subscribe('test-deliver-2', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    unsub();
+
+    ws.simulateMessage({ type: 'block_delta', blockId: 'b1', delta: 'hello' });
+
+    const received: WsMsg[] = [];
+    pool.subscribe('test-deliver-2', (msg) => received.push(msg));
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe('WsPool subscribe for session keys', () => {
+  let pool: WsPool;
+
+  beforeEach(() => {
+    pool = createPool();
+  });
+
+  it('sends subscribe message for session: keys after client_id', () => {
+    pool.subscribe('session:sdk-test-123', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+
+    ws.simulateMessage({ type: 'client_id', clientId: 'new-client' });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'subscribe', sessionId: 'sdk-test-123' }),
+    );
+  });
+
+  it('does NOT send subscribe for non-session keys', () => {
+    pool.subscribe('new:abc123', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    ws.simulateMessage({ type: 'client_id', clientId: 'c1' });
+
+    const calls = ws.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+    expect(calls.some((c: Record<string, unknown>) => c.type === 'subscribe')).toBe(false);
+  });
+
+  it('broadcasts _open after subscribed response', () => {
+    const received: WsMsg[] = [];
+    pool.subscribe('session:sdk-sub-test', (msg) => received.push(msg));
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    ws.simulateMessage({ type: 'client_id', clientId: 'c2' });
+
+    const opensBefore = received.filter((m) => m.type === '_open').length;
+
+    ws.simulateMessage({ type: 'subscribed', sessionId: 'sdk-sub-test', running: true });
+
+    const opensAfter = received.filter((m) => m.type === '_open').length;
+    expect(opensAfter).toBeGreaterThan(opensBefore);
+  });
+
+  it('sets wasRunning when subscribed with running: true', () => {
+    pool.subscribe('session:sdk-running-test', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    ws.simulateMessage({ type: 'client_id', clientId: 'c3' });
+    ws.simulateMessage({ type: 'subscribed', sessionId: 'sdk-running-test', running: true });
+
+    // Simulate disconnect + reconnect
+    ws.simulateClose();
+
+    // Wait for reconnect timer
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(100);
+    vi.useRealTimers();
+
+    const ws2 = lastCreatedWs!;
+    ws2.simulateOpen();
+    ws2.simulateMessage({ type: 'client_id', clientId: 'c4' });
+
+    const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+    expect(calls.some((c: Record<string, unknown>) => c.type === 'reattach')).toBe(true);
+  });
+});
+
+describe('WsPool reattach_failed handling', () => {
+  let pool: WsPool;
+
+  beforeEach(() => {
+    pool = createPool();
+  });
+
+  it('broadcasts _open after reattach_failed', () => {
+    const received: WsMsg[] = [];
+    pool.subscribe('test-reattach-fail-1', (msg) => received.push(msg));
+    const ws1 = lastCreatedWs!;
+    ws1.simulateOpen();
+
+    ws1.simulateMessage({ type: 'client_id', clientId: 'old-id' });
+    pool.setRunning('test-reattach-fail-1', true);
+
+    received.length = 0;
+
+    // Simulate disconnect + reconnect
+    ws1.simulateClose();
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(100);
+    vi.useRealTimers();
+
+    const ws2 = lastCreatedWs!;
+    ws2.simulateOpen();
+
+    ws2.simulateMessage({ type: 'client_id', clientId: 'new-id' });
+
+    const openCountBefore = received.filter((m) => m.type === '_open').length;
+
+    ws2.simulateMessage({ type: 'reattach_failed', reason: 'no session' });
+
+    const types = received.map((m) => m.type);
+    expect(types).toContain('reattach_failed');
+    const openCountAfter = received.filter((m) => m.type === '_open').length;
+    expect(openCountAfter).toBeGreaterThan(openCountBefore);
+  });
+});
+
+describe('WsPool utility methods', () => {
+  let pool: WsPool;
+
+  beforeEach(() => {
+    pool = createPool();
+  });
+
+  it('isOpen returns true for open connections', () => {
+    pool.subscribe('test-open', () => {});
+    const ws = lastCreatedWs!;
+    expect(pool.isOpen('test-open')).toBe(false);
+    ws.simulateOpen();
+    expect(pool.isOpen('test-open')).toBe(true);
+  });
+
+  it('send returns false when connection is not open', () => {
+    expect(pool.send('nonexistent', { type: 'test' })).toBe(false);
+  });
+
+  it('send returns true and sends when connection is open', () => {
+    pool.subscribe('test-send', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    const result = pool.send('test-send', { type: 'test', data: 42 });
+    expect(result).toBe(true);
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'test', data: 42 }));
+  });
+
+  it('removeIfIdle removes idle entries', () => {
+    const unsub = pool.subscribe('test-idle', () => {});
+    unsub();
+    expect(pool.removeIfIdle('test-idle')).toBe(true);
+    expect(pool.isOpen('test-idle')).toBe(false);
+  });
+
+  it('removeIfIdle does not remove running entries', () => {
+    pool.subscribe('test-running', () => {});
+    pool.setRunning('test-running', true);
+    expect(pool.removeIfIdle('test-running')).toBe(false);
+  });
+
+  it('removeIfIdle does not remove entries with listeners', () => {
+    pool.subscribe('test-listeners', () => {});
+    expect(pool.removeIfIdle('test-listeners')).toBe(false);
+  });
+
+  it('destroy closes all connections', () => {
+    pool.subscribe('test-destroy-1', () => {});
+    pool.subscribe('test-destroy-2', () => {});
+    pool.destroy();
+    expect(pool.isOpen('test-destroy-1')).toBe(false);
+    expect(pool.isOpen('test-destroy-2')).toBe(false);
+  });
+});
+
+describe('WsPool session key aliasing', () => {
+  let pool: WsPool;
+
+  beforeEach(() => {
+    pool = createPool();
+  });
+
+  it('registers session key alias on session_id', () => {
+    pool.subscribe('new:abc', () => {});
+    const ws = lastCreatedWs!;
+    ws.simulateOpen();
+    ws.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    ws.simulateMessage({ type: 'session_id', sessionId: 'real-sid' });
+
+    // The pool should now respond to 'session:real-sid' too
+    expect(pool.isOpen('session:real-sid')).toBe(true);
+  });
+});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mitzo/client",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./hooks": {
+      "types": "./dist/hooks/index.d.ts",
+      "import": "./dist/hooks/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc --build"
+  },
+  "dependencies": {
+    "@mitzo/protocol": "*",
+    "zustand": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "react": "^19.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/packages/client/src/api-client.ts
+++ b/packages/client/src/api-client.ts
@@ -72,12 +72,12 @@ export class MitzoApiClient {
   }
 
   async login(passphrase: string): Promise<Response> {
-    return this.fetch('/api/auth/login', {
+    return this.assertOk(await this.fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ passphrase }),
-    });
+    }));
   }
 
   // ── Sessions ─────────────────────────────────────────────────────────────

--- a/packages/client/src/api-client.ts
+++ b/packages/client/src/api-client.ts
@@ -1,0 +1,327 @@
+/**
+ * Typed REST API client for Mitzo server.
+ *
+ * Replaces ad-hoc fetch() calls scattered across 20+ frontend files.
+ * Uses a TransportAdapter.fetch so it works in both browser and Theia.
+ */
+
+import type { FinishedMessage, Session, MitzoMode } from '@mitzo/protocol';
+import type { Task } from './slices/tasks.js';
+import type { TodoItem } from './slices/todos.js';
+import type { InboxItem } from './slices/inbox.js';
+import type { CalendarEvent, SprintInfo } from './slices/calendar.js';
+import type { ContextBlockEntry, SkillMetadata } from './slices/config.js';
+
+// ─── Transport ───────────────────────────────────────────────────────────────
+
+export interface ApiFetch {
+  (url: string, init?: RequestInit): Promise<Response>;
+}
+
+// ─── Response types ──────────────────────────────────────────────────────────
+
+export interface AuthCheckResult {
+  authenticated: boolean;
+}
+
+export interface VersionInfo {
+  version: string;
+  commit?: string;
+}
+
+export interface GitInfo {
+  branch: string;
+  worktrees: Array<{ path: string; branch: string }>;
+}
+
+export interface FileEntry {
+  name: string;
+  type: 'file' | 'directory';
+  size?: number;
+}
+
+export interface AppConfig {
+  contextBlocks: Record<string, ContextBlockEntry>;
+  fileRoots: string[];
+  quickActions?: Array<{ label: string; prompt: string }>;
+}
+
+export interface CalendarData {
+  events: CalendarEvent[];
+  sprints: SprintInfo[];
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+export class MitzoApiClient {
+  constructor(private fetch: ApiFetch) {}
+
+  // ── Auth ─────────────────────────────────────────────────────────────────
+
+  async checkAuth(): Promise<AuthCheckResult> {
+    const res = await this.fetch('/api/auth/check', { credentials: 'include' });
+    return res.json();
+  }
+
+  async login(passphrase: string): Promise<Response> {
+    return this.fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ passphrase }),
+    });
+  }
+
+  // ── Sessions ─────────────────────────────────────────────────────────────
+
+  async listSessions(offset?: number): Promise<Session[]> {
+    const url = offset ? `/api/sessions?offset=${offset}` : '/api/sessions';
+    const res = await this.fetch(url, { credentials: 'include' });
+    return res.json();
+  }
+
+  async getSessionMessages(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<FinishedMessage[]> {
+    const res = await this.fetch(`/api/sessions/${sessionId}/messages`, {
+      credentials: 'include',
+      signal,
+    });
+    return res.json();
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await this.fetch(`/api/sessions/${sessionId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+  }
+
+  async deleteAllSessions(): Promise<void> {
+    await this.fetch('/api/sessions', {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<void> {
+    await this.fetch(`/api/sessions/${sessionId}/rename`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ title }),
+    });
+  }
+
+  // ── Config ───────────────────────────────────────────────────────────────
+
+  async getConfig(): Promise<AppConfig> {
+    const res = await this.fetch('/api/config', { credentials: 'include' });
+    return res.json();
+  }
+
+  async getVersion(): Promise<VersionInfo> {
+    const res = await this.fetch('/api/version', { credentials: 'include' });
+    return res.json();
+  }
+
+  async checkForUpdate(): Promise<{ updateAvailable: boolean; latestVersion?: string }> {
+    const res = await this.fetch('/api/version/check', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    return res.json();
+  }
+
+  // ── Files ────────────────────────────────────────────────────────────────
+
+  async getFileRoots(): Promise<string[]> {
+    const res = await this.fetch('/api/files/roots', { credentials: 'include' });
+    return res.json();
+  }
+
+  async getGitInfo(): Promise<GitInfo> {
+    const res = await this.fetch('/api/git/info', { credentials: 'include' });
+    return res.json();
+  }
+
+  async listDirectory(dir: string, root?: string): Promise<FileEntry[]> {
+    const params = new URLSearchParams({ dir });
+    if (root) params.set('root', root);
+    const res = await this.fetch(`/api/files?${params}`, { credentials: 'include' });
+    return res.json();
+  }
+
+  async readFile(path: string): Promise<string> {
+    const params = new URLSearchParams({ path });
+    const res = await this.fetch(`/api/files/read?${params}`, { credentials: 'include' });
+    return res.text();
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    await this.fetch('/api/files/write', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ path, content }),
+    });
+  }
+
+  // ── Tasks & Loop ─────────────────────────────────────────────────────────
+
+  async getTasks(): Promise<Task[]> {
+    const res = await this.fetch('/api/tasks', { credentials: 'include' });
+    return res.json();
+  }
+
+  async createTask(input: Partial<Task>): Promise<Task> {
+    const res = await this.fetch('/api/tasks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(input),
+    });
+    return res.json();
+  }
+
+  async updateTask(taskId: string, update: Partial<Task>): Promise<Task> {
+    const res = await this.fetch(`/api/tasks/${taskId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(update),
+    });
+    return res.json();
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    await this.fetch(`/api/tasks/${taskId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+  }
+
+  async approveTask(taskId: string): Promise<void> {
+    await this.fetch(`/api/tasks/${taskId}/approve`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  }
+
+  async rejectTask(taskId: string, feedback: string): Promise<void> {
+    await this.fetch(`/api/tasks/${taskId}/reject`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ feedback }),
+    });
+  }
+
+  async getLoopStatus(): Promise<{ state: string; goalId: string | null }> {
+    const res = await this.fetch('/api/loop/status', { credentials: 'include' });
+    return res.json();
+  }
+
+  async startLoop(goalId: string, specMode?: boolean): Promise<void> {
+    await this.fetch('/api/loop/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ goalId, specMode }),
+    });
+  }
+
+  async pauseLoop(): Promise<void> {
+    await this.fetch('/api/loop/pause', { method: 'POST', credentials: 'include' });
+  }
+
+  async resumeLoop(): Promise<void> {
+    await this.fetch('/api/loop/resume', { method: 'POST', credentials: 'include' });
+  }
+
+  async stopLoop(): Promise<void> {
+    await this.fetch('/api/loop/stop', { method: 'POST', credentials: 'include' });
+  }
+
+  async approveSpec(): Promise<void> {
+    await this.fetch('/api/loop/spec/approve', { method: 'POST', credentials: 'include' });
+  }
+
+  async rejectSpec(): Promise<void> {
+    await this.fetch('/api/loop/spec/reject', { method: 'POST', credentials: 'include' });
+  }
+
+  // ── Todos ────────────────────────────────────────────────────────────────
+
+  async getTodos(profile?: string): Promise<TodoItem[]> {
+    const url = profile ? `/api/todos?profile=${encodeURIComponent(profile)}` : '/api/todos';
+    const res = await this.fetch(url, { credentials: 'include' });
+    return res.json();
+  }
+
+  async createTodo(summary: string, profile: string, parentId?: string): Promise<TodoItem> {
+    const res = await this.fetch('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ summary, profile, parentId }),
+    });
+    return res.json();
+  }
+
+  async todoAction(
+    todoId: string,
+    action: string,
+    days?: number,
+  ): Promise<void> {
+    await this.fetch(`/api/todos/${todoId}/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ action, days }),
+    });
+  }
+
+  // ── Calendar ─────────────────────────────────────────────────────────────
+
+  async getCalendar(date: string, days: number): Promise<CalendarData> {
+    const params = new URLSearchParams({ date, days: String(days) });
+    const res = await this.fetch(`/api/calendar?${params}`, { credentials: 'include' });
+    return res.json();
+  }
+
+  // ── Inbox ────────────────────────────────────────────────────────────────
+
+  async getInbox(): Promise<InboxItem[]> {
+    const res = await this.fetch('/api/inbox', { credentials: 'include' });
+    return res.json();
+  }
+
+  async getInboxItem(filename: string): Promise<string> {
+    const res = await this.fetch(`/api/inbox/${filename}`, { credentials: 'include' });
+    return res.text();
+  }
+
+  async approveInboxItem(filename: string): Promise<void> {
+    await this.fetch(`/api/inbox/${filename}/approve`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  }
+
+  async deleteInboxItem(filename: string): Promise<void> {
+    await this.fetch(`/api/inbox/${filename}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+  }
+
+  // ── Skills ───────────────────────────────────────────────────────────────
+
+  async getSkills(cwd?: string): Promise<SkillMetadata[]> {
+    const url = cwd ? `/api/skills?cwd=${encodeURIComponent(cwd)}` : '/api/skills';
+    const res = await this.fetch(url, { credentials: 'include' });
+    return res.json();
+  }
+}

--- a/packages/client/src/api-client.ts
+++ b/packages/client/src/api-client.ts
@@ -56,10 +56,18 @@ export interface CalendarData {
 export class MitzoApiClient {
   constructor(private fetch: ApiFetch) {}
 
+  private async assertOk(res: Response): Promise<Response> {
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`API ${res.status}: ${body || res.statusText}`);
+    }
+    return res;
+  }
+
   // ── Auth ─────────────────────────────────────────────────────────────────
 
   async checkAuth(): Promise<AuthCheckResult> {
-    const res = await this.fetch('/api/auth/check', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/auth/check', { credentials: 'include' }));
     return res.json();
   }
 
@@ -76,7 +84,7 @@ export class MitzoApiClient {
 
   async listSessions(offset?: number): Promise<Session[]> {
     const url = offset ? `/api/sessions?offset=${offset}` : '/api/sessions';
-    const res = await this.fetch(url, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(url, { credentials: 'include' }));
     return res.json();
   }
 
@@ -84,189 +92,189 @@ export class MitzoApiClient {
     sessionId: string,
     signal?: AbortSignal,
   ): Promise<FinishedMessage[]> {
-    const res = await this.fetch(`/api/sessions/${sessionId}/messages`, {
+    const res = await this.assertOk(await this.fetch(`/api/sessions/${sessionId}/messages`, {
       credentials: 'include',
       signal,
-    });
+    }));
     return res.json();
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    await this.fetch(`/api/sessions/${sessionId}`, {
+    await this.assertOk(await this.fetch(`/api/sessions/${sessionId}`, {
       method: 'DELETE',
       credentials: 'include',
-    });
+    }));
   }
 
   async deleteAllSessions(): Promise<void> {
-    await this.fetch('/api/sessions', {
+    await this.assertOk(await this.fetch('/api/sessions', {
       method: 'DELETE',
       credentials: 'include',
-    });
+    }));
   }
 
   async renameSession(sessionId: string, title: string): Promise<void> {
-    await this.fetch(`/api/sessions/${sessionId}/rename`, {
+    await this.assertOk(await this.fetch(`/api/sessions/${sessionId}/rename`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ title }),
-    });
+    }));
   }
 
   // ── Config ───────────────────────────────────────────────────────────────
 
   async getConfig(): Promise<AppConfig> {
-    const res = await this.fetch('/api/config', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/config', { credentials: 'include' }));
     return res.json();
   }
 
   async getVersion(): Promise<VersionInfo> {
-    const res = await this.fetch('/api/version', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/version', { credentials: 'include' }));
     return res.json();
   }
 
   async checkForUpdate(): Promise<{ updateAvailable: boolean; latestVersion?: string }> {
-    const res = await this.fetch('/api/version/check', {
+    const res = await this.assertOk(await this.fetch('/api/version/check', {
       method: 'POST',
       credentials: 'include',
-    });
+    }));
     return res.json();
   }
 
   // ── Files ────────────────────────────────────────────────────────────────
 
   async getFileRoots(): Promise<string[]> {
-    const res = await this.fetch('/api/files/roots', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/files/roots', { credentials: 'include' }));
     return res.json();
   }
 
   async getGitInfo(): Promise<GitInfo> {
-    const res = await this.fetch('/api/git/info', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/git/info', { credentials: 'include' }));
     return res.json();
   }
 
   async listDirectory(dir: string, root?: string): Promise<FileEntry[]> {
     const params = new URLSearchParams({ dir });
     if (root) params.set('root', root);
-    const res = await this.fetch(`/api/files?${params}`, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(`/api/files?${params}`, { credentials: 'include' }));
     return res.json();
   }
 
   async readFile(path: string): Promise<string> {
     const params = new URLSearchParams({ path });
-    const res = await this.fetch(`/api/files/read?${params}`, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(`/api/files/read?${params}`, { credentials: 'include' }));
     return res.text();
   }
 
   async writeFile(path: string, content: string): Promise<void> {
-    await this.fetch('/api/files/write', {
+    await this.assertOk(await this.fetch('/api/files/write', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ path, content }),
-    });
+    }));
   }
 
   // ── Tasks & Loop ─────────────────────────────────────────────────────────
 
   async getTasks(): Promise<Task[]> {
-    const res = await this.fetch('/api/tasks', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/tasks', { credentials: 'include' }));
     return res.json();
   }
 
   async createTask(input: Partial<Task>): Promise<Task> {
-    const res = await this.fetch('/api/tasks', {
+    const res = await this.assertOk(await this.fetch('/api/tasks', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify(input),
-    });
+    }));
     return res.json();
   }
 
   async updateTask(taskId: string, update: Partial<Task>): Promise<Task> {
-    const res = await this.fetch(`/api/tasks/${taskId}`, {
+    const res = await this.assertOk(await this.fetch(`/api/tasks/${taskId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify(update),
-    });
+    }));
     return res.json();
   }
 
   async deleteTask(taskId: string): Promise<void> {
-    await this.fetch(`/api/tasks/${taskId}`, {
+    await this.assertOk(await this.fetch(`/api/tasks/${taskId}`, {
       method: 'DELETE',
       credentials: 'include',
-    });
+    }));
   }
 
   async approveTask(taskId: string): Promise<void> {
-    await this.fetch(`/api/tasks/${taskId}/approve`, {
+    await this.assertOk(await this.fetch(`/api/tasks/${taskId}/approve`, {
       method: 'POST',
       credentials: 'include',
-    });
+    }));
   }
 
   async rejectTask(taskId: string, feedback: string): Promise<void> {
-    await this.fetch(`/api/tasks/${taskId}/reject`, {
+    await this.assertOk(await this.fetch(`/api/tasks/${taskId}/reject`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ feedback }),
-    });
+    }));
   }
 
   async getLoopStatus(): Promise<{ state: string; goalId: string | null }> {
-    const res = await this.fetch('/api/loop/status', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/loop/status', { credentials: 'include' }));
     return res.json();
   }
 
   async startLoop(goalId: string, specMode?: boolean): Promise<void> {
-    await this.fetch('/api/loop/start', {
+    await this.assertOk(await this.fetch('/api/loop/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ goalId, specMode }),
-    });
+    }));
   }
 
   async pauseLoop(): Promise<void> {
-    await this.fetch('/api/loop/pause', { method: 'POST', credentials: 'include' });
+    await this.assertOk(await this.fetch('/api/loop/pause', { method: 'POST', credentials: 'include' }));
   }
 
   async resumeLoop(): Promise<void> {
-    await this.fetch('/api/loop/resume', { method: 'POST', credentials: 'include' });
+    await this.assertOk(await this.fetch('/api/loop/resume', { method: 'POST', credentials: 'include' }));
   }
 
   async stopLoop(): Promise<void> {
-    await this.fetch('/api/loop/stop', { method: 'POST', credentials: 'include' });
+    await this.assertOk(await this.fetch('/api/loop/stop', { method: 'POST', credentials: 'include' }));
   }
 
   async approveSpec(): Promise<void> {
-    await this.fetch('/api/loop/spec/approve', { method: 'POST', credentials: 'include' });
+    await this.assertOk(await this.fetch('/api/loop/spec/approve', { method: 'POST', credentials: 'include' }));
   }
 
   async rejectSpec(): Promise<void> {
-    await this.fetch('/api/loop/spec/reject', { method: 'POST', credentials: 'include' });
+    await this.assertOk(await this.fetch('/api/loop/spec/reject', { method: 'POST', credentials: 'include' }));
   }
 
   // ── Todos ────────────────────────────────────────────────────────────────
 
   async getTodos(profile?: string): Promise<TodoItem[]> {
     const url = profile ? `/api/todos?profile=${encodeURIComponent(profile)}` : '/api/todos';
-    const res = await this.fetch(url, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(url, { credentials: 'include' }));
     return res.json();
   }
 
   async createTodo(summary: string, profile: string, parentId?: string): Promise<TodoItem> {
-    const res = await this.fetch('/api/todos', {
+    const res = await this.assertOk(await this.fetch('/api/todos', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ summary, profile, parentId }),
-    });
+    }));
     return res.json();
   }
 
@@ -275,53 +283,53 @@ export class MitzoApiClient {
     action: string,
     days?: number,
   ): Promise<void> {
-    await this.fetch(`/api/todos/${todoId}/action`, {
+    await this.assertOk(await this.fetch(`/api/todos/${todoId}/action`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ action, days }),
-    });
+    }));
   }
 
   // ── Calendar ─────────────────────────────────────────────────────────────
 
   async getCalendar(date: string, days: number): Promise<CalendarData> {
     const params = new URLSearchParams({ date, days: String(days) });
-    const res = await this.fetch(`/api/calendar?${params}`, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(`/api/calendar?${params}`, { credentials: 'include' }));
     return res.json();
   }
 
   // ── Inbox ────────────────────────────────────────────────────────────────
 
   async getInbox(): Promise<InboxItem[]> {
-    const res = await this.fetch('/api/inbox', { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch('/api/inbox', { credentials: 'include' }));
     return res.json();
   }
 
   async getInboxItem(filename: string): Promise<string> {
-    const res = await this.fetch(`/api/inbox/${filename}`, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(`/api/inbox/${filename}`, { credentials: 'include' }));
     return res.text();
   }
 
   async approveInboxItem(filename: string): Promise<void> {
-    await this.fetch(`/api/inbox/${filename}/approve`, {
+    await this.assertOk(await this.fetch(`/api/inbox/${filename}/approve`, {
       method: 'POST',
       credentials: 'include',
-    });
+    }));
   }
 
   async deleteInboxItem(filename: string): Promise<void> {
-    await this.fetch(`/api/inbox/${filename}`, {
+    await this.assertOk(await this.fetch(`/api/inbox/${filename}`, {
       method: 'DELETE',
       credentials: 'include',
-    });
+    }));
   }
 
   // ── Skills ───────────────────────────────────────────────────────────────
 
   async getSkills(cwd?: string): Promise<SkillMetadata[]> {
     const url = cwd ? `/api/skills?cwd=${encodeURIComponent(cwd)}` : '/api/skills';
-    const res = await this.fetch(url, { credentials: 'include' });
+    const res = await this.assertOk(await this.fetch(url, { credentials: 'include' }));
     return res.json();
   }
 }

--- a/packages/client/src/hooks/index.ts
+++ b/packages/client/src/hooks/index.ts
@@ -1,0 +1,7 @@
+// @mitzo/client/hooks — React-specific wrappers (tree-shakeable)
+
+export { MitzoStoreProvider, useMitzoStore } from './useStore.js';
+export { useMessages } from './useMessages.js';
+export { useSessions } from './useSessions.js';
+export { useConnection } from './useConnection.js';
+export { usePermission } from './usePermission.js';

--- a/packages/client/src/hooks/useConnection.ts
+++ b/packages/client/src/hooks/useConnection.ts
@@ -1,0 +1,5 @@
+import { useMitzoStore } from './useStore.js';
+
+export function useConnection() {
+  return useMitzoStore((s) => s.connection);
+}

--- a/packages/client/src/hooks/useMessages.ts
+++ b/packages/client/src/hooks/useMessages.ts
@@ -1,0 +1,5 @@
+import { useMitzoStore } from './useStore.js';
+
+export function useMessages() {
+  return useMitzoStore((s) => s.messages);
+}

--- a/packages/client/src/hooks/usePermission.ts
+++ b/packages/client/src/hooks/usePermission.ts
@@ -1,0 +1,5 @@
+import { useMitzoStore } from './useStore.js';
+
+export function usePermission() {
+  return useMitzoStore((s) => s.permissions);
+}

--- a/packages/client/src/hooks/useSessions.ts
+++ b/packages/client/src/hooks/useSessions.ts
@@ -1,0 +1,5 @@
+import { useMitzoStore } from './useStore.js';
+
+export function useSessions() {
+  return useMitzoStore((s) => s.sessions);
+}

--- a/packages/client/src/hooks/useStore.ts
+++ b/packages/client/src/hooks/useStore.ts
@@ -1,0 +1,27 @@
+/**
+ * React context + hook for MitzoStore.
+ *
+ * Usage in Mitzo mobile:
+ *   <MitzoStoreProvider store={store}>
+ *     <App />
+ *   </MitzoStoreProvider>
+ *
+ *   const messages = useMitzoStore(s => s.messages);
+ */
+
+import { createContext, useContext } from 'react';
+import { useStore } from 'zustand';
+import type { StoreApi } from 'zustand/vanilla';
+import type { MitzoStoreState } from '../store.js';
+
+const MitzoStoreContext = createContext<StoreApi<MitzoStoreState> | null>(null);
+
+export const MitzoStoreProvider = MitzoStoreContext.Provider;
+
+export function useMitzoStore<T>(selector: (state: MitzoStoreState) => T): T {
+  const store = useContext(MitzoStoreContext);
+  if (!store) {
+    throw new Error('useMitzoStore must be used within a <MitzoStoreProvider>');
+  }
+  return useStore(store, selector);
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,5 +3,37 @@
 // Framework-agnostic store, protocol parser, API client, and WS connection.
 // React hooks are a separate tree-shakeable export at '@mitzo/client/hooks'.
 
+// Transport
 export type { TransportAdapter, WsConnection, WsHandlers } from './types.js';
 export { WS_READY_STATE } from './types.js';
+
+// Store
+export { createMitzoStore } from './store.js';
+export type { MitzoStoreState, MitzoStoreOptions } from './store.js';
+
+// Slices — state shapes and types
+export type { MessagesState, MessagesAction, ActiveWorktree } from './slices/messages.js';
+export { messagesReducer, INITIAL_MESSAGES_STATE } from './slices/messages.js';
+export type { SessionsState } from './slices/sessions.js';
+export type { ConnectionState, ConnectionStatus } from './slices/connection.js';
+export type { PermissionsState } from './slices/permissions.js';
+export type { TasksState, Task, TaskStatus, SessionPolicy, LoopStatus } from './slices/tasks.js';
+export type { InboxState, InboxItem } from './slices/inbox.js';
+export type { CalendarState, CalendarEvent, SprintInfo } from './slices/calendar.js';
+export type { TodosState, TodoItem, TodoSource, TodoContextHints } from './slices/todos.js';
+export type { ConfigState, ContextBlockEntry, SkillMetadata } from './slices/config.js';
+
+// Protocol parser
+export { parseServerMessage } from './protocol-parser.js';
+export type { ProtocolCallbacks, ProtocolParserState, ParseResult } from './protocol-parser.js';
+
+// Server messages
+export type { ServerMessage, WsMsg } from './server-messages.js';
+
+// API client
+export { MitzoApiClient } from './api-client.js';
+export type { ApiFetch, AppConfig, AuthCheckResult, VersionInfo, GitInfo, FileEntry, CalendarData } from './api-client.js';
+
+// WS connection
+export { WsPool } from './ws-connection.js';
+export type { WsPoolConfig, WebSocketLike, MsgListener } from './ws-connection.js';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,7 @@
+// @mitzo/client — shared frontend package
+//
+// Framework-agnostic store, protocol parser, API client, and WS connection.
+// React hooks are a separate tree-shakeable export at '@mitzo/client/hooks'.
+
+export type { TransportAdapter, WsConnection, WsHandlers } from './types.js';
+export { WS_READY_STATE } from './types.js';

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -1,0 +1,326 @@
+/**
+ * Protocol parser — maps ServerMessage → store actions.
+ *
+ * Extracted from frontend/src/hooks/useChatMessages.ts handleWsMessage.
+ * Framework-agnostic: no React, no hooks, no DOM.
+ *
+ * The parser receives a WsMsg and calls the appropriate store dispatch.
+ * Side-effect callbacks (session assignment, reattach recovery) are injected
+ * via the Callbacks interface so the store factory can wire them.
+ */
+
+import type { FinishedMessage, FinishedBlock, BlockType, ToolTier, RawToolInput } from '@mitzo/protocol';
+import type { MessagesAction } from './slices/messages.js';
+import type { WsMsg } from './server-messages.js';
+import type { Task, LoopStatus } from './slices/tasks.js';
+
+// ─── Callback interface ──────────────────────────────────────────────────────
+
+export interface ProtocolCallbacks {
+  /** Called when the server assigns or confirms a session ID. */
+  onSessionAssigned(sessionId: string): void;
+
+  /** Called when the server reports "No conversation found". */
+  onSessionExpired(sessionId: string): void;
+
+  /** Called after reattach_failed recovery restores messages from API. */
+  onMessagesRestored?(): void;
+
+  /** Called when the server renames a session. */
+  onSessionRenamed?(name: string): void;
+
+  /** Called to fetch messages from REST API for reattach recovery. */
+  fetchMessages?(sessionId: string, signal: AbortSignal): Promise<FinishedMessage[]>;
+
+  /** Called to mark the WS pool entry as running/not-running. */
+  setWsRunning?(poolKey: string, running: boolean): void;
+
+  /** Called to send a queued message after session_end. */
+  sendQueued?(poolKey: string, msg: unknown): void;
+}
+
+// ─── Parser state ────────────────────────────────────────────────────────────
+
+export interface ProtocolParserState {
+  /** Currently tracked session ID (used for expiry detection). */
+  currentSessionId: string | undefined;
+
+  /** Queued message to send after current session ends. */
+  pendingSend: Record<string, unknown> | null;
+}
+
+// ─── Parser result ───────────────────────────────────────────────────────────
+
+export interface ParseResult {
+  /** Messages actions to dispatch to the messages slice. */
+  messagesActions: MessagesAction[];
+
+  /** Tasks state update, if any. */
+  tasksUpdate?: { type: 'task_state'; tasks: Task[] }
+    | { type: 'task_updated'; task: Task }
+    | { type: 'task_deleted'; taskId: string }
+    | { type: 'loop_status'; status: LoopStatus };
+
+  /** Connection state update, if any. */
+  connectionUpdate?: { status: 'connected' | 'disconnected' | 'reconnecting' };
+
+  /** Inbox refresh signal. */
+  inboxRefresh?: boolean;
+}
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+export function parseServerMessage(
+  msg: WsMsg,
+  state: ProtocolParserState,
+  callbacks: ProtocolCallbacks,
+  poolKey: string,
+): ParseResult {
+  const result: ParseResult = { messagesActions: [] };
+
+  switch (msg.type) {
+    case '_open':
+    case '_close':
+      break;
+
+    case 'reattached':
+      result.messagesActions.push({ type: 'SET_RUNNING', running: true });
+      callbacks.setWsRunning?.(poolKey, true);
+      if (msg.sessionId) callbacks.onSessionAssigned(msg.sessionId as string);
+      break;
+
+    case 'reattach_failed':
+      result.messagesActions.push({ type: 'SET_RUNNING', running: false });
+      callbacks.setWsRunning?.(poolKey, false);
+      if (state.currentSessionId && callbacks.fetchMessages) {
+        const sessionId = state.currentSessionId;
+        const controller = new AbortController();
+        callbacks.fetchMessages(sessionId, controller.signal)
+          .then((msgs) => {
+            if (controller.signal.aborted) return;
+            if (Array.isArray(msgs) && msgs.length > 0) {
+              // This is async — the caller needs to dispatch RESTORE separately.
+              // The store factory handles this by dispatching into the store directly.
+            }
+          })
+          .catch(() => {});
+      }
+      break;
+
+    case 'session_info':
+      result.messagesActions.push({
+        type: 'SESSION_INFO',
+        branch: msg.branch as string,
+        isWorktree: msg.worktree as boolean,
+        wtId: msg.wtId as string | undefined,
+      });
+      break;
+
+    case 'worktree_opened':
+      result.messagesActions.push({
+        type: 'WORKTREE_OPENED',
+        repoName: msg.repoName as string,
+        path: msg.path as string,
+      });
+      break;
+
+    case 'session_id':
+      callbacks.onSessionAssigned(msg.sessionId as string);
+      break;
+
+    case 'session_renamed':
+      callbacks.onSessionRenamed?.(msg.name as string);
+      break;
+
+    case 'message_start':
+      result.messagesActions.push({
+        type: 'MESSAGE_START',
+        messageId: msg.messageId as string,
+      });
+      break;
+
+    case 'block_start':
+      result.messagesActions.push({
+        type: 'BLOCK_START',
+        messageId: msg.messageId as string,
+        blockId: msg.blockId as string,
+        blockType: msg.blockType as BlockType,
+        toolName: msg.toolName as string | undefined,
+      });
+      break;
+
+    case 'block_delta':
+      result.messagesActions.push({
+        type: 'BLOCK_DELTA',
+        messageId: msg.messageId as string,
+        blockId: msg.blockId as string,
+        blockType: msg.blockType as BlockType,
+        delta: msg.delta as string,
+      });
+      break;
+
+    case 'block_end':
+      result.messagesActions.push({
+        type: 'BLOCK_END',
+        messageId: msg.messageId as string,
+        blockId: msg.blockId as string,
+        blockType: msg.blockType as BlockType,
+        toolName: msg.toolName as string | undefined,
+        toolId: msg.toolId as string | undefined,
+        input: msg.input as string | undefined,
+        rawInput: msg.rawInput as RawToolInput | undefined,
+      });
+      break;
+
+    case 'tool_result':
+      result.messagesActions.push({
+        type: 'TOOL_RESULT',
+        toolId: msg.toolId as string,
+        result: msg.result as string,
+        isError: (msg.isError as boolean) ?? false,
+      });
+      break;
+
+    case 'message_end':
+      result.messagesActions.push({
+        type: 'MESSAGE_END',
+        messageId: msg.messageId as string,
+        sessionId: msg.sessionId as string | undefined,
+      });
+      if (msg.sessionId && !state.currentSessionId) {
+        callbacks.onSessionAssigned(msg.sessionId as string);
+      }
+      break;
+
+    case 'message_snapshot':
+      if (Array.isArray(msg.blocks)) {
+        result.messagesActions.push({
+          type: 'MESSAGE_SNAPSHOT',
+          messageId: msg.messageId as string,
+          blocks: msg.blocks as FinishedBlock[],
+        });
+      }
+      break;
+
+    case 'session_end': {
+      result.messagesActions.push({
+        type: 'SESSION_END',
+        sessionId: msg.sessionId as string | undefined,
+      });
+      callbacks.setWsRunning?.(poolKey, false);
+      if (msg.sessionId && !state.currentSessionId) {
+        callbacks.onSessionAssigned(msg.sessionId as string);
+      }
+      const pending = state.pendingSend;
+      if (pending) {
+        state.pendingSend = null;
+        result.messagesActions.push({ type: 'SET_RUNNING', running: true });
+        callbacks.setWsRunning?.(poolKey, true);
+        callbacks.sendQueued?.(poolKey, pending);
+      }
+      break;
+    }
+
+    case 'permission_request':
+      result.messagesActions.push({
+        type: 'PERMISSION_REQUEST',
+        payload: {
+          permId: msg.permId as string,
+          toolName: msg.toolName as string,
+          toolInput: msg.toolInput as string,
+          title: msg.title as string | undefined,
+          description: msg.description as string | undefined,
+          displayName: msg.displayName as string | undefined,
+          tier: msg.tier as ToolTier | undefined,
+        },
+      });
+      break;
+
+    case 'permission_timeout':
+      result.messagesActions.push({
+        type: 'PERMISSION_TIMEOUT',
+        permId: msg.permId as string,
+      });
+      break;
+
+    case 'native_command_result':
+      result.messagesActions.push({
+        type: 'NATIVE_COMMAND_RESULT',
+        command: msg.command as string,
+        content: msg.content as string,
+      });
+      break;
+
+    case 'skill_invoked':
+      break;
+
+    case 'subscribed':
+      if (msg.running) {
+        result.messagesActions.push({ type: 'SET_RUNNING', running: true });
+        callbacks.setWsRunning?.(poolKey, true);
+      }
+      break;
+
+    case 'user_message':
+      result.messagesActions.push({
+        type: 'USER_MESSAGE_RECEIVED',
+        messageId: msg.messageId as string,
+        text: msg.text as string,
+      });
+      break;
+
+    case 'error': {
+      const errorMsg = msg.error as string;
+      callbacks.setWsRunning?.(poolKey, false);
+      state.pendingSend = null;
+      if (errorMsg?.includes('No conversation found')) {
+        if (state.currentSessionId) {
+          callbacks.onSessionExpired(state.currentSessionId);
+        }
+        result.messagesActions.push({
+          type: 'ERROR',
+          error: 'Session expired. Send your message again to start fresh.',
+        });
+      } else {
+        result.messagesActions.push({
+          type: 'ERROR',
+          error: errorMsg || 'Unknown error',
+        });
+      }
+      break;
+    }
+
+    // Task system messages
+    case 'task_state':
+      result.tasksUpdate = { type: 'task_state', tasks: msg.tasks as Task[] };
+      break;
+
+    case 'task_updated':
+      result.tasksUpdate = { type: 'task_updated', task: msg.task as Task };
+      break;
+
+    case 'task_deleted':
+      result.tasksUpdate = { type: 'task_deleted', taskId: msg.taskId as string };
+      break;
+
+    case 'loop_status':
+      result.tasksUpdate = {
+        type: 'loop_status',
+        status: {
+          state: msg.state as LoopStatus['state'],
+          goalId: (msg.goalId as string | null) ?? null,
+          activeTaskId: (msg.activeTaskId as string | null) ?? null,
+          progress: (msg.progress as LoopStatus['progress']) ?? null,
+          specMode: (msg.specMode as boolean) ?? false,
+          awaitingApproval: (msg.awaitingApproval as boolean) ?? false,
+        },
+      };
+      break;
+
+    case 'inbox_updated':
+      result.inboxRefresh = true;
+      break;
+  }
+
+  return result;
+}

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -99,8 +99,7 @@ export function parseServerMessage(
           .then((msgs) => {
             if (controller.signal.aborted) return;
             if (Array.isArray(msgs) && msgs.length > 0) {
-              // This is async — the caller needs to dispatch RESTORE separately.
-              // The store factory handles this by dispatching into the store directly.
+              callbacks.onMessagesRestored?.();
             }
           })
           .catch(() => {});

--- a/packages/client/src/server-messages.ts
+++ b/packages/client/src/server-messages.ts
@@ -1,0 +1,27 @@
+/**
+ * Server → client WebSocket message types.
+ *
+ * These mirror the types in frontend/src/types/ws-messages.ts.
+ * Ideally these would live in @mitzo/protocol, but moving them
+ * is out of scope for Phase 3 — tracked for a future cleanup.
+ */
+
+import type { BlockType, FinishedBlock, ToolTier, RawToolInput } from '@mitzo/protocol';
+
+// Using a record-based approach rather than discriminated unions
+// so the protocol parser can handle unknown message types gracefully.
+export interface ServerMessage {
+  type: string;
+  [key: string]: unknown;
+}
+
+// Pool lifecycle events (not from server, injected by ws-connection)
+export interface PoolOpenEvent {
+  type: '_open';
+}
+
+export interface PoolCloseEvent {
+  type: '_close';
+}
+
+export type WsMsg = ServerMessage | PoolOpenEvent | PoolCloseEvent;

--- a/packages/client/src/server-messages.ts
+++ b/packages/client/src/server-messages.ts
@@ -6,8 +6,6 @@
  * is out of scope for Phase 3 — tracked for a future cleanup.
  */
 
-import type { BlockType, FinishedBlock, ToolTier, RawToolInput } from '@mitzo/protocol';
-
 // Using a record-based approach rather than discriminated unions
 // so the protocol parser can handle unknown message types gracefully.
 export interface ServerMessage {

--- a/packages/client/src/slices/calendar.ts
+++ b/packages/client/src/slices/calendar.ts
@@ -1,0 +1,37 @@
+export interface CalendarEvent {
+  id: string;
+  type: 'meeting' | 'milestone';
+  title: string;
+  start: string;
+  end: string;
+  allDay?: boolean;
+  location?: string;
+  attendees?: string[];
+  attendeeCount?: number;
+  status?: string;
+  hangoutLink?: string;
+  version?: string;
+  milestone?: string;
+  label?: string;
+  daysAway?: number;
+  ourFeatures?: number;
+  totalFeatures?: number;
+}
+
+export interface SprintInfo {
+  id: string;
+  type: 'sprint';
+  title: string;
+  start: string;
+  end: string;
+}
+
+export interface CalendarState {
+  events: CalendarEvent[];
+  sprints: SprintInfo[];
+}
+
+export const INITIAL_CALENDAR_STATE: CalendarState = {
+  events: [],
+  sprints: [],
+};

--- a/packages/client/src/slices/config.ts
+++ b/packages/client/src/slices/config.ts
@@ -1,0 +1,27 @@
+import type { MitzoMode } from '@mitzo/protocol';
+
+export interface ContextBlockEntry {
+  name: string;
+  path: string;
+  sizeBytes: number;
+}
+
+export interface SkillMetadata {
+  name: string;
+  source: 'repo' | 'user' | 'bundled';
+  description?: string;
+}
+
+export interface ConfigState {
+  contextBlocks: Record<string, ContextBlockEntry>;
+  skills: SkillMetadata[];
+  mode: MitzoMode;
+  modelId: string | null;
+}
+
+export const INITIAL_CONFIG_STATE: ConfigState = {
+  contextBlocks: {},
+  skills: [],
+  mode: 'auto',
+  modelId: null,
+};

--- a/packages/client/src/slices/connection.ts
+++ b/packages/client/src/slices/connection.ts
@@ -1,0 +1,11 @@
+export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
+
+export interface ConnectionState {
+  status: ConnectionStatus;
+  clientId: string | null;
+}
+
+export const INITIAL_CONNECTION_STATE: ConnectionState = {
+  status: 'disconnected',
+  clientId: null,
+};

--- a/packages/client/src/slices/inbox.ts
+++ b/packages/client/src/slices/inbox.ts
@@ -1,0 +1,18 @@
+export interface InboxItem {
+  filename: string;
+  agent: string;
+  title: string;
+  tags: string[];
+  timestamp: string;
+  preview: string;
+}
+
+export interface InboxState {
+  items: InboxItem[];
+  count: number;
+}
+
+export const INITIAL_INBOX_STATE: InboxState = {
+  items: [],
+  count: 0,
+};

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -301,7 +301,7 @@ export function messagesReducer(
         ...state,
         branch: action.branch,
         isWorktree: action.isWorktree,
-        wtId: action.wtId ?? state.wtId,
+        wtId: action.isWorktree ? (action.wtId ?? state.wtId) : null,
       };
 
     case 'WORKTREE_OPENED': {

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -1,0 +1,464 @@
+/**
+ * Messages slice — pure state management for chat messages.
+ *
+ * Extracted from frontend/src/hooks/useChatMessages.ts.
+ * Framework-agnostic: no React, no hooks, no DOM.
+ */
+
+import type {
+  FinishedMessage,
+  FinishedBlock,
+  StreamingMessage,
+  StreamingBlock,
+  PermissionRequest,
+  ToolTier,
+  RawToolInput,
+  BlockType,
+} from '@mitzo/protocol';
+
+// ─── State ───────────────────────────────────────────────────────────────────
+
+export interface ActiveWorktree {
+  repoName: string;
+  path: string;
+}
+
+export interface MessagesState {
+  messages: FinishedMessage[];
+  current: StreamingMessage | null;
+  running: boolean;
+  permission: PermissionRequest | null;
+  branch: string | null;
+  isWorktree: boolean;
+  wtId: string | null;
+  activeWorktrees: ActiveWorktree[];
+}
+
+export const INITIAL_MESSAGES_STATE: MessagesState = {
+  messages: [],
+  current: null,
+  running: false,
+  permission: null,
+  branch: null,
+  isWorktree: false,
+  wtId: null,
+  activeWorktrees: [],
+};
+
+// ─── Actions ─────────────────────────────────────────────────────────────────
+
+export type MessagesAction =
+  // v2 content events
+  | { type: 'MESSAGE_START'; messageId: string }
+  | {
+      type: 'BLOCK_START';
+      messageId: string;
+      blockId: string;
+      blockType: BlockType;
+      toolName?: string;
+    }
+  | { type: 'BLOCK_DELTA'; messageId: string; blockId: string; blockType: BlockType; delta: string }
+  | {
+      type: 'BLOCK_END';
+      messageId: string;
+      blockId: string;
+      blockType: BlockType;
+      toolName?: string;
+      toolId?: string;
+      input?: string;
+      rawInput?: RawToolInput;
+    }
+  | {
+      type: 'TOOL_RESULT';
+      toolId: string;
+      result: string;
+      isError: boolean;
+    }
+  | { type: 'MESSAGE_END'; messageId: string; sessionId?: string }
+  | { type: 'SESSION_END'; sessionId?: string }
+  // Reattach snapshot
+  | { type: 'MESSAGE_SNAPSHOT'; messageId: string; blocks: FinishedBlock[] }
+  // Session / UI lifecycle
+  | { type: 'ERROR'; error: string }
+  | { type: 'SESSION_INFO'; branch: string; isWorktree: boolean; wtId?: string }
+  | {
+      type: 'USER_SEND';
+      text: string;
+      clientMsgId: string;
+      images?: string[];
+      contextBlocks?: string[];
+    }
+  | { type: 'SET_RUNNING'; running: boolean }
+  | { type: 'CONNECTION_LOST' }
+  | { type: 'PERMISSION_REQUEST'; payload: PermissionRequest }
+  | { type: 'PERMISSION_TIMEOUT'; permId: string }
+  | { type: 'RESTORE'; messages: FinishedMessage[]; interrupted?: boolean }
+  | { type: 'USER_MESSAGE_RECEIVED'; messageId: string; text: string }
+  | { type: 'WORKTREE_OPENED'; repoName: string; path: string }
+  | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string }
+  | { type: 'CLEAR' };
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+export function finishCurrent(current: StreamingMessage): FinishedMessage {
+  const blocks: FinishedBlock[] = current.blockOrder.map((blockId) => {
+    const b = current.blocks.get(blockId)!;
+    return {
+      blockId: b.blockId,
+      blockType: b.blockType,
+      content: b.content,
+      toolName: b.toolName,
+      toolId: b.toolId,
+      toolInput: b.toolInput,
+      rawInput: b.rawInput,
+      toolResult: b.toolResult,
+      toolError: b.toolError,
+    };
+  });
+  return { messageId: current.messageId, role: 'assistant', blocks };
+}
+
+export function patchToolResult(
+  messages: FinishedMessage[],
+  current: StreamingMessage | null,
+  toolId: string,
+  result: string,
+  isError: boolean,
+): { messages: FinishedMessage[]; current: StreamingMessage | null } {
+  // Check current first (tool result may arrive before message_end in edge cases).
+  if (current) {
+    for (const block of current.blocks.values()) {
+      if (block.toolId === toolId) {
+        const newBlocks = new Map(current.blocks);
+        newBlocks.set(block.blockId, { ...block, toolResult: result, toolError: isError });
+        return { messages, current: { ...current, blocks: newBlocks } };
+      }
+    }
+  }
+  // Search finished messages.
+  const newMessages = messages.map((msg) => {
+    const idx = msg.blocks.findIndex((b) => b.toolId === toolId);
+    if (idx === -1) return msg;
+    const newBlocks = [...msg.blocks];
+    newBlocks[idx] = { ...newBlocks[idx], toolResult: result, toolError: isError };
+    return { ...msg, blocks: newBlocks };
+  });
+  return { messages: newMessages, current };
+}
+
+// ─── Reducer ─────────────────────────────────────────────────────────────────
+
+export function messagesReducer(
+  state: MessagesState,
+  action: MessagesAction,
+): MessagesState {
+  switch (action.type) {
+    case 'MESSAGE_START': {
+      const base = state.current
+        ? { ...state, messages: [...state.messages, finishCurrent(state.current)] }
+        : state;
+      return {
+        ...base,
+        current: {
+          messageId: action.messageId,
+          blocks: new Map<string, StreamingBlock>(),
+          blockOrder: [],
+        },
+      };
+    }
+
+    case 'BLOCK_START': {
+      if (!state.current) return state;
+      const newBlock: StreamingBlock = {
+        blockId: action.blockId,
+        blockType: action.blockType,
+        content: '',
+        done: false,
+        ...(action.toolName ? { toolName: action.toolName } : {}),
+      };
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.blockId, newBlock);
+      return {
+        ...state,
+        current: {
+          ...state.current,
+          blocks: newBlocks,
+          blockOrder: [...state.current.blockOrder, action.blockId],
+        },
+      };
+    }
+
+    case 'BLOCK_DELTA': {
+      if (!state.current) return state;
+      const block = state.current.blocks.get(action.blockId);
+      if (!block) return state;
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.blockId, { ...block, content: block.content + action.delta });
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'BLOCK_END': {
+      if (!state.current) return state;
+      const block = state.current.blocks.get(action.blockId);
+      if (!block) return state;
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.blockId, {
+        ...block,
+        done: true,
+        ...(action.toolName ? { toolName: action.toolName } : {}),
+        ...(action.toolId ? { toolId: action.toolId } : {}),
+        ...(action.input ? { toolInput: action.input } : {}),
+        ...(action.rawInput ? { rawInput: action.rawInput } : {}),
+      });
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'TOOL_RESULT': {
+      const { messages, current } = patchToolResult(
+        state.messages,
+        state.current,
+        action.toolId,
+        action.result,
+        action.isError,
+      );
+      return { ...state, messages, current };
+    }
+
+    case 'MESSAGE_END': {
+      if (!state.current) return { ...state };
+      const finished = finishCurrent(state.current);
+      return { ...state, messages: [...state.messages, finished], current: null };
+    }
+
+    case 'SESSION_END': {
+      if (state.current) {
+        const finished = finishCurrent(state.current);
+        return {
+          ...state,
+          running: false,
+          messages: [...state.messages, finished],
+          current: null,
+        };
+      }
+      return { ...state, running: false };
+    }
+
+    case 'MESSAGE_SNAPSHOT': {
+      const snapshotBlocks = action.blocks ?? [];
+      if (!Array.isArray(snapshotBlocks) || snapshotBlocks.length === 0) return state;
+      const blocks = new Map<string, StreamingBlock>();
+      const blockOrder: string[] = [];
+      for (const b of snapshotBlocks) {
+        blocks.set(b.blockId, {
+          blockId: b.blockId,
+          blockType: b.blockType as BlockType,
+          content: b.content ?? '',
+          done: (b as unknown as { done?: boolean }).done ?? false,
+          toolName: b.toolName,
+          toolId: b.toolId,
+          toolInput: b.toolInput,
+          rawInput: b.rawInput,
+          toolResult: b.toolResult,
+          toolError: b.toolError,
+        });
+        blockOrder.push(b.blockId);
+      }
+      return { ...state, current: { messageId: action.messageId, blocks, blockOrder } };
+    }
+
+    case 'PERMISSION_REQUEST':
+      return { ...state, permission: action.payload };
+
+    case 'PERMISSION_TIMEOUT':
+      return {
+        ...state,
+        permission: state.permission?.permId === action.permId ? null : state.permission,
+      };
+
+    case 'ERROR':
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            messageId: `err-${Date.now()}`,
+            role: 'assistant',
+            blocks: [
+              {
+                blockId: `err-${Date.now()}`,
+                blockType: 'text',
+                content: `**Error:** ${action.error}`,
+              },
+            ],
+          },
+        ],
+        running: false,
+        current: null,
+      };
+
+    case 'SESSION_INFO':
+      return {
+        ...state,
+        branch: action.branch,
+        isWorktree: action.isWorktree,
+        wtId: action.wtId ?? state.wtId,
+      };
+
+    case 'WORKTREE_OPENED': {
+      const already = state.activeWorktrees.some((w) => w.repoName === action.repoName);
+      if (already) return state;
+      return {
+        ...state,
+        activeWorktrees: [
+          ...state.activeWorktrees,
+          { repoName: action.repoName, path: action.path },
+        ],
+      };
+    }
+
+    case 'NATIVE_COMMAND_RESULT': {
+      const cmdMsg: FinishedMessage = {
+        messageId: `native-${Date.now()}`,
+        role: 'assistant',
+        blocks: [
+          {
+            blockId: `native-b-${Date.now()}`,
+            blockType: 'text',
+            content: action.content,
+          },
+        ],
+      };
+      return {
+        ...state,
+        messages: [...state.messages, cmdMsg],
+      };
+    }
+
+    case 'CLEAR':
+      return { ...INITIAL_MESSAGES_STATE };
+
+    case 'RESTORE': {
+      const valid = action.messages.filter(
+        (m) => m && typeof m.messageId === 'string' && Array.isArray(m.blocks),
+      );
+      if (!action.interrupted) {
+        const existingIds = new Set(state.messages.map((m) => m.messageId));
+        const hasNewMessages = valid.some((m) => !existingIds.has(m.messageId));
+        if (!hasNewMessages && state.messages.length > 0) {
+          return state;
+        }
+      }
+      if (action.interrupted) {
+        const restoredIds = new Set(valid.map((m) => m.messageId));
+        const optimisticUserMsgs = state.messages.filter(
+          (m) =>
+            m.role === 'user' && m.messageId.startsWith('user-') && !restoredIds.has(m.messageId),
+        );
+        const notice: FinishedMessage = {
+          messageId: `notice-${Date.now()}`,
+          role: 'assistant',
+          blocks: [
+            {
+              blockId: `notice-text-${Date.now()}`,
+              blockType: 'text',
+              content:
+                '**Session interrupted.** Messages above were restored from history — some recent content may be missing.',
+            },
+          ],
+        };
+        const merged: FinishedMessage[] = [...valid];
+        for (const opt of optimisticUserMsgs) {
+          const localIdx = state.messages.indexOf(opt);
+          let insertAfter = -1;
+          for (let i = localIdx - 1; i >= 0; i--) {
+            const precedingId = state.messages[i].messageId;
+            const restoredIdx = merged.findIndex((m) => m.messageId === precedingId);
+            if (restoredIdx !== -1) {
+              insertAfter = restoredIdx;
+              break;
+            }
+          }
+          merged.splice(insertAfter + 1, 0, opt);
+        }
+        merged.push(notice);
+        return { ...state, messages: merged };
+      }
+      return { ...state, messages: valid };
+    }
+
+    case 'USER_MESSAGE_RECEIVED': {
+      if (state.messages.some((m) => m.messageId === action.messageId)) {
+        return state;
+      }
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            messageId: action.messageId,
+            role: 'user',
+            blocks: [
+              {
+                blockId: `user-text-${action.messageId}`,
+                blockType: 'text' as BlockType,
+                content: action.text,
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    case 'USER_SEND':
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            messageId: action.clientMsgId,
+            role: 'user',
+            blocks: [],
+            images: action.images,
+            contextBlocks: action.contextBlocks,
+            ...(action.text
+              ? {
+                  blocks: [
+                    {
+                      blockId: `user-text-${action.clientMsgId}`,
+                      blockType: 'text' as BlockType,
+                      content: action.text,
+                    },
+                  ],
+                }
+              : {}),
+          },
+        ],
+        running: true,
+      };
+
+    case 'SET_RUNNING':
+      return { ...state, running: action.running };
+
+    case 'CONNECTION_LOST':
+      return {
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            messageId: `conn-${Date.now()}`,
+            role: 'assistant',
+            blocks: [
+              {
+                blockId: `conn-text-${Date.now()}`,
+                blockType: 'text',
+                content: '**Connection lost.** Reconnecting — try again in a moment.',
+              },
+            ],
+          },
+        ],
+      };
+
+    default:
+      return state;
+  }
+}

--- a/packages/client/src/slices/permissions.ts
+++ b/packages/client/src/slices/permissions.ts
@@ -1,0 +1,9 @@
+import type { PermissionRequest } from '@mitzo/protocol';
+
+export interface PermissionsState {
+  pending: PermissionRequest | null;
+}
+
+export const INITIAL_PERMISSIONS_STATE: PermissionsState = {
+  pending: null,
+};

--- a/packages/client/src/slices/sessions.ts
+++ b/packages/client/src/slices/sessions.ts
@@ -1,0 +1,13 @@
+import type { Session } from '@mitzo/protocol';
+
+export interface SessionsState {
+  list: Session[];
+  active: string | null;
+  loading: boolean;
+}
+
+export const INITIAL_SESSIONS_STATE: SessionsState = {
+  list: [],
+  active: null,
+  loading: false,
+};

--- a/packages/client/src/slices/tasks.ts
+++ b/packages/client/src/slices/tasks.ts
@@ -1,0 +1,58 @@
+export type TaskStatus =
+  | 'pending'
+  | 'active'
+  | 'done'
+  | 'pending_review'
+  | 'blocked'
+  | 'skipped'
+  | 'failed';
+
+export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
+
+export interface Task {
+  id: string;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  sessionId: string | null;
+  sessionPolicy: SessionPolicy;
+  priority: number;
+  depth: number;
+  annotations: string[];
+  summary: string | null;
+  requiresApproval: boolean;
+  tokenUsage: number;
+  claimedBy: string | null;
+  claimedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  children: Task[];
+}
+
+export interface LoopStatus {
+  state: 'idle' | 'running' | 'paused';
+  goalId: string | null;
+  activeTaskId: string | null;
+  progress: { done: number; total: number } | null;
+  specMode: boolean;
+  awaitingApproval: boolean;
+}
+
+export interface TasksState {
+  tree: Task[];
+  loopStatus: LoopStatus;
+}
+
+export const INITIAL_TASKS_STATE: TasksState = {
+  tree: [],
+  loopStatus: {
+    state: 'idle',
+    goalId: null,
+    activeTaskId: null,
+    progress: null,
+    specMode: false,
+    awaitingApproval: false,
+  },
+};

--- a/packages/client/src/slices/todos.ts
+++ b/packages/client/src/slices/todos.ts
@@ -1,0 +1,44 @@
+export interface TodoSource {
+  type: string;
+  url: string;
+  title: string;
+  author: string;
+  snippet: string;
+}
+
+export interface TodoContextHints {
+  repos: string[];
+  paths: string[];
+  issues: string[];
+  docIds: string[];
+  people: string[];
+  jiraKeys: string[];
+  keywords: string[];
+  taskHint: string;
+}
+
+export interface TodoItem {
+  id: string;
+  summary: string;
+  profile: string;
+  urgency: number;
+  starred: boolean;
+  status: 'active' | 'acknowledged' | 'snoozed' | 'completed';
+  ageDays: number;
+  parentId: string | null;
+  children: TodoItem[];
+  childCount: number;
+  completedChildCount: number;
+  sources: TodoSource[];
+  contextHints: TodoContextHints;
+}
+
+export interface TodosState {
+  items: TodoItem[];
+  profiles: string[];
+}
+
+export const INITIAL_TODOS_STATE: TodosState = {
+  items: [],
+  profiles: [],
+};

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -70,6 +70,33 @@ export interface MitzoStoreOptions {
   wsConfig: WsPoolConfig;
 }
 
+// ─── Tree helpers ───────────────────────────────────────────────────────────
+
+/** Recursively replace a task by ID anywhere in the tree. */
+function updateTaskInTree(tasks: Task[], updated: Task): Task[] {
+  return tasks.map((t) => {
+    if (t.id === updated.id) return updated;
+    if (t.children.length > 0) {
+      const newChildren = updateTaskInTree(t.children, updated);
+      return newChildren !== t.children ? { ...t, children: newChildren } : t;
+    }
+    return t;
+  });
+}
+
+/** Recursively remove a task by ID anywhere in the tree. */
+function removeTaskFromTree(tasks: Task[], id: string): Task[] {
+  return tasks
+    .filter((t) => t.id !== id)
+    .map((t) => {
+      if (t.children.length > 0) {
+        const newChildren = removeTaskFromTree(t.children, id);
+        return newChildren !== t.children ? { ...t, children: newChildren } : t;
+      }
+      return t;
+    });
+}
+
 // ─── Factory ─────────────────────────────────────────────────────────────────
 
 export function createMitzoStore(
@@ -83,6 +110,9 @@ export function createMitzoStore(
     currentSessionId: undefined,
     pendingSend: null,
   };
+
+  // Track the actual WS pool key so wsListener routes to the correct entry
+  let activePoolKey: string | null = null;
 
   const store = createStore<MitzoStoreState>((set, get) => ({
     // ── Initial state ────────────────────────────────────────────────────
@@ -107,6 +137,7 @@ export function createMitzoStore(
     async switchSession(id: string) {
       parserState.currentSessionId = id;
       const poolKey = `session:${id}`;
+      activePoolKey = poolKey;
 
       // Reset messages state for new session
       set((s) => ({
@@ -149,6 +180,7 @@ export function createMitzoStore(
       // For new sessions, subscribe first so the pool entry exists
       if (!poolKey) {
         const newKey = `new:${Date.now()}`;
+        activePoolKey = newKey;
         wsPool.subscribe(newKey, wsListener);
 
         // Optimistic update
@@ -258,6 +290,7 @@ export function createMitzoStore(
   const callbacks: ProtocolCallbacks = {
     onSessionAssigned(sessionId: string) {
       parserState.currentSessionId = sessionId;
+      activePoolKey = `session:${sessionId}`;
       store.setState((s) => ({
         sessions: { ...s.sessions, active: sessionId },
       }));
@@ -298,9 +331,7 @@ export function createMitzoStore(
   };
 
   function wsListener(wsMsg: WsMsg) {
-    const poolKey = parserState.currentSessionId
-      ? `session:${parserState.currentSessionId}`
-      : 'default';
+    const poolKey = activePoolKey ?? 'default';
 
     const result = parseServerMessage(wsMsg, parserState, callbacks, poolKey);
 
@@ -315,22 +346,19 @@ export function createMitzoStore(
     if (result.tasksUpdate) {
       switch (result.tasksUpdate.type) {
         case 'task_state':
-          store.setState((s) => ({ tasks: { ...s.tasks, tree: result.tasksUpdate!.type === 'task_state' ? (result.tasksUpdate as { tasks: Task[] }).tasks : s.tasks.tree } }));
+          store.setState((s) => ({ tasks: { ...s.tasks, tree: (result.tasksUpdate as { tasks: Task[] }).tasks } }));
           break;
         case 'task_updated': {
           const updated = result.tasksUpdate.task;
           store.setState((s) => ({
-            tasks: {
-              ...s.tasks,
-              tree: s.tasks.tree.map((t) => (t.id === updated.id ? updated : t)),
-            },
+            tasks: { ...s.tasks, tree: updateTaskInTree(s.tasks.tree, updated) },
           }));
           break;
         }
         case 'task_deleted': {
           const deletedId = result.tasksUpdate.taskId;
           store.setState((s) => ({
-            tasks: { ...s.tasks, tree: s.tasks.tree.filter((t) => t.id !== deletedId) },
+            tasks: { ...s.tasks, tree: removeTaskFromTree(s.tasks.tree, deletedId) },
           }));
           break;
         }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -19,7 +19,7 @@ import type { ConnectionState } from './slices/connection.js';
 import { INITIAL_PERMISSIONS_STATE } from './slices/permissions.js';
 import type { PermissionsState } from './slices/permissions.js';
 import { INITIAL_TASKS_STATE } from './slices/tasks.js';
-import type { TasksState, Task } from './slices/tasks.js';
+import type { TasksState, Task, LoopStatus } from './slices/tasks.js';
 import { INITIAL_INBOX_STATE } from './slices/inbox.js';
 import type { InboxState } from './slices/inbox.js';
 import { INITIAL_CALENDAR_STATE } from './slices/calendar.js';
@@ -29,7 +29,8 @@ import type { TodosState } from './slices/todos.js';
 import { INITIAL_CONFIG_STATE } from './slices/config.js';
 import type { ConfigState } from './slices/config.js';
 import { parseServerMessage } from './protocol-parser.js';
-import type { ProtocolParserState } from './protocol-parser.js';
+import type { ProtocolParserState, ProtocolCallbacks } from './protocol-parser.js';
+import type { WsMsg } from './server-messages.js';
 import { MitzoApiClient } from './api-client.js';
 import { WsPool } from './ws-connection.js';
 import type { WsPoolConfig } from './ws-connection.js';
@@ -105,6 +106,7 @@ export function createMitzoStore(
 
     async switchSession(id: string) {
       parserState.currentSessionId = id;
+      const poolKey = `session:${id}`;
 
       // Reset messages state for new session
       set((s) => ({
@@ -112,6 +114,9 @@ export function createMitzoStore(
         messages: INITIAL_MESSAGES_STATE,
         permissions: INITIAL_PERMISSIONS_STATE,
       }));
+
+      // Subscribe to WS messages for this session
+      wsPool.subscribe(poolKey, wsListener);
 
       // Load session messages
       try {
@@ -138,8 +143,40 @@ export function createMitzoStore(
     sendMessage(text: string, opts?: { contextBlocks?: string[]; images?: ImageAttachment[] }) {
       const poolKey = parserState.currentSessionId
         ? `session:${parserState.currentSessionId}`
-        : `new:${Date.now()}`;
+        : null;
       const clientMsgId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      // For new sessions, subscribe first so the pool entry exists
+      if (!poolKey) {
+        const newKey = `new:${Date.now()}`;
+        wsPool.subscribe(newKey, wsListener);
+
+        // Optimistic update
+        set((s) => ({
+          messages: messagesReducer(s.messages, {
+            type: 'USER_SEND',
+            text,
+            clientMsgId,
+            images: opts?.images?.map((img) => img.preview),
+            contextBlocks: opts?.contextBlocks,
+          }),
+          sendError: null,
+        }));
+
+        const msg: Record<string, unknown> = {
+          type: 'send',
+          prompt: text,
+          clientMsgId,
+        };
+        if (opts?.contextBlocks) msg.contextBlocks = opts.contextBlocks;
+        if (opts?.images) msg.images = opts.images;
+
+        const sent = wsPool.send(newKey, msg);
+        if (!sent) {
+          set({ sendError: 'Not connected. Message will be sent when reconnected.' });
+        }
+        return;
+      }
 
       // Optimistic update
       set((s) => ({
@@ -162,7 +199,7 @@ export function createMitzoStore(
       if (opts?.images) msg.images = opts.images;
 
       // If running, queue for after session_end
-      if (get().messages.running && parserState.currentSessionId) {
+      if (get().messages.running) {
         parserState.pendingSend = msg;
       } else {
         const sent = wsPool.send(poolKey, msg);
@@ -192,9 +229,7 @@ export function createMitzoStore(
           decision,
         });
       }
-      set((s) => ({
-        permissions: { pending: null },
-      }));
+      set({ permissions: { pending: null } });
     },
 
     setMode(mode: MitzoMode) {
@@ -215,6 +250,112 @@ export function createMitzoStore(
       }));
     },
   }));
+
+  // ── WS → store wiring ──────────────────────────────────────────────────
+  // Central listener: routes every WS message through the protocol parser
+  // and dispatches resulting actions into the store.
+
+  const callbacks: ProtocolCallbacks = {
+    onSessionAssigned(sessionId: string) {
+      parserState.currentSessionId = sessionId;
+      store.setState((s) => ({
+        sessions: { ...s.sessions, active: sessionId },
+      }));
+    },
+
+    onSessionExpired(sessionId: string) {
+      parserState.currentSessionId = undefined;
+      store.setState((s) => ({
+        sessions: { ...s.sessions, active: null },
+        messages: INITIAL_MESSAGES_STATE,
+      }));
+    },
+
+    onMessagesRestored() {
+      // Triggered after reattach_failed recovery — reload messages from API
+      if (parserState.currentSessionId) {
+        api.getSessionMessages(parserState.currentSessionId).then((msgs) => {
+          if (Array.isArray(msgs) && msgs.length > 0) {
+            store.setState((s) => ({
+              messages: messagesReducer(s.messages, { type: 'RESTORE', messages: msgs }),
+            }));
+          }
+        }).catch(() => {});
+      }
+    },
+
+    fetchMessages(sessionId: string, signal: AbortSignal) {
+      return api.getSessionMessages(sessionId, signal);
+    },
+
+    setWsRunning(poolKey: string, running: boolean) {
+      wsPool.setRunning(poolKey, running);
+    },
+
+    sendQueued(poolKey: string, msg: unknown) {
+      wsPool.send(poolKey, msg);
+    },
+  };
+
+  function wsListener(wsMsg: WsMsg) {
+    const poolKey = parserState.currentSessionId
+      ? `session:${parserState.currentSessionId}`
+      : 'default';
+
+    const result = parseServerMessage(wsMsg, parserState, callbacks, poolKey);
+
+    // Dispatch messages actions
+    for (const action of result.messagesActions) {
+      store.setState((s) => ({
+        messages: messagesReducer(s.messages, action),
+      }));
+    }
+
+    // Dispatch tasks update
+    if (result.tasksUpdate) {
+      switch (result.tasksUpdate.type) {
+        case 'task_state':
+          store.setState((s) => ({ tasks: { ...s.tasks, tree: result.tasksUpdate!.type === 'task_state' ? (result.tasksUpdate as { tasks: Task[] }).tasks : s.tasks.tree } }));
+          break;
+        case 'task_updated': {
+          const updated = result.tasksUpdate.task;
+          store.setState((s) => ({
+            tasks: {
+              ...s.tasks,
+              tree: s.tasks.tree.map((t) => (t.id === updated.id ? updated : t)),
+            },
+          }));
+          break;
+        }
+        case 'task_deleted': {
+          const deletedId = result.tasksUpdate.taskId;
+          store.setState((s) => ({
+            tasks: { ...s.tasks, tree: s.tasks.tree.filter((t) => t.id !== deletedId) },
+          }));
+          break;
+        }
+        case 'loop_status':
+          store.setState((s) => ({
+            tasks: { ...s.tasks, loopStatus: (result.tasksUpdate as { status: LoopStatus }).status },
+          }));
+          break;
+      }
+    }
+
+    // Connection update
+    if (result.connectionUpdate) {
+      store.setState((s) => ({
+        connection: { ...s.connection, ...result.connectionUpdate },
+      }));
+    }
+
+    // Inbox refresh
+    if (result.inboxRefresh) {
+      api.getInbox().then((items) => {
+        store.setState({ inbox: { items, count: items.length } });
+      }).catch(() => {});
+    }
+  }
 
   return store;
 }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -1,0 +1,220 @@
+/**
+ * MitzoStore factory — zustand vanilla store wiring all slices.
+ *
+ * Framework-agnostic: creates a vanilla zustand store, not a React hook.
+ * React wrappers live in hooks/ and are a separate tree-shakeable import.
+ */
+
+import { createStore } from 'zustand/vanilla';
+import type { StoreApi } from 'zustand/vanilla';
+import type { FinishedMessage, MitzoMode, ImageAttachment } from '@mitzo/protocol';
+
+import type { TransportAdapter } from './types.js';
+import { messagesReducer, INITIAL_MESSAGES_STATE } from './slices/messages.js';
+import type { MessagesState, MessagesAction } from './slices/messages.js';
+import { INITIAL_SESSIONS_STATE } from './slices/sessions.js';
+import type { SessionsState } from './slices/sessions.js';
+import { INITIAL_CONNECTION_STATE } from './slices/connection.js';
+import type { ConnectionState } from './slices/connection.js';
+import { INITIAL_PERMISSIONS_STATE } from './slices/permissions.js';
+import type { PermissionsState } from './slices/permissions.js';
+import { INITIAL_TASKS_STATE } from './slices/tasks.js';
+import type { TasksState, Task } from './slices/tasks.js';
+import { INITIAL_INBOX_STATE } from './slices/inbox.js';
+import type { InboxState } from './slices/inbox.js';
+import { INITIAL_CALENDAR_STATE } from './slices/calendar.js';
+import type { CalendarState } from './slices/calendar.js';
+import { INITIAL_TODOS_STATE } from './slices/todos.js';
+import type { TodosState } from './slices/todos.js';
+import { INITIAL_CONFIG_STATE } from './slices/config.js';
+import type { ConfigState } from './slices/config.js';
+import { parseServerMessage } from './protocol-parser.js';
+import type { ProtocolParserState } from './protocol-parser.js';
+import { MitzoApiClient } from './api-client.js';
+import { WsPool } from './ws-connection.js';
+import type { WsPoolConfig } from './ws-connection.js';
+
+// ─── Store state ─────────────────────────────────────────────────────────────
+
+export interface MitzoStoreState {
+  // Slices
+  sessions: SessionsState;
+  messages: MessagesState;
+  connection: ConnectionState;
+  permissions: PermissionsState;
+  tasks: TasksState;
+  inbox: InboxState;
+  calendar: CalendarState;
+  todos: TodosState;
+  config: ConfigState;
+
+  // Error state
+  sendError: string | null;
+
+  // Actions
+  dispatchMessages(action: MessagesAction): void;
+  switchSession(id: string): Promise<void>;
+  newSession(): void;
+  sendMessage(text: string, opts?: { contextBlocks?: string[]; images?: ImageAttachment[] }): void;
+  stopGeneration(): void;
+  respondToPermission(permId: string, decision: 'once' | 'always' | 'deny'): void;
+  setMode(mode: MitzoMode): void;
+  setModel(modelId: string): void;
+}
+
+// ─── Store options ───────────────────────────────────────────────────────────
+
+export interface MitzoStoreOptions {
+  transport: TransportAdapter;
+  wsConfig: WsPoolConfig;
+}
+
+// ─── Factory ─────────────────────────────────────────────────────────────────
+
+export function createMitzoStore(
+  options: MitzoStoreOptions,
+): StoreApi<MitzoStoreState> {
+  const api = new MitzoApiClient(options.transport.fetch.bind(options.transport));
+  const wsPool = new WsPool(options.wsConfig);
+
+  // Protocol parser state — mutable, shared across all messages
+  const parserState: ProtocolParserState = {
+    currentSessionId: undefined,
+    pendingSend: null,
+  };
+
+  const store = createStore<MitzoStoreState>((set, get) => ({
+    // ── Initial state ────────────────────────────────────────────────────
+
+    sessions: INITIAL_SESSIONS_STATE,
+    messages: INITIAL_MESSAGES_STATE,
+    connection: INITIAL_CONNECTION_STATE,
+    permissions: INITIAL_PERMISSIONS_STATE,
+    tasks: INITIAL_TASKS_STATE,
+    inbox: INITIAL_INBOX_STATE,
+    calendar: INITIAL_CALENDAR_STATE,
+    todos: INITIAL_TODOS_STATE,
+    config: INITIAL_CONFIG_STATE,
+    sendError: null,
+
+    // ── Actions ──────────────────────────────────────────────────────────
+
+    dispatchMessages(action: MessagesAction) {
+      set((s) => ({ messages: messagesReducer(s.messages, action) }));
+    },
+
+    async switchSession(id: string) {
+      parserState.currentSessionId = id;
+
+      // Reset messages state for new session
+      set((s) => ({
+        sessions: { ...s.sessions, active: id },
+        messages: INITIAL_MESSAGES_STATE,
+        permissions: INITIAL_PERMISSIONS_STATE,
+      }));
+
+      // Load session messages
+      try {
+        const msgs = await api.getSessionMessages(id);
+        if (Array.isArray(msgs) && msgs.length > 0) {
+          set((s) => ({
+            messages: messagesReducer(s.messages, { type: 'RESTORE', messages: msgs }),
+          }));
+        }
+      } catch {
+        // Session may be expired — handle gracefully
+      }
+    },
+
+    newSession() {
+      parserState.currentSessionId = undefined;
+      set({
+        sessions: { ...get().sessions, active: null },
+        messages: INITIAL_MESSAGES_STATE,
+        permissions: INITIAL_PERMISSIONS_STATE,
+      });
+    },
+
+    sendMessage(text: string, opts?: { contextBlocks?: string[]; images?: ImageAttachment[] }) {
+      const poolKey = parserState.currentSessionId
+        ? `session:${parserState.currentSessionId}`
+        : `new:${Date.now()}`;
+      const clientMsgId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      // Optimistic update
+      set((s) => ({
+        messages: messagesReducer(s.messages, {
+          type: 'USER_SEND',
+          text,
+          clientMsgId,
+          images: opts?.images?.map((img) => img.preview),
+          contextBlocks: opts?.contextBlocks,
+        }),
+        sendError: null,
+      }));
+
+      const msg: Record<string, unknown> = {
+        type: 'send',
+        prompt: text,
+        clientMsgId,
+      };
+      if (opts?.contextBlocks) msg.contextBlocks = opts.contextBlocks;
+      if (opts?.images) msg.images = opts.images;
+
+      // If running, queue for after session_end
+      if (get().messages.running && parserState.currentSessionId) {
+        parserState.pendingSend = msg;
+      } else {
+        const sent = wsPool.send(poolKey, msg);
+        if (!sent) {
+          set({ sendError: 'Not connected. Message will be sent when reconnected.' });
+        }
+      }
+    },
+
+    stopGeneration() {
+      const poolKey = parserState.currentSessionId
+        ? `session:${parserState.currentSessionId}`
+        : null;
+      if (poolKey) {
+        wsPool.send(poolKey, { type: 'interrupt' });
+      }
+    },
+
+    respondToPermission(permId: string, decision: 'once' | 'always' | 'deny') {
+      const poolKey = parserState.currentSessionId
+        ? `session:${parserState.currentSessionId}`
+        : null;
+      if (poolKey) {
+        wsPool.send(poolKey, {
+          type: 'permission_response',
+          permId,
+          decision,
+        });
+      }
+      set((s) => ({
+        permissions: { pending: null },
+      }));
+    },
+
+    setMode(mode: MitzoMode) {
+      const poolKey = parserState.currentSessionId
+        ? `session:${parserState.currentSessionId}`
+        : null;
+      if (poolKey) {
+        wsPool.send(poolKey, { type: 'set_mode', mode });
+      }
+      set((s) => ({
+        config: { ...s.config, mode },
+      }));
+    },
+
+    setModel(modelId: string) {
+      set((s) => ({
+        config: { ...s.config, modelId },
+      }));
+    },
+  }));
+
+  return store;
+}

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Transport abstraction — each frontend provides its own implementation.
+ *
+ * Mitzo mobile: browser WebSocket + fetch
+ * Mitzo-Theia: Theia RPC + fetch proxy
+ */
+
+export interface WsHandlers {
+  onOpen(): void;
+  onMessage(data: string): void;
+  onClose(): void;
+  onError(error: unknown): void;
+}
+
+export interface WsConnection {
+  send(data: string): void;
+  close(): void;
+  readonly readyState: number;
+}
+
+export interface TransportAdapter {
+  connectWs(url: string, handlers: WsHandlers): WsConnection;
+  fetch(url: string, init?: RequestInit): Promise<Response>;
+}
+
+/** WebSocket readyState constants (matching the WebSocket spec). */
+export const WS_READY_STATE = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+} as const;

--- a/packages/client/src/ws-connection.ts
+++ b/packages/client/src/ws-connection.ts
@@ -70,10 +70,11 @@ export class WsPool {
     if (typeof document === 'undefined') return;
 
     const reconnectAll = () => this.reconnectAll();
-
-    document.addEventListener('visibilitychange', () => {
+    const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') reconnectAll();
-    });
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
     window.addEventListener('pageshow', reconnectAll);
     window.addEventListener('focus', reconnectAll);
 
@@ -81,6 +82,7 @@ export class WsPool {
 
     this.visibilityCleanup = () => {
       clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       window.removeEventListener('pageshow', reconnectAll);
       window.removeEventListener('focus', reconnectAll);
     };
@@ -138,7 +140,7 @@ export class WsPool {
   /** Close all connections and clear the pool. */
   destroy(): void {
     this.stopVisibilityMonitor();
-    for (const [key, entry] of this.pool) {
+    for (const entry of this.pool.values()) {
       if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
       if (entry.ws) {
         entry.ws.onclose = null;

--- a/packages/client/src/ws-connection.ts
+++ b/packages/client/src/ws-connection.ts
@@ -1,0 +1,286 @@
+/**
+ * WebSocket connection pool — transport-agnostic.
+ *
+ * Extracted from frontend/src/lib/ws-pool.ts. The key difference:
+ * the WebSocket constructor and URL builder are injected, so this
+ * works in both browser and Theia RPC environments.
+ */
+
+import type { WsMsg } from './server-messages.js';
+import { WS_READY_STATE } from './types.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type MsgListener = (msg: WsMsg) => void;
+
+export interface WsPoolConfig {
+  /** Build the WebSocket URL from the pool key. */
+  buildUrl(): string;
+
+  /** WebSocket constructor — `new ctor(url)`. */
+  createWebSocket(url: string): WebSocketLike;
+
+  /** Delay before first reconnect attempt (ms). Default: 500 */
+  reconnectDelayMs?: number;
+
+  /** Interval for heartbeat reconnect polling (ms). Default: 5000 */
+  reconnectPollMs?: number;
+}
+
+/** Minimal WebSocket interface — matches browser WebSocket. */
+export interface WebSocketLike {
+  readyState: number;
+  onopen: ((ev: unknown) => void) | null;
+  onmessage: ((ev: { data: string }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((ev: unknown) => void) | null;
+  send(data: string): void;
+  close(): void;
+}
+
+// ─── Pool entry ──────────────────────────────────────────────────────────────
+
+interface PoolEntry {
+  ws: WebSocketLike | null;
+  clientId: string | null;
+  prevClientId: string | null;
+  wasRunning: boolean;
+  lastSeq: number;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  listeners: Set<MsgListener>;
+}
+
+// ─── Pool ────────────────────────────────────────────────────────────────────
+
+export class WsPool {
+  private pool = new Map<string, PoolEntry>();
+  private config: Required<WsPoolConfig>;
+  private visibilityCleanup: (() => void) | null = null;
+
+  constructor(config: WsPoolConfig) {
+    this.config = {
+      reconnectDelayMs: 500,
+      reconnectPollMs: 5_000,
+      ...config,
+    };
+  }
+
+  /** Start listening for visibility/focus events to trigger reconnects. */
+  startVisibilityMonitor(): void {
+    if (typeof document === 'undefined') return;
+
+    const reconnectAll = () => this.reconnectAll();
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') reconnectAll();
+    });
+    window.addEventListener('pageshow', reconnectAll);
+    window.addEventListener('focus', reconnectAll);
+
+    const interval = setInterval(reconnectAll, this.config.reconnectPollMs);
+
+    this.visibilityCleanup = () => {
+      clearInterval(interval);
+      window.removeEventListener('pageshow', reconnectAll);
+      window.removeEventListener('focus', reconnectAll);
+    };
+  }
+
+  /** Stop visibility monitoring. */
+  stopVisibilityMonitor(): void {
+    this.visibilityCleanup?.();
+    this.visibilityCleanup = null;
+  }
+
+  /** Subscribe to messages for a pool key. Returns unsubscribe function. */
+  subscribe(key: string, listener: MsgListener): () => void {
+    const entry = this.getOrCreate(key);
+    entry.listeners.add(listener);
+    return () => entry.listeners.delete(listener);
+  }
+
+  /** Send a message on the connection for this key. */
+  send(key: string, msg: unknown): boolean {
+    const entry = this.pool.get(key);
+    if (entry?.ws?.readyState === WS_READY_STATE.OPEN) {
+      entry.ws.send(JSON.stringify(msg));
+      return true;
+    }
+    return false;
+  }
+
+  /** True if the connection for this key is currently open. */
+  isOpen(key: string): boolean {
+    const entry = this.pool.get(key);
+    return entry?.ws?.readyState === WS_READY_STATE.OPEN;
+  }
+
+  /** Mark a session as running/not-running for reattach purposes. */
+  setRunning(key: string, running: boolean): void {
+    const entry = this.pool.get(key);
+    if (entry) entry.wasRunning = running;
+  }
+
+  /** Remove a pool entry if idle (not running, no listeners). */
+  removeIfIdle(key: string): boolean {
+    const entry = this.pool.get(key);
+    if (!entry) return false;
+    if (entry.wasRunning || entry.listeners.size > 0) return false;
+    if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
+    if (entry.ws) {
+      entry.ws.onclose = null;
+      entry.ws.close();
+    }
+    this.pool.delete(key);
+    return true;
+  }
+
+  /** Close all connections and clear the pool. */
+  destroy(): void {
+    this.stopVisibilityMonitor();
+    for (const [key, entry] of this.pool) {
+      if (entry.reconnectTimer) clearTimeout(entry.reconnectTimer);
+      if (entry.ws) {
+        entry.ws.onclose = null;
+        entry.ws.close();
+      }
+    }
+    this.pool.clear();
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private broadcast(entry: PoolEntry, msg: WsMsg): void {
+    entry.listeners.forEach((l) => l(msg));
+  }
+
+  private reconnectAll(): void {
+    this.pool.forEach((entry, key) => {
+      if (!entry.ws || entry.ws.readyState > WS_READY_STATE.OPEN) {
+        this.connectEntry(key, entry);
+      }
+    });
+  }
+
+  private getOrCreate(key: string): PoolEntry {
+    let entry = this.pool.get(key);
+    if (!entry) {
+      entry = {
+        ws: null,
+        clientId: null,
+        prevClientId: null,
+        wasRunning: false,
+        lastSeq: 0,
+        reconnectTimer: null,
+        listeners: new Set(),
+      };
+      this.pool.set(key, entry);
+      this.connectEntry(key, entry);
+    }
+    return entry;
+  }
+
+  private connectEntry(key: string, entry: PoolEntry): void {
+    if (
+      entry.ws?.readyState === WS_READY_STATE.OPEN ||
+      entry.ws?.readyState === WS_READY_STATE.CONNECTING
+    )
+      return;
+
+    if (entry.reconnectTimer) {
+      clearTimeout(entry.reconnectTimer);
+      entry.reconnectTimer = null;
+    }
+
+    const url = this.config.buildUrl();
+    const ws = this.config.createWebSocket(url);
+    entry.ws = ws;
+
+    ws.onopen = () => this.broadcast(entry, { type: '_open' });
+
+    ws.onmessage = (e: { data: string }) => {
+      let msg: WsMsg;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+
+      // Track lastSeq
+      const msgAny = msg as unknown as Record<string, unknown>;
+      if (typeof msgAny.seq === 'number') {
+        entry.lastSeq = msgAny.seq as number;
+      }
+
+      if (msg.type === 'client_id') {
+        entry.prevClientId = entry.clientId;
+        entry.clientId = (msg as Record<string, unknown>).clientId as string;
+        if (entry.wasRunning && entry.prevClientId) {
+          ws.send(
+            JSON.stringify({
+              type: 'reattach',
+              clientId: entry.prevClientId,
+              lastSeq: entry.lastSeq,
+            }),
+          );
+          return;
+        }
+        const sessionPrefix = 'session:';
+        if (key.startsWith(sessionPrefix)) {
+          const sessionId = key.slice(sessionPrefix.length);
+          ws.send(JSON.stringify({ type: 'subscribe', sessionId }));
+          return;
+        }
+        this.broadcast(entry, { type: '_open' });
+        return;
+      }
+
+      if (msg.type === 'reattached') {
+        entry.wasRunning = true;
+        this.broadcast(entry, { type: '_open' });
+      }
+
+      if (msg.type === 'reattach_failed') {
+        entry.wasRunning = false;
+        this.broadcast(entry, { type: '_open' });
+      }
+
+      if (msg.type === 'subscribed') {
+        if ((msg as Record<string, unknown>).running) entry.wasRunning = true;
+        this.broadcast(entry, { type: '_open' });
+      }
+
+      if (msg.type === 'session_end' || msg.type === 'error') {
+        entry.wasRunning = false;
+      }
+
+      // Register session key alias
+      const assignedId =
+        (msg.type === 'session_id' || msg.type === 'session_end') &&
+        (msg as Record<string, unknown>).sessionId
+          ? ((msg as Record<string, unknown>).sessionId as string)
+          : null;
+      if (assignedId) {
+        const sessionKey = `session:${assignedId}`;
+        if (!this.pool.has(sessionKey)) {
+          this.pool.set(sessionKey, entry);
+        }
+      }
+
+      this.broadcast(entry, msg);
+    };
+
+    ws.onclose = () => {
+      entry.ws = null;
+      this.broadcast(entry, { type: '_close' });
+      entry.reconnectTimer = setTimeout(
+        () => this.connectEntry(key, entry),
+        this.config.reconnectDelayMs,
+      );
+    };
+
+    ws.onerror = () => {
+      // Error events always precede close — reconnect handled in onclose
+    };
+  }
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    { "path": "../protocol" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Extracts ~1,600 lines of framework-agnostic state management from frontend React hooks into `@mitzo/client`
- Zustand vanilla store with slices: messages, sessions, connection, permissions, tasks, inbox, calendar, todos, config
- Transport-agnostic WS connection pool (`WsPool`) with reattach, session aliasing, reconnect
- Protocol parser mapping all v2 server messages to store actions
- Typed REST API client covering all 25 endpoints
- Tree-shakeable React hooks via `@mitzo/client/hooks` export path

## What's included
- `packages/client/` — full package with TypeScript, exports `.` and `./hooks`
- 123 new tests (52 messages reducer, 32 protocol parser, 15 WS pool, 24 API client)
- All 326 workspace tests pass

## Test plan
- [x] Unit tests: `npm test` — 123 tests pass
- [x] TypeScript build: `tsc --build` clean
- [x] Frontend build: Vite builds successfully with `@mitzo/client` imported
- [x] Manual test: wired `MitzoStoreProvider` into existing app, served via Tailscale HTTPS — chat, voice, sessions all functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)