### PR TITLE
docs: add Jaeger observability section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,15 @@ Web-based command center for Claude Code sessions via the Agent SDK. Two npm pro
 - `FileViewer` fetches git info on mount, shows branch pill, worktree selector bar when worktrees exist.
 - Markdown files have an Edit button — toggles to a full-height textarea with Save/Cancel and unsaved-changes guards.
 
+**Observability (Jaeger):**
+
+- OpenTelemetry tracing via `server/tracing.ts`, opt-in when `OTEL_EXPORTER_OTLP_ENDPOINT` is set
+- Jaeger UI at http://localhost:16686, service name: "mitzo"
+- Currently instrumented: `ws.switch_session`, `ws.send`, `ws.reconnect` (all in `ws-handler-v2.ts`)
+- Query traces via Jaeger API: `curl http://localhost:16686/api/traces?service=mitzo&operation=<op>`
+- Deep instrumentation roadmap in `docs/design/otel-deep-instrumentation.md`
+- When debugging session/streaming issues, check Jaeger first — it shows routing decisions, timing, and errors
+
 **MCP integration:**
 
 - On startup, `loadMcpServers()` reads `~/.cursor/mcp.json` (or `MCP_CONFIG_PATH`).


### PR DESCRIPTION
## Summary
- Adds an **Observability (Jaeger)** section to CLAUDE.md so future sessions know tracing exists
- Documents the Jaeger UI URL, service name, instrumented spans, API query pattern, and the design doc pointer
- Key guidance: check Jaeger first when debugging session/streaming/WS issues

## Context
Discovered during investigation of a session-switching streaming bug — Jaeger traces immediately confirmed the root cause (switch_session spans doing no replay/snapshot). This capability was undocumented, so future sessions had no way to know it was available.

## Test plan
- [x] CLAUDE.md renders correctly
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)