### PR TITLE
feat: session index and graceful closeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "helmet": "^8.1.0",
         "http-proxy-middleware": "^3.0.5",
         "jose": "^5.9.0",
+        "js-yaml": "^4.1.1",
         "nanoid": "^5.0.9",
         "ws": "^8.18.0",
         "zod": "^4.3.6"
@@ -41,6 +42,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/cookie-parser": "^1.4.7",
         "@types/express": "^5.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/supertest": "^7.2.0",
         "@types/ws": "^8.5.13",
@@ -3296,6 +3298,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4001,7 +4010,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -6729,7 +6737,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "helmet": "^8.1.0",
     "http-proxy-middleware": "^3.0.5",
     "jose": "^5.9.0",
+    "js-yaml": "^4.1.1",
     "nanoid": "^5.0.9",
     "ws": "^8.18.0",
     "zod": "^4.3.6"
@@ -55,6 +56,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/cookie-parser": "^1.4.7",
     "@types/express": "^5.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/supertest": "^7.2.0",
     "@types/ws": "^8.5.13",

--- a/packages/harness/__tests__/session-registry.test.ts
+++ b/packages/harness/__tests__/session-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { SessionRegistry } from '../src/session-registry.js';
-import { DETACHED_TTL_MS } from '../src/constants.js';
+import { DETACHED_TTL_MS, CLOSEOUT_LEAD_MS, CLOSEOUT_TIMEOUT_MS } from '../src/constants.js';
 import type { SessionTransport } from '../src/session-transport.js';
 
 function fakeTransport(): SessionTransport {
@@ -542,6 +542,113 @@ describe('SessionRegistry', () => {
       expect(active).toHaveLength(2);
       expect(active.map((s) => s.sessionId)).toContain('sdk-1');
       expect(active.map((s) => s.sessionId)).toContain('sdk-2');
+    });
+  });
+
+  describe('closeout', () => {
+    it('calls onCloseout handler before TTL expiry', () => {
+      vi.useFakeTimers();
+      const onCloseout = vi.fn();
+      registry.setCloseoutHandler(onCloseout);
+
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to just before closeout fires (TTL - LEAD)
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS - 1000);
+      expect(onCloseout).not.toHaveBeenCalled();
+
+      // Advance past closeout trigger
+      vi.advanceTimersByTime(2000);
+      expect(onCloseout).toHaveBeenCalledWith('client-1');
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('aborts session after CLOSEOUT_TIMEOUT_MS if closeout completes or times out', () => {
+      vi.useFakeTimers();
+      const onCloseout = vi.fn();
+      registry.setCloseoutHandler(onCloseout);
+
+      const abort = new AbortController();
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to closeout
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS + 100);
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      // Advance through closeout timeout
+      vi.advanceTimersByTime(CLOSEOUT_TIMEOUT_MS + 100);
+      expect(registry.isActive('client-1')).toBe(false);
+      expect(abort.signal.aborted).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('cancels closeout on reattach', () => {
+      vi.useFakeTimers();
+      const onCloseout = vi.fn();
+      registry.setCloseoutHandler(onCloseout);
+
+      const abort = new AbortController();
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to closeout
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS + 100);
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      // Reattach during closeout
+      registry.reattach('client-1', fakeTransport());
+      expect(registry.isClosingOut('client-1')).toBe(false);
+
+      // Advance well past timeout — session should still be alive
+      vi.advanceTimersByTime(CLOSEOUT_TIMEOUT_MS + DETACHED_TTL_MS);
+      expect(registry.isActive('client-1')).toBe(true);
+      expect(abort.signal.aborted).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('falls back to direct abort when no closeout handler is set', () => {
+      vi.useFakeTimers();
+
+      const abort = new AbortController();
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance past full TTL
+      vi.advanceTimersByTime(DETACHED_TTL_MS + 100);
+      expect(registry.isActive('client-1')).toBe(false);
+      expect(abort.signal.aborted).toBe(true);
+
+      vi.useRealTimers();
     });
   });
 

--- a/packages/harness/src/constants.ts
+++ b/packages/harness/src/constants.ts
@@ -12,6 +12,8 @@ export {
 } from '@mitzo/protocol';
 
 // --- Session & Permission ---
-export const DETACHED_TTL_MS = 3_600_000; // 1 hour — events survive in durable store regardless
+export const DETACHED_TTL_MS = 21_600_000; // 6 hours — personal instance, negligible resource cost
+export const CLOSEOUT_LEAD_MS = 600_000; // 10 minutes before TTL expiry, start closeout
+export const CLOSEOUT_TIMEOUT_MS = 600_000; // 10 minutes max for the agent to finish closeout
 export const PERMISSION_TIMEOUT_MS = 120_000; // 2 minutes
 export const NTFY_NOTIFICATION_DELAY_MS = 10_000; // 10 seconds

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -3,7 +3,7 @@ export type { SessionTransport } from './session-transport.js';
 
 // Session registry
 export { SessionRegistry } from './session-registry.js';
-export type { ManagedSession, ActiveSessionInfo } from './session-registry.js';
+export type { ManagedSession, ActiveSessionInfo, CloseoutHandler } from './session-registry.js';
 export type {
   MitzoMode,
   SnapshotBlock,
@@ -38,7 +38,13 @@ export * as pushover from './pushover.js';
 export { extractSnippet } from './notification-helpers.js';
 
 // Constants
-export { DETACHED_TTL_MS, PERMISSION_TIMEOUT_MS, NTFY_NOTIFICATION_DELAY_MS } from './constants.js';
+export {
+  DETACHED_TTL_MS,
+  CLOSEOUT_LEAD_MS,
+  CLOSEOUT_TIMEOUT_MS,
+  PERMISSION_TIMEOUT_MS,
+  NTFY_NOTIFICATION_DELAY_MS,
+} from './constants.js';
 
 // Permission handler
 export { buildPermissionHandler } from './permission-handler.js';

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -1,11 +1,16 @@
 import type { SessionTransport } from './session-transport.js';
-import { DETACHED_TTL_MS, MAX_OBSERVERS_PER_SESSION } from './constants.js';
+import {
+  DETACHED_TTL_MS,
+  CLOSEOUT_LEAD_MS,
+  CLOSEOUT_TIMEOUT_MS,
+  MAX_OBSERVERS_PER_SESSION,
+} from './constants.js';
 import { createLogger } from './logger.js';
 
 const log = createLogger('session-registry');
 
 export type { MitzoMode, SnapshotBlock, MessageSnapshot, RawToolInput } from '@mitzo/protocol';
-import type { MitzoMode, SnapshotBlock, MessageSnapshot } from '@mitzo/protocol';
+import type { MitzoMode, MessageSnapshot } from '@mitzo/protocol';
 
 export interface ManagedSession {
   transport: SessionTransport;
@@ -45,10 +50,25 @@ export interface ActiveSessionInfo {
   observerCount: number;
 }
 
+export type CloseoutHandler = (clientId: string) => void;
+
 export class SessionRegistry {
   private sessions = new Map<string, ManagedSession>();
   private attached = new Set<string>();
   private detachTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private closeoutTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private closingOut = new Set<string>();
+  private closeoutHandler: CloseoutHandler | null = null;
+
+  /** Register a handler called when a session enters closeout. */
+  setCloseoutHandler(handler: CloseoutHandler): void {
+    this.closeoutHandler = handler;
+  }
+
+  /** Check if a session is currently in the closeout phase. */
+  isClosingOut(clientId: string): boolean {
+    return this.closingOut.has(clientId);
+  }
 
   register(
     clientId: string,
@@ -98,30 +118,55 @@ export class SessionRegistry {
 
   /**
    * Detach the transport from a session without killing the SDK query.
-   * Starts a TTL timer — if no reattach arrives, the session is aborted.
+   * Starts a two-phase timer:
+   * 1. At TTL - CLOSEOUT_LEAD_MS: start graceful closeout (if handler set)
+   * 2. At TTL (or CLOSEOUT_TIMEOUT_MS after closeout start): abort
    */
   detach(clientId: string): void {
     const session = this.sessions.get(clientId);
     if (!session) return;
 
     this.attached.delete(clientId);
-
     this.clearDetachTimer(clientId);
+    this.clearCloseoutTimer(clientId);
 
-    const timer = setTimeout(() => {
-      this.detachTimers.delete(clientId);
-      if (this.sessions.has(clientId) && !this.attached.has(clientId)) {
-        log.info(`detach TTL expired for ${clientId}, aborting`);
-        this.abort(clientId);
-      }
-    }, DETACHED_TTL_MS);
-
-    this.detachTimers.set(clientId, timer);
+    if (this.closeoutHandler) {
+      // Phase 1: fire closeout at TTL - CLOSEOUT_LEAD_MS
+      const closeoutDelay = DETACHED_TTL_MS - CLOSEOUT_LEAD_MS;
+      const timer = setTimeout(() => {
+        this.detachTimers.delete(clientId);
+        if (!this.sessions.has(clientId) || this.attached.has(clientId)) return;
+        log.info(`detach closeout starting for ${clientId}`);
+        this.closingOut.add(clientId);
+        this.closeoutHandler!(clientId);
+        // Phase 2: hard abort after CLOSEOUT_TIMEOUT_MS
+        const abortTimer = setTimeout(() => {
+          this.closeoutTimers.delete(clientId);
+          this.closingOut.delete(clientId);
+          if (this.sessions.has(clientId) && !this.attached.has(clientId)) {
+            log.info(`closeout timeout for ${clientId}, aborting`);
+            this.abort(clientId);
+          }
+        }, CLOSEOUT_TIMEOUT_MS);
+        this.closeoutTimers.set(clientId, abortTimer);
+      }, closeoutDelay);
+      this.detachTimers.set(clientId, timer);
+    } else {
+      // No closeout handler — fall back to direct abort at full TTL
+      const timer = setTimeout(() => {
+        this.detachTimers.delete(clientId);
+        if (this.sessions.has(clientId) && !this.attached.has(clientId)) {
+          log.info(`detach TTL expired for ${clientId}, aborting`);
+          this.abort(clientId);
+        }
+      }, DETACHED_TTL_MS);
+      this.detachTimers.set(clientId, timer);
+    }
   }
 
   /**
    * Reattach a new transport to an existing session.
-   * Returns true if the session was found and reattached.
+   * Cancels any pending closeout. Returns true if reattached.
    */
   reattach(clientId: string, transport: SessionTransport): boolean {
     const session = this.sessions.get(clientId);
@@ -130,6 +175,8 @@ export class SessionRegistry {
     session.transport = transport;
     this.attached.add(clientId);
     this.clearDetachTimer(clientId);
+    this.clearCloseoutTimer(clientId);
+    this.closingOut.delete(clientId);
     return true;
   }
 
@@ -227,6 +274,8 @@ export class SessionRegistry {
     if (!session) return;
 
     this.clearDetachTimer(clientId);
+    this.clearCloseoutTimer(clientId);
+    this.closingOut.delete(clientId);
     session.abortController.abort();
     session.observers.clear();
     this.sessions.delete(clientId);
@@ -253,6 +302,12 @@ export class SessionRegistry {
       clearTimeout(timer);
     }
     this.detachTimers.clear();
+
+    for (const timer of this.closeoutTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.closeoutTimers.clear();
+    this.closingOut.clear();
 
     for (const [clientId] of this.sessions) {
       this.abort(clientId);
@@ -286,6 +341,14 @@ export class SessionRegistry {
     if (existing) {
       clearTimeout(existing);
       this.detachTimers.delete(clientId);
+    }
+  }
+
+  private clearCloseoutTimer(clientId: string): void {
+    const existing = this.closeoutTimers.get(clientId);
+    if (existing) {
+      clearTimeout(existing);
+      this.closeoutTimers.delete(clientId);
     }
   }
 }

--- a/server/__tests__/multi-client-sessions.test.ts
+++ b/server/__tests__/multi-client-sessions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionRegistry } from '../session-registry.js';
 import { broadcastToObservers } from '../query-loop.js';
-import { MAX_OBSERVERS_PER_SESSION } from '../constants.js';
+import { MAX_OBSERVERS_PER_SESSION, DETACHED_TTL_MS } from '../constants.js';
 import type { SessionTransport } from '../../packages/harness/src/session-transport.js';
 
 function mockTransport(open = true): SessionTransport & { _sent: unknown[] } {
@@ -149,7 +149,7 @@ describe('SessionRegistry.removeObserver', () => {
     expect(registry.isActive('c1')).toBe(true); // still alive
 
     // Fast-forward past TTL — session should be aborted
-    vi.advanceTimersByTime(3_600_001);
+    vi.advanceTimersByTime(DETACHED_TTL_MS + 1);
     expect(registry.isActive('c1')).toBe(false);
 
     vi.useRealTimers();

--- a/server/__tests__/session-index.test.ts
+++ b/server/__tests__/session-index.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  readIndex,
+  upsertEntry,
+  registerSession,
+  updateSessionTitle,
+  updateSessionSdkId,
+} from '../session-index.js';
+
+describe('session-index', () => {
+  let repoPath: string;
+
+  beforeEach(() => {
+    repoPath = mkdtempSync(join(tmpdir(), 'session-index-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  const INDEX_PATH = (rp: string) => join(rp, '.claude', 'sessions', 'index.yaml');
+
+  describe('readIndex', () => {
+    it('returns empty array when index file does not exist', () => {
+      expect(readIndex(repoPath)).toEqual([]);
+    });
+
+    it('returns empty array when file exists but is empty', () => {
+      const dir = join(repoPath, '.claude', 'sessions');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(INDEX_PATH(repoPath), '');
+      expect(readIndex(repoPath)).toEqual([]);
+    });
+
+    it('reads existing entries from YAML', () => {
+      const dir = join(repoPath, '.claude', 'sessions');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        INDEX_PATH(repoPath),
+        `sessions:
+  - id: "2026-04-16-abc123"
+    sha: "abc123"
+    date: "2026-04-16"
+    status: active
+`,
+      );
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].id).toBe('2026-04-16-abc123');
+      expect(entries[0].sha).toBe('abc123');
+      expect(entries[0].status).toBe('active');
+    });
+  });
+
+  describe('upsertEntry', () => {
+    it('creates the directory and file if they do not exist', () => {
+      upsertEntry(repoPath, {
+        id: '2026-04-16-abc123',
+        sha: 'abc123',
+        date: '2026-04-16',
+        status: 'active',
+        repos: [],
+      });
+
+      const content = readFileSync(INDEX_PATH(repoPath), 'utf-8');
+      expect(content).toContain('2026-04-16-abc123');
+    });
+
+    it('adds a new entry when no entries exist', () => {
+      upsertEntry(repoPath, {
+        id: '2026-04-16-abc123',
+        sha: 'abc123',
+        date: '2026-04-16',
+        status: 'active',
+        repos: [],
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].id).toBe('2026-04-16-abc123');
+    });
+
+    it('updates an existing entry by id (merge semantics)', () => {
+      upsertEntry(repoPath, {
+        id: '2026-04-16-abc123',
+        sha: 'abc123',
+        date: '2026-04-16',
+        status: 'active',
+        repos: [],
+      });
+
+      upsertEntry(repoPath, {
+        id: '2026-04-16-abc123',
+        initial_title: 'Email draft for Cat',
+        status: 'active',
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].initial_title).toBe('Email draft for Cat');
+      expect(entries[0].sha).toBe('abc123'); // preserved from original
+    });
+
+    it('appends a second entry without overwriting the first', () => {
+      upsertEntry(repoPath, {
+        id: 'session-1',
+        sha: 'aaa',
+        date: '2026-04-15',
+        status: 'active',
+        repos: [],
+      });
+
+      upsertEntry(repoPath, {
+        id: 'session-2',
+        sha: 'bbb',
+        date: '2026-04-16',
+        status: 'active',
+        repos: [],
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(2);
+      expect(entries.map((e) => e.id)).toContain('session-1');
+      expect(entries.map((e) => e.id)).toContain('session-2');
+    });
+
+    it('updates status and closeout_summary on closeout', () => {
+      upsertEntry(repoPath, {
+        id: 'session-1',
+        sha: 'aaa',
+        date: '2026-04-16',
+        status: 'active',
+        repos: [],
+      });
+
+      upsertEntry(repoPath, {
+        id: 'session-1',
+        status: 'closed',
+        closeout_summary: 'Drafted email. Needs review.',
+        tokens_used: 45200,
+        cost_usd: 0.34,
+        has_uncommitted: false,
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].status).toBe('closed');
+      expect(entries[0].closeout_summary).toBe('Drafted email. Needs review.');
+      expect(entries[0].tokens_used).toBe(45200);
+      expect(entries[0].cost_usd).toBe(0.34);
+      expect(entries[0].has_uncommitted).toBe(false);
+    });
+
+    it('preserves repos array through updates', () => {
+      const repos = [
+        { name: 'mgmt', worktree: '.claude/worktrees/session-1', branch: 'session/session-1' },
+      ];
+
+      upsertEntry(repoPath, {
+        id: 'session-1',
+        sha: 'aaa',
+        date: '2026-04-16',
+        status: 'active',
+        repos,
+      });
+
+      upsertEntry(repoPath, {
+        id: 'session-1',
+        last_title: 'Updated title',
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].repos).toEqual(repos);
+      expect(entries[0].last_title).toBe('Updated title');
+    });
+  });
+
+  describe('registerSession', () => {
+    it('creates a skeleton entry with id, sha, date, repos, status=active', () => {
+      const worktrees = new Map([
+        [
+          'primary',
+          { path: '/tmp/repo/.claude/worktrees/2026-04-16-abc123', wtId: '2026-04-16-abc123' },
+        ],
+        [
+          'mitzo',
+          { path: '/tmp/mitzo/.claude/worktrees/2026-04-16-abc123', wtId: '2026-04-16-abc123' },
+        ],
+      ]);
+
+      registerSession(repoPath, '2026-04-16-abc123', worktrees, 'session/2026-04-16-abc123');
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].id).toBe('2026-04-16-abc123');
+      expect(entries[0].sha).toBe('abc123');
+      expect(entries[0].date).toBe('2026-04-16');
+      expect(entries[0].status).toBe('active');
+      expect(entries[0].repos).toHaveLength(2);
+      expect(entries[0].repos![0].name).toBe('primary');
+      expect(entries[0].repos![1].name).toBe('mitzo');
+    });
+
+    it('does not overwrite an existing entry', () => {
+      upsertEntry(repoPath, {
+        id: '2026-04-16-abc123',
+        sha: 'abc123',
+        date: '2026-04-16',
+        status: 'closed',
+        initial_title: 'Already done',
+      });
+
+      registerSession(repoPath, '2026-04-16-abc123', new Map(), 'main');
+
+      const entries = readIndex(repoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].status).toBe('closed'); // not overwritten
+      expect(entries[0].initial_title).toBe('Already done');
+    });
+  });
+
+  describe('updateSessionTitle', () => {
+    it('sets initial_title on first call', () => {
+      upsertEntry(repoPath, { id: 'sess-1', status: 'active' });
+
+      updateSessionTitle(repoPath, 'sess-1', 'Email draft');
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].initial_title).toBe('Email draft');
+      expect(entries[0].last_title).toBeUndefined();
+    });
+
+    it('sets last_title on subsequent calls (initial_title frozen)', () => {
+      upsertEntry(repoPath, { id: 'sess-1', status: 'active', initial_title: 'First title' });
+
+      updateSessionTitle(repoPath, 'sess-1', 'Updated title');
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].initial_title).toBe('First title'); // frozen
+      expect(entries[0].last_title).toBe('Updated title');
+    });
+
+    it('is a no-op if session does not exist in index', () => {
+      updateSessionTitle(repoPath, 'nonexistent', 'Some title');
+      expect(readIndex(repoPath)).toEqual([]);
+    });
+  });
+
+  describe('updateSessionSdkId', () => {
+    it('sets sdk_session_id on existing entry', () => {
+      upsertEntry(repoPath, { id: 'sess-1', status: 'active' });
+
+      updateSessionSdkId(repoPath, 'sess-1', 'sdk-abc-123');
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].sdk_session_id).toBe('sdk-abc-123');
+    });
+
+    it('is a no-op if session does not exist', () => {
+      updateSessionSdkId(repoPath, 'nonexistent', 'sdk-abc');
+      expect(readIndex(repoPath)).toEqual([]);
+    });
+  });
+});

--- a/server/__tests__/session-index.test.ts
+++ b/server/__tests__/session-index.test.ts
@@ -8,6 +8,7 @@ import {
   registerSession,
   updateSessionTitle,
   updateSessionSdkId,
+  finalizeCloseout,
 } from '../session-index.js';
 
 describe('session-index', () => {
@@ -246,6 +247,45 @@ describe('session-index', () => {
 
     it('is a no-op if session does not exist in index', () => {
       updateSessionTitle(repoPath, 'nonexistent', 'Some title');
+      expect(readIndex(repoPath)).toEqual([]);
+    });
+  });
+
+  describe('finalizeCloseout', () => {
+    it('sets status to closed with tokens, cost, and summary', () => {
+      upsertEntry(repoPath, { id: 'sess-1', status: 'active', initial_title: 'Test' });
+
+      finalizeCloseout(repoPath, 'sess-1', {
+        status: 'closed',
+        tokens_used: 50000,
+        cost_usd: 0.42,
+        has_uncommitted: false,
+        closeout_summary: 'Finished the email draft.',
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].status).toBe('closed');
+      expect(entries[0].tokens_used).toBe(50000);
+      expect(entries[0].cost_usd).toBe(0.42);
+      expect(entries[0].has_uncommitted).toBe(false);
+      expect(entries[0].closeout_summary).toBe('Finished the email draft.');
+    });
+
+    it('sets status to abandoned when closeout fails', () => {
+      upsertEntry(repoPath, { id: 'sess-1', status: 'active' });
+
+      finalizeCloseout(repoPath, 'sess-1', {
+        status: 'abandoned',
+        tokens_used: 30000,
+        cost_usd: 0.25,
+      });
+
+      const entries = readIndex(repoPath);
+      expect(entries[0].status).toBe('abandoned');
+    });
+
+    it('is a no-op if session does not exist', () => {
+      finalizeCloseout(repoPath, 'nonexistent', { status: 'closed' });
       expect(readIndex(repoPath)).toEqual([]);
     });
   });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -39,7 +39,7 @@ export function setConnectionRegistry(registry: ConnectionRegistry): void {
 import { EventStore } from './event-store.js';
 import { capturePromptComparison } from './prompt-compare.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
-import { registerSession, updateSessionTitle } from './session-index.js';
+import { registerSession, updateSessionTitle, finalizeCloseout } from './session-index.js';
 import { createLogger } from './logger.js';
 
 const log = createLogger('chat');
@@ -713,6 +713,69 @@ function cleanupSessionWorktrees(session: import('./session-registry.js').Manage
   }
   session.worktreePaths.clear();
 }
+
+const CLOSEOUT_PROMPT = `This session is closing in 10 minutes due to inactivity.
+Please perform session closeout:
+
+1. If there is uncommitted work in any worktree, commit it now with a descriptive message
+2. If there are memory-worthy observations, decisions, or patterns — write them to memory/Observations/ or memory/Decisions/
+3. Write a 2-3 sentence summary of what was accomplished and what remains unfinished — output it as your final chat message so it appears in the conversation history
+4. Do not ask for confirmation — just do it`;
+
+/**
+ * Graceful session closeout. Called by the registry's closeout handler
+ * when the detach TTL is about to expire. Injects a closeout prompt into
+ * the agent's input queue so it can commit work and write memory while it
+ * still has full conversation context.
+ */
+export function closeoutSession(clientId: string): void {
+  const session = registry.get(clientId);
+  if (!session?.inputQueue) {
+    // No active session or input queue — just finalize as abandoned
+    if (session?.wtId) {
+      try {
+        finalizeCloseout(BASE_REPO, session.wtId, {
+          status: 'abandoned',
+          tokens_used: session.cumulativeSessionTokens,
+          cost_usd: session.cumulativeCostUsd,
+        });
+      } catch {
+        // best-effort
+      }
+    }
+    return;
+  }
+
+  log.info('injecting closeout prompt', { clientId, wtId: session.wtId });
+
+  // Push the closeout prompt as an interrupt so the agent sees it immediately
+  session.inputQueue.push(makeUserMessage(CLOSEOUT_PROMPT, 'now'));
+
+  // The registry's CLOSEOUT_TIMEOUT_MS timer will abort the session after
+  // 10 minutes regardless. When the session is finally aborted (by the
+  // registry or by natural completion), the index gets finalized.
+  //
+  // We register a one-time listener on the abort signal to finalize.
+  if (session.wtId) {
+    const wtId = session.wtId;
+    const onAbort = () => {
+      const status = registry.isClosingOut(clientId) ? 'abandoned' : 'closed';
+      try {
+        finalizeCloseout(BASE_REPO, wtId, {
+          status,
+          tokens_used: session.cumulativeSessionTokens,
+          cost_usd: session.cumulativeCostUsd,
+        });
+      } catch {
+        // best-effort
+      }
+    };
+    session.abortController.signal.addEventListener('abort', onAbort, { once: true });
+  }
+}
+
+// Wire closeout handler on the registry
+registry.setCloseoutHandler(closeoutSession);
 
 export function stopChat(clientId: string) {
   const session = registry.get(clientId);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -39,6 +39,7 @@ export function setConnectionRegistry(registry: ConnectionRegistry): void {
 import { EventStore } from './event-store.js';
 import { capturePromptComparison } from './prompt-compare.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
+import { registerSession, updateSessionTitle } from './session-index.js';
 import { createLogger } from './logger.js';
 
 const log = createLogger('chat');
@@ -487,6 +488,15 @@ export async function startChat(
     });
   }
 
+  // Register session in the workspace index (fire-and-forget, best-effort)
+  try {
+    registerSession(BASE_REPO, wtId, repoWorktrees, branch);
+  } catch (err: unknown) {
+    log.warn('session index write failed', {
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+  }
+
   // Build session env with worktree paths for the agent
   const sessionEnv = sdkEnv();
   sessionEnv.MITZO_SESSION_ID = wtId;
@@ -596,8 +606,19 @@ async function tryAutoRename(sessionId: string, clientId: string): Promise<void>
       });
     });
 
-    // Push the new name to the connected frontend
+    // Update session index title (initial_title frozen, last_title updated)
     const session = registry.get(clientId);
+    if (session?.wtId) {
+      try {
+        updateSessionTitle(BASE_REPO, session.wtId, newName);
+      } catch (err: unknown) {
+        log.warn('session index title update failed', {
+          error: err instanceof Error ? err.message : 'unknown',
+        });
+      }
+    }
+
+    // Push the new name to the connected frontend
     if (session) {
       send(session.transport, { type: 'session_renamed', sessionId, name: newName });
     }

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -15,9 +15,14 @@ export {
 } from '@mitzo/protocol';
 
 // --- Session & Permission ---
-export const DETACHED_TTL_MS = 3_600_000; // 1 hour — events survive in durable store regardless
-export const PERMISSION_TIMEOUT_MS = 120_000; // 2 minutes
-export const NTFY_NOTIFICATION_DELAY_MS = 10_000; // 10 seconds
+// Re-export session lifecycle constants from harness (canonical source).
+export {
+  DETACHED_TTL_MS,
+  CLOSEOUT_LEAD_MS,
+  CLOSEOUT_TIMEOUT_MS,
+  PERMISSION_TIMEOUT_MS,
+  NTFY_NOTIFICATION_DELAY_MS,
+} from '@mitzo/harness';
 
 // --- Worktree ---
 export const WORKTREE_BRANCH_PREFIX = 'session/';

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -9,6 +9,7 @@ import {
 import { createLogger } from './logger.js';
 import type { SessionRegistry, SnapshotBlock } from './session-registry.js';
 import type { EventStore } from './event-store.js';
+import { updateSessionSdkId } from './session-index.js';
 import { sendTurnCompleteNotification as ntfyTurnComplete } from './notify.js';
 import { sendTurnCompleteNotification as pushoverTurnComplete } from './pushover.js';
 import { extractSnippet } from './notification-helpers.js';
@@ -273,6 +274,15 @@ export async function runQueryLoop(
           registry.setSessionId(clientId, resolvedSessionId);
           onSessionResolved?.(resolvedSessionId);
           emit({ type: 'session_id', sessionId: msg.session_id });
+          // Update session index with SDK session ID
+          if (currentSession.wtId) {
+            try {
+              const repoPath = process.env.REPO_PATH || '';
+              updateSessionSdkId(repoPath, currentSession.wtId, resolvedSessionId);
+            } catch {
+              // best-effort — session index write failure is non-fatal
+            }
+          }
           // Persist session metadata (including initial prompt) to durable store
           if (store) {
             store.upsertSession({

--- a/server/session-index.ts
+++ b/server/session-index.ts
@@ -1,0 +1,131 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import yaml from 'js-yaml';
+
+export interface SessionIndexRepo {
+  name: string;
+  worktree: string;
+  branch: string;
+}
+
+export interface SessionIndexEntry {
+  id: string;
+  sha?: string;
+  sdk_session_id?: string;
+  date?: string;
+  initial_title?: string;
+  last_title?: string;
+  repos?: SessionIndexRepo[];
+  status?: 'active' | 'closed' | 'abandoned';
+  has_uncommitted?: boolean;
+  closeout_summary?: string;
+  tokens_used?: number;
+  cost_usd?: number;
+}
+
+interface IndexFile {
+  sessions: SessionIndexEntry[];
+}
+
+function indexPath(repoPath: string): string {
+  return join(repoPath, '.claude', 'sessions', 'index.yaml');
+}
+
+/**
+ * Read the session index from disk. Returns [] if the file doesn't exist or is empty.
+ */
+export function readIndex(repoPath: string): SessionIndexEntry[] {
+  const path = indexPath(repoPath);
+  if (!existsSync(path)) return [];
+
+  const raw = readFileSync(path, 'utf-8').trim();
+  if (!raw) return [];
+
+  const parsed = yaml.load(raw) as IndexFile | null;
+  return parsed?.sessions ?? [];
+}
+
+/**
+ * Insert or update a session index entry. Merge semantics: fields in the
+ * partial entry overwrite matching fields; unset fields are preserved.
+ * The `id` field is used as the merge key.
+ */
+export function upsertEntry(
+  repoPath: string,
+  partial: Partial<SessionIndexEntry> & { id: string },
+): void {
+  const entries = readIndex(repoPath);
+  const idx = entries.findIndex((e) => e.id === partial.id);
+
+  if (idx >= 0) {
+    entries[idx] = { ...entries[idx], ...partial };
+  } else {
+    entries.push(partial as SessionIndexEntry);
+  }
+
+  const path = indexPath(repoPath);
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const out: IndexFile = { sessions: entries };
+  writeFileSync(path, yaml.dump(out, { lineWidth: 120, noRefs: true }));
+}
+
+/**
+ * Register a new session in the index with a skeleton entry.
+ * No-op if the session ID already exists (idempotent for resumed sessions).
+ */
+export function registerSession(
+  repoPath: string,
+  wtId: string,
+  worktreePaths: Map<string, { path: string; wtId: string }>,
+  branch: string,
+): void {
+  const existing = readIndex(repoPath);
+  if (existing.some((e) => e.id === wtId)) return;
+
+  const sha = wtId.includes('-') ? wtId.split('-').pop()! : wtId;
+  const date = wtId.slice(0, 10); // YYYY-MM-DD prefix
+
+  const repos = Array.from(worktreePaths.entries()).map(([name, { path }]) => ({
+    name,
+    worktree: path,
+    branch,
+  }));
+
+  upsertEntry(repoPath, {
+    id: wtId,
+    sha,
+    date,
+    status: 'active',
+    repos,
+  });
+}
+
+/**
+ * Update session title. Sets `initial_title` on first call (when not yet set),
+ * `last_title` on subsequent calls. `initial_title` is frozen after first write.
+ */
+export function updateSessionTitle(repoPath: string, wtId: string, title: string): void {
+  const entries = readIndex(repoPath);
+  const entry = entries.find((e) => e.id === wtId);
+  if (!entry) return;
+
+  if (!entry.initial_title) {
+    upsertEntry(repoPath, { id: wtId, initial_title: title });
+  } else {
+    upsertEntry(repoPath, { id: wtId, last_title: title });
+  }
+}
+
+/**
+ * Set the SDK session ID on an existing index entry.
+ */
+export function updateSessionSdkId(repoPath: string, wtId: string, sdkSessionId: string): void {
+  const entries = readIndex(repoPath);
+  if (!entries.some((e) => e.id === wtId)) return;
+
+  upsertEntry(repoPath, { id: wtId, sdk_session_id: sdkSessionId });
+}

--- a/server/session-index.ts
+++ b/server/session-index.ts
@@ -121,6 +121,26 @@ export function updateSessionTitle(repoPath: string, wtId: string, title: string
 }
 
 /**
+ * Finalize a session's closeout state in the index.
+ */
+export function finalizeCloseout(
+  repoPath: string,
+  wtId: string,
+  fields: {
+    status: 'closed' | 'abandoned';
+    tokens_used?: number;
+    cost_usd?: number;
+    has_uncommitted?: boolean;
+    closeout_summary?: string;
+  },
+): void {
+  const entries = readIndex(repoPath);
+  if (!entries.some((e) => e.id === wtId)) return;
+
+  upsertEntry(repoPath, { id: wtId, ...fields });
+}
+
+/**
  * Set the SDK session ID on an existing index entry.
  */
 export function updateSessionSdkId(repoPath: string, wtId: string, sdkSessionId: string): void {


### PR DESCRIPTION
## Summary

- **Session index** — persistent YAML manifest at `REPO_PATH/.claude/sessions/index.yaml` tracks all sessions with human-readable titles, repos, status, tokens, and cost
- **Graceful closeout** — when the detach TTL is about to expire, inject a closeout prompt so the agent can commit work and write memory observations while it still has full context
- **TTL increase** — `DETACHED_TTL_MS` from 1h to 6h (personal instance, negligible resource cost)
- **Constitution guidance** — teaches Claude to check the session index before grepping worktrees

Design doc: `docs/design/session-index-and-closeout.md`

## Key changes

| File | Change |
|------|--------|
| `server/session-index.ts` | New module: YAML index read/write/upsert with helpers |
| `server/chat.ts` | Wire index writes into `startChat()` and `tryAutoRename()`, add `closeoutSession()` |
| `server/query-loop.ts` | Capture SDK session ID in index on first resolve |
| `packages/harness/src/session-registry.ts` | Two-phase detach timer: closeout at T-10min, abort at T-0 |
| `packages/harness/src/constants.ts` | `DETACHED_TTL_MS=6h`, `CLOSEOUT_LEAD_MS=10m`, `CLOSEOUT_TIMEOUT_MS=10m` |
| `server/constants.ts` | Re-export session constants from harness (single source of truth) |

## Test plan

- [x] 19 tests for session-index module (read, upsert, register, title, SDK ID, closeout)
- [x] 4 tests for registry closeout (handler fires, timeout aborts, reattach cancels, fallback)
- [x] Full suite: 1675 tests passing across 126 files
- [ ] Manual: start a session, verify `index.yaml` skeleton is created
- [ ] Manual: verify title updates flow into index on auto-rename
- [ ] Manual: detach and let TTL expire — verify closeout prompt fires

> **Note:** depends on PR #217 (shares 4 base commits). Merge #217 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)