### PR TITLE
fix(client): eliminate double-fetch on reattach + store tests

### DIFF
--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -64,6 +64,49 @@ describe('reattach', () => {
     expect(r.messagesActions).toEqual([{ type: 'SET_RUNNING', running: false }]);
     expect(cb.setWsRunning).toHaveBeenCalledWith(POOL_KEY, false);
   });
+
+  it('reattach_failed calls onMessagesRestored with fetched messages', async () => {
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'hello' }],
+      },
+    ];
+    const fetchMessages = vi.fn().mockResolvedValue(msgs);
+    const onMessagesRestored = vi.fn();
+    const cb = makeCallbacks({ fetchMessages, onMessagesRestored });
+    const state = makeState({ currentSessionId: 'sid-1' });
+
+    parseServerMessage({ type: 'reattach_failed', clientId: 'old' }, state, cb, POOL_KEY);
+
+    // Wait for the async fetchMessages to resolve
+    await vi.waitFor(() => {
+      expect(onMessagesRestored).toHaveBeenCalledWith(msgs);
+    });
+  });
+
+  it('reattach_failed does not call onMessagesRestored when fetch returns empty', async () => {
+    const fetchMessages = vi.fn().mockResolvedValue([]);
+    const onMessagesRestored = vi.fn();
+    const cb = makeCallbacks({ fetchMessages, onMessagesRestored });
+    const state = makeState({ currentSessionId: 'sid-1' });
+
+    parseServerMessage({ type: 'reattach_failed', clientId: 'old' }, state, cb, POOL_KEY);
+
+    // Give async a chance to resolve
+    await new Promise((r) => setTimeout(r, 10));
+    expect(onMessagesRestored).not.toHaveBeenCalled();
+  });
+
+  it('reattach_failed skips fetch when no currentSessionId', () => {
+    const fetchMessages = vi.fn();
+    const cb = makeCallbacks({ fetchMessages });
+
+    parseServerMessage({ type: 'reattach_failed', clientId: 'old' }, makeState(), cb, POOL_KEY);
+
+    expect(fetchMessages).not.toHaveBeenCalled();
+  });
 });
 
 // ─── Session lifecycle ────────────────────────────────────────────────────────

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -94,8 +94,10 @@ describe('reattach', () => {
 
     parseServerMessage({ type: 'reattach_failed', clientId: 'old' }, state, cb, POOL_KEY);
 
-    // Give async a chance to resolve
-    await new Promise((r) => setTimeout(r, 10));
+    // Flush the microtask queue so the mockResolvedValue resolves
+    await vi.waitFor(() => {
+      expect(fetchMessages).toHaveBeenCalled();
+    });
     expect(onMessagesRestored).not.toHaveBeenCalled();
   });
 

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createMitzoStore } from '../src/store.js';
+import type { MitzoStoreOptions, MitzoStoreState } from '../src/store.js';
+import type { TransportAdapter } from '../src/types.js';
+import type { WebSocketLike } from '../src/ws-connection.js';
+import { WS_READY_STATE } from '../src/types.js';
+import type { StoreApi } from 'zustand/vanilla';
+
+// ─── Mock WebSocket ─────────────────────────────────────────────────────────
+
+class MockWebSocket implements WebSocketLike {
+  readyState = WS_READY_STATE.OPEN;
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  sent: string[] = [];
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = WS_READY_STATE.CLOSED;
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.onopen?.({});
+  }
+
+  simulateMessage(msg: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(msg) });
+  }
+}
+
+// ─── Mock transport ─────────────────────────────────────────────────────────
+
+function mockTransport(): TransportAdapter {
+  return {
+    connectWs: vi.fn(),
+    fetch: vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    }),
+  };
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let lastWs: MockWebSocket;
+
+function makeOptions(transport?: TransportAdapter): MitzoStoreOptions {
+  return {
+    transport: transport ?? mockTransport(),
+    wsConfig: {
+      buildUrl: () => 'ws://localhost:3000/ws',
+      createWebSocket: () => {
+        lastWs = new MockWebSocket();
+        return lastWs;
+      },
+    },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('createMitzoStore', () => {
+  it('creates a store with initial state', () => {
+    const store = createMitzoStore(makeOptions());
+    const state = store.getState();
+
+    expect(state.sessions.active).toBeNull();
+    expect(state.messages.messages).toHaveLength(0);
+    expect(state.messages.running).toBe(false);
+    expect(state.messages.current).toBeNull();
+    expect(state.connection.status).toBeDefined();
+    expect(state.tasks.tree).toHaveLength(0);
+    expect(state.sendError).toBeNull();
+  });
+
+  it('exposes action methods on the state', () => {
+    const store = createMitzoStore(makeOptions());
+    const state = store.getState();
+
+    expect(typeof state.dispatchMessages).toBe('function');
+    expect(typeof state.switchSession).toBe('function');
+    expect(typeof state.newSession).toBe('function');
+    expect(typeof state.sendMessage).toBe('function');
+    expect(typeof state.stopGeneration).toBe('function');
+    expect(typeof state.respondToPermission).toBe('function');
+    expect(typeof state.setMode).toBe('function');
+    expect(typeof state.setModel).toBe('function');
+  });
+});
+
+describe('switchSession', () => {
+  it('updates active session and resets messages', async () => {
+    const transport = mockTransport();
+    const store = createMitzoStore(makeOptions(transport));
+
+    // Pre-populate some messages
+    store.getState().dispatchMessages({
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'c1',
+    });
+    expect(store.getState().messages.messages).toHaveLength(1);
+
+    await store.getState().switchSession('session-abc');
+
+    expect(store.getState().sessions.active).toBe('session-abc');
+    expect(store.getState().messages.messages).toHaveLength(0);
+  });
+
+  it('fetches messages for the session via API', async () => {
+    const transport = mockTransport();
+    const msgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'hi' }],
+      },
+    ];
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(msgs),
+      text: () => Promise.resolve(''),
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().switchSession('session-abc');
+
+    expect(transport.fetch).toHaveBeenCalledWith(
+      '/api/sessions/session-abc/messages',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    expect(store.getState().messages.messages).toHaveLength(1);
+    expect(store.getState().messages.messages[0].messageId).toBe('m1');
+  });
+});
+
+describe('newSession', () => {
+  it('clears active session and resets messages', () => {
+    const store = createMitzoStore(makeOptions());
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'old-session' },
+    }));
+
+    store.getState().newSession();
+
+    expect(store.getState().sessions.active).toBeNull();
+    expect(store.getState().messages.messages).toHaveLength(0);
+  });
+});
+
+describe('sendMessage', () => {
+  it('adds optimistic user message', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().sendMessage('hello');
+
+    const { messages, running } = store.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].blocks[0].content).toBe('hello');
+    expect(running).toBe(true);
+  });
+
+  it('subscribes to WS pool for new sessions', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().sendMessage('hello');
+
+    // The WS was created (subscribe triggers getOrCreate → connectEntry)
+    expect(lastWs).toBeDefined();
+  });
+});
+
+describe('WS → store wiring', () => {
+  let store: StoreApi<MitzoStoreState>;
+
+  beforeEach(async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    store = createMitzoStore(makeOptions(transport));
+
+    // Switch to a session to wire up the WS listener
+    await store.getState().switchSession('test-session');
+  });
+
+  it('dispatches MESSAGE_START through the protocol parser', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    // client_id triggers a subscribe message, then we get server messages
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({ type: 'message_start', messageId: 'msg-1' });
+
+    expect(store.getState().messages.current).not.toBeNull();
+    expect(store.getState().messages.current!.messageId).toBe('msg-1');
+  });
+
+  it('dispatches full message turn and finalizes', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({ type: 'message_start', messageId: 'msg-1' });
+    lastWs.simulateMessage({
+      type: 'block_start',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    lastWs.simulateMessage({
+      type: 'block_delta',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'Hello!',
+    });
+    lastWs.simulateMessage({
+      type: 'block_end',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    lastWs.simulateMessage({ type: 'message_end', messageId: 'msg-1' });
+
+    expect(store.getState().messages.current).toBeNull();
+    expect(store.getState().messages.messages).toHaveLength(1);
+    expect(store.getState().messages.messages[0].blocks[0].content).toBe('Hello!');
+  });
+
+  it('dispatches session_end and clears running', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: true });
+
+    expect(store.getState().messages.running).toBe(true);
+
+    lastWs.simulateMessage({ type: 'session_end', sessionId: 'test-session' });
+
+    expect(store.getState().messages.running).toBe(false);
+  });
+
+  it('dispatches task_state updates', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({
+      type: 'task_state',
+      tasks: [{ id: 't1', summary: 'Task 1', status: 'pending', children: [] }],
+    });
+
+    expect(store.getState().tasks.tree).toHaveLength(1);
+    expect(store.getState().tasks.tree[0].id).toBe('t1');
+  });
+
+  it('dispatches task_updated recursively', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+
+    // Set up a tree with nested tasks
+    lastWs.simulateMessage({
+      type: 'task_state',
+      tasks: [
+        {
+          id: 't1',
+          summary: 'Parent',
+          status: 'pending',
+          children: [{ id: 't2', summary: 'Child', status: 'pending', children: [] }],
+        },
+      ],
+    });
+
+    // Update the nested task
+    lastWs.simulateMessage({
+      type: 'task_updated',
+      task: { id: 't2', summary: 'Child Updated', status: 'done', children: [] },
+    });
+
+    expect(store.getState().tasks.tree[0].children[0].summary).toBe('Child Updated');
+    expect(store.getState().tasks.tree[0].children[0].status).toBe('done');
+  });
+
+  it('dispatches task_deleted recursively', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+
+    lastWs.simulateMessage({
+      type: 'task_state',
+      tasks: [
+        {
+          id: 't1',
+          summary: 'Parent',
+          status: 'pending',
+          children: [{ id: 't2', summary: 'Child', status: 'pending', children: [] }],
+        },
+      ],
+    });
+
+    lastWs.simulateMessage({ type: 'task_deleted', taskId: 't2' });
+
+    expect(store.getState().tasks.tree).toHaveLength(1);
+    expect(store.getState().tasks.tree[0].children).toHaveLength(0);
+  });
+
+  it('updates session on session_id message', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'new-sid' });
+
+    expect(store.getState().sessions.active).toBe('new-sid');
+  });
+
+  it('dispatches error messages', () => {
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({ type: 'error', error: 'Something broke' });
+
+    const msgs = store.getState().messages.messages;
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs[msgs.length - 1].blocks[0].content).toContain('Something broke');
+  });
+});
+
+describe('setMode', () => {
+  it('updates config mode', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().setMode('auto');
+    expect(store.getState().config.mode).toBe('auto');
+  });
+});
+
+describe('setModel', () => {
+  it('updates config modelId', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().setModel('claude-sonnet-4-5-20250514');
+    expect(store.getState().config.modelId).toBe('claude-sonnet-4-5-20250514');
+  });
+});
+
+describe('dispatchMessages', () => {
+  it('applies messages reducer action directly', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().dispatchMessages({ type: 'SET_RUNNING', running: true });
+    expect(store.getState().messages.running).toBe(true);
+  });
+});

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -323,6 +323,111 @@ describe('WS → store wiring', () => {
   });
 });
 
