### PR TITLE
feat(server): wire query-loop outbound events through ConnectionRegistry (phase 2)

### DIFF
--- a/packages/harness/__tests__/connection-registry.test.ts
+++ b/packages/harness/__tests__/connection-registry.test.ts
@@ -159,4 +159,46 @@ describe('ConnectionRegistry', () => {
       expect(() => registry.broadcast('sess-a', { type: 'test' })).not.toThrow();
     });
   });
+
+  describe('broadcastAll', () => {
+    it('sends to every open connection regardless of watched sessions', () => {
+      const t1 = mockTransport(true);
+      const t2 = mockTransport(true);
+      registry.register('conn-1', t1);
+      registry.register('conn-2', t2);
+      // conn-1 watches sess-a, conn-2 watches nothing
+      registry.watch('conn-1', 'sess-a');
+
+      registry.broadcastAll({ type: 'update_available' });
+
+      expect(t1.send).toHaveBeenCalledWith({ type: 'update_available' });
+      expect(t2.send).toHaveBeenCalledWith({ type: 'update_available' });
+    });
+
+    it('skips closed connections', () => {
+      const tOpen = mockTransport(true);
+      const tClosed = mockTransport(false);
+      registry.register('conn-open', tOpen);
+      registry.register('conn-closed', tClosed);
+
+      registry.broadcastAll({ type: 'inbox_updated' });
+
+      expect(tOpen.send).toHaveBeenCalledWith({ type: 'inbox_updated' });
+      expect(tClosed.send).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when a send fails', () => {
+      const t = mockTransport(true);
+      (t.send as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('socket closing');
+      });
+      registry.register('conn-1', t);
+
+      expect(() => registry.broadcastAll({ type: 'test' })).not.toThrow();
+    });
+
+    it('is a no-op when no connections exist', () => {
+      expect(() => registry.broadcastAll({ type: 'test' })).not.toThrow();
+    });
+  });
 });

--- a/packages/harness/src/connection-registry.ts
+++ b/packages/harness/src/connection-registry.ts
@@ -102,4 +102,21 @@ export class ConnectionRegistry {
       }
     }
   }
+
+  /**
+   * Send a message to every open connection regardless of watched sessions.
+   * Used for global events (update_available, inbox_updated, task state).
+   */
+  broadcastAll(data: Record<string, unknown>): void {
+    for (const conn of this.connections.values()) {
+      if (!conn.transport.isOpen()) continue;
+      try {
+        conn.transport.send(data);
+      } catch {
+        log.warn('broadcastAll send failed', {
+          connectionId: conn.connectionId,
+        });
+      }
+    }
+  }
 }

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SessionTransport } from '../../packages/harness/src/session-transport.js';
+import { ConnectionRegistry } from '../../packages/harness/src/connection-registry.js';
 import { runQueryLoop } from '../query-loop.js';
 import type { SessionRegistry } from '../session-registry.js';
 import { EventStore } from '../event-store.js';
