### PR TITLE
feat(client): replace WsPool with MitzoConnection for v2 single-WS protocol

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -20,7 +20,6 @@ export const clientStore = createMitzoStore({
     buildUrl: () => wsUrl,
     createWebSocket: (url) => new WebSocket(url) as import('@mitzo/client').WebSocketLike,
     reconnectDelayMs: 500,
-    reconnectPollMs: 5_000,
   },
 });
 

--- a/packages/client/__tests__/connection.test.ts
+++ b/packages/client/__tests__/connection.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MitzoConnection } from '../src/connection.js';
+import type { WebSocketLike } from '../src/ws-connection.js';
+
+// ─── Mock WebSocket ──────────────────────────────────────────────────────────
+
+class MockWebSocket implements WebSocketLike {
+  readyState = 0;
+  onopen: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+
+  simulateOpen() {
+    this.readyState = 1;
+    this.onopen?.(null);
+  }
+
+  simulateMessage(data: Record<string, unknown>) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+
+  simulateClose() {
+    this.readyState = 3;
+    this.onclose?.();
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+let lastWs: MockWebSocket | null = null;
+
+function createConnection() {
+  lastWs = null;
+  return new MitzoConnection({
+    buildUrl: () => 'ws://localhost:3100/ws/chat',
+    createWebSocket: () => {
+      const ws = new MockWebSocket();
+      lastWs = ws;
+      return ws;
+    },
+    reconnectDelayMs: 50,
+  });
+}
+
+function openWithHandshake(conn: MitzoConnection): MockWebSocket {
+  conn.connect();
+  const ws = lastWs!;
+  ws.simulateOpen();
+  // hello is sent automatically
+  ws.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-1' });
+  return ws;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('MitzoConnection', () => {
+  describe('hello handshake', () => {
+    it('sends hello on WS open', () => {
+      const conn = createConnection();
+      conn.connect();
+      const ws = lastWs!;
+      ws.simulateOpen();
+
+      expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'hello', protocolVersion: 2 }));
+    });
+
+    it('fires _open to listener after welcome response', () => {
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+
+      const ws = openWithHandshake(conn);
+
+      expect(received.some((m) => m.type === '_open')).toBe(true);
+      expect(conn.isConnected()).toBe(true);
+      void ws; // suppress unused
+    });
+
+    it('stores connectionId from welcome', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      openWithHandshake(conn);
+
+      expect(conn.getConnectionId()).toBe('conn-1');
+    });
+
+    it('does not fire _open before welcome arrives', () => {
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+      conn.connect();
+      const ws = lastWs!;
+      ws.simulateOpen();
+
+      // Only hello sent, no _open yet
+      expect(received.some((m) => m.type === '_open')).toBe(false);
+      expect(conn.isConnected()).toBe(false);
+    });
+  });
+
+  describe('send and queue', () => {
+    it('sends message when connected', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      const sent = conn.send({ type: 'send', sessionId: null, prompt: 'hi', clientMsgId: 'u1' });
+      expect(sent).toBe(true);
+      // hello + the send message
+      expect(ws.send).toHaveBeenLastCalledWith(
+        JSON.stringify({ type: 'send', sessionId: null, prompt: 'hi', clientMsgId: 'u1' }),
+      );
+    });
+
+    it('queues sends before handshake completes and flushes after welcome', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      conn.connect();
+      const ws = lastWs!;
+
+      const sent = conn.send({ type: 'send', prompt: 'queued' });
+      expect(sent).toBe(true);
+      // Only hello should be on the wire after open, not the queued send
+      ws.simulateOpen();
+      const callsBeforeWelcome = ws.send.mock.calls.length;
+
+      ws.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'c1' });
+
+      // After welcome, queued message should be flushed
+      expect(ws.send.mock.calls.length).toBeGreaterThan(callsBeforeWelcome);
+      const lastPayload = JSON.parse(ws.send.mock.calls[ws.send.mock.calls.length - 1][0]);
+      expect(lastPayload).toEqual({ type: 'send', prompt: 'queued' });
+    });
+
+    it('returns false when disconnected with no reconnect pending', () => {
+      const conn = createConnection();
+      expect(conn.send({ type: 'test' })).toBe(false);
+    });
+  });
+
+  describe('message delivery', () => {
+    it('forwards inbound messages to the listener', () => {
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+      const ws = openWithHandshake(conn);
+
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', delta: 'hi' });
+
+      expect(received.some((m) => m.type === 'block_delta')).toBe(true);
+    });
+
+    it('does not deliver welcome to the listener as a protocol event', () => {
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+      openWithHandshake(conn);
+
+      // welcome should be consumed internally, not forwarded
+      expect(received.filter((m) => m.type === 'welcome')).toHaveLength(0);
+    });
+  });
+
+  describe('seq tracking', () => {
+    it('tracks lastSeq from inbound events', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 5 });
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 8 });
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's2', seq: 3 });
+
+      expect(conn.getLastSeq('s1')).toBe(8);
+      expect(conn.getLastSeq('s2')).toBe(3);
+      expect(conn.getLastSeq('unknown')).toBe(0);
+    });
+
+    it('allows manual seq tracking via trackSeq', () => {
+      const conn = createConnection();
+      conn.trackSeq('s1', 10);
+      expect(conn.getLastSeq('s1')).toBe(10);
+    });
+
+    it('clears session seq on clearSession', () => {
+      const conn = createConnection();
+      conn.trackSeq('s1', 10);
+      conn.clearSession('s1');
+      expect(conn.getLastSeq('s1')).toBe(0);
+    });
+  });
+
+  describe('reconnect', () => {
+    it('reconnects after close and sends hello + reconnect with tracked sessions', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+
+      const ws1 = openWithHandshake(conn);
+      ws1.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 5 });
+      ws1.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's2', seq: 3 });
+
+      // Disconnect
+      ws1.simulateClose();
+      expect(received.some((m) => m.type === '_close')).toBe(true);
+
+      // Advance past reconnect delay
+      vi.advanceTimersByTime(100);
+
+      const ws2 = lastWs!;
+      expect(ws2).not.toBe(ws1);
+      ws2.simulateOpen();
+
+      // hello should be sent
+      expect(ws2.send).toHaveBeenCalledWith(JSON.stringify({ type: 'hello', protocolVersion: 2 }));
+
+      // Simulate welcome
+      ws2.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+
+      // reconnect should be sent with both tracked sessions
+      const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      const reconnectMsg = calls.find((c: Record<string, unknown>) => c.type === 'reconnect');
+      expect(reconnectMsg).toBeDefined();
+      expect(reconnectMsg.sessions).toEqual(
+        expect.arrayContaining([
+          { sessionId: 's1', lastSeq: 5 },
+          { sessionId: 's2', lastSeq: 3 },
+        ]),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it('does not send reconnect if no sessions are tracked', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+
+      const ws1 = openWithHandshake(conn);
+      ws1.simulateClose();
+      vi.advanceTimersByTime(100);
+
+      const ws2 = lastWs!;
+      ws2.simulateOpen();
+      ws2.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+
+      const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      expect(calls.some((c: Record<string, unknown>) => c.type === 'reconnect')).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('flushes pending sends after reconnect handshake', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws1 = openWithHandshake(conn);
+      ws1.simulateClose();
+
+      // Queue a send during disconnect
+      conn.send({ type: 'send', prompt: 'pending' });
+
+      vi.advanceTimersByTime(100);
+      const ws2 = lastWs!;
+      ws2.simulateOpen();
+      ws2.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+
+      const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      expect(calls).toContainEqual({ type: 'send', prompt: 'pending' });
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('closes the WS and clears reconnect timer', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+      ws.simulateClose();
+
+      // Reconnect is pending
+      conn.disconnect();
+
+      // Advance timer — no new WS should be created
+      const wsBefore = lastWs;
+      vi.advanceTimersByTime(200);
+      expect(lastWs).toBe(wsBefore);
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -441,10 +441,18 @@ describe('WS → store wiring', () => {
     expect(store.getState().tasks.tree[0].children).toHaveLength(0);
   });
 
-  it('updates session on session_id message', () => {
-    lastWs.simulateMessage({ type: 'session_id', sessionId: 'new-sid' });
+  it('accepts session_id matching the active session', () => {
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'test-session' });
 
-    expect(store.getState().sessions.active).toBe('new-sid');
+    // Active session remains test-session (confirmed, not changed)
+    expect(store.getState().sessions.active).toBe('test-session');
+  });
+
+  it('rejects session_id from a different session when active is set', () => {
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'foreign-session' });
+
+    // Should NOT hijack the active session
+    expect(store.getState().sessions.active).toBe('test-session');
   });
 
   it('dispatches error messages', () => {
@@ -467,6 +475,18 @@ describe('stopGeneration', () => {
     const stop = sent.find((m) => m.type === 'stop');
     expect(stop).toBeDefined();
     expect(stop!.sessionId).toBe('test-session');
+  });
+
+  it('sends stop with null sessionId during first turn before session_id arrives', () => {
+    const store = createReadyStore();
+    store.getState().sendMessage('hello');
+
+    store.getState().stopGeneration();
+
+    const sent = lastWs.parsedSent();
+    const stop = sent.find((m) => m.type === 'stop');
+    expect(stop).toBeDefined();
+    expect(stop!.sessionId).toBeNull();
   });
 });
 
@@ -495,6 +515,31 @@ describe('respondToPermission', () => {
       permId: 'perm-1',
       decision: 'once',
     });
+  });
+});
+
+describe('respondToPermission — first turn edge case', () => {
+  it('sends permission_response with null sessionId when no session is active', () => {
+    const store = createReadyStore();
+    store.getState().sendMessage('hello');
+
+    // Permission arrives before session_id
+    lastWs.simulateMessage({
+      type: 'permission_request',
+      permId: 'perm-1',
+      toolName: 'Bash',
+      toolInput: 'ls',
+      tier: 'elevated',
+    });
+
+    store.getState().respondToPermission('perm-1', 'once');
+
+    const sent = lastWs.parsedSent();
+    const response = sent.find((m) => m.type === 'permission_response');
+    expect(response).toBeDefined();
+    expect(response!.sessionId).toBeNull();
+    expect(response!.permId).toBe('perm-1');
+    expect(response!.decision).toBe('once');
   });
 });
 
