### PR TITLE
fix: new session connection + resume CWD mismatch

### DIFF
--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -111,7 +111,11 @@ export function ChatView() {
   // ── Actions ──────────────────────────────────────────────────────────────
 
   function handleSend(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): boolean {
-    if (connection.status !== 'connected') {
+    // For new sessions (no activeSessionId) the store bootstraps a WS on
+    // demand inside sendMessage(), so we must not block on connection status.
+    // Only gate on connection for existing sessions where a WS should already
+    // be open.
+    if (activeSessionId && connection.status !== 'connected') {
       storeDispatchMessages({ type: 'CONNECTION_LOST' });
       return false;
     }

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -144,7 +144,11 @@ export function DesktopChatView() {
   // ── Actions ──────────────────────────────────────────────────────────────
 
   function handleSend(text: string, images?: ImageAttachment[], ctxBlocks?: string[]): boolean {
-    if (connection.status !== 'connected') {
+    // For new sessions (no activeSessionId) the store bootstraps a WS on
+    // demand inside sendMessage(), so we must not block on connection status.
+    // Only gate on connection for existing sessions where a WS should already
+    // be open.
+    if (activeSessionId && connection.status !== 'connected') {
       storeDispatchMessages({ type: 'CONNECTION_LOST' });
       return false;
     }

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -459,6 +459,83 @@ describe('respondToPermission', () => {
   });
 });
 
+describe('sendMessage — new session connection bootstrap', () => {
+  it('new session send works even when connection.status is disconnected', () => {
+    const store = createMitzoStore(makeOptions());
+
+    // Initial state: connection is disconnected (no WS subscription yet)
+    expect(store.getState().connection.status).toBe('disconnected');
+
+    // sendMessage should still work — it creates a pool entry on demand
+    store.getState().sendMessage('hello from a new session');
+
+    const { messages, running } = store.getState().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0].blocks[0].content).toBe('hello from a new session');
+    expect(running).toBe(true);
+    // A WebSocket was created (pool entry bootstrapped)
+    expect(lastWs).toBeDefined();
+  });
+
+  it('connection becomes connected after new-session WS opens and receives client_id', () => {
+    const store = createMitzoStore(makeOptions());
+    store.getState().sendMessage('hello');
+
+    // Simulate full handshake
+    lastWs.simulateOpen();
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+
+    expect(store.getState().connection.status).toBe('connected');
+  });
+});
+
+describe('sendMessage — resume drops stale session ID after error', () => {
+  it('clears currentSessionId on "No conversation found" so next send is fresh', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+
+    // Switch to an existing session (sets parserState.currentSessionId)
+    await store.getState().switchSession('old-session-id');
+
+    // Simulate WS handshake
+    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    lastWs.simulateMessage({ type: 'subscribed', running: false });
+
+    // Send a message — should include resume
+    store.getState().sendMessage('first attempt');
+    const firstSent = lastWs.sent.map((s) => JSON.parse(s));
+    const resumeMsg = firstSent.find(
+      (m: Record<string, unknown>) => m.type === 'send' && m.resume === 'old-session-id',
+    );
+    expect(resumeMsg).toBeDefined();
+
+    // Server responds with "No conversation found"
+    lastWs.simulateMessage({
+      type: 'error',
+      error:
+        'Claude Code returned an error result: No conversation found with session ID: old-session-id',
+    });
+
+    // Session should be expired — active cleared
+    expect(store.getState().sessions.active).toBeNull();
+
+    // Send another message — should NOT include resume (fresh session)
+    store.getState().sendMessage('second attempt');
+
+    // The second send should go through a new pool key (no resume)
+    // It creates a new WS, so check the new lastWs
+    const newWsSent = lastWs.sent.map((s) => JSON.parse(s));
+    const freshMsg = newWsSent.find((m: Record<string, unknown>) => m.type === 'send' && !m.resume);
+    expect(freshMsg).toBeDefined();
+    expect(freshMsg.prompt).toBe('second attempt');
+  });
+});
+
 describe('setMode', () => {
   it('updates config mode', () => {
     const store = createMitzoStore(makeOptions());

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -405,7 +405,22 @@ export async function startChat(
 ) {
   const abortController = new AbortController();
   const mode = options.mode || 'agent';
-  const baseCwd = options.cwd || BASE_REPO;
+
+  // When resuming, look up the original session's CWD from the event store.
+  // The SDK stores conversation data under ~/.claude/projects/<encoded-cwd>/,
+  // so we must use the same CWD the session was created with — otherwise the
+  // SDK can't find the conversation and returns "No conversation found".
+  let baseCwd = options.cwd || BASE_REPO;
+  if (options.resume && !options.cwd) {
+    const sessionMeta = eventStore.getSession(options.resume);
+    if (sessionMeta?.cwd) {
+      baseCwd = sessionMeta.cwd;
+      log.info('resume: using original session CWD', {
+        sessionId: options.resume,
+        cwd: baseCwd,
+      });
+    }
+  }
 
   // Generate session-scoped worktree ID and create worktrees in all repos
   const wtId = generateWtId();


### PR DESCRIPTION
## Summary

- **Bug 1 — New sessions can't connect**: After PR #207 migrated from hooks to `@mitzo/client` store, `handleSend` in ChatView/DesktopChatView gates on `connection.status !== 'connected'`. For new sessions no WS exists yet, so the guard blocks forever. Fixed by skipping the guard when there's no `activeSessionId` — the store's `sendMessage()` bootstraps the WS on demand.

- **Bug 2 — Resume shows "Session expired" on first prompt**: Worktree sessions store SDK conversation data under `~/.claude/projects/<encoded-worktree-path>/`. Resume skips worktree creation and uses `BASE_REPO` as CWD, so the SDK can't find the conversation → "No conversation found". Fixed by looking up the original session CWD from the event store and passing it to `query()`.

## Test plan

- [x] Store-level tests for new-session bootstrap and stale session ID recovery
- [x] All 569 relevant tests pass (`packages/client/`, `server/`)
- [x] Lint clean (0 errors)
- [ ] Manual: start a new chat session from mobile — should connect immediately
- [ ] Manual: navigate to an existing session and send a prompt — should resume without "Session expired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)