@@ -1113,6 +1114,348 @@ describe('runQueryLoop', () => {
 
       // Closed observer should not receive any messages
       expect(closedTransport.sent).toHaveLength(0);
+    });
+  });
+
+  describe('v2 ConnectionRegistry delivery', () => {
+    it('routes events through connRegistry.broadcast when clientId is a v2 connection', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+      connRegistry.watch(clientId, 'sess-v2');
+      connRegistry.setActive(clientId, 'sess-v2');
+
+      // Pre-set sessionId so broadcast has a target from the start
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-v2';
+
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-v2' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'v2 hello' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-v2' },
+        { type: 'result', session_id: 'sess-v2' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { connRegistry },
+      );
+
+      // v2Transport should receive events via connRegistry.broadcast
+      expect(v2Transport.sent.some((m) => m.type === 'message_start')).toBe(true);
+      expect(v2Transport.sent.some((m) => m.type === 'block_delta')).toBe(true);
+      expect(v2Transport.sent.some((m) => m.type === 'session_end')).toBe(true);
+    });
+
+    it('falls back to v1 path when clientId is NOT in connRegistry', async () => {
+      const connRegistry = new ConnectionRegistry();
+      // Do NOT register clientId in connRegistry — it's a v1 connection
+
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-v1' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'v1 hello' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-v1' },
+        { type: 'result', session_id: 'sess-v1' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { connRegistry },
+      );
+
+      // Driver transport should still receive events (v1 path)
+      expect(transport.sent.some((m) => m.type === 'message_start')).toBe(true);
+      expect(transport.sent.some((m) => m.type === 'block_delta')).toBe(true);
+      expect(transport.sent.some((m) => m.type === 'session_end')).toBe(true);
+    });
+
+    it('falls back to direct driver send before sessionId is resolved', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+
+      // sessionId not pre-set — will be resolved on first assistant event
+      // Provide onSessionResolved to auto-watch (mirrors handleSendV2 behavior)
+      const onSessionResolved = (sessionId: string) => {
+        connRegistry.watch(clientId, sessionId);
+        connRegistry.setActive(clientId, sessionId);
+      };
+
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-pre' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'before sessionId' },
+          },
+        },
+        // assistant resolves sessionId
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-late' },
+        // After sessionId resolved, events should go through connRegistry
+        {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: 'msg-post' } },
+        },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'after sessionId' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-late' },
+        { type: 'result', session_id: 'sess-late' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { connRegistry, onSessionResolved },
+      );
+
+      // Pre-sessionId events should still reach the driver transport (v1 fallback)
+      expect(transport.sent.some((m) => m.type === 'message_start')).toBe(true);
+
+      // Post-sessionId events should reach v2Transport via broadcast
+      expect(v2Transport.sent.some((m) => m.type === 'session_end')).toBe(true);
+    });
+
+    it('sends session_end via connRegistry.broadcast in finally block for v2 connections', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+      connRegistry.watch(clientId, 'sess-abort');
+      connRegistry.setActive(clientId, 'sess-abort');
+
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-abort';
+
+      // Stream that errors before result (simulates abort)
+      async function* errorStream() {
+        yield {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: 'msg-abort' } },
+        };
+        throw new Error('connection lost');
+      }
+
+      await runQueryLoop(errorStream(), clientId, registry, abortController, undefined, undefined, {
+        connRegistry,
+      });
+
+      // session_end should reach v2Transport via connRegistry in the finally block
+      expect(v2Transport.sent.some((m) => m.type === 'session_end')).toBe(true);
+    });
+  });
+
+  describe('onSessionResolved callback', () => {
+    it('invokes the callback with sessionId when first resolved', async () => {
+      const onResolved = vi.fn();
+
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-cb' },
+        { type: 'result', session_id: 'sess-cb' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { onSessionResolved: onResolved },
+      );
+
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onResolved).toHaveBeenCalledWith('sess-cb');
+    });
+
+    it('does not invoke the callback on subsequent assistant events', async () => {
+      const onResolved = vi.fn();
+
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-t1' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'Turn 1' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-multi' },
+        // Second assistant event (multi-turn)
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-t2' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'Turn 2' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-multi' },
+        { type: 'result', session_id: 'sess-multi' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { onSessionResolved: onResolved },
+      );
+
+      expect(onResolved).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not invoked when session already has sessionId (resume case)', async () => {
+      const onResolved = vi.fn();
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-resume';
+
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-resume' },
+        { type: 'result', session_id: 'sess-resume' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { onSessionResolved: onResolved },
+      );
+
+      // Callback should not fire because sessionId was already set
+      expect(onResolved).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('session_end cleanup via ConnectionRegistry', () => {
+    it('clears activeSession on the v2 connection when session ends normally', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+      connRegistry.watch(clientId, 'sess-cleanup');
+      connRegistry.setActive(clientId, 'sess-cleanup');
+
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-cleanup';
+
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-cleanup' },
+        { type: 'result', session_id: 'sess-cleanup' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { connRegistry },
+      );
+
+      const conn = connRegistry.get(clientId);
+      expect(conn).toBeDefined();
+      expect(conn!.activeSession).toBeNull();
+      // Session should remain in watchedSessions
+      expect(conn!.watchedSessions.has('sess-cleanup')).toBe(true);
+    });
+
+    it('clears activeSession in finally block when session ends abnormally', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+      connRegistry.watch(clientId, 'sess-err-cleanup');
+      connRegistry.setActive(clientId, 'sess-err-cleanup');
+
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-err-cleanup';
+
+      async function* errorStream() {
+        yield {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: 'msg-err' } },
+        };
+        throw new Error('unexpected');
+      }
+
+      await runQueryLoop(errorStream(), clientId, registry, abortController, undefined, undefined, {
+        connRegistry,
+      });
+
+      const conn = connRegistry.get(clientId);
+      expect(conn).toBeDefined();
+      expect(conn!.activeSession).toBeNull();
+      expect(conn!.watchedSessions.has('sess-err-cleanup')).toBe(true);
     });
   });
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -7,6 +7,7 @@ import {
   handleWatch,
   handleUnwatch,
   handleSwitchSession,
+  handleSendV2,
   handleSetModeV2,
   handleStopV2,
   handlePermissionResponseV2,
@@ -302,6 +303,43 @@ describe('handleSetModeV2', () => {
     expect(modeMsg).toEqual(
       expect.objectContaining({ type: 'mode_changed', sessionId: 'sess-1', mode: 'auto' }),
     );
+  });
+});
+
+// ─── handleSendV2 auto-watch ─────────────────────────────────────────────────
+
+describe('handleSendV2 auto-watch', () => {
+  it('watches + activates the session on the resume path', () => {
+    const sessionReg = mockSessionRegistry();
+    // findBySessionId returns a result but isActive returns false → resume path
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-driver', session: {} });
+    sessionReg.isActive.mockReturnValue(false);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    // We can't fully test startChat without mocking the Agent SDK, but we can
+    // verify that watch + setActive are called before startChat. The resume
+    // path should ensure the connection is watching the session.
+    handleSendV2(
+      'c1',
+      transport,
+      {
+        type: 'send' as const,
+        sessionId: 'sess-resume',
+        prompt: 'continue',
+        clientMsgId: 'cmsg-1',
+      },
+      ctx,
+    );
+
+    const conn = ctx.connRegistry.get('c1');
+    expect(conn).toBeDefined();
+    expect(conn!.watchedSessions.has('sess-resume')).toBe(true);
+    expect(conn!.activeSession).toBe('sess-resume');
   });
 });
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SessionTransport } from '@mitzo/harness';
 import { ConnectionRegistry } from '@mitzo/harness';
