### PR TITLE
fix(client): unsubscribe old WS when switching sessions

### DIFF
--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -568,6 +568,34 @@ describe('sendMessage — new session connection bootstrap', () => {
 
     expect(store.getState().connection.status).toBe('connected');
   });
+
+  it('unsubscribes previous session WS when first message creates a new pool entry', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+
+    // Start in an existing session
+    await store.getState().switchSession('old-session');
+    const oldWs = lastWs;
+    oldWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    oldWs.simulateMessage({ type: 'subscribed', running: false });
+
+    // Start a brand-new session by calling newSession then sendMessage
+    store.getState().newSession();
+    store.getState().sendMessage('fresh start');
+
+    // Messages on the old WS must not leak into the new session
+    oldWs.simulateMessage({ type: 'message_start', messageId: 'old-leak' });
+
+    // Only the user message from sendMessage should be present
+    expect(store.getState().messages.messages).toHaveLength(1);
+    expect(store.getState().messages.messages[0].role).toBe('user');
+    expect(store.getState().messages.current).toBeNull();
+  });
 });
 
 describe('sendMessage — resume drops stale session ID after error', () => {

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -139,6 +139,44 @@ describe('switchSession', () => {
     expect(store.getState().messages.messages).toHaveLength(1);
     expect(store.getState().messages.messages[0].messageId).toBe('m1');
   });
+
+  it('unsubscribes old session WS when switching to a new one', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+
+    // Switch to session A
+    await store.getState().switchSession('session-a');
+    const wsA = lastWs;
+    wsA.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    wsA.simulateMessage({ type: 'subscribed', running: true });
+
+    // Switch to session B
+    await store.getState().switchSession('session-b');
+
+    // Messages on session A's WS should NOT dispatch into session B's state
+    wsA.simulateMessage({ type: 'message_start', messageId: 'a-msg' });
+    wsA.simulateMessage({
+      type: 'block_start',
+      messageId: 'a-msg',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    wsA.simulateMessage({
+      type: 'block_delta',
+      messageId: 'a-msg',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'should not appear',
+    });
+
+    expect(store.getState().messages.messages).toHaveLength(0);
+    expect(store.getState().messages.current).toBeNull();
+  });
 });
 
 describe('newSession', () => {
@@ -152,6 +190,49 @@ describe('newSession', () => {
 
     expect(store.getState().sessions.active).toBeNull();
     expect(store.getState().messages.messages).toHaveLength(0);
+  });
+
+  it('isolates new session from old session messages', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      text: () => Promise.resolve(''),
+    });
+    const store = createMitzoStore(makeOptions(transport));
+
+    // Start in an existing session with an active WS
+    await store.getState().switchSession('old-session');
+    const oldWs = lastWs;
+
+    // Complete the handshake so messages flow
+    oldWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
+    oldWs.simulateMessage({ type: 'subscribed', running: true });
+
+    // Now switch to a new session
+    store.getState().newSession();
+    expect(store.getState().messages.messages).toHaveLength(0);
+
+    // Simulate messages arriving on the OLD session's WS — these must
+    // NOT appear in the new session's state.
+    oldWs.simulateMessage({ type: 'message_start', messageId: 'old-msg' });
+    oldWs.simulateMessage({
+      type: 'block_start',
+      messageId: 'old-msg',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    oldWs.simulateMessage({
+      type: 'block_delta',
+      messageId: 'old-msg',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'leaked!',
+    });
+
+    // The store should still have zero messages — old session is unsubscribed
+    expect(store.getState().messages.messages).toHaveLength(0);
+    expect(store.getState().messages.current).toBeNull();
   });
 });
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -128,6 +128,11 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
   // Track the actual WS pool key so wsListener routes to the correct entry
   let activePoolKey: string | null = null;
 
+  // Unsubscribe handle for the current WS subscription — called when
+  // switching sessions or starting a new one so old session messages
+  // don't leak into the new session's state.
+  let activeUnsub: (() => void) | null = null;
+
   const store = createStore<MitzoStoreState>((set, get) => ({
     // ── Initial state ────────────────────────────────────────────────────
 
@@ -150,6 +155,11 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     async switchSession(id: string) {
+      // Unsubscribe from previous session's WS before subscribing to the new
+      // one — otherwise the old listener keeps dispatching messages into the
+      // store, causing sessions to "merge."
+      activeUnsub?.();
+
       parserState.currentSessionId = id;
       const poolKey = `session:${id}`;
       activePoolKey = poolKey;
@@ -163,7 +173,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }));
 
       // Subscribe to WS messages for this session
-      wsPool.subscribe(poolKey, wsListener);
+      activeUnsub = wsPool.subscribe(poolKey, wsListener);
 
       // Load session messages
       try {
@@ -179,6 +189,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     newSession() {
+      activeUnsub?.();
+      activeUnsub = null;
+      activePoolKey = null;
       parserState.currentSessionId = undefined;
       set({
         sessions: { ...get().sessions, active: null },
@@ -234,9 +247,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
       // For new sessions, subscribe first so the pool entry exists
       if (!poolKey) {
+        activeUnsub?.();
         const newKey = `new:${Date.now()}`;
         activePoolKey = newKey;
-        wsPool.subscribe(newKey, wsListener);
+        activeUnsub = wsPool.subscribe(newKey, wsListener);
 
         const sent = wsPool.send(newKey, buildPayload());
         if (!sent) {


### PR DESCRIPTION
## Summary

- **Bug**: `switchSession()` and `newSession()` subscribed to a new WS pool entry but never unsubscribed the previous one. Messages from the old session kept dispatching through `wsListener`, causing sessions to visually "merge" — the UI showed messages from the previous session in the new one.
- **Fix**: Track the unsubscribe handle from `wsPool.subscribe()` and call it before subscribing to a new session in `switchSession()`, `newSession()`, and `sendMessage()` (new-session path).
- Adds 2 isolation tests verifying old-session messages don't leak after switching.

## Test plan

- [x] 27 store tests pass (including 2 new isolation tests)
- [x] Lint clean
- [ ] Manual: switch sessions — old session messages should not appear
- [ ] Manual: start new session while old one is running — only new session content visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)