### PR TITLE
fix: token bar crash, compaction tracking, scroll UX

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -37,6 +37,18 @@ export function ChatArea({
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
+  const prevMessageCount = useRef(0);
+
+  // Scroll to bottom on session restore (messages jump from 0 to N)
+  useEffect(() => {
+    const wasEmpty = prevMessageCount.current === 0;
+    prevMessageCount.current = messages.length;
+    if (wasEmpty && messages.length > 0) {
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+      });
+    }
+  }, [messages, scrollRef]);
 
   // Auto-scroll during streaming: follow new content if user is near the bottom
   useEffect(() => {

--- a/frontend/src/components/ScrollFab.tsx
+++ b/frontend/src/components/ScrollFab.tsx
@@ -15,9 +15,7 @@ export function ScrollFab({ scrollRef }: Props) {
     if (!el) return;
 
     function update() {
-      const el = scrollRef.current;
-      if (!el) return;
-      const { scrollTop, scrollHeight, clientHeight } = el;
+      const { scrollTop, scrollHeight, clientHeight } = el!;
       const canScroll = scrollHeight > clientHeight;
       setShowTop(canScroll && scrollTop > THRESHOLD);
       setShowBottom(canScroll && scrollHeight - scrollTop - clientHeight > THRESHOLD);
@@ -36,7 +34,6 @@ export function ScrollFab({ scrollRef }: Props) {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
   }, [scrollRef]);
 
-  if (!scrollRef.current) return null;
   if (!showTop && !showBottom) return null;
 
   return (

--- a/frontend/src/components/ScrollFab.tsx
+++ b/frontend/src/components/ScrollFab.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const THRESHOLD = 200; // px from edge to show button
+
+interface Props {
+  scrollRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function ScrollFab({ scrollRef }: Props) {
+  const [showTop, setShowTop] = useState(false);
+  const [showBottom, setShowBottom] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    function update() {
+      const el = scrollRef.current;
+      if (!el) return;
+      const { scrollTop, scrollHeight, clientHeight } = el;
+      const canScroll = scrollHeight > clientHeight;
+      setShowTop(canScroll && scrollTop > THRESHOLD);
+      setShowBottom(canScroll && scrollHeight - scrollTop - clientHeight > THRESHOLD);
+    }
+
+    el.addEventListener('scroll', update, { passive: true });
+    update();
+    return () => el.removeEventListener('scroll', update);
+  }, [scrollRef]);
+
+  const scrollToTop = useCallback(() => {
+    scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  const scrollToBottom = useCallback(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+  }, [scrollRef]);
+
+  if (!scrollRef.current) return null;
+  if (!showTop && !showBottom) return null;
+
+  return (
+    <div className="scroll-fab-container">
+      {showTop && (
+        <button
+          className="scroll-fab scroll-fab--up"
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+            <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" />
+          </svg>
+        </button>
+      )}
+      {showBottom && (
+        <button
+          className="scroll-fab scroll-fab--down"
+          onClick={scrollToBottom}
+          aria-label="Scroll to bottom"
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+            <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TokenBar.tsx
+++ b/frontend/src/components/TokenBar.tsx
@@ -19,12 +19,15 @@ export function TokenBar({ tokenState }: Props) {
   // Don't render until we have data
   if (tokenState.turnIndex === 0) return null;
 
-  const ceiling = tokenState.contextCeiling;
-  const ratio = ceiling > 0 ? tokenState.agentContext / ceiling : 0;
+  const ceiling = tokenState.contextCeiling ?? 0;
+  const agentContext = tokenState.agentContext ?? 0;
+  const sessionTotal = tokenState.sessionTotal ?? 0;
+  const numCompactions = tokenState.numCompactions ?? 0;
+  const ratio = ceiling > 0 ? agentContext / ceiling : 0;
   const color = getContextColor(ratio);
   // Completed sessions have agentContext=0 but sessionTotal>0 (hydrated from event store).
   // Show only session total in that case — the agent context bar is meaningless.
-  const isCompleted = tokenState.agentContext === 0 && tokenState.sessionTotal > 0;
+  const isCompleted = agentContext === 0 && sessionTotal > 0;
 
   return (
     <>
@@ -45,13 +48,13 @@ export function TokenBar({ tokenState }: Props) {
             >
               <path d="M12 2a9 9 0 0 0-9 9c0 3.1 1.6 5.8 4 7.4V21h2v-2h6v2h2v-2.6c2.4-1.6 4-4.3 4-7.4a9 9 0 0 0-9-9zm-1 14h-1v-4h1v4zm1-6H9.5V8.5a2.5 2.5 0 0 1 5 0V10H12zm3 6h-1v-4h1v4z" />
             </svg>
-            {formatTokens(tokenState.agentContext)}/{formatTokens(ceiling)}
+            {formatTokens(agentContext)}/{formatTokens(ceiling)}
           </span>
         )}
-        {tokenState.sessionTotal > 0 && (
+        {sessionTotal > 0 && (
           <span className="token-bar-session">
             <span className="token-bar-sigma">Σ</span>
-            {formatTokens(tokenState.sessionTotal)}
+            {formatTokens(sessionTotal)}
           </span>
         )}
       </button>
@@ -60,17 +63,23 @@ export function TokenBar({ tokenState }: Props) {
           <div className="token-bar-detail-row">
             <span>Agent context</span>
             <span>
-              {tokenState.agentContext.toLocaleString()} / {ceiling.toLocaleString()}
+              {agentContext.toLocaleString()} / {ceiling.toLocaleString()}
             </span>
           </div>
           <div className="token-bar-detail-row">
             <span>Session tokens</span>
-            <span>{tokenState.sessionTotal.toLocaleString()}</span>
+            <span>{sessionTotal.toLocaleString()}</span>
           </div>
           {tokenState.numTurns > 0 && (
             <div className="token-bar-detail-row">
               <span>Turns</span>
               <span>{tokenState.numTurns} turns</span>
+            </div>
+          )}
+          {numCompactions > 0 && (
+            <div className="token-bar-detail-row">
+              <span>Compactions</span>
+              <span>{numCompactions}</span>
             </div>
           )}
           <div className="token-bar-detail-row">

--- a/frontend/src/components/__tests__/ChatArea.test.tsx
+++ b/frontend/src/components/__tests__/ChatArea.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, act } from '@testing-library/react';
 import { ChatArea } from '../ChatArea';
 import type { FinishedMessage, StreamingBlock } from '../../types/chat';
 
@@ -126,5 +126,42 @@ describe('ChatArea', () => {
     ];
     render(<ChatArea {...defaultProps} messages={messages} />);
     expect(screen.getByTestId('thinking-block')).toBeTruthy();
+  });
+
+  it('scrolls to bottom when messages appear for the first time (session restore)', async () => {
+    const scrollRef = { current: null as HTMLDivElement | null };
+    const restoredMessages: FinishedMessage[] = [
+      {
+        messageId: 'u1',
+        role: 'user',
+        blocks: [{ blockId: 'b1', blockType: 'text', content: 'Hello' }],
+      },
+      {
+        messageId: 'a1',
+        role: 'assistant',
+        blocks: [{ blockId: 'b2', blockType: 'text', content: 'Hi there' }],
+      },
+    ];
+
+    // Initial render with no messages
+    const { rerender } = render(<ChatArea {...defaultProps} scrollRef={scrollRef} />);
+
+    // Spy on scrollTo after the ref is attached
+    const scrollTo = vi.fn();
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo = scrollTo;
+    }
+
+    // Simulate RESTORE: messages appear in one shot
+    await act(async () => {
+      rerender(<ChatArea {...defaultProps} messages={restoredMessages} scrollRef={scrollRef} />);
+    });
+
+    // Give the rAF time to fire
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(scrollTo).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/__tests__/ChatArea.test.tsx
+++ b/frontend/src/components/__tests__/ChatArea.test.tsx
@@ -162,6 +162,6 @@ describe('ChatArea', () => {
       await new Promise((r) => setTimeout(r, 50));
     });
 
-    expect(scrollTo).toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalledWith({ top: expect.any(Number) });
   });
 });

--- a/frontend/src/components/__tests__/ScrollFab.test.tsx
+++ b/frontend/src/components/__tests__/ScrollFab.test.tsx
@@ -31,7 +31,7 @@ describe('ScrollFab', () => {
 
     // Trigger the scroll event handler
     const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([event]: [string]) => event === 'scroll',
+      ([event]: string[]) => event === 'scroll',
     )?.[1];
     expect(scrollHandler).toBeTruthy();
 
@@ -47,7 +47,7 @@ describe('ScrollFab', () => {
     render(<ScrollFab scrollRef={ref} />);
 
     const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([event]: [string]) => event === 'scroll',
+      ([event]: string[]) => event === 'scroll',
     )?.[1];
 
     act(() => scrollHandler!());
@@ -62,7 +62,7 @@ describe('ScrollFab', () => {
     render(<ScrollFab scrollRef={ref} />);
 
     const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([event]: [string]) => event === 'scroll',
+      ([event]: string[]) => event === 'scroll',
     )?.[1];
 
     act(() => scrollHandler!());
@@ -82,7 +82,7 @@ describe('ScrollFab', () => {
     render(<ScrollFab scrollRef={ref} />);
 
     const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([event]: [string]) => event === 'scroll',
+      ([event]: string[]) => event === 'scroll',
     )?.[1];
 
     act(() => scrollHandler!());

--- a/frontend/src/components/__tests__/ScrollFab.test.tsx
+++ b/frontend/src/components/__tests__/ScrollFab.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react';
+import { ScrollFab } from '../ScrollFab';
+
+afterEach(() => cleanup());
+
+function makeScrollEl(overrides: Partial<HTMLDivElement> = {}): HTMLDivElement {
+  return {
+    scrollTop: 0,
+    scrollHeight: 2000,
+    clientHeight: 600,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    scrollTo: vi.fn(),
+    ...overrides,
+  } as unknown as HTMLDivElement;
+}
+
+describe('ScrollFab', () => {
+  it('renders nothing when scrollRef is null', () => {
+    const ref = { current: null };
+    const { container } = render(<ScrollFab scrollRef={ref} />);
+    expect(container.querySelector('.scroll-fab')).toBeNull();
+  });
+
+  it('shows scroll-to-bottom button when far from bottom', () => {
+    const el = makeScrollEl({ scrollTop: 0 });
+    const ref = { current: el };
+    render(<ScrollFab scrollRef={ref} />);
+
+    // Trigger the scroll event handler
+    const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event]: [string]) => event === 'scroll',
+    )?.[1];
+    expect(scrollHandler).toBeTruthy();
+
+    act(() => scrollHandler!());
+
+    const downBtn = screen.queryByLabelText('Scroll to bottom');
+    expect(downBtn).toBeTruthy();
+  });
+
+  it('shows scroll-to-top button when far from top', () => {
+    const el = makeScrollEl({ scrollTop: 1400 }); // near bottom
+    const ref = { current: el };
+    render(<ScrollFab scrollRef={ref} />);
+
+    const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event]: [string]) => event === 'scroll',
+    )?.[1];
+
+    act(() => scrollHandler!());
+
+    const upBtn = screen.queryByLabelText('Scroll to top');
+    expect(upBtn).toBeTruthy();
+  });
+
+  it('calls scrollTo when buttons are clicked', () => {
+    const el = makeScrollEl({ scrollTop: 500 }); // middle
+    const ref = { current: el };
+    render(<ScrollFab scrollRef={ref} />);
+
+    const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event]: [string]) => event === 'scroll',
+    )?.[1];
+
+    act(() => scrollHandler!());
+
+    const downBtn = screen.getByLabelText('Scroll to bottom');
+    fireEvent.click(downBtn);
+    expect(el.scrollTo).toHaveBeenCalledWith({ top: el.scrollHeight, behavior: 'smooth' });
+
+    const upBtn = screen.getByLabelText('Scroll to top');
+    fireEvent.click(upBtn);
+    expect(el.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('hides both buttons when content fits without scrolling', () => {
+    const el = makeScrollEl({ scrollTop: 0, scrollHeight: 500, clientHeight: 600 });
+    const ref = { current: el };
+    render(<ScrollFab scrollRef={ref} />);
+
+    const scrollHandler = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([event]: [string]) => event === 'scroll',
+    )?.[1];
+
+    act(() => scrollHandler!());
+
+    expect(screen.queryByLabelText('Scroll to top')).toBeNull();
+    expect(screen.queryByLabelText('Scroll to bottom')).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/TokenBar.test.tsx
+++ b/frontend/src/components/__tests__/TokenBar.test.tsx
@@ -11,6 +11,7 @@ function makeState(overrides: Partial<TokenState> = {}): TokenState {
     sessionTotal: 0,
     numTurns: 0,
     turnIndex: 0,
+    numCompactions: 0,
     ...overrides,
   };
 }
@@ -94,7 +95,7 @@ describe('TokenBar', () => {
       turnIndex: 1,
     });
     // Simulate the bug: sessionTotal clobbered to undefined by partial spread
-    (state as Record<string, unknown>).sessionTotal = undefined;
+    (state as unknown as Record<string, unknown>).sessionTotal = undefined;
     const { container } = render(<TokenBar tokenState={state} />);
     const bar = container.querySelector('.token-bar')!;
     fireEvent.click(bar);

--- a/frontend/src/components/__tests__/TokenBar.test.tsx
+++ b/frontend/src/components/__tests__/TokenBar.test.tsx
@@ -88,6 +88,21 @@ describe('TokenBar', () => {
     expect(screen.queryByText(/0\/200k/)).toBeNull();
   });
 
+  it('does not crash when sessionTotal is undefined (mid-turn state)', () => {
+    const state = makeState({
+      agentContext: 87204,
+      turnIndex: 1,
+    });
+    // Simulate the bug: sessionTotal clobbered to undefined by partial spread
+    (state as Record<string, unknown>).sessionTotal = undefined;
+    const { container } = render(<TokenBar tokenState={state} />);
+    const bar = container.querySelector('.token-bar')!;
+    fireEvent.click(bar);
+    // Should render detail panel without crashing
+    expect(screen.getByText(/Agent context/)).toBeTruthy();
+    expect(screen.getByText(/Session tokens/)).toBeTruthy();
+  });
+
   it('expands detail panel on tap', () => {
     render(
       <TokenBar

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
+import { ScrollFab } from '../components/ScrollFab';
 import { VoiceSettings } from '../components/VoiceSettings';
 import { MitzoLogo } from '../components/MitzoLogo';
 import { useMessages, useConnection, useTokens, useMitzoStore } from '@mitzo/client/hooks';
@@ -212,6 +213,7 @@ export function ChatView() {
         onPermissionRespond={handlePermission}
         scrollRef={scrollRef}
       />
+      <ScrollFab scrollRef={scrollRef} />
 
       <ChatInput
         onSend={handleSend}

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -6,6 +6,7 @@ import { ContextPanel } from '../components/ContextPanel';
 import { FileBrowserPanel } from '../components/FileBrowserPanel';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
+import { ScrollFab } from '../components/ScrollFab';
 import { StatusBar } from '../components/StatusBar';
 import { VoiceSettings } from '../components/VoiceSettings';
 import { useMessages, useConnection, useTokens, useMitzoStore } from '@mitzo/client/hooks';
@@ -259,6 +260,7 @@ export function DesktopChatView() {
             onPermissionRespond={handlePermission}
             scrollRef={scrollRef}
           />
+          <ScrollFab scrollRef={scrollRef} />
           <ChatInput
             onSend={handleSend}
             onStop={handleStop}

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -110,6 +110,7 @@ function createMockStore() {
       sessionTotal: 0,
       numTurns: 0,
       turnIndex: 0,
+      numCompactions: 0,
     },
     sendError: null,
     dispatchMessages: vi.fn(),

--- a/frontend/src/styles/desktop.css
+++ b/frontend/src/styles/desktop.css
@@ -73,6 +73,7 @@
     flex-direction: column;
     height: 100%;
     min-height: 0;
+    position: relative;
   }
 
   /* Override chat-page fixed positioning when inside desktop shell */

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1184,6 +1184,41 @@ textarea:focus {
   overscroll-behavior-y: contain;
 }
 
+/* ===== Scroll FAB ===== */
+
+.scroll-fab-container {
+  position: absolute;
+  right: 12px;
+  bottom: 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 20;
+  pointer-events: none;
+}
+
+.scroll-fab {
+  pointer-events: auto;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: var(--surface-elevated, #333);
+  color: var(--text-dim, #aaa);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.scroll-fab:hover,
+.scroll-fab:active {
+  opacity: 1;
+}
+
 /* ===== Message Bubbles ===== */
 
 .msg-bubble {

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -235,6 +235,7 @@ export interface TokenUpdateMsg {
   contextCeiling?: number;
   sessionTotal?: number;
   numTurns?: number;
+  numCompactions?: number;
   turnIndex: number;
 }
 

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -475,6 +475,56 @@ describe('task system messages', () => {
   });
 });
 
+// ─── Token updates ───────────────────────────────────────────────────────────
+
+describe('token_update', () => {
+  it('produces tokensUpdate with all fields', () => {
+    const r = parseServerMessage(
+      {
+        type: 'token_update',
+        agentContext: 80000,
+        contextCeiling: 200000,
+        sessionTotal: 150000,
+        numTurns: 3,
+        turnIndex: 2,
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tokensUpdate).toEqual({
+      agentContext: 80000,
+      contextCeiling: 200000,
+      sessionTotal: 150000,
+      numTurns: 3,
+      turnIndex: 2,
+    });
+  });
+
+  it('omits undefined fields so partial spread does not clobber existing values', () => {
+    const r = parseServerMessage(
+      {
+        type: 'token_update',
+        agentContext: 90000,
+        contextCeiling: 200000,
+        turnIndex: 4,
+        // sessionTotal and numTurns intentionally absent (mid-turn update)
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.tokensUpdate).toEqual({
+      agentContext: 90000,
+      contextCeiling: 200000,
+      turnIndex: 4,
+    });
+    // Must NOT have sessionTotal key at all
+    expect('sessionTotal' in r.tokensUpdate!).toBe(false);
+    expect('numTurns' in r.tokensUpdate!).toBe(false);
+  });
+});
+
 // ─── Inbox ────────────────────────────────────────────────────────────────────
 
 describe('inbox', () => {

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -362,15 +362,20 @@ export function parseServerMessage(
       };
       break;
 
-    case 'token_update':
-      result.tokensUpdate = {
+    case 'token_update': {
+      // Build partial update, omitting undefined fields so the store spread
+      // does not clobber existing values (mid-turn updates lack sessionTotal).
+      const tu: Partial<TokensState> = {
         agentContext: msg.agentContext as number,
-        contextCeiling: msg.contextCeiling as number | undefined,
-        sessionTotal: msg.sessionTotal as number | undefined,
-        numTurns: msg.numTurns as number | undefined,
         turnIndex: msg.turnIndex as number,
       };
+      if (msg.contextCeiling != null) tu.contextCeiling = msg.contextCeiling as number;
+      if (msg.sessionTotal != null) tu.sessionTotal = msg.sessionTotal as number;
+      if (msg.numTurns != null) tu.numTurns = msg.numTurns as number;
+      if (msg.numCompactions != null) tu.numCompactions = msg.numCompactions as number;
+      result.tokensUpdate = tu;
       break;
+    }
 
     case 'inbox_updated':
       result.inboxRefresh = true;

--- a/packages/client/src/slices/tokens.ts
+++ b/packages/client/src/slices/tokens.ts
@@ -4,6 +4,7 @@ export interface TokensState {
   sessionTotal: number;
   numTurns: number;
   turnIndex: number;
+  numCompactions: number;
 }
 
 export const DEFAULT_CONTEXT_CEILING = 200_000;
@@ -14,4 +15,5 @@ export const INITIAL_TOKENS_STATE: TokensState = {
   sessionTotal: 0,
   numTurns: 0,
   turnIndex: 0,
+  numCompactions: 0,
 };

--- a/server/__tests__/token-update.test.ts
+++ b/server/__tests__/token-update.test.ts
@@ -370,6 +370,65 @@ describe('token_update emission', () => {
     expect(resultUpdates[1]).toMatchObject({ sessionTotal: 15000 });
   });
 
+  it('counts compaction events from SDK system messages', async () => {
+    const events: Record<string, unknown>[] = [
+      // Parent message_start
+      {
+        type: 'stream_event',
+        parent_tool_use_id: null,
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-c1', usage: { input_tokens: 180000 } },
+        },
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'assistant', message: { content: [] }, session_id: 'sess-compact' },
+      // SDK system status: compaction completed
+      {
+        type: 'system',
+        subtype: 'status',
+        status: null,
+        compact_result: 'success',
+        session_id: 'sess-compact',
+      },
+      // Next turn after compaction — context dropped
+      {
+        type: 'stream_event',
+        parent_tool_use_id: null,
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-c2', usage: { input_tokens: 40000 } },
+        },
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'assistant', message: { content: [] }, session_id: 'sess-compact' },
+      {
+        type: 'result',
+        session_id: 'sess-compact',
+        usage: { input_tokens: 40000, output_tokens: 1000 },
+        total_cost_usd: 0.02,
+        num_turns: 2,
+        duration_ms: 5000,
+        duration_api_ms: 3000,
+      },
+    ];
+
+    await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+    const tokenUpdates = transport.sent.filter((m) => m.type === 'token_update');
+    // The final token_update should include numCompactions: 1
+    const last = tokenUpdates[tokenUpdates.length - 1];
+    expect(last).toMatchObject({ numCompactions: 1 });
+  });
+
   it('handles missing usage on message_start gracefully', async () => {
     const events: Record<string, unknown>[] = [
       {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -140,6 +140,7 @@ export async function runQueryLoop(
   let agentContextTokens = 0; // full context window size (input + cached) from parent message_start
   let turnIndex = 0; // increments on each parent message_start (excludes sub-agents)
   let numCompactions = 0; // counts successful compaction events from SDK
+  const compactionFields = () => (numCompactions > 0 ? { numCompactions } : {});
 
   // Track last-reported cumulative usage to compute deltas (SDK reports cumulative totals).
   let lastReportedUsage = {
@@ -344,7 +345,7 @@ export async function runQueryLoop(
           sessionTotal: currentSession.cumulativeSessionTokens,
           numTurns: usageData.numTurns,
           turnIndex,
-          ...(numCompactions > 0 ? { numCompactions } : {}),
+          ...compactionFields(),
         });
 
         // Resolve goal creation (if pending) and report usage
@@ -436,7 +437,7 @@ export async function runQueryLoop(
                 agentContext: agentContextTokens,
                 contextCeiling: CONTEXT_CEILING_TOKENS,
                 turnIndex,
-                ...(numCompactions > 0 ? { numCompactions } : {}),
+                ...compactionFields(),
               });
             }
           }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -139,6 +139,7 @@ export async function runQueryLoop(
   // Token tracking state for live token_update events
   let agentContextTokens = 0; // full context window size (input + cached) from parent message_start
   let turnIndex = 0; // increments on each parent message_start (excludes sub-agents)
+  let numCompactions = 0; // counts successful compaction events from SDK
 
   // Track last-reported cumulative usage to compute deltas (SDK reports cumulative totals).
   let lastReportedUsage = {
@@ -343,6 +344,7 @@ export async function runQueryLoop(
           sessionTotal: currentSession.cumulativeSessionTokens,
           numTurns: usageData.numTurns,
           turnIndex,
+          ...(numCompactions > 0 ? { numCompactions } : {}),
         });
 
         // Resolve goal creation (if pending) and report usage
@@ -434,6 +436,7 @@ export async function runQueryLoop(
                 agentContext: agentContextTokens,
                 contextCeiling: CONTEXT_CEILING_TOKENS,
                 turnIndex,
+                ...(numCompactions > 0 ? { numCompactions } : {}),
               });
             }
           }
@@ -600,6 +603,14 @@ export async function runQueryLoop(
           }
           openBlockCount = Math.max(0, openBlockCount - 1);
           tryFlushMessageEnd(currentSession);
+        }
+      } else if (msg.type === 'system') {
+        // Track compaction events from SDK system status messages
+        const subtype = (msg as Record<string, unknown>).subtype;
+        const compactResult = (msg as Record<string, unknown>).compact_result;
+        if (subtype === 'status' && compactResult === 'success') {
+          numCompactions++;
+          log.info('compaction completed', { clientId, numCompactions });
         }
       } else if (msg.type === 'user') {
         // Only extract tool_result events from SDK user turns.


### PR DESCRIPTION
## Summary

- **Fix token bar crash** — mid-turn `token_update` events omit `sessionTotal`, causing `undefined.toLocaleString()` crash when tapping the detail panel. Protocol parser now filters undefined fields; TokenBar uses safe defaults.
- **Track compaction count** — detect `compact_result: 'success'` SDK system messages and display compaction count in the token bar detail panel.
- **Scroll to bottom on session resume** — auto-scroll when messages load via RESTORE (0 → N transition) so you land at the freshest content.
- **Scroll FAB buttons** — floating up/down arrows appear when scrolled away from top or bottom of chat. Tap to jump.

## Test plan

- [x] TokenBar renders without crash when `sessionTotal` is undefined
- [x] Protocol parser omits undefined fields from partial token updates
- [x] Compaction events from SDK system messages increment `numCompactions`
- [x] ChatArea scrolls to bottom when messages appear for the first time (restore)
- [x] ScrollFab shows/hides buttons based on scroll position
- [x] ScrollFab calls `scrollTo` on click
- [ ] Manual: resume a session on mobile — should land at the bottom
- [ ] Manual: scroll up in a long session — FAB arrows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)