+
+vi.mock('../chat.js', () => ({
+  startChat: vi.fn(),
+  sendToChat: vi.fn(),
+  interruptChat: vi.fn(),
+  stopChat: vi.fn(),
+  isActive: vi.fn().mockReturnValue(false),
+  BASE_REPO: '/tmp/test-repo',
+}));
+
+vi.mock('../app.js', () => ({
+  buildSkillRegistry: vi.fn().mockReturnValue(new Map()),
+  isAllowedPath: vi.fn().mockReturnValue(true),
+  NATIVE_COMMAND_NAMES: new Set(),
+}));
+
+vi.mock('../slash-commands.js', () => ({
+  resolveSlashCommand: vi.fn().mockReturnValue({ type: 'plain' }),
+}));
+
+vi.mock('../skill-policy.js', () => ({
+  setSkillPolicy: vi.fn(),
+  clearSkillPolicy: vi.fn(),
+}));
+
+import { startChat } from '../chat.js';
+
 import {
   handleHello,
   handleReconnect,
@@ -340,6 +367,37 @@ describe('handleSendV2 auto-watch', () => {
     expect(conn).toBeDefined();
     expect(conn!.watchedSessions.has('sess-resume')).toBe(true);
     expect(conn!.activeSession).toBe('sess-resume');
+  });
+
+  it('passes onSessionResolved callback to startChat on the create path', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      {
+        type: 'send' as const,
+        sessionId: null,
+        prompt: 'hello world',
+        clientMsgId: 'cmsg-2',
+      },
+      ctx,
+    );
+
+    expect(startChat).toHaveBeenCalledTimes(1);
+    const callArgs = (startChat as ReturnType<typeof vi.fn>).mock.calls[0];
+    const options = callArgs[3];
+    expect(options.onSessionResolved).toBeTypeOf('function');
+
+    // Simulate the callback firing — should watch + activate
+    options.onSessionResolved('sess-new');
+    const conn = ctx.connRegistry.get('c1');
+    expect(conn).toBeDefined();
+    expect(conn!.watchedSessions.has('sess-new')).toBe(true);
+    expect(conn!.activeSession).toBe('sess-new');
   });
 });
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -538,8 +538,8 @@ export async function startChat(
       eventStore,
       options.resume ? undefined : fullPrompt,
       {
-        ...(_connRegistry ? { connRegistry: _connRegistry } : {}),
-        ...(options.onSessionResolved ? { onSessionResolved: options.onSessionResolved } : {}),
+        connRegistry: _connRegistry ?? undefined,
+        onSessionResolved: options.onSessionResolved,
       },
     );
   } catch (err: unknown) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -5,7 +5,7 @@ import {
   renameSession,
 } from '@anthropic-ai/claude-agent-sdk';
 import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