@@ -567,6 +612,44 @@ describe('session isolation via sessionId filtering', () => {
 
     expect(store.getState().messages.current).not.toBeNull();
     expect(store.getState().messages.current!.messageId).toBe('b-msg');
+  });
+
+  it('rejects session_end from a foreign session when active session is set', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('session-b');
+    store.getState().dispatchMessages({ type: 'SET_RUNNING', running: true });
+
+    lastWs.simulateMessage({
+      type: 'session_end',
+      sessionId: 'session-a',
+    });
+
+    // running should NOT be cleared — the event was from a different session
+    expect(store.getState().messages.running).toBe(true);
+  });
+
+  it('rejects session_id from a foreign session when active session is set', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('session-b');
+
+    lastWs.simulateMessage({
+      type: 'session_id',
+      sessionId: 'session-a',
+    });
+
+    // Active session should NOT change
+    expect(store.getState().sessions.active).toBe('session-b');
+  });
+
+  it('accepts session_id when no active session (new session assignment)', () => {
+    const store = createReadyStore();
+
+    lastWs.simulateMessage({
+      type: 'session_id',
+      sessionId: 'brand-new',
+    });
+
+    expect(store.getState().sessions.active).toBe('brand-new');
   });
 
   it('accepts global events without sessionId', async () => {

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -9,7 +9,7 @@ import type { StoreApi } from 'zustand/vanilla';
 // ─── Mock WebSocket ─────────────────────────────────────────────────────────
 
 class MockWebSocket implements WebSocketLike {
-  readyState = WS_READY_STATE.OPEN;
+  readyState = WS_READY_STATE.CONNECTING;
   onopen: ((ev: unknown) => void) | null = null;
   onmessage: ((ev: { data: string }) => void) | null = null;
   onclose: (() => void) | null = null;
@@ -24,7 +24,6 @@ class MockWebSocket implements WebSocketLike {
     this.readyState = WS_READY_STATE.CLOSED;
   }
 
-  // Test helpers
   simulateOpen() {
     this.readyState = WS_READY_STATE.OPEN;
     this.onopen?.({});
@@ -37,6 +36,16 @@ class MockWebSocket implements WebSocketLike {
   simulateClose() {
     this.readyState = WS_READY_STATE.CLOSED;
     this.onclose?.();
+  }
+
+  /** Complete the v2 hello/welcome handshake. */
+  completeHandshake() {
+    this.simulateOpen();
+    this.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-1' });
+  }
+
+  parsedSent(): Record<string, unknown>[] {
+    return this.sent.map((s) => JSON.parse(s));
   }
 }
 
@@ -70,6 +79,13 @@ function makeOptions(transport?: TransportAdapter): MitzoStoreOptions {
   };
 }
 
+/** Create store and complete the v2 handshake so it's ready to use. */
+function createReadyStore(transport?: TransportAdapter) {
+  const store = createMitzoStore(makeOptions(transport));
+  lastWs.completeHandshake();
+  return store;
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('createMitzoStore', () => {
@@ -99,14 +115,25 @@ describe('createMitzoStore', () => {
     expect(typeof state.setMode).toBe('function');
     expect(typeof state.setModel).toBe('function');
   });
+
+  it('connects to WS and completes v2 handshake on creation', () => {
+    createMitzoStore(makeOptions());
+    const ws = lastWs;
+    ws.simulateOpen();
+
+    expect(ws.parsedSent()).toContainEqual({ type: 'hello', protocolVersion: 2 });
+  });
+
+  it('sets connection status to connected after welcome', () => {
+    const store = createReadyStore();
+    expect(store.getState().connection.status).toBe('connected');
+  });
 });
 
 describe('switchSession', () => {
   it('updates active session and resets messages', async () => {
-    const transport = mockTransport();
-    const store = createMitzoStore(makeOptions(transport));
+    const store = createReadyStore();
 
-    // Pre-populate some messages
     store.getState().dispatchMessages({
       type: 'USER_SEND',
       text: 'hello',
@@ -135,7 +162,7 @@ describe('switchSession', () => {
       text: () => Promise.resolve(''),
     });
 
-    const store = createMitzoStore(makeOptions(transport));
+    const store = createReadyStore(transport);
     await store.getState().switchSession('session-abc');
 
     expect(transport.fetch).toHaveBeenCalledWith(
@@ -146,48 +173,35 @@ describe('switchSession', () => {
     expect(store.getState().messages.messages[0].messageId).toBe('m1');
   });
 
-  it('unsubscribes old session WS when switching to a new one', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
+  it('sends switch_session over WS', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('session-abc');
+
+    expect(lastWs.parsedSent()).toContainEqual({
+      type: 'switch_session',
+      sessionId: 'session-abc',
     });
-    const store = createMitzoStore(makeOptions(transport));
+  });
 
-    // Switch to session A
-    await store.getState().switchSession('session-a');
-    const wsA = lastWs;
-    wsA.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    wsA.simulateMessage({ type: 'subscribed', running: true });
-
-    // Switch to session B
+  it('filters events from non-active sessions after switch', async () => {
+    const store = createReadyStore();
     await store.getState().switchSession('session-b');
 
-    // Messages on session A's WS should NOT dispatch into session B's state
-    wsA.simulateMessage({ type: 'message_start', messageId: 'a-msg' });
-    wsA.simulateMessage({
-      type: 'block_start',
+    // Events tagged with session-a should be ignored
+    lastWs.simulateMessage({
+      type: 'message_start',
       messageId: 'a-msg',
-      blockId: 'b1',
-      blockType: 'text',
-    });
-    wsA.simulateMessage({
-      type: 'block_delta',
-      messageId: 'a-msg',
-      blockId: 'b1',
-      blockType: 'text',
-      delta: 'should not appear',
+      sessionId: 'session-a',
     });
 
-    expect(store.getState().messages.messages).toHaveLength(0);
     expect(store.getState().messages.current).toBeNull();
+    expect(store.getState().messages.messages).toHaveLength(0);
   });
 });
 
 describe('newSession', () => {
   it('clears active session and resets messages', () => {
-    const store = createMitzoStore(makeOptions());
+    const store = createReadyStore();
     store.setState((s) => ({
       sessions: { ...s.sessions, active: 'old-session' },
     }));
@@ -198,45 +212,30 @@ describe('newSession', () => {
     expect(store.getState().messages.messages).toHaveLength(0);
   });
 
-  it('isolates new session from old session messages', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
-
-    // Start in an existing session with an active WS
-    await store.getState().switchSession('old-session');
-    const oldWs = lastWs;
-
-    // Complete the handshake so messages flow
-    oldWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    oldWs.simulateMessage({ type: 'subscribed', running: true });
-
-    // Now switch to a new session
+  it('sends switch_session with null to clear server-side active', () => {
+    const store = createReadyStore();
     store.getState().newSession();
-    expect(store.getState().messages.messages).toHaveLength(0);
 
-    // Simulate messages arriving on the OLD session's WS — these must
-    // NOT appear in the new session's state.
-    oldWs.simulateMessage({ type: 'message_start', messageId: 'old-msg' });
-    oldWs.simulateMessage({
-      type: 'block_start',
-      messageId: 'old-msg',
-      blockId: 'b1',
-      blockType: 'text',
+    expect(lastWs.parsedSent()).toContainEqual({
+      type: 'switch_session',
+      sessionId: null,
     });
-    oldWs.simulateMessage({
-      type: 'block_delta',
+  });
+
+  it('isolates new session from old session messages via sessionId filter', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('old-session');
+
+    store.getState().newSession();
+
+    // Messages tagged with old-session should be filtered out since
+    // currentSessionId is now undefined (no active session)
+    lastWs.simulateMessage({
+      type: 'message_start',
       messageId: 'old-msg',
-      blockId: 'b1',
-      blockType: 'text',
-      delta: 'leaked!',
+      sessionId: 'old-session',
     });
 
-    // The store should still have zero messages — old session is unsubscribed
     expect(store.getState().messages.messages).toHaveLength(0);
     expect(store.getState().messages.current).toBeNull();
   });
@@ -244,7 +243,7 @@ describe('newSession', () => {
 
 describe('sendMessage', () => {
   it('adds optimistic user message', () => {
-    const store = createMitzoStore(makeOptions());
+    const store = createReadyStore();
     store.getState().sendMessage('hello');
 
     const { messages, running } = store.getState().messages;
@@ -254,70 +253,71 @@ describe('sendMessage', () => {
     expect(running).toBe(true);
   });
 
-  it('subscribes to WS pool for new sessions', () => {
-    const store = createMitzoStore(makeOptions());
+  it('sends v2 send message with sessionId=null for new sessions', () => {
+    const store = createReadyStore();
     store.getState().sendMessage('hello');
 
-    // The WS was created (subscribe triggers getOrCreate → connectEntry)
-    expect(lastWs).toBeDefined();
+    const sends = lastWs.parsedSent().filter((m) => m.type === 'send');
+    expect(sends).toHaveLength(1);
+    expect(sends[0].sessionId).toBeNull();
+    expect(sends[0].prompt).toBe('hello');
+    expect(sends[0].clientMsgId).toBeDefined();
   });
 
-  it('marks the pool entry running on new-session send so iOS reconnects attempt reattach', () => {
-    vi.useFakeTimers();
-    const store = createMitzoStore(makeOptions());
+  it('sends v2 send message with sessionId for existing sessions', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('sess-abc');
 
-    store.getState().sendMessage('hello');
-    const ws1 = lastWs;
+    // Simulate server assigning session (via session_id event)
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-abc' });
 
-    // Server assigns client_id (pool entry now has clientId set).
-    ws1.simulateMessage({ type: 'client_id', clientId: 'c-original' });
+    store.getState().sendMessage('follow-up');
 
-    // iOS kills the socket mid-first-turn. If wasRunning is true, the
-    // reconnect will send reattach; if false, it'll send subscribe.
-    ws1.simulateClose();
-    vi.advanceTimersByTime(1000);
-
-    const ws2 = lastWs;
-    expect(ws2).not.toBe(ws1);
-    ws2.simulateOpen();
-    ws2.simulateMessage({ type: 'client_id', clientId: 'c-reconnected' });
-
-    const ws2Sends = ws2.sent.map((s) => JSON.parse(s));
-    expect(ws2Sends).toContainEqual(
-      expect.objectContaining({ type: 'reattach', clientId: 'c-original' }),
-    );
-    vi.useRealTimers();
+    const sends = lastWs.parsedSent().filter((m) => m.type === 'send');
+    expect(sends).toHaveLength(1);
+    expect(sends[0].sessionId).toBe('sess-abc');
+    expect(sends[0].prompt).toBe('follow-up');
+    // v2: no `resume` field
+    expect(sends[0].resume).toBeUndefined();
   });
 
-  it('sends the second message to the WS after the first turn completes', async () => {
-    const store = createMitzoStore(makeOptions());
+  it('sends the second message to WS after first turn completes', async () => {
+    const store = createReadyStore();
 
-    // First send — establishes the session via new: pool key
     store.getState().sendMessage('first');
-    const ws = lastWs;
-
-    // Simulate the server assigning a session id, then ending the turn so
-    // running flips back to false. This is the state the app is in when the
-    // user types their follow-up prompt.
-    ws.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    ws.simulateMessage({ type: 'session_id', sessionId: 'sess-xyz' });
-    ws.simulateMessage({ type: 'session_end', sessionId: 'sess-xyz' });
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-xyz' });
+    lastWs.simulateMessage({ type: 'session_end', sessionId: 'sess-xyz' });
 
     expect(store.getState().messages.running).toBe(false);
-    const sentBeforeSecond = ws.sent.length;
+    const sentBefore = lastWs.sent.length;
 
-    // Second send — must actually hit the WS, not be silently queued in
-    // parserState.pendingSend. Reproduces the "hang after second prompt" bug
-    // where USER_SEND flipped running=true before the is-running check ran,
-    // causing every follow-up to stall.
     store.getState().sendMessage('second');
 
-    const newlySent = ws.sent.slice(sentBeforeSecond).map((s) => JSON.parse(s));
-    expect(newlySent).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ type: 'send', prompt: 'second', resume: 'sess-xyz' }),
-      ]),
+    const newSends = lastWs.sent.slice(sentBefore).map((s) => JSON.parse(s));
+    expect(newSends).toContainEqual(
+      expect.objectContaining({ type: 'send', prompt: 'second', sessionId: 'sess-xyz' }),
     );
+  });
+
+  it('queues second message while first turn is running', async () => {
+    const store = createReadyStore();
+
+    store.getState().sendMessage('first');
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-q' });
+
+    // Turn is still running — second send should queue
+    const sentBefore = lastWs.sent.length;
+    store.getState().sendMessage('second');
+
+    // Should NOT have sent yet
+    const newSendsImmediate = lastWs.sent.slice(sentBefore).map((s) => JSON.parse(s));
+    expect(newSendsImmediate.filter((m) => m.type === 'send')).toHaveLength(0);
+
+    // session_end triggers flush of queued message
+    lastWs.simulateMessage({ type: 'session_end', sessionId: 'sess-q' });
+
+    const newSends = lastWs.sent.slice(sentBefore).map((s) => JSON.parse(s));
+    expect(newSends).toContainEqual(expect.objectContaining({ type: 'send', prompt: 'second' }));
   });
 });
 
@@ -331,31 +331,33 @@ describe('WS → store wiring', () => {
       json: () => Promise.resolve([]),
       text: () => Promise.resolve(''),
     });
-    store = createMitzoStore(makeOptions(transport));
-
-    // Switch to a session to wire up the WS listener
+    store = createReadyStore(transport);
     await store.getState().switchSession('test-session');
   });
 
   it('dispatches MESSAGE_START through the protocol parser', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    // client_id triggers a subscribe message, then we get server messages
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-    lastWs.simulateMessage({ type: 'message_start', messageId: 'msg-1' });
+    lastWs.simulateMessage({
+      type: 'message_start',
+      messageId: 'msg-1',
+      sessionId: 'test-session',
+    });
 
     expect(store.getState().messages.current).not.toBeNull();
     expect(store.getState().messages.current!.messageId).toBe('msg-1');
   });
 
   it('dispatches full message turn and finalizes', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-    lastWs.simulateMessage({ type: 'message_start', messageId: 'msg-1' });
+    lastWs.simulateMessage({
+      type: 'message_start',
+      messageId: 'msg-1',
+      sessionId: 'test-session',
+    });
     lastWs.simulateMessage({
       type: 'block_start',
       messageId: 'msg-1',
       blockId: 'b1',
       blockType: 'text',
+      sessionId: 'test-session',
     });
     lastWs.simulateMessage({
       type: 'block_delta',
@@ -363,14 +365,16 @@ describe('WS → store wiring', () => {
       blockId: 'b1',
       blockType: 'text',
       delta: 'Hello!',
+      sessionId: 'test-session',
     });
     lastWs.simulateMessage({
       type: 'block_end',
       messageId: 'msg-1',
       blockId: 'b1',
       blockType: 'text',
+      sessionId: 'test-session',
     });
-    lastWs.simulateMessage({ type: 'message_end', messageId: 'msg-1' });
+    lastWs.simulateMessage({ type: 'message_end', messageId: 'msg-1', sessionId: 'test-session' });
 
     expect(store.getState().messages.current).toBeNull();
     expect(store.getState().messages.messages).toHaveLength(1);
@@ -378,9 +382,7 @@ describe('WS → store wiring', () => {
   });
 
   it('dispatches session_end and clears running', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: true });
-
+    store.getState().dispatchMessages({ type: 'SET_RUNNING', running: true });
     expect(store.getState().messages.running).toBe(true);
 
     lastWs.simulateMessage({ type: 'session_end', sessionId: 'test-session' });
@@ -389,8 +391,6 @@ describe('WS → store wiring', () => {
   });
 
   it('dispatches task_state updates', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
     lastWs.simulateMessage({
       type: 'task_state',
       tasks: [{ id: 't1', summary: 'Task 1', status: 'pending', children: [] }],
@@ -401,10 +401,6 @@ describe('WS → store wiring', () => {
   });
 
   it('dispatches task_updated recursively', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-
-    // Set up a tree with nested tasks
     lastWs.simulateMessage({
       type: 'task_state',
       tasks: [
@@ -417,7 +413,6 @@ describe('WS → store wiring', () => {
       ],
     });
 
-    // Update the nested task
     lastWs.simulateMessage({
       type: 'task_updated',
       task: { id: 't2', summary: 'Child Updated', status: 'done', children: [] },
@@ -428,9 +423,6 @@ describe('WS → store wiring', () => {
   });
 
   it('dispatches task_deleted recursively', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-
     lastWs.simulateMessage({
       type: 'task_state',
       tasks: [
@@ -450,16 +442,12 @@ describe('WS → store wiring', () => {
   });
 
   it('updates session on session_id message', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
     lastWs.simulateMessage({ type: 'session_id', sessionId: 'new-sid' });
 
     expect(store.getState().sessions.active).toBe('new-sid');
   });
 
   it('dispatches error messages', () => {
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
     lastWs.simulateMessage({ type: 'error', error: 'Something broke' });
 
     const msgs = store.getState().messages.messages;
@@ -468,304 +456,151 @@ describe('WS → store wiring', () => {
   });
 });
 
-describe('reattach_failed → onMessagesRestored', () => {
-  it('restores messages exactly once via passed-through messages (no double-fetch)', async () => {
-    const transport = mockTransport();
-    const restoredMsgs = [
-      {
-        messageId: 'm1',
-        role: 'assistant',
-        blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
-      },
-    ];
-    // getSessionMessages returns restored messages
-    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
-      if (url.includes('/messages')) {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(restoredMsgs),
-          text: () => Promise.resolve(''),
-        });
-      }
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve([]),
-        text: () => Promise.resolve(''),
-      });
-    });
-
-    const store = createMitzoStore(makeOptions(transport));
-    await store.getState().switchSession('test-session');
-
-    // Simulate WS connection + reattach_failed
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-    lastWs.simulateMessage({ type: 'reattach_failed', clientId: 'old' });
-
-    // Wait for the async fetch to resolve and messages to be restored
-    await vi.waitFor(() => {
-      expect(store.getState().messages.messages).toHaveLength(1);
-    });
-
-    expect(store.getState().messages.messages[0].messageId).toBe('m1');
-    expect(store.getState().messages.messages[0].blocks[0].content).toBe('restored');
-  });
-});
-
 describe('stopGeneration', () => {
-  it('sends interrupt message over WS', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
+  it('sends v2 stop message with sessionId over WS', async () => {
+    const store = createReadyStore();
     await store.getState().switchSession('test-session');
-
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: true });
 
     store.getState().stopGeneration();
 
-    const sent = lastWs.sent.map((s) => JSON.parse(s));
-    const interrupt = sent.find((m) => m.type === 'interrupt');
-    expect(interrupt).toBeDefined();
+    const sent = lastWs.parsedSent();
+    const stop = sent.find((m) => m.type === 'stop');
+    expect(stop).toBeDefined();
+    expect(stop!.sessionId).toBe('test-session');
   });
 });
 
 describe('respondToPermission', () => {
-  it('sends permission_response and clears pending', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
+  it('sends v2 permission_response with sessionId and clears pending', async () => {
+    const store = createReadyStore();
     await store.getState().switchSession('test-session');
 
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: true });
-
-    // Simulate a permission request arriving (lands in messages.permission via reducer)
     lastWs.simulateMessage({
       type: 'permission_request',
       permId: 'perm-1',
       toolName: 'Bash',
       toolInput: 'rm -rf /',
       tier: 'elevated',
+      sessionId: 'test-session',
     });
     expect(store.getState().messages.permission).not.toBeNull();
-    expect(store.getState().messages.permission!.permId).toBe('perm-1');
 
-    // Respond to the permission
     store.getState().respondToPermission('perm-1', 'once');
 
-    // WS should have sent the response
-    const sent = lastWs.sent.map((s) => JSON.parse(s));
+    const sent = lastWs.parsedSent();
     const response = sent.find((m) => m.type === 'permission_response');
     expect(response).toEqual({
       type: 'permission_response',
+      sessionId: 'test-session',
       permId: 'perm-1',
       decision: 'once',
     });
   });
 });
 
-describe('sendMessage — new session connection bootstrap', () => {
-  it('new session send works even when connection.status is disconnected', () => {
-    const store = createMitzoStore(makeOptions());
-
-    // Initial state: connection is disconnected (no WS subscription yet)
-    expect(store.getState().connection.status).toBe('disconnected');
-
-    // sendMessage should still work — it creates a pool entry on demand
-    store.getState().sendMessage('hello from a new session');
-
-    const { messages, running } = store.getState().messages;
-    expect(messages).toHaveLength(1);
-    expect(messages[0].blocks[0].content).toBe('hello from a new session');
-    expect(running).toBe(true);
-    // A WebSocket was created (pool entry bootstrapped)
-    expect(lastWs).toBeDefined();
-  });
-
-  it('connection becomes connected after new-session WS opens and receives client_id', () => {
-    const store = createMitzoStore(makeOptions());
-    store.getState().sendMessage('hello');
-
-    // Simulate full handshake
-    lastWs.simulateOpen();
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-
-    expect(store.getState().connection.status).toBe('connected');
-  });
-
-  it('unsubscribes previous session WS when first message creates a new pool entry', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
-
-    // Start in an existing session
-    await store.getState().switchSession('old-session');
-    const oldWs = lastWs;
-    oldWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    oldWs.simulateMessage({ type: 'subscribed', running: false });
-
-    // Start a brand-new session by calling newSession then sendMessage
-    store.getState().newSession();
-    store.getState().sendMessage('fresh start');
-
-    // Messages on the old WS must not leak into the new session
-    oldWs.simulateMessage({ type: 'message_start', messageId: 'old-leak' });
-
-    // Only the user message from sendMessage should be present
-    expect(store.getState().messages.messages).toHaveLength(1);
-    expect(store.getState().messages.messages[0].role).toBe('user');
-    expect(store.getState().messages.current).toBeNull();
-  });
-});
-
-describe('sendMessage — resume drops stale session ID after error', () => {
+describe('sendMessage — session expired recovery', () => {
   it('clears currentSessionId on "No conversation found" so next send is fresh', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
-
-    // Switch to an existing session (sets parserState.currentSessionId)
+    const store = createReadyStore();
     await store.getState().switchSession('old-session-id');
 
-    // Simulate WS handshake
-    lastWs.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    lastWs.simulateMessage({ type: 'subscribed', running: false });
-
-    // Send a message — should include resume
     store.getState().sendMessage('first attempt');
-    const firstSent = lastWs.sent.map((s) => JSON.parse(s));
-    const resumeMsg = firstSent.find(
-      (m: Record<string, unknown>) => m.type === 'send' && m.resume === 'old-session-id',
-    );
+    const firstSent = lastWs.parsedSent();
+    const resumeMsg = firstSent.find((m) => m.type === 'send' && m.sessionId === 'old-session-id');
     expect(resumeMsg).toBeDefined();
 
-    // Server responds with "No conversation found"
     lastWs.simulateMessage({
       type: 'error',
       error:
         'Claude Code returned an error result: No conversation found with session ID: old-session-id',
     });
 
-    // Session should be expired — active cleared
     expect(store.getState().sessions.active).toBeNull();
 
-    // Send another message — should NOT include resume (fresh session)
     store.getState().sendMessage('second attempt');
 
-    // The second send should go through a new pool key (no resume)
-    // It creates a new WS, so check the new lastWs
-    const newWsSent = lastWs.sent.map((s) => JSON.parse(s));
-    const freshMsg = newWsSent.find((m: Record<string, unknown>) => m.type === 'send' && !m.resume);
-    expect(freshMsg).toBeDefined();
-    expect(freshMsg.prompt).toBe('second attempt');
+    const allSends = lastWs.parsedSent().filter((m) => m.type === 'send');
+    const fresh = allSends.find((m) => m.prompt === 'second attempt');
+    expect(fresh).toBeDefined();
+    expect(fresh!.sessionId).toBeNull();
   });
 });
 
-describe('session bleed prevention — pool cleanup', () => {
-  it('switchSession defuses reattach on the old pool entry', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
-    });
-    const store = createMitzoStore(makeOptions(transport));
-
-    // Switch to session A — creates a pool entry + WS
-    await store.getState().switchSession('session-a');
-    const wsA = lastWs;
-    wsA.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    wsA.simulateMessage({ type: 'subscribed', running: true });
-
-    // Switch to session B — old entry should be cleaned up (idle after unsub)
+describe('session isolation via sessionId filtering', () => {
+  it('ignores events tagged with a different sessionId', async () => {
+    const store = createReadyStore();
     await store.getState().switchSession('session-b');
 
-    // Old WS should be closed (removeIfIdle succeeds after unsub + setRunning(false))
-    expect(wsA.readyState).toBe(WS_READY_STATE.CLOSED);
-  });
-
-  it('newSession defuses reattach on the old pool entry', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
+    lastWs.simulateMessage({
+      type: 'message_start',
+      messageId: 'a-msg',
+      sessionId: 'session-a',
     });
-    const store = createMitzoStore(makeOptions(transport));
-
-    await store.getState().switchSession('session-a');
-    const wsA = lastWs;
-    wsA.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    wsA.simulateMessage({ type: 'subscribed', running: true });
-
-    store.getState().newSession();
-
-    expect(wsA.readyState).toBe(WS_READY_STATE.CLOSED);
-  });
-
-  it('newSession + sendMessage creates a fully independent WS without bleed', async () => {
-    const transport = mockTransport();
-    (transport.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-      text: () => Promise.resolve(''),
+    lastWs.simulateMessage({
+      type: 'block_start',
+      messageId: 'a-msg',
+      blockId: 'b1',
+      blockType: 'text',
+      sessionId: 'session-a',
     });
-    const store = createMitzoStore(makeOptions(transport));
+    lastWs.simulateMessage({
+      type: 'block_delta',
+      messageId: 'a-msg',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'should not appear',
+      sessionId: 'session-a',
+    });
 
-    // Start session A, get a session ID assigned, then session ends
-    await store.getState().switchSession('session-a');
-    const wsA = lastWs;
-    wsA.simulateMessage({ type: 'client_id', clientId: 'c1' });
-    wsA.simulateMessage({ type: 'subscribed', running: true });
-    wsA.simulateMessage({ type: 'session_end', sessionId: 'session-a' });
-
-    // Go to new session
-    store.getState().newSession();
-
-    // Send first message in new session
-    store.getState().sendMessage('fresh start');
-    const wsNew = lastWs;
-
-    // The new WS should be a different instance
-    expect(wsNew).not.toBe(wsA);
-
-    // Messages on old WS must not leak into new session's state
-    wsA.simulateMessage({ type: 'message_start', messageId: 'stale' });
+    expect(store.getState().messages.messages).toHaveLength(0);
     expect(store.getState().messages.current).toBeNull();
-    // Only the optimistic user message
-    expect(store.getState().messages.messages).toHaveLength(1);
-    expect(store.getState().messages.messages[0].role).toBe('user');
+  });
+
+  it('accepts events tagged with the active sessionId', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('session-b');
+
+    lastWs.simulateMessage({
+      type: 'message_start',
+      messageId: 'b-msg',
+      sessionId: 'session-b',
+    });
+
+    expect(store.getState().messages.current).not.toBeNull();
+    expect(store.getState().messages.current!.messageId).toBe('b-msg');
+  });
+
+  it('accepts global events without sessionId', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('session-b');
+
+    lastWs.simulateMessage({
+      type: 'task_state',
+      tasks: [{ id: 't1', summary: 'Global task', status: 'pending', children: [] }],
+    });
+
+    expect(store.getState().tasks.tree).toHaveLength(1);
   });
 });
 
 describe('setMode', () => {
-  it('updates config mode', () => {
-    const store = createMitzoStore(makeOptions());
+  it('updates config mode and sends v2 set_mode', async () => {
+    const store = createReadyStore();
+    await store.getState().switchSession('test-session');
+
     store.getState().setMode('auto');
+
     expect(store.getState().config.mode).toBe('auto');
+    expect(lastWs.parsedSent()).toContainEqual({
+      type: 'set_mode',
+      sessionId: 'test-session',
+      mode: 'auto',
+    });
   });
 });
 
 describe('setModel', () => {
   it('updates config modelId', () => {
-    const store = createMitzoStore(makeOptions());
+    const store = createReadyStore();
     store.getState().setModel('claude-sonnet-4-5-20250514');
     expect(store.getState().config.modelId).toBe('claude-sonnet-4-5-20250514');
   });
@@ -773,7 +608,7 @@ describe('setModel', () => {
 
 describe('dispatchMessages', () => {
   it('applies messages reducer action directly', () => {
-    const store = createMitzoStore(makeOptions());
+    const store = createReadyStore();
     store.getState().dispatchMessages({ type: 'SET_RUNNING', running: true });
     expect(store.getState().messages.running).toBe(true);
   });

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -162,7 +162,10 @@ export class MitzoConnection {
       this.reconnectTimer = setTimeout(() => this.doConnect(), this.config.reconnectDelayMs);
     };
 
-    ws.onerror = () => {};
+    ws.onerror = () => {
+      // Intentionally empty — error events always precede close, and
+      // reconnect is handled in onclose. Nothing actionable here.
+    };
   }
 
   private flushPendingSends(): void {

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -1,0 +1,181 @@
+/**
+ * MitzoConnection — single multiplexed WebSocket for the v2 protocol.
+ *
+ * Replaces the per-session WsPool. One WebSocket connection handles all
+ * sessions via sessionId-tagged messages. Manages hello/welcome handshake,
+ * reconnect with per-session seq replay, and pending send queue.
+ */
+
+import type { WebSocketLike } from './ws-connection.js';
+import { WS_READY_STATE } from './types.js';
+
+export interface MitzoConnectionConfig {
+  buildUrl(): string;
+  createWebSocket(url: string): WebSocketLike;
+  reconnectDelayMs?: number;
+}
+
+export type ConnectionListener = (msg: Record<string, unknown>) => void;
+
+const MAX_PENDING_SENDS = 100;
+
+export class MitzoConnection {
+  private ws: WebSocketLike | null = null;
+  private _connectionId: string | null = null;
+  private _connected = false;
+  private _isReconnect = false;
+  private listener: ConnectionListener | null = null;
+  private seqBySession = new Map<string, number>();
+  private pendingSends: string[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private config: Required<MitzoConnectionConfig>;
+
+  constructor(config: MitzoConnectionConfig) {
+    this.config = {
+      reconnectDelayMs: 500,
+      ...config,
+    };
+  }
+
+  connect(): void {
+    this.doConnect();
+  }
+
+  disconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.close();
+      this.ws = null;
+    }
+    this._connected = false;
+  }
+
+  send(msg: Record<string, unknown>): boolean {
+    const payload = JSON.stringify(msg);
+    if (this._connected && this.ws?.readyState === WS_READY_STATE.OPEN) {
+      this.ws.send(payload);
+      return true;
+    }
+    if (
+      this.ws?.readyState === WS_READY_STATE.CONNECTING ||
+      this.reconnectTimer ||
+      (this.ws?.readyState === WS_READY_STATE.OPEN && !this._connected)
+    ) {
+      if (this.pendingSends.length >= MAX_PENDING_SENDS) {
+        this.pendingSends.shift();
+      }
+      this.pendingSends.push(payload);
+      return true;
+    }
+    return false;
+  }
+
+  onMessage(listener: ConnectionListener): void {
+    this.listener = listener;
+  }
+
+  isConnected(): boolean {
+    return this._connected;
+  }
+
+  getConnectionId(): string | null {
+    return this._connectionId;
+  }
+
+  trackSeq(sessionId: string, seq: number): void {
+    this.seqBySession.set(sessionId, seq);
+  }
+
+  getLastSeq(sessionId: string): number {
+    return this.seqBySession.get(sessionId) ?? 0;
+  }
+
+  clearSession(sessionId: string): void {
+    this.seqBySession.delete(sessionId);
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private doConnect(): void {
+    if (
+      this.ws?.readyState === WS_READY_STATE.OPEN ||
+      this.ws?.readyState === WS_READY_STATE.CONNECTING
+    ) {
+      return;
+    }
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    const url = this.config.buildUrl();
+    const ws = this.config.createWebSocket(url);
+    this.ws = ws;
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'hello', protocolVersion: 2 }));
+    };
+
+    ws.onmessage = (e: { data: string }) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+
+      if (msg.type === 'welcome') {
+        this._connectionId = msg.connectionId as string;
+        this._connected = true;
+
+        if (this._isReconnect && this.seqBySession.size > 0) {
+          const sessions = Array.from(this.seqBySession.entries()).map(([sessionId, lastSeq]) => ({
+            sessionId,
+            lastSeq,
+          }));
+          ws.send(JSON.stringify({ type: 'reconnect', sessions }));
+        }
+        this._isReconnect = true;
+
+        this.flushPendingSends();
+        this.listener?.({ type: '_open' });
+        return;
+      }
+
+      // Track seq for reconnect replay
+      if (typeof msg.seq === 'number' && typeof msg.sessionId === 'string') {
+        this.seqBySession.set(msg.sessionId as string, msg.seq as number);
+      }
+
+      this.listener?.(msg);
+    };
+
+    ws.onclose = () => {
+      this.ws = null;
+      this._connected = false;
+      this.listener?.({ type: '_close' });
+      this.reconnectTimer = setTimeout(() => this.doConnect(), this.config.reconnectDelayMs);
+    };
+
+    ws.onerror = () => {};
+  }
+
+  private flushPendingSends(): void {
+    if (this.pendingSends.length === 0 || !this.ws) return;
+    const toFlush = this.pendingSends;
+    this.pendingSends = [];
+    for (let i = 0; i < toFlush.length; i++) {
+      try {
+        this.ws.send(toFlush[i]);
+      } catch {
+        this.pendingSends.unshift(...toFlush.slice(i));
+        break;
+      }
+    }
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -45,6 +45,10 @@ export type {
   SessionMetaResponse,
 } from './api-client.js';
 
-// WS connection
+// WS connection (v2)
+export { MitzoConnection } from './connection.js';
+export type { MitzoConnectionConfig, ConnectionListener } from './connection.js';
+
+// WS connection (v1 — legacy, used by frontend ws-pool consumers)
 export { WsPool } from './ws-connection.js';
 export type { WsPoolConfig, WebSocketLike, MsgListener } from './ws-connection.js';

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -39,11 +39,17 @@ export interface ProtocolCallbacks {
   /** Called to fetch messages from REST API for reattach recovery. */
   fetchMessages?(sessionId: string): Promise<FinishedMessage[]>;
 
-  /** Called to mark the WS pool entry as running/not-running. */
+  /** @deprecated v1 only — called to mark the WS pool entry as running/not-running. */
   setWsRunning?(poolKey: string, running: boolean): void;
 
-  /** Called to send a queued message after session_end. */
+  /** @deprecated v1 only — called to send a queued message after session_end. */
   sendQueued?(poolKey: string, msg: unknown): void;
+
+  /** v2: Called when a queued message should be sent after session_end. */
+  onSendQueued?(msg: Record<string, unknown>): void;
+
+  /** v2: Called with token data from session_switched response. */
+  onTokensHydrated?(tokens: Record<string, unknown>): void;
 }
 
 // ─── Parser state ────────────────────────────────────────────────────────────
@@ -96,6 +102,25 @@ export function parseServerMessage(
     case '_close':
       result.connectionUpdate = { status: 'disconnected' };
       break;
+
+    // ── v2 handshake events ────────────────────────────────────────────────
+
+    case 'reconnected':
+      result.connectionUpdate = { status: 'connected' };
+      break;
+
+    case 'session_switched': {
+      const tokens = msg.tokens as Record<string, unknown> | undefined;
+      if (tokens) {
+        callbacks.onTokensHydrated?.(tokens);
+      }
+      break;
+    }
+
+    case 'session_cleared':
+      break;
+
+    // ── v1 handshake events (kept for backward compat) ─────────────────────
 
     case 'reattached':
       result.messagesActions.push({ type: 'SET_RUNNING', running: true });
@@ -229,8 +254,14 @@ export function parseServerMessage(
       if (pending) {
         state.pendingSend = null;
         result.messagesActions.push({ type: 'SET_RUNNING', running: true });
-        callbacks.setWsRunning?.(poolKey, true);
-        callbacks.sendQueued?.(poolKey, pending);
+        // v2 path: use onSendQueued callback (no pool key needed)
+        if (callbacks.onSendQueued) {
+          callbacks.onSendQueued(pending);
+        } else {
+          // v1 fallback
+          callbacks.setWsRunning?.(poolKey, true);
+          callbacks.sendQueued?.(poolKey, pending);
+        }
       }
       break;
     }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -262,20 +262,19 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     stopGeneration() {
-      if (parserState.currentSessionId) {
-        connection.send({ type: 'stop', sessionId: parserState.currentSessionId });
-      }
+      connection.send({
+        type: 'stop',
+        sessionId: parserState.currentSessionId ?? null,
+      });
     },
 
     respondToPermission(permId: string, decision: 'once' | 'always' | 'deny') {
-      if (parserState.currentSessionId) {
-        connection.send({
-          type: 'permission_response',
-          sessionId: parserState.currentSessionId,
-          permId,
-          decision,
-        });
-      }
+      connection.send({
+        type: 'permission_response',
+        sessionId: parserState.currentSessionId ?? null,
+        permId,
+        decision,
+      });
       set({ permissions: { pending: null } });
     },
 
@@ -414,20 +413,21 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
   };
 
-  // Session-scoped events that assign/change the active session — always accepted
-  const SESSION_ASSIGNING_TYPES = new Set(['session_id', 'session_end']);
-
   function wsListener(msg: Record<string, unknown>) {
     const eventSessionId = msg.sessionId as string | undefined;
 
-    // Session-scoped event filtering:
-    // - Global events (no sessionId) always pass through
-    // - Session-assigning events (session_id, session_end) always pass through
-    // - When no active session: only accept globals + session-assigning events
-    // - When active session set: reject events from other sessions
-    if (eventSessionId && !SESSION_ASSIGNING_TYPES.has(msg.type as string)) {
-      if (!parserState.currentSessionId) return;
-      if (eventSessionId !== parserState.currentSessionId) return;
+    // Session-scoped event filtering for multiplexed v2 connections:
+    // - No sessionId on the event → global (task_state, inbox_updated, etc.) → always accept
+    // - sessionId matches currentSessionId → accept
+    // - No active session AND event is session_id/session_end → accept (new session assignment)
+    // - Otherwise → drop (foreign session event)
+    if (eventSessionId) {
+      if (parserState.currentSessionId) {
+        if (eventSessionId !== parserState.currentSessionId) return;
+      } else {
+        const isAssignment = msg.type === 'session_id' || msg.type === 'session_end';
+        if (!isAssignment) return;
+      }
     }
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -34,8 +34,8 @@ import { parseServerMessage } from './protocol-parser.js';
 import type { ProtocolParserState, ProtocolCallbacks } from './protocol-parser.js';
 import type { WsMsg } from './server-messages.js';
 import { MitzoApiClient } from './api-client.js';
-import { WsPool } from './ws-connection.js';
-import type { WsPoolConfig } from './ws-connection.js';
+import { MitzoConnection } from './connection.js';
+import type { MitzoConnectionConfig } from './connection.js';
 
 // ─── Store state ─────────────────────────────────────────────────────────────
 
@@ -83,7 +83,7 @@ export interface MitzoStoreState {
 
 export interface MitzoStoreOptions {
   transport: TransportAdapter;
-  wsConfig: WsPoolConfig;
+  wsConfig: MitzoConnectionConfig;
 }
 
 // ─── Tree helpers ───────────────────────────────────────────────────────────
@@ -117,21 +117,12 @@ function removeTaskFromTree(tasks: Task[], id: string): Task[] {
 
 export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStoreState> {
   const api = new MitzoApiClient(options.transport.fetch.bind(options.transport));
-  const wsPool = new WsPool(options.wsConfig);
+  const connection = new MitzoConnection(options.wsConfig);
 
-  // Protocol parser state — mutable, shared across all messages
   const parserState: ProtocolParserState = {
     currentSessionId: undefined,
     pendingSend: null,
   };
-
-  // Track the actual WS pool key so wsListener routes to the correct entry
-  let activePoolKey: string | null = null;
-
-  // Unsubscribe handle for the current WS subscription — called when
-  // switching sessions or starting a new one so old session messages
-  // don't leak into the new session's state.
-  let activeUnsub: (() => void) | null = null;
 
   const store = createStore<MitzoStoreState>((set, get) => ({
     // ── Initial state ────────────────────────────────────────────────────
@@ -155,20 +146,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     async switchSession(id: string) {
-      // Unsubscribe the listener so old events stop hitting the store,
-      // then defuse the pool entry so it won't reattach on reconnect
-      // (wasRunning=false prevents the reattach handshake that causes bleed).
-      activeUnsub?.();
-      if (activePoolKey) {
-        wsPool.setRunning(activePoolKey, false);
-        wsPool.removeIfIdle(activePoolKey);
-      }
-
       parserState.currentSessionId = id;
-      const poolKey = `session:${id}`;
-      activePoolKey = poolKey;
 
-      // Reset messages state for new session
       set((s) => ({
         sessions: { ...s.sessions, active: id },
         messages: INITIAL_MESSAGES_STATE,
@@ -176,10 +155,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         tokens: INITIAL_TOKENS_STATE,
       }));
 
-      // Subscribe to WS messages for this session
-      activeUnsub = wsPool.subscribe(poolKey, wsListener);
+      // v2: send switch_session for token hydration + server-side active tracking
+      connection.send({ type: 'switch_session', sessionId: id });
 
-      // Load session messages
       try {
         const msgs = await api.getSessionMessages(id);
         if (Array.isArray(msgs) && msgs.length > 0) {
@@ -193,14 +171,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     newSession() {
-      activeUnsub?.();
-      if (activePoolKey) {
-        wsPool.setRunning(activePoolKey, false);
-        wsPool.removeIfIdle(activePoolKey);
-      }
-      activeUnsub = null;
-      activePoolKey = null;
       parserState.currentSessionId = undefined;
+      parserState.pendingSend = null;
+      connection.send({ type: 'switch_session', sessionId: null });
       set({
         sessions: { ...get().sessions, active: null },
         messages: INITIAL_MESSAGES_STATE,
@@ -209,21 +182,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     sendMessage(text: string, opts?: SendMessageOptions) {
-      const poolKey = parserState.currentSessionId
-        ? `session:${parserState.currentSessionId}`
-        : null;
       const clientMsgId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-      // Capture whether a turn is in-flight BEFORE we dispatch USER_SEND.
-      // USER_SEND flips messages.running to true so the composer can show
-      // the stop button — if we read running after dispatching, every
-      // follow-up would incorrectly look like it arrived mid-turn and get
-      // silently queued in parserState.pendingSend forever.
       const wasRunning = get().messages.running;
 
       const buildPayload = (): Record<string, unknown> => {
         const msg: Record<string, unknown> = {
           type: 'send',
+          sessionId: parserState.currentSessionId ?? null,
           prompt: text,
           clientMsgId,
         };
@@ -231,7 +196,6 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         const mode = opts?.mode ?? get().config.mode;
         if (model) msg.model = model;
         if (mode) msg.mode = mode;
-        if (parserState.currentSessionId) msg.resume = parserState.currentSessionId;
         if (opts?.contextBlocks?.length) msg.contextBlocks = opts.contextBlocks;
         if (opts?.images?.length) {
           msg.images = opts.images.map((img) => ({ data: img.data, mediaType: img.mediaType }));
@@ -241,7 +205,6 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         return msg;
       };
 
-      // Optimistic update
       set((s) => ({
         messages: messagesReducer(s.messages, {
           type: 'USER_SEND',
@@ -253,30 +216,12 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         sendError: null,
       }));
 
-      // For new sessions, subscribe first so the pool entry exists
-      if (!poolKey) {
-        activeUnsub?.();
-        const newKey = `new:${Date.now()}`;
-        activePoolKey = newKey;
-        activeUnsub = wsPool.subscribe(newKey, wsListener);
-        wsPool.setRunning(newKey, true);
-
-        const sent = wsPool.send(newKey, buildPayload());
-        if (!sent) {
-          set({ sendError: 'Not connected. Message will be sent when reconnected.' });
-        }
-        return;
-      }
-
       const msg = buildPayload();
 
-      // If a turn was already running when the user hit send, queue the
-      // payload and flush it once the server signals session_end.
       if (wasRunning) {
         parserState.pendingSend = msg;
       } else {
-        wsPool.setRunning(poolKey, true);
-        const sent = wsPool.send(poolKey, msg);
+        const sent = connection.send(msg);
         if (!sent) {
           set({ sendError: 'Not connected. Message will be sent when reconnected.' });
         }
@@ -284,15 +229,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     interruptMessage(text: string, opts?: SendMessageOptions) {
-      const poolKey = parserState.currentSessionId
-        ? `session:${parserState.currentSessionId}`
-        : null;
-      if (!poolKey || !get().messages.running) return;
+      if (!parserState.currentSessionId || !get().messages.running) return;
 
       const clientMsgId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
       const msg: Record<string, unknown> = {
         type: 'interrupt',
+        sessionId: parserState.currentSessionId,
         prompt: text,
         clientMsgId,
       };
@@ -301,7 +244,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }
       if (opts?.contextBlocks?.length) msg.contextBlocks = opts.contextBlocks;
 
-      const sent = wsPool.send(poolKey, msg);
+      const sent = connection.send(msg);
       if (!sent) {
         set({ sendError: 'Not connected. Interrupt was not delivered.' });
         return;
@@ -319,21 +262,16 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     stopGeneration() {
-      const poolKey = parserState.currentSessionId
-        ? `session:${parserState.currentSessionId}`
-        : null;
-      if (poolKey) {
-        wsPool.send(poolKey, { type: 'interrupt' });
+      if (parserState.currentSessionId) {
+        connection.send({ type: 'stop', sessionId: parserState.currentSessionId });
       }
     },
 
     respondToPermission(permId: string, decision: 'once' | 'always' | 'deny') {
-      const poolKey = parserState.currentSessionId
-        ? `session:${parserState.currentSessionId}`
-        : null;
-      if (poolKey) {
-        wsPool.send(poolKey, {
+      if (parserState.currentSessionId) {
+        connection.send({
           type: 'permission_response',
+          sessionId: parserState.currentSessionId,
           permId,
           decision,
         });
@@ -342,11 +280,12 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     setMode(mode: MitzoMode) {
-      const poolKey = parserState.currentSessionId
-        ? `session:${parserState.currentSessionId}`
-        : null;
-      if (poolKey) {
-        wsPool.send(poolKey, { type: 'set_mode', mode });
+      if (parserState.currentSessionId) {
+        connection.send({
+          type: 'set_mode',
+          sessionId: parserState.currentSessionId,
+          mode,
+        });
       }
       set((s) => ({
         config: { ...s.config, mode },
@@ -415,13 +354,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
   }));
 
   // ── WS → store wiring ──────────────────────────────────────────────────
-  // Central listener: routes every WS message through the protocol parser
-  // and dispatches resulting actions into the store.
 
   const callbacks: ProtocolCallbacks = {
     onSessionAssigned(sessionId: string) {
       parserState.currentSessionId = sessionId;
-      activePoolKey = `session:${sessionId}`;
       store.setState((s) => ({
         sessions: { ...s.sessions, active: sessionId },
       }));
@@ -430,6 +366,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     onSessionExpired() {
       parserState.currentSessionId = undefined;
+      parserState.pendingSend = null;
       store.setState((s) => ({
         sessions: { ...s.sessions, active: null },
         messages: INITIAL_MESSAGES_STATE,
@@ -459,28 +396,48 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       return api.getSessionMessages(sessionId);
     },
 
-    setWsRunning(poolKey: string, running: boolean) {
-      wsPool.setRunning(poolKey, running);
+    onSendQueued(msg: Record<string, unknown>) {
+      connection.send(msg);
     },
 
-    sendQueued(poolKey: string, msg: unknown) {
-      wsPool.send(poolKey, msg);
+    onTokensHydrated(tokens: Record<string, unknown>) {
+      store.setState((s) => ({
+        tokens: {
+          ...s.tokens,
+          sessionTotal:
+            ((tokens.input as number) ?? 0) +
+            ((tokens.output as number) ?? 0) +
+            ((tokens.cacheRead as number) ?? 0) +
+            ((tokens.cacheCreation as number) ?? 0),
+        },
+      }));
     },
   };
 
-  function wsListener(wsMsg: WsMsg) {
-    const poolKey = activePoolKey ?? 'default';
+  // Session-scoped events that assign/change the active session — always accepted
+  const SESSION_ASSIGNING_TYPES = new Set(['session_id', 'session_end']);
 
-    const result = parseServerMessage(wsMsg, parserState, callbacks, poolKey);
+  function wsListener(msg: Record<string, unknown>) {
+    const eventSessionId = msg.sessionId as string | undefined;
 
-    // Dispatch messages actions
+    // Session-scoped event filtering:
+    // - Global events (no sessionId) always pass through
+    // - Session-assigning events (session_id, session_end) always pass through
+    // - When no active session: only accept globals + session-assigning events
+    // - When active session set: reject events from other sessions
+    if (eventSessionId && !SESSION_ASSIGNING_TYPES.has(msg.type as string)) {
+      if (!parserState.currentSessionId) return;
+      if (eventSessionId !== parserState.currentSessionId) return;
+    }
+
+    const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
+
     for (const action of result.messagesActions) {
       store.setState((s) => ({
         messages: messagesReducer(s.messages, action),
       }));
     }
 
-    // Dispatch tasks update
     if (result.tasksUpdate) {
       switch (result.tasksUpdate.type) {
         case 'task_state':
@@ -513,21 +470,18 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       }
     }
 
-    // Token update
     if (result.tokensUpdate) {
       store.setState((s) => ({
         tokens: { ...s.tokens, ...result.tokensUpdate },
       }));
     }
 
-    // Connection update
     if (result.connectionUpdate) {
       store.setState((s) => ({
         connection: { ...s.connection, ...result.connectionUpdate },
       }));
     }
 
-    // Inbox refresh
     if (result.inboxRefresh) {
       api
         .getInbox()
@@ -538,6 +492,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       store.getState().refreshSessions();
     }
   }
+
+  connection.onMessage(wsListener);
+  connection.connect();
 
   return store;
 }


### PR DESCRIPTION
## Summary

- Replace per-session `WsPool` (one WS per session key) with a single `MitzoConnection` that speaks v2 protocol: `hello`/`welcome` handshake, `reconnect` with per-session seq replay, pending send queue
- Rewrite store to use `MitzoConnection` — no more `activePoolKey`, `activeUnsub`, per-session subscriptions. All outbound messages include `sessionId` (null for new sessions). Session isolation via `sessionId` filtering in `wsListener` instead of WS unsubscribe
- Update protocol parser with `welcome`, `reconnected`, `session_switched` handlers; v1 handlers kept for backward compat
- `stopGeneration` sends v2 `stop` (not `interrupt`); all actions include `sessionId`

## Files changed

| File | Change |
|------|--------|
| `packages/client/src/connection.ts` | **New** — `MitzoConnection` class |
| `packages/client/__tests__/connection.test.ts` | **New** — 16 tests |
| `packages/client/src/store.ts` | Rewritten for `MitzoConnection` |
| `packages/client/__tests__/store.test.ts` | Rewritten for v2 (61 tests) |
| `packages/client/src/protocol-parser.ts` | v2 handlers added |
| `packages/client/src/index.ts` | Export `MitzoConnection` |
| `frontend/src/client-store.ts` | Remove `reconnectPollMs` |

## Test plan

- [x] MitzoConnection: hello handshake, send/queue, seq tracking, reconnect with replay, disconnect (16 tests)
- [x] Store v2: session switch, new session, send with sessionId, session isolation via filtering, queued sends, task/error dispatch, permissions, session expired recovery (61 tests)
- [x] Protocol parser: existing tests pass (backward compat), new v2 events handled
- [x] Full suite: 1733 tests pass, 0 lint errors, type checks pass (server + frontend)


Made with [Cursor](https://cursor.com)