+describe('reattach_failed → onMessagesRestored', () => {
+  it('restores messages exactly once via passed-through messages (no double-fetch)', async () => {
+    const transport = mockTransport();
+    const restoredMsgs = [
+      {
+        messageId: 'm1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
+      },
+    ];
+    // getSessionMessages returns restored messages
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url.includes('/messages')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(restoredMsgs),
+          text: () => Promise.resolve(''),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(''),
+      });
+    });
+
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().switchSession('test-session');
+
+    // Simulate WS connection + reattach_failed
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+    lastWs.simulateMessage({ type: 'reattach_failed', clientId: 'old' });
+
+    // Wait for the async fetch to resolve and messages to be restored
+    await vi.waitFor(() => {
+      expect(store.getState().messages.messages).toHaveLength(1);
+    });
+
+    expect(store.getState().messages.messages[0].messageId).toBe('m1');
+    expect(store.getState().messages.messages[0].blocks[0].content).toBe('restored');
+  });
+});
+
+describe('stopGeneration', () => {
+  it('sends interrupt message over WS', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().switchSession('test-session');
+
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: true });
+
+    store.getState().stopGeneration();
+
+    const sent = lastWs.sent.map((s) => JSON.parse(s));
+    const interrupt = sent.find((m) => m.type === 'interrupt');
+    expect(interrupt).toBeDefined();
+  });
+});
+
+describe('respondToPermission', () => {
+  it('sends permission_response and clears pending', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+    await store.getState().switchSession('test-session');
+
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: true });
+
+    // Simulate a permission request arriving (lands in messages.permission via reducer)
+    lastWs.simulateMessage({
+      type: 'permission_request',
+      permId: 'perm-1',
+      toolName: 'Bash',
+      toolInput: 'rm -rf /',
+      tier: 'elevated',
+    });
+    expect(store.getState().messages.permission).not.toBeNull();
+    expect(store.getState().messages.permission!.permId).toBe('perm-1');
+
+    // Respond to the permission
+    store.getState().respondToPermission('perm-1', 'once');
+
+    // WS should have sent the response
+    const sent = lastWs.sent.map((s) => JSON.parse(s));
+    const response = sent.find((m) => m.type === 'permission_response');
+    expect(response).toEqual({
+      type: 'permission_response',
+      permId: 'perm-1',
+      decision: 'once',
+    });
+  });
+});
+
 describe('setMode', () => {
   it('updates config mode', () => {
     const store = createMitzoStore(makeOptions());

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -30,7 +30,7 @@ export interface ProtocolCallbacks {
   onSessionExpired(sessionId: string): void;
 
   /** Called after reattach_failed recovery restores messages from API. */
-  onMessagesRestored?(): void;
+  onMessagesRestored?(messages: FinishedMessage[]): void;
 
   /** Called when the server renames a session. */
   onSessionRenamed?(name: string): void;
@@ -107,7 +107,7 @@ export function parseServerMessage(
           .then((msgs) => {
             if (controller.signal.aborted) return;
             if (Array.isArray(msgs) && msgs.length > 0) {
-              callbacks.onMessagesRestored?.();
+              callbacks.onMessagesRestored?.(msgs);
             }
           })
           .catch(() => {});

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -36,7 +36,7 @@ export interface ProtocolCallbacks {
   onSessionRenamed?(name: string): void;
 
   /** Called to fetch messages from REST API for reattach recovery. */
-  fetchMessages?(sessionId: string, signal: AbortSignal): Promise<FinishedMessage[]>;
+  fetchMessages?(sessionId: string): Promise<FinishedMessage[]>;
 
   /** Called to mark the WS pool entry as running/not-running. */
   setWsRunning?(poolKey: string, running: boolean): void;
@@ -101,11 +101,9 @@ export function parseServerMessage(
       callbacks.setWsRunning?.(poolKey, false);
       if (state.currentSessionId && callbacks.fetchMessages) {
         const sessionId = state.currentSessionId;
-        const controller = new AbortController();
         callbacks
-          .fetchMessages(sessionId, controller.signal)
+          .fetchMessages(sessionId)
           .then((msgs) => {
-            if (controller.signal.aborted) return;
             if (Array.isArray(msgs) && msgs.length > 0) {
               callbacks.onMessagesRestored?.(msgs);
             }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -7,7 +7,7 @@
 
 import { createStore } from 'zustand/vanilla';
 import type { StoreApi } from 'zustand/vanilla';
-import type { MitzoMode, ImageAttachment } from '@mitzo/protocol';
+import type { FinishedMessage, MitzoMode, ImageAttachment } from '@mitzo/protocol';
 
 import type { TransportAdapter } from './types.js';
 import { messagesReducer, INITIAL_MESSAGES_STATE } from './slices/messages.js';
@@ -302,20 +302,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }));
     },
 
-    onMessagesRestored() {
-      // Triggered after reattach_failed recovery — reload messages from API
-      if (parserState.currentSessionId) {
-        api
-          .getSessionMessages(parserState.currentSessionId)
-          .then((msgs) => {
-            if (Array.isArray(msgs) && msgs.length > 0) {
-              store.setState((s) => ({
-                messages: messagesReducer(s.messages, { type: 'RESTORE', messages: msgs }),
-              }));
-            }
-          })
-          .catch(() => {});
-      }
+    onMessagesRestored(messages: FinishedMessage[]) {
+      store.setState((s) => ({
+        messages: messagesReducer(s.messages, { type: 'RESTORE', messages }),
+      }));
     },
 
     fetchMessages(sessionId: string, signal: AbortSignal) {

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -308,8 +308,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }));
     },
 
-    fetchMessages(sessionId: string, signal: AbortSignal) {
-      return api.getSessionMessages(sessionId, signal);
+    fetchMessages(sessionId: string) {
+      return api.getSessionMessages(sessionId);
     },
 
     setWsRunning(poolKey: string, running: boolean) {


### PR DESCRIPTION
## Summary
- **Fix double-fetch in reattach recovery**: `onMessagesRestored` now receives `FinishedMessage[]` directly from the protocol parser instead of re-fetching via `getSessionMessages()`, eliminating a redundant API call (10 lines → 3 lines in store.ts)
- **Store integration tests**: 18 new tests covering `createMitzoStore`, `switchSession`, `newSession`, `sendMessage`, WS→store wiring, `setMode`, `setModel`, and `dispatchMessages`
- **ESLint config**: extends `argsIgnorePattern: '^_'` to `packages/`

All 150 `packages/client/` tests pass.

## Test plan
- [x] `npx vitest run packages/client` — 150 tests pass
- [x] Pre-commit hooks (eslint + prettier) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)