-import type { SessionTransport } from '@mitzo/harness';
+import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'fs';
 import { join, resolve, dirname } from 'path';
@@ -29,6 +29,11 @@ import type { TaskStore } from './task-store.js';
 let _taskStore: TaskStore | null = null;
 export function setTaskStore(store: TaskStore): void {
   _taskStore = store;
+}
+
+let _connRegistry: ConnectionRegistry | null = null;
+export function setConnectionRegistry(registry: ConnectionRegistry): void {
+  _connRegistry = registry;
 }
 import { EventStore } from './event-store.js';
 import { capturePromptComparison } from './prompt-compare.js';
@@ -401,6 +406,7 @@ export async function startChat(
     images?: Array<{ data: string; mediaType: string }>;
     contextBlocks?: string[];
     clientMsgId?: string;
+    onSessionResolved?: (sessionId: string) => void;
   },
 ) {
   const abortController = new AbortController();
@@ -531,6 +537,10 @@ export async function startChat(
       abortController,
       eventStore,
       options.resume ? undefined : fullPrompt,
+      {
+        ...(_connRegistry ? { connRegistry: _connRegistry } : {}),
+        ...(options.onSessionResolved ? { onSessionResolved: options.onSessionResolved } : {}),
+      },
     );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import {
   registry,
   eventStore,
   getRepoConfig,
+  setConnectionRegistry,
 } from './chat.js';
 import { cleanupStaleWorktrees } from './worktree.js';
 import { HEARTBEAT_INTERVAL_MS, PORT_DEFAULT, SHUTDOWN_GRACE_MS } from './constants.js';
@@ -58,6 +59,7 @@ const PORT = parseInt(process.env.PORT || String(PORT_DEFAULT), 10);
 
 const nativeCommands = new NativeCommandRegistry();
 const connRegistry = new ConnectionRegistry();
+setConnectionRegistry(connRegistry);
 
 // Resolve cert paths relative to the project root (where package.json lives)
 const __filename = fileURLToPath(import.meta.url);
@@ -73,17 +75,21 @@ const server = USE_TLS
 const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
 
 setUpdateBroadcast(() => {
-  const msg = JSON.stringify({ type: 'update_available' });
+  const data = { type: 'update_available' };
+  const msg = JSON.stringify(data);
   wss.clients.forEach((client) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
+  connRegistry.broadcastAll(data);
 });
 
 setInboxBroadcast(() => {
-  const msg = JSON.stringify({ type: 'inbox_updated' });
+  const data = { type: 'inbox_updated' };
+  const msg = JSON.stringify(data);
   wss.clients.forEach((client) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
+  connRegistry.broadcastAll(data);
 });
 
 setTaskBroadcast((event) => {
@@ -91,6 +97,7 @@ setTaskBroadcast((event) => {
   wss.clients.forEach((client) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
+  connRegistry.broadcastAll(event as Record<string, unknown>);
 });
 
 // --- Task Orchestrator ---
@@ -120,17 +127,21 @@ const orchestrator = new TaskOrchestrator({
     }
   },
   broadcastStatus: (status) => {
-    const msg = JSON.stringify({ type: 'loop_status', ...status });
+    const data = { type: 'loop_status', ...status };
+    const msg = JSON.stringify(data);
     wss.clients.forEach((client) => {
       if (client.readyState === client.OPEN) client.send(msg);
     });
+    connRegistry.broadcastAll(data);
   },
   broadcastTasks: () => {
     const tree = taskStore.getTree();
-    const msg = JSON.stringify({ type: 'task_state', tasks: tree });
+    const data = { type: 'task_state', tasks: tree };
+    const msg = JSON.stringify(data);
     wss.clients.forEach((client) => {
       if (client.readyState === client.OPEN) client.send(msg);
     });
+    connRegistry.broadcastAll(data as Record<string, unknown>);
   },
   getActiveSessionIds: () => {
     const ids = new Set<string>();

--- a/server/index.ts
+++ b/server/index.ts
@@ -78,6 +78,7 @@ setUpdateBroadcast(() => {
   const data = { type: 'update_available' };
   const msg = JSON.stringify(data);
   wss.clients.forEach((client) => {
+    if (v2Sockets.has(client)) return;
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(data);
@@ -87,6 +88,7 @@ setInboxBroadcast(() => {
   const data = { type: 'inbox_updated' };
   const msg = JSON.stringify(data);
   wss.clients.forEach((client) => {
+    if (v2Sockets.has(client)) return;
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(data);
@@ -95,6 +97,7 @@ setInboxBroadcast(() => {
 setTaskBroadcast((event) => {
   const msg = JSON.stringify(event);
   wss.clients.forEach((client) => {
+    if (v2Sockets.has(client)) return;
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(event as Record<string, unknown>);
@@ -130,6 +133,7 @@ const orchestrator = new TaskOrchestrator({
     const data = { type: 'loop_status', ...status };
     const msg = JSON.stringify(data);
     wss.clients.forEach((client) => {
+      if (v2Sockets.has(client)) return;
       if (client.readyState === client.OPEN) client.send(msg);
     });
     connRegistry.broadcastAll(data);
@@ -139,6 +143,7 @@ const orchestrator = new TaskOrchestrator({
     const data = { type: 'task_state', tasks: tree };
     const msg = JSON.stringify(data);
     wss.clients.forEach((client) => {
+      if (v2Sockets.has(client)) return;
       if (client.readyState === client.OPEN) client.send(msg);
     });
     connRegistry.broadcastAll(data as Record<string, unknown>);
@@ -232,6 +237,7 @@ const v2Ctx: V2HandlerContext = {
  */
 function handleChatWsV2(ws: WebSocket, connectionId: string) {
   const transport = getTransport(ws);
+  v2Sockets.add(ws);
   handleHello(connectionId, transport, v2Ctx);
 
   const heartbeat = setInterval(() => {
@@ -250,6 +256,7 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
 
   ws.on('close', (code, reason) => {
     clearInterval(heartbeat);
+    v2Sockets.delete(ws);
     connRegistry.remove(connectionId);
     registry.removeObserver(transport);
     transportMap.delete(ws);
@@ -267,6 +274,9 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
 
 /** Map raw WebSocket → WsTransport wrapper, so removeObserver can look up the transport. */
 const transportMap = new Map<WebSocket, WsTransport>();
+
+/** v2 WebSockets — tracked so wss.clients broadcasts skip them (v2 gets events via connRegistry). */
+const v2Sockets = new Set<WebSocket>();
 
 /**
  * Get or create a WsTransport wrapper for a raw WebSocket.

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -653,9 +653,9 @@ export async function runQueryLoop(
           send(finalSession.transport, endMsg);
           broadcastToObservers(finalSession.observers, endMsg);
         }
-      }
-      if (connRegistry?.get(clientId)) {
-        connRegistry.setActive(clientId, null);
+        if (connRegistry?.get(clientId)) {
+          connRegistry.setActive(clientId, null);
+        }
       }
       registry.remove(clientId);
     }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1,4 +1,4 @@
-import type { SessionTransport } from '@mitzo/harness';
+import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { summarizeToolInput, getRawInput } from './tool-summary.js';
 import { extractToolResultText } from './content-blocks.js';
 import {
@@ -67,6 +67,7 @@ function sendOrBuffer(
   registry: SessionRegistry,
   store?: EventStore,
   sessionId?: string,
+  connRegistry?: ConnectionRegistry,
 ) {
   let enriched: Record<string, unknown> = data;
   // Tag v2 events with sessionId for v2 client demuxing. v1 clients
@@ -78,6 +79,15 @@ function sendOrBuffer(
       enriched = { ...enriched, seq };
     }
   }
+
+  // v2 path: deliver via ConnectionRegistry when clientId is a registered v2
+  // connection AND sessionId is resolved (broadcast needs a session target).
+  if (connRegistry?.get(clientId) && sessionId) {
+    connRegistry.broadcast(sessionId, enriched);
+    return;
+  }
+
+  // v1 path (or pre-sessionId fallback for v2): driver transport + observers
   const session = registry.get(clientId);
   if (session) {
     if (registry.isAttached(clientId)) {
@@ -91,6 +101,11 @@ function v2(type: string, rest: Record<string, unknown> = {}): Record<string, un
   return { v: 2, type, ts: Date.now(), ...rest };
 }
 
+export interface QueryLoopOptions {
+  connRegistry?: ConnectionRegistry;
+  onSessionResolved?: (sessionId: string) => void;
+}
+
 export async function runQueryLoop(
   q: AsyncIterable<Record<string, unknown>>,
   clientId: string,
@@ -98,7 +113,10 @@ export async function runQueryLoop(
   abortController: AbortController,
   store?: EventStore,
   initialPrompt?: string,
+  options?: QueryLoopOptions,
 ) {
+  const connRegistry = options?.connRegistry;
+  const onSessionResolved = options?.onSessionResolved;
   // Tool input buffers keyed by content block index (reset per message_start).
   const toolInputBuffers = new Map<
     number,
@@ -134,9 +152,9 @@ export async function runQueryLoop(
     durationApiMs: 0,
   };
 
-  /** Wrapper that auto-injects store + sessionId into sendOrBuffer */
+  /** Wrapper that auto-injects store + sessionId + connRegistry into sendOrBuffer */
   function emit(data: Record<string, unknown>) {
-    sendOrBuffer(data, clientId, registry, store, resolvedSessionId);
+    sendOrBuffer(data, clientId, registry, store, resolvedSessionId, connRegistry);
   }
 
   function nextBlockId(): string {
@@ -251,6 +269,7 @@ export async function runQueryLoop(
         if (!currentSession.sessionId && msg.session_id) {
           resolvedSessionId = msg.session_id as string;
           registry.setSessionId(clientId, resolvedSessionId);
+          onSessionResolved?.(resolvedSessionId);
           emit({ type: 'session_id', sessionId: msg.session_id });
           // Persist session metadata (including initial prompt) to durable store
           if (store) {
@@ -367,6 +386,9 @@ export async function runQueryLoop(
         }
 
         emit(v2('session_end', { sessionId: msg.session_id, usage: usageData }));
+        if (connRegistry?.get(clientId)) {
+          connRegistry.setActive(clientId, null);
+        }
         if (!registry.isAttached(clientId)) {
           const snippet = extractSnippet(snapshotBlocks, NOTIFY_SNIPPET_MAX_CHARS);
           const sid = (msg.session_id as string) || currentSession.sessionId;
@@ -625,8 +647,15 @@ export async function runQueryLoop(
       finalSession.currentSnapshot = null;
       if (!doneSent) {
         const endMsg = v2('session_end', { sessionId: finalSession.sessionId });
-        send(finalSession.transport, endMsg);
-        broadcastToObservers(finalSession.observers, endMsg);
+        if (connRegistry?.get(clientId) && finalSession.sessionId) {
+          connRegistry.broadcast(finalSession.sessionId, endMsg);
+        } else {
+          send(finalSession.transport, endMsg);
+          broadcastToObservers(finalSession.observers, endMsg);
+        }
+      }
+      if (connRegistry?.get(clientId)) {
+        connRegistry.setActive(clientId, null);
       }
       registry.remove(clientId);
     }

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -295,6 +295,8 @@ export function handleSendV2(
       }
 
       // Session exists in store but no active driver — start with resume
+      ctx.connRegistry.watch(connectionId, sessionId);
+      ctx.connRegistry.setActive(connectionId, sessionId);
       span.setAttribute('routing.decision', 'resume');
       startChat(transport, connectionId, prompt, {
         resume: sessionId,
@@ -307,8 +309,13 @@ export function handleSendV2(
         clientMsgId: msg.clientMsgId,
       });
     } else {
-      // null sessionId — new session
+      // null sessionId — new session. Supply onSessionResolved so the
+      // connection auto-watches once the SDK resolves the session ID.
       span.setAttribute('routing.decision', 'create');
+      const onSessionResolved = (resolvedId: string) => {
+        ctx.connRegistry.watch(connectionId, resolvedId);
+        ctx.connRegistry.setActive(connectionId, resolvedId);
+      };
       startChat(transport, connectionId, prompt, {
         cwd: msg.cwd,
         model: msg.model,
@@ -317,6 +324,7 @@ export function handleSendV2(
         images: msg.images,
         contextBlocks: msg.contextBlocks,
         clientMsgId: msg.clientMsgId,
+        onSessionResolved,
       });
     }
 


### PR DESCRIPTION
## Summary

- Wire `sendOrBuffer` in `query-loop.ts` to deliver v2 session events through `ConnectionRegistry.broadcast` instead of direct driver transport + v1 observers
- Add `broadcastAll` to `ConnectionRegistry` for global events (`update_available`, `inbox_updated`, task state)
- Auto-watch + setActive on session creation: resume path watches immediately, create path uses `onSessionResolved` callback
- Global and task orchestrator broadcasts now dual-path through both `wss.clients` (v1) and `connRegistry.broadcastAll` (v2)
- `session_end` clears `activeSession` via `setActive(null)` on the v2 connection
- `connRegistry` threaded from `index.ts` to `query-loop` via `setConnectionRegistry` (same pattern as `setTaskStore`)

## Design decisions

- **v2 detection**: `connRegistry.get(clientId)` existing = v2 connection. No flags needed.
- **Pre-sessionId fallback**: Before `resolvedSessionId` is set, v2 connections fall back to v1 driver transport send.
- **Dual delivery**: v1 and v2 paths coexist. No v1 breakage. v1 removal is Phase 3.
- **`onSessionResolved` callback**: Lightweight hook — query-loop stays generic, `handleSendV2` supplies the watch/activate logic.

## Test plan

- [x] `broadcastAll` — 4 tests (sends to all, skips closed, error resilience, no-op)
- [x] v2 delivery path — 4 tests (routes through connRegistry, v1 fallback, pre-sessionId fallback, finally block)
- [x] `onSessionResolved` callback — 3 tests (fires once, idempotent on multi-turn, skipped on resume)
- [x] session_end cleanup — 2 tests (normal end clears active, abnormal end clears active)
- [x] handleSendV2 resume auto-watch — 1 test
- [x] Full suite: 1715 tests pass, 0 lint errors


Made with [Cursor](https://cursor.com)