### PR TITLE
fix: reconcile orphaned sessions between SDK and EventStore

### DIFF
--- a/packages/protocol/__tests__/event-store.test.ts
+++ b/packages/protocol/__tests__/event-store.test.ts
@@ -318,6 +318,46 @@ describe('EventStore', () => {
     });
   });
 
+  describe('getKnownSessionIds', () => {
+    it('returns empty set for empty input', () => {
+      expect(store.getKnownSessionIds([])).toEqual(new Set());
+    });
+
+    it('returns empty set when none of the IDs exist', () => {
+      expect(store.getKnownSessionIds(['a', 'b', 'c'])).toEqual(new Set());
+    });
+
+    it('returns only IDs that exist in the store', () => {
+      store.upsertSession({ sessionId: 'sess-1' });
+      store.upsertSession({ sessionId: 'sess-3' });
+
+      const result = store.getKnownSessionIds(['sess-1', 'sess-2', 'sess-3', 'sess-4']);
+      expect(result).toEqual(new Set(['sess-1', 'sess-3']));
+    });
+
+    it('returns all IDs when all exist', () => {
+      store.upsertSession({ sessionId: 'a' });
+      store.upsertSession({ sessionId: 'b' });
+
+      expect(store.getKnownSessionIds(['a', 'b'])).toEqual(new Set(['a', 'b']));
+    });
+
+    it('handles large batches via chunking', () => {
+      const ids: string[] = [];
+      for (let i = 0; i < 600; i++) {
+        const id = `sess-${i}`;
+        ids.push(id);
+        if (i % 2 === 0) store.upsertSession({ sessionId: id });
+      }
+      const result = store.getKnownSessionIds(ids);
+      expect(result.size).toBe(300);
+      expect(result.has('sess-0')).toBe(true);
+      expect(result.has('sess-1')).toBe(false);
+      expect(result.has('sess-598')).toBe(true);
+      expect(result.has('sess-599')).toBe(false);
+    });
+  });
+
   describe('close', () => {
     it('is safe to call multiple times', () => {
       store.close();

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -261,13 +261,14 @@ export class EventStore {
       );
     } else {
       this.db!.prepare(
-        'INSERT INTO sessions (session_id, summary, branch, cwd, mode, initial_prompt, wt_id, goal_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO sessions (session_id, summary, branch, cwd, mode, is_active, initial_prompt, wt_id, goal_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
       ).run(
         meta.sessionId,
         meta.summary ?? null,
         meta.branch ?? null,
         meta.cwd ?? null,
         meta.mode ?? 'agent',
+        meta.isActive === false ? 0 : 1,
         meta.initialPrompt ?? null,
         meta.wtId ?? null,
         meta.goalId ?? null,
@@ -282,15 +283,21 @@ export class EventStore {
 
   /**
    * Return the subset of `sessionIds` that already exist in the sessions table.
-   * Single query regardless of input size — used for batch reconciliation.
+   * Batches into chunks of 500 to stay within SQLite's SQLITE_MAX_VARIABLE_NUMBER.
    */
   getKnownSessionIds(sessionIds: string[]): Set<string> {
     if (sessionIds.length === 0) return new Set();
-    const placeholders = sessionIds.map(() => '?').join(',');
-    const rows = this.db!.prepare(
-      `SELECT session_id FROM sessions WHERE session_id IN (${placeholders})`,
-    ).all(...sessionIds) as Array<{ session_id: string }>;
-    return new Set(rows.map((r) => r.session_id));
+    const CHUNK = 500;
+    const result = new Set<string>();
+    for (let i = 0; i < sessionIds.length; i += CHUNK) {
+      const chunk = sessionIds.slice(i, i + CHUNK);
+      const placeholders = chunk.map(() => '?').join(',');
+      const rows = this.db!.prepare(
+        `SELECT session_id FROM sessions WHERE session_id IN (${placeholders})`,
+      ).all(...chunk) as Array<{ session_id: string }>;
+      for (const r of rows) result.add(r.session_id);
+    }
+    return result;
   }
 
   listSessions(limit?: number): SessionMeta[] {

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -280,6 +280,19 @@ export class EventStore {
     return row ? rowToSession(row) : null;
   }
 
+  /**
+   * Return the subset of `sessionIds` that already exist in the sessions table.
+   * Single query regardless of input size — used for batch reconciliation.
+   */
+  getKnownSessionIds(sessionIds: string[]): Set<string> {
+    if (sessionIds.length === 0) return new Set();
+    const placeholders = sessionIds.map(() => '?').join(',');
+    const rows = this.db!.prepare(
+      `SELECT session_id FROM sessions WHERE session_id IN (${placeholders})`,
+    ).all(...sessionIds) as Array<{ session_id: string }>;
+    return new Set(rows.map((r) => r.session_id));
+  }
+
   listSessions(limit?: number): SessionMeta[] {
     const rows =
       limit != null ? this.stmts.listSessionsLimited.all(limit) : this.stmts.listSessions.all();

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,6 +16,7 @@ echo "Installing launchd plist..."
 sed "s|__MITZO_HOME__|${MITZO_HOME}|g" com.mitzo.server.plist > "$PLIST_DEST"
 
 echo "Restarting service..."
+# kickstart -k sends SIGTERM and waits for termination before restarting.
 launchctl kickstart -k "gui/$(id -u)/com.mitzo.server"
 
 echo "Deployed and restarted."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,6 +13,6 @@ for f in "$LOGDIR/server-stdout.log" "$LOGDIR/server-stderr.log"; do
 done
 
 # Prune rotated logs older than 7 days
-find "$LOGDIR" -name 'server-*.2*.log' -mtime +7 -delete 2>/dev/null || true
+find "$LOGDIR" -name 'server-std*.????????-??????.log' -mtime +7 -delete 2>/dev/null || true
 
 exec node dist/index.js

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 cd "$(dirname "$0")/.."
+
+LOGDIR="logs"
+mkdir -p "$LOGDIR"
+
+# Rotate previous logs before starting (launchd truncates StandardOutPath
+# on each process start, so we preserve the old log here instead).
+for f in "$LOGDIR/server-stdout.log" "$LOGDIR/server-stderr.log"; do
+  if [ -s "$f" ]; then
+    mv "$f" "${f%.log}.$(date +%Y%m%d-%H%M%S).log"
+  fi
+done
+
+# Prune rotated logs older than 7 days
+find "$LOGDIR" -name 'server-*.2*.log' -mtime +7 -delete 2>/dev/null || true
+
 exec node dist/index.js

--- a/server/__tests__/discover-session.test.ts
+++ b/server/__tests__/discover-session.test.ts
@@ -132,7 +132,7 @@ describe('getSessions reconciliation', () => {
     mockGetKnownSessionIds.mockReturnValue(new Set(['sess-known']));
 
     const { getSessions } = await import('../chat.js');
-    await getSessions();
+    const result = await getSessions();
 
     expect(mockGetKnownSessionIds).toHaveBeenCalled();
     expect(mockUpsertSession).toHaveBeenCalledTimes(1);
@@ -142,7 +142,13 @@ describe('getSessions reconciliation', () => {
         summary: 'Orphan',
         cwd: '/projects/bar',
         branch: 'feat',
+        isActive: false,
       }),
     );
+
+    // Backfilled sessions should appear in the returned list
+    const ids = result.sessions.map((s: { id: string }) => s.id);
+    expect(ids).toContain('sess-orphan');
+    expect(ids).toContain('sess-known');
   });
 });

--- a/server/__tests__/discover-session.test.ts
+++ b/server/__tests__/discover-session.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetSessionInfo = vi.fn();
+const mockUpsertSession = vi.fn();
+const mockGetSession = vi.fn();
+const mockGetKnownSessionIds = vi.fn();
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+  listSessions: vi.fn().mockResolvedValue([]),
+  getSessionInfo: (...args: unknown[]) => mockGetSessionInfo(...args),
+  getSessionMessages: vi.fn().mockResolvedValue([]),
+  renameSession: vi.fn(),
+}));
+
+const mockEventStore = {
+  upsertSession: mockUpsertSession,
+  getSession: mockGetSession,
+  getKnownSessionIds: mockGetKnownSessionIds,
+  listSessions: vi.fn().mockReturnValue([]),
+  getEventsAfter: vi.fn().mockReturnValue([]),
+  getSessionEvents: vi.fn().mockReturnValue([]),
+  markSessionInactive: vi.fn(),
+  hideSession: vi.fn(),
+  incrementPromptCount: vi.fn().mockReturnValue(1),
+  recordUsage: vi.fn(),
+  markManuallyRenamed: vi.fn(),
+  append: vi.fn().mockReturnValue(1),
+};
+
+class FakeEventStore {
+  constructor() {
+    return mockEventStore;
+  }
+}
+
+vi.mock('@mitzo/protocol/event-store', () => ({
+  EventStore: FakeEventStore,
+}));
+
+vi.mock('../repo-config.js', () => ({
+  loadRepoConfig: vi.fn().mockReturnValue({ repos: {}, roots: [] }),
+}));
+
+vi.mock('../mcp-config.js', () => ({
+  loadMcpServers: vi.fn().mockReturnValue({}),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('discoverSession', () => {
+  it('returns backfilled SessionMeta when SDK finds the session', async () => {
+    mockGetSessionInfo.mockResolvedValue({
+      sessionId: 'sess-orphan',
+      summary: 'Orphaned session',
+      cwd: '/projects/foo',
+      gitBranch: 'main',
+      lastModified: Date.now(),
+    });
+    mockGetSession.mockReturnValue({
+      sessionId: 'sess-orphan',
+      summary: 'Orphaned session',
+      cwd: '/projects/foo',
+      branch: 'main',
+      mode: 'agent',
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+    });
+
+    const { discoverSession } = await import('../chat.js');
+    const result = await discoverSession('sess-orphan');
+
+    expect(mockGetSessionInfo).toHaveBeenCalledWith('sess-orphan');
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-orphan',
+        cwd: '/projects/foo',
+        branch: 'main',
+      }),
+    );
+    expect(result).toBeTruthy();
+    expect(result!.sessionId).toBe('sess-orphan');
+  });
+
+  it('returns null when SDK does not find the session', async () => {
+    mockGetSessionInfo.mockResolvedValue(undefined);
+
+    const { discoverSession } = await import('../chat.js');
+    const result = await discoverSession('sess-gone');
+
+    expect(mockGetSessionInfo).toHaveBeenCalledWith('sess-gone');
+    expect(mockUpsertSession).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('returns null and logs warning when SDK throws', async () => {
+    mockGetSessionInfo.mockRejectedValue(new Error('SDK exploded'));
+
+    const { discoverSession } = await import('../chat.js');
+    const result = await discoverSession('sess-boom');
+
+    expect(result).toBeNull();
+    expect(mockUpsertSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('getSessions reconciliation', () => {
+  it('backfills EventStore for sessions the SDK knows but EventStore does not', async () => {
+    const mockListSessions = (await import('@anthropic-ai/claude-agent-sdk'))
+      .listSessions as ReturnType<typeof vi.fn>;
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-known',
+        summary: 'Known',
+        lastModified: 1000,
+        cwd: '/projects/foo',
+        gitBranch: 'main',
+      },
+      {
+        sessionId: 'sess-orphan',
+        summary: 'Orphan',
+        lastModified: 2000,
+        cwd: '/projects/bar',
+        gitBranch: 'feat',
+      },
+    ]);
+    mockGetKnownSessionIds.mockReturnValue(new Set(['sess-known']));
+
+    const { getSessions } = await import('../chat.js');
+    await getSessions();
+
+    expect(mockGetKnownSessionIds).toHaveBeenCalled();
+    expect(mockUpsertSession).toHaveBeenCalledTimes(1);
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-orphan',
+        summary: 'Orphan',
+        cwd: '/projects/bar',
+        branch: 'feat',
+      }),
+    );
+  });
+});

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -9,6 +9,7 @@ vi.mock('../chat.js', () => ({
   stopChat: vi.fn(),
   isActive: vi.fn().mockReturnValue(false),
   BASE_REPO: '/tmp/test-repo',
+  discoverSession: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../app.js', () => ({
@@ -26,7 +27,7 @@ vi.mock('../skill-policy.js', () => ({
   clearSkillPolicy: vi.fn(),
 }));
 
-import { startChat, interruptChat, sendToChat, isActive } from '../chat.js';
+import { startChat, interruptChat, sendToChat, isActive, discoverSession } from '../chat.js';
 import { setSkillPolicy } from '../skill-policy.js';
 import { resolveSlashCommand } from '../slash-commands.js';
 
@@ -248,7 +249,7 @@ describe('handleUnwatch', () => {
 // ─── handleSwitchSession ─────────────────────────────────────────────────────
 
 describe('handleSwitchSession', () => {
-  it('sets active session and sends session metadata from event store', () => {
+  it('sets active session and sends session metadata from event store', async () => {
     const eventStore = mockEventStore();
     eventStore.getSession.mockReturnValue({
       sessionId: 'sess-1',
@@ -269,7 +270,7 @@ describe('handleSwitchSession', () => {
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
 
-    handleSwitchSession('c1', { type: 'switch_session', sessionId: 'sess-1' }, ctx);
+    await handleSwitchSession('c1', { type: 'switch_session', sessionId: 'sess-1' }, ctx);
 
     expect(ctx.connRegistry.get('c1')!.activeSession).toBe('sess-1');
     const resp = transport.sent[0];
@@ -286,29 +287,68 @@ describe('handleSwitchSession', () => {
     expect(resp).toHaveProperty('tokens');
   });
 
-  it('clears active session when sessionId is null', () => {
+  it('clears active session when sessionId is null', async () => {
     const ctx = createContext();
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
     ctx.connRegistry.setActive('c1', 'sess-old');
 
-    handleSwitchSession('c1', { type: 'switch_session', sessionId: null }, ctx);
+    await handleSwitchSession('c1', { type: 'switch_session', sessionId: null }, ctx);
 
     expect(ctx.connRegistry.get('c1')!.activeSession).toBeNull();
     expect(transport.sent[0]).toEqual(expect.objectContaining({ type: 'session_cleared' }));
   });
 
-  it('sends error for unknown session', () => {
+  it('sends error for unknown session when SDK discovery also fails', async () => {
     const ctx = createContext();
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
 
-    handleSwitchSession('c1', { type: 'switch_session', sessionId: 'nope' }, ctx);
+    await handleSwitchSession('c1', { type: 'switch_session', sessionId: 'nope' }, ctx);
 
+    expect(discoverSession).toHaveBeenCalledWith('nope');
     expect(transport.sent[0]).toEqual(
       expect.objectContaining({
         type: 'error',
         error: expect.stringContaining('nope'),
+      }),
+    );
+  });
+
+  it('falls back to SDK discovery when EventStore misses, then succeeds', async () => {
+    const eventStore = mockEventStore();
+    // First call: not found. Second call (after backfill): found.
+    eventStore.getSession.mockReturnValueOnce(null).mockReturnValueOnce(null);
+
+    const discoveredMeta = {
+      sessionId: 'orphan-1',
+      mode: 'agent',
+      cwd: '/projects/orphan',
+      branch: 'main',
+      wtId: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      totalCostUsd: 0,
+    };
+
+    (discoverSession as ReturnType<typeof vi.fn>).mockResolvedValueOnce(discoveredMeta);
+
+    const ctx = createContext({
+      eventStore: eventStore as unknown as V2HandlerContext['eventStore'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await handleSwitchSession('c1', { type: 'switch_session', sessionId: 'orphan-1' }, ctx);
+
+    expect(discoverSession).toHaveBeenCalledWith('orphan-1');
+    expect(ctx.connRegistry.get('c1')!.activeSession).toBe('orphan-1');
+    expect(transport.sent[0]).toEqual(
+      expect.objectContaining({
+        type: 'session_switched',
+        sessionId: 'orphan-1',
       }),
     );
   });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1,6 +1,7 @@
 import {
   query,
   listSessions,
+  getSessionInfo,
   getSessionMessages,
   renameSession,
 } from '@anthropic-ai/claude-agent-sdk';
@@ -474,6 +475,18 @@ export async function startChat(
   session.branch = branch;
   send(transport, { type: 'session_info', branch, cwd, worktree: !!worktreePath, wtId });
 
+  // Pre-register resumed sessions in EventStore so they're discoverable
+  // even if the query loop dies before the first assistant event.
+  if (options.resume) {
+    eventStore.upsertSession({
+      sessionId: options.resume,
+      cwd,
+      mode,
+      branch,
+      ...(worktreePath ? { wtId } : {}),
+    });
+  }
+
   // Build session env with worktree paths for the agent
   const sessionEnv = sdkEnv();
   sessionEnv.MITZO_SESSION_ID = wtId;
@@ -826,7 +839,7 @@ export async function renameSessionById(
 export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
   const seen = new Map<
     string,
-    { id: string; summary: string; lastModified: number; branch?: string }
+    { id: string; summary: string; lastModified: number; branch?: string; cwd?: string }
   >();
   // Fetch enough from each dir to cover the requested window after dedup.
   // The SDK handles worktree discovery via includeWorktrees (default true).
@@ -843,6 +856,7 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
             summary: s.summary,
             lastModified: s.lastModified,
             branch: s.gitBranch,
+            cwd: s.cwd ?? dir,
           });
         }
       }
@@ -850,11 +864,56 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
       // Expected when session dir doesn't exist
     }
   }
+
+  // Reconcile: backfill EventStore for SDK-discovered sessions that Mitzo
+  // doesn't track (e.g. sessions orphaned by a server restart mid-query,
+  // or created by external agents in a worktree).
+  for (const [sessionId, entry] of seen) {
+    if (!eventStore.getSession(sessionId)) {
+      eventStore.upsertSession({
+        sessionId,
+        summary: entry.summary || null,
+        cwd: entry.cwd ?? null,
+        branch: entry.branch ?? null,
+      });
+      log.info('reconciled orphaned session', { sessionId });
+    }
+  }
+
   const deduped = Array.from(seen.values());
   deduped.sort((a, b) => b.lastModified - a.lastModified);
   const page = deduped.slice(offset, offset + limit);
   const hasMore = deduped.length > offset + limit;
   return { sessions: page, hasMore };
+}
+
+/**
+ * Look up a single session by ID via the Claude SDK.
+ * Used as a fallback when the EventStore doesn't have the session yet
+ * (e.g. orphaned by a restart or created externally). If found, backfills
+ * the EventStore so subsequent lookups are fast.
+ */
+export async function discoverSession(
+  sessionId: string,
+): Promise<import('./event-store.js').SessionMeta | null> {
+  try {
+    const info = await getSessionInfo(sessionId);
+    if (!info) return null;
+    eventStore.upsertSession({
+      sessionId,
+      summary: info.summary || null,
+      cwd: info.cwd ?? null,
+      branch: info.gitBranch ?? null,
+    });
+    log.info('discovered and backfilled session', { sessionId, cwd: info.cwd });
+    return eventStore.getSession(sessionId);
+  } catch (err: unknown) {
+    log.warn('discoverSession failed', {
+      sessionId,
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+    return null;
+  }
 }
 
 export interface RestoredMessage {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -856,7 +856,7 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
             summary: s.summary,
             lastModified: s.lastModified,
             branch: s.gitBranch,
-            cwd: s.cwd ?? dir,
+            cwd: s.cwd || undefined,
           });
         }
       }
@@ -868,12 +868,13 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
   // Reconcile: backfill EventStore for SDK-discovered sessions that Mitzo
   // doesn't track (e.g. sessions orphaned by a server restart mid-query,
   // or created by external agents in a worktree).
+  const knownIds = eventStore.getKnownSessionIds(Array.from(seen.keys()));
   for (const [sessionId, entry] of seen) {
-    if (!eventStore.getSession(sessionId)) {
+    if (!knownIds.has(sessionId)) {
       eventStore.upsertSession({
         sessionId,
         summary: entry.summary || null,
-        cwd: entry.cwd ?? null,
+        cwd: entry.cwd ?? (BASE_REPO || null),
         branch: entry.branch ?? null,
       });
       log.info('reconciled orphaned session', { sessionId });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -869,6 +869,7 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
   // doesn't track (e.g. sessions orphaned by a server restart mid-query,
   // or created by external agents in a worktree).
   const knownIds = eventStore.getKnownSessionIds(Array.from(seen.keys()));
+  let reconciledCount = 0;
   for (const [sessionId, entry] of seen) {
     if (!knownIds.has(sessionId)) {
       eventStore.upsertSession({
@@ -876,9 +877,13 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
         summary: entry.summary || null,
         cwd: entry.cwd ?? (BASE_REPO || null),
         branch: entry.branch ?? null,
+        isActive: false,
       });
-      log.info('reconciled orphaned session', { sessionId });
+      reconciledCount++;
     }
+  }
+  if (reconciledCount > 0) {
+    log.info('reconciled orphaned sessions', { count: reconciledCount });
   }
 
   const deduped = Array.from(seen.values());
@@ -905,6 +910,7 @@ export async function discoverSession(
       summary: info.summary || null,
       cwd: info.cwd ?? null,
       branch: info.gitBranch ?? null,
+      isActive: false,
     });
     log.info('discovered and backfilled session', { sessionId, cwd: info.cwd });
     return eventStore.getSession(sessionId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -245,12 +245,18 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
     if (ws.readyState === ws.OPEN) ws.ping();
   }, HEARTBEAT_INTERVAL_MS);
 
+  // Per-connection promise chain ensures FIFO ordering even when individual
+  // dispatches are async (e.g. switch_session awaits SDK discovery).
+  let dispatchChain = Promise.resolve();
+
   ws.on('message', (raw) => {
-    dispatchV2Message(connectionId, transport, raw.toString(), v2Ctx).catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      log.warn('v2 message dispatch error', { connectionId, error: message });
-      transport.send({ type: 'error', error: message });
-    });
+    dispatchChain = dispatchChain
+      .then(() => dispatchV2Message(connectionId, transport, raw.toString(), v2Ctx))
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        log.warn('v2 message dispatch error', { connectionId, error: message });
+        transport.send({ type: 'error', error: message });
+      });
   });
 
   ws.on('close', (code, reason) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -246,13 +246,11 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
   }, HEARTBEAT_INTERVAL_MS);
 
   ws.on('message', (raw) => {
-    try {
-      dispatchV2Message(connectionId, transport, raw.toString(), v2Ctx);
-    } catch (err: unknown) {
+    dispatchV2Message(connectionId, transport, raw.toString(), v2Ctx).catch((err: unknown) => {
       const message = err instanceof Error ? err.message : 'Unknown error';
       log.warn('v2 message dispatch error', { connectionId, error: message });
       transport.send({ type: 'error', error: message });
-    }
+    });
   });
 
   ws.on('close', (code, reason) => {

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -35,7 +35,15 @@ type SetModeMsg = z.infer<typeof V2SetModeMessage>;
 import { tracer } from './tracing.js';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { resolvePending } from './permissions.js';
-import { startChat, sendToChat, interruptChat, stopChat, isActive, BASE_REPO } from './chat.js';
+import {
+  startChat,
+  sendToChat,
+  interruptChat,
+  stopChat,
+  isActive,
+  BASE_REPO,
+  discoverSession,
+} from './chat.js';
 import { setSkillPolicy, clearSkillPolicy } from './skill-policy.js';
 import { resolveSlashCommand } from './slash-commands.js';
 import { buildSkillRegistry, isAllowedPath, NATIVE_COMMAND_NAMES } from './app.js';
@@ -164,11 +172,11 @@ export function handleUnwatch(connectionId: string, msg: UnwatchMsg, ctx: V2Hand
   log.info('unwatch', { connectionId, sessionId: msg.sessionId });
 }
 
-export function handleSwitchSession(
+export async function handleSwitchSession(
   connectionId: string,
   msg: SwitchSessionMsg,
   ctx: V2HandlerContext,
-): void {
+): Promise<void> {
   const span = tracer.startSpan('ws.switch_session');
   span.setAttribute('ws.connectionId', connectionId);
   span.setAttribute('ws.sessionId', msg.sessionId ?? 'null');
@@ -182,8 +190,18 @@ export function handleSwitchSession(
       return;
     }
 
-    const sessionMeta = ctx.eventStore.getSession(msg.sessionId);
+    let sessionMeta = ctx.eventStore.getSession(msg.sessionId);
+
+    // Fallback: if EventStore doesn't know the session, try discovering it
+    // via the Claude SDK. This handles sessions orphaned by server restarts
+    // or created by external agents.
     if (!sessionMeta) {
+      span.setAttribute('ws.discovery', 'sdk_fallback');
+      sessionMeta = await discoverSession(msg.sessionId);
+    }
+
+    if (!sessionMeta) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'session not found' });
       ctx.connRegistry.get(connectionId)?.transport.send({
         type: 'error',
         error: `Session not found: ${msg.sessionId}`,
@@ -422,12 +440,12 @@ export function handleSetModeV2(
  * Main v2 message dispatcher. Called for every WS message after hello handshake.
  * Hello is NOT dispatched here — it's handled at the routing layer.
  */
-export function dispatchV2Message(
+export async function dispatchV2Message(
   connectionId: string,
   transport: SessionTransport,
   raw: string,
   ctx: V2HandlerContext,
-): void {
+): Promise<void> {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -461,7 +479,7 @@ export function dispatchV2Message(
       handleUnwatch(connectionId, msg, ctx);
       break;
     case 'switch_session':
-      handleSwitchSession(connectionId, msg, ctx);
+      await handleSwitchSession(connectionId, msg, ctx);
       break;
     case 'send':
       handleSendV2(connectionId, transport, msg, ctx);


### PR DESCRIPTION
## Summary

Fixes the "Session expired" error on mobile when tapping sessions that were orphaned by a server restart mid-query or created by external agents in worktrees.

- **Self-healing EventStore**: `getSessions()` reconciles SDK-discovered sessions into the EventStore using a single batch query (`getKnownSessionIds`), chunked to stay within SQLite variable limits. Backfilled sessions are marked inactive.
- **Resilient `switch_session`**: Falls back to `getSessionInfo()` (targeted SDK lookup) when the EventStore misses, backfills the row, then proceeds. Fixes the missing OTel span status on the not-found path.
- **FIFO dispatch**: Per-connection promise chain in `handleChatWsV2` serializes async dispatch, preventing message reordering when `switch_session` awaits SDK discovery.
- **Early registration on resume**: `startChat()` pre-registers resumed sessions in the EventStore before the query loop starts.
- **Log rotation**: `start.sh` rotates logs before starting so launchd's truncate-on-start doesn't destroy the previous instance's history.

Supersedes #227 (rebased onto main after #222 merged).

## Local CI results

- [x] Build workspace packages — pass
- [x] Lint — pass (1 pre-existing warning in untracked local file)
- [x] Format check — pass
- [x] Type check (server + frontend) — pass
- [x] Tests — 1734 passed (guard: ≥250)
- [x] Full build — pass

## Test plan

- [x] `getKnownSessionIds`: empty, partial, full match, unknown IDs, large batch (600 IDs spanning chunk boundary)
- [x] `discoverSession`: success+backfill, SDK returns null, SDK throws
- [x] `getSessions` reconciliation: verifies orphaned sessions get backfilled with `isActive: false`
- [x] `handleSwitchSession`: SDK fallback succeeds, error when both fail, existing tests updated for async
- [x] All 1734 existing tests pass


Made with [Cursor](https://cursor.com)