### PR TITLE
feat(client): add loadSessions + refreshSessions store actions

### DIFF
--- a/packages/client/__tests__/store-sessions.test.ts
+++ b/packages/client/__tests__/store-sessions.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMitzoStore } from '../src/store.js';
+import type { MitzoStoreOptions } from '../src/store.js';
+import type { TransportAdapter } from '../src/types.js';
+import type { WebSocketLike } from '../src/ws-connection.js';
+import { WS_READY_STATE } from '../src/types.js';
+
+// ─── Mock transport ─────────────────────────────────────────────────────────
+
+class MockWebSocket implements WebSocketLike {
+  readyState = WS_READY_STATE.OPEN;
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  sent: string[] = [];
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = WS_READY_STATE.CLOSED;
+  }
+}
+
+function mockTransport(): TransportAdapter {
+  return {
+    connectWs: vi.fn(),
+    fetch: vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    }),
+  };
+}
+
+function makeOptions(transport?: TransportAdapter): MitzoStoreOptions {
+  return {
+    transport: transport ?? mockTransport(),
+    wsConfig: {
+      buildUrl: () => 'ws://localhost:3000/ws',
+      createWebSocket: () => new MockWebSocket(),
+    },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('loadSessions', () => {
+  it('sets loading=true then false, populates list on success', async () => {
+    const transport = mockTransport();
+    const sessions = [
+      { sessionId: 's1', name: 'Session 1', createdAt: 1000, updatedAt: 2000 },
+      { sessionId: 's2', name: 'Session 2', createdAt: 1001, updatedAt: 2001 },
+    ];
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sessions),
+      text: () => Promise.resolve(''),
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+
+    const promise = store.getState().loadSessions();
+
+    // loading should be true while in-flight
+    expect(store.getState().sessions.loading).toBe(true);
+
+    await promise;
+
+    expect(store.getState().sessions.loading).toBe(false);
+    expect(store.getState().sessions.list).toHaveLength(2);
+    expect(store.getState().sessions.list[0].sessionId).toBe('s1');
+  });
+
+  it('resets loading on failure and preserves empty list', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('fail')),
+      text: () => Promise.resolve('Internal Server Error'),
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().loadSessions();
+
+    expect(store.getState().sessions.loading).toBe(false);
+    expect(store.getState().sessions.list).toHaveLength(0);
+  });
+});
+
+describe('refreshSessions', () => {
+  it('updates list silently on success', async () => {
+    const transport = mockTransport();
+    const sessions = [{ sessionId: 's1', name: 'Refreshed', createdAt: 1000, updatedAt: 3000 }];
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sessions),
+      text: () => Promise.resolve(''),
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().refreshSessions();
+
+    expect(store.getState().sessions.list).toHaveLength(1);
+    expect(store.getState().sessions.list[0].name).toBe('Refreshed');
+  });
+
+  it('keeps existing list on failure', async () => {
+    const transport = mockTransport();
+
+    // First load succeeds
+    const sessions = [{ sessionId: 's1', name: 'Existing', createdAt: 1000, updatedAt: 2000 }];
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(sessions),
+      text: () => Promise.resolve(''),
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().loadSessions();
+    expect(store.getState().sessions.list).toHaveLength(1);
+
+    // Refresh fails
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error('fail')),
+      text: () => Promise.resolve('error'),
+    });
+
+    await store.getState().refreshSessions();
+
+    // List preserved
+    expect(store.getState().sessions.list).toHaveLength(1);
+    expect(store.getState().sessions.list[0].name).toBe('Existing');
+  });
+});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,11 +7,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./hooks": {
       "types": "./dist/hooks/index.d.ts",
-      "import": "./dist/hooks/index.js"
+      "import": "./dist/hooks/index.js",
+      "default": "./dist/hooks/index.js"
     }
   },
   "files": [

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -61,7 +61,7 @@ export interface MitzoStoreState {
   respondToPermission(permId: string, decision: 'once' | 'always' | 'deny'): void;
   setMode(mode: MitzoMode): void;
   setModel(modelId: string): void;
-  loadSessions(offset?: number): Promise<void>;
+  loadSessions(): Promise<void>;
   refreshSessions(): Promise<void>;
 }
 
@@ -282,11 +282,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }));
     },
 
