### PR TITLE
feat(models): add Opus 4.7 + effort-tier model selector

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -7,7 +7,7 @@ export const WS_RECONNECT_POLL_MS = 5_000;
 export const SCROLL_NEAR_BOTTOM_PX = 150;
 export const SCROLL_RESTORE_DELAY_MS = 100;
 export const LAST_SESSION_KEY = 'mitzo-last-session';
-export const DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const DEFAULT_MODEL = 'claude-opus-4-7';
 
 // --- Tool grouping ---
 export const TOOL_GROUP_THRESHOLD = 3;

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -172,9 +172,11 @@ export function ChatView() {
           onChange={(e) => setModel(e.target.value)}
           disabled={messages.running}
         >
-          <option value="claude-sonnet-4-6">Sonnet</option>
-          <option value="claude-opus-4-6">Opus</option>
-          <option value="claude-haiku-4-5">Haiku</option>
+          <option value="claude-opus-4-7">Opus 4.7</option>
+          <option value="claude-opus-4-7:max">Opus 4.7 Max</option>
+          <option value="claude-opus-4-6">Opus 4.6</option>
+          <option value="claude-sonnet-4-6">Sonnet 4.6</option>
+          <option value="claude-haiku-4-5">Haiku 4.5</option>
         </select>
         <div className="mode-pills">
           {(['ask', 'agent', 'auto'] as const).map((m) => (

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -220,9 +220,11 @@ export function DesktopChatView() {
               onChange={(e) => setModel(e.target.value)}
               disabled={messages.running}
             >
-              <option value="claude-sonnet-4-6">Sonnet</option>
-              <option value="claude-opus-4-6">Opus</option>
-              <option value="claude-haiku-4-5">Haiku</option>
+              <option value="claude-opus-4-7">Opus 4.7</option>
+              <option value="claude-opus-4-7:max">Opus 4.7 Max</option>
+              <option value="claude-opus-4-6">Opus 4.6</option>
+              <option value="claude-sonnet-4-6">Sonnet 4.6</option>
+              <option value="claude-haiku-4-5">Haiku 4.5</option>
             </select>
             <div className="mode-pills">
               {(['ask', 'agent', 'auto'] as const).map((m) => (

--- a/server/__tests__/model-spec.test.ts
+++ b/server/__tests__/model-spec.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { parseModelSpec, resolveThinking } from '../chat.js';
+
+describe('parseModelSpec', () => {
+  it('returns empty model and no effort for undefined', () => {
+    expect(parseModelSpec(undefined)).toEqual({ model: '', effort: undefined });
+  });
+
+  it('parses a plain model ID', () => {
+    expect(parseModelSpec('claude-opus-4-7')).toEqual({
+      model: 'claude-opus-4-7',
+      effort: undefined,
+    });
+  });
+
+  it('splits model and effort on colon', () => {
+    expect(parseModelSpec('claude-opus-4-7:max')).toEqual({
+      model: 'claude-opus-4-7',
+      effort: 'max',
+    });
+  });
+
+  it('handles trailing colon as empty effort', () => {
+    expect(parseModelSpec('claude-opus-4-7:')).toEqual({ model: 'claude-opus-4-7', effort: '' });
+  });
+
+  it('handles multiple colons — only splits on first', () => {
+    expect(parseModelSpec('claude-opus-4-7:max:extra')).toEqual({
+      model: 'claude-opus-4-7',
+      effort: 'max:extra',
+    });
+  });
+});
+
+describe('resolveThinking', () => {
+  it('returns adaptive for undefined (default)', () => {
+    expect(resolveThinking(undefined)).toEqual({ type: 'adaptive' });
+  });
+
+  it('returns adaptive for plain opus model', () => {
+    expect(resolveThinking('claude-opus-4-7')).toEqual({ type: 'adaptive' });
+  });
+
+  it('returns adaptive for opus 4-6', () => {
+    expect(resolveThinking('claude-opus-4-6')).toEqual({ type: 'adaptive' });
+  });
+
+  it('returns 128k budget for opus :max', () => {
+    expect(resolveThinking('claude-opus-4-7:max')).toEqual({
+      type: 'enabled',
+      budgetTokens: 128_000,
+    });
+  });
+
+  it('returns 10k budget for sonnet', () => {
+    expect(resolveThinking('claude-sonnet-4-6')).toEqual({
+      type: 'enabled',
+      budgetTokens: 10_000,
+    });
+  });
+
+  it('returns undefined for haiku', () => {
+    expect(resolveThinking('claude-haiku-4-5')).toBeUndefined();
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -93,10 +93,20 @@ export function getRepoConfig() {
 }
 
 export const AVAILABLE_MODELS = [
+  { id: 'claude-opus-4-7', label: 'Opus 4.7', desc: 'Adaptive thinking' },
+  { id: 'claude-opus-4-7:max', label: 'Opus 4.7 Max', desc: 'Max thinking (128k)' },
+  { id: 'claude-opus-4-6', label: 'Opus 4.6', desc: 'Previous Opus' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6', desc: 'Balanced' },
-  { id: 'claude-opus-4-6', label: 'Opus 4.6', desc: 'Most capable' },
   { id: 'claude-haiku-4-5', label: 'Haiku 4.5', desc: 'Fastest' },
 ];
+
+/** Split "claude-opus-4-7:max" → { model: "claude-opus-4-7", effort: "max" } */
+export function parseModelSpec(spec?: string): { model: string; effort: string | undefined } {
+  if (!spec) return { model: '', effort: undefined };
+  const idx = spec.indexOf(':');
+  if (idx === -1) return { model: spec, effort: undefined };
+  return { model: spec.slice(0, idx), effort: spec.slice(idx + 1) };
+}
 
 // --- Pure helper functions ---
 
@@ -122,8 +132,10 @@ function sdkEnv(): Record<string, string> {
 }
 
 function resolveThinking(
-  model?: string,
+  spec?: string,
 ): { type: 'adaptive' } | { type: 'enabled'; budgetTokens: number } | undefined {
+  const { model, effort } = parseModelSpec(spec);
+  if (model.includes('opus') && effort === 'max') return { type: 'enabled', budgetTokens: 128_000 };
   if (!model || model.includes('opus')) return { type: 'adaptive' };
   if (model.includes('sonnet')) return { type: 'enabled', budgetTokens: 10_000 };
   return undefined;
@@ -487,7 +499,7 @@ export async function startChat(
         permissionMode: MODE_TO_SDK[mode] as 'plan' | 'default' | 'bypassPermissions',
         allowedTools: [...modeAllowed, ...mcpAllowed, ...extraTools],
         thinking: resolveThinking(options.model),
-        ...(options.model ? { model: options.model } : {}),
+        ...(options.model ? { model: parseModelSpec(options.model).model } : {}),
         ...(options.resume ? { resume: options.resume } : {}),
         ...(Object.keys(allMcpServers).length > 0 ? { mcpServers: allMcpServers } : {}),
         ...(hooks ? { hooks } : {}),

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -131,7 +131,7 @@ function sdkEnv(): Record<string, string> {
   return env;
 }
 
-function resolveThinking(
+export function resolveThinking(
   spec?: string,
 ): { type: 'adaptive' } | { type: 'enabled'; budgetTokens: number } | undefined {
   const { model, effort } = parseModelSpec(spec);


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` and `claude-opus-4-7:max` (128k thinking budget) to the model selector
- Retains `claude-opus-4-6` as a previous-gen option
- New `parseModelSpec()` strips the `:max` effort suffix before sending the model ID to the SDK
- `resolveThinking()` maps `:max` → explicit 128k budget, default Opus stays adaptive
- Updates both mobile and desktop dropdowns

## Test plan
- [ ] Select Opus 4.7 from dropdown — verify adaptive thinking works
- [ ] Select Opus 4.7 Max — verify extended thinking with 128k budget
- [ ] Select Opus 4.6, Sonnet 4.6, Haiku 4.5 — verify no regression
- [ ] Verify `/api/models` returns all 5 entries
- [ ] Check Vertex availability for `claude-opus-4-7` (may not be GA yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)