-    async loadSessions(offset?: number) {
+    async loadSessions() {
       set((s) => ({ sessions: { ...s.sessions, loading: true } }));
       try {
-        const raw = await api.listSessions(offset);
-        const list = Array.isArray(raw) ? raw : (raw as unknown as { sessions: typeof raw }).sessions ?? [];
+        const raw = await api.listSessions();
+        const list = Array.isArray(raw)
+          ? raw
+          : ((raw as unknown as { sessions: typeof raw }).sessions ?? []);
         set((s) => ({ sessions: { ...s.sessions, list, loading: false } }));
       } catch {
         set((s) => ({ sessions: { ...s.sessions, loading: false } }));
@@ -296,7 +298,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     async refreshSessions() {
       try {
         const raw = await api.listSessions();
-        const list = Array.isArray(raw) ? raw : (raw as unknown as { sessions: typeof raw }).sessions ?? [];
+        const list = Array.isArray(raw)
+          ? raw
+          : ((raw as unknown as { sessions: typeof raw }).sessions ?? []);
         set((s) => ({ sessions: { ...s.sessions, list } }));
       } catch {
         // Silent — keep existing list on failure

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -61,6 +61,8 @@ export interface MitzoStoreState {
   respondToPermission(permId: string, decision: 'once' | 'always' | 'deny'): void;
   setMode(mode: MitzoMode): void;
   setModel(modelId: string): void;
+  loadSessions(offset?: number): Promise<void>;
+  refreshSessions(): Promise<void>;
 }
 
 // ─── Store options ───────────────────────────────────────────────────────────
@@ -279,6 +281,27 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         config: { ...s.config, modelId },
       }));
     },
+
+    async loadSessions(offset?: number) {
+      set((s) => ({ sessions: { ...s.sessions, loading: true } }));
+      try {
+        const raw = await api.listSessions(offset);
+        const list = Array.isArray(raw) ? raw : (raw as unknown as { sessions: typeof raw }).sessions ?? [];
+        set((s) => ({ sessions: { ...s.sessions, list, loading: false } }));
+      } catch {
+        set((s) => ({ sessions: { ...s.sessions, loading: false } }));
+      }
+    },
+
+    async refreshSessions() {
+      try {
+        const raw = await api.listSessions();
+        const list = Array.isArray(raw) ? raw : (raw as unknown as { sessions: typeof raw }).sessions ?? [];
+        set((s) => ({ sessions: { ...s.sessions, list } }));
+      } catch {
+        // Silent — keep existing list on failure
+      }
+    },
   }));
 
   // ── WS → store wiring ──────────────────────────────────────────────────
@@ -292,6 +315,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       store.setState((s) => ({
         sessions: { ...s.sessions, active: sessionId },
       }));
+      store.getState().refreshSessions();
     },
 
     onSessionExpired(_sessionId: string) {
@@ -391,6 +415,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
           store.setState({ inbox: { items, count: items.length } });
         })
         .catch(() => {});
+      store.getState().refreshSessions();
     }
   }
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -7,11 +7,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./event-store": {
       "types": "./dist/event-store.d.ts",
-      "import": "./dist/event-store.js"
+      "import": "./dist/event-store.js",
+      "default": "./dist/event-store.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Add `loadSessions(offset?)` action: sets loading state, fetches from API, replaces list
- Add `refreshSessions()` action: silently updates list without loading indicator (used after rename/delete)

Consumed by mitzo-theia Phase 1 (Sessions widget) — the first standalone widget built on the store pattern.

## Test plan

- [ ] `npm test` passes
- [ ] `loadSessions()` populates `sessions.list` from `api.listSessions()`
- [ ] `refreshSessions()` updates list without setting `loading: true`
- [ ] Error paths: failed fetch leaves existing list intact

Made with [Cursor](https://cursor.com)