### PR TITLE
fix(harness): fire abort signal before clearing closingOut set

### DIFF
--- a/packages/harness/__tests__/session-registry.test.ts
+++ b/packages/harness/__tests__/session-registry.test.ts
@@ -664,6 +664,64 @@ describe('SessionRegistry', () => {
       vi.useRealTimers();
     });
 
+    it('reports isClosingOut=true during direct abort() mid-closeout', () => {
+      vi.useFakeTimers();
+
+      const abort = new AbortController();
+      let closingOutDuringAbort = false;
+      abort.signal.addEventListener('abort', () => {
+        closingOutDuringAbort = registry.isClosingOut('client-1');
+      });
+
+      registry.setCloseoutHandler(() => {});
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to closeout phase
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS + 100);
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      // Direct abort (e.g., user stops session mid-closeout)
+      registry.abort('client-1');
+      expect(abort.signal.aborted).toBe(true);
+      expect(closingOutDuringAbort).toBe(true);
+      expect(registry.isActive('client-1')).toBe(false);
+      expect(registry.isClosingOut('client-1')).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('cleans up closingOut when remove() is called during closeout', () => {
+      vi.useFakeTimers();
+
+      registry.setCloseoutHandler(() => {});
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to closeout phase
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS + 100);
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      // Natural completion during closeout
+      registry.remove('client-1');
+      expect(registry.isClosingOut('client-1')).toBe(false);
+      expect(registry.isActive('client-1')).toBe(false);
+
+      vi.useRealTimers();
+    });
+
     it('falls back to direct abort when no closeout handler is set', () => {
       vi.useFakeTimers();
 

--- a/packages/harness/__tests__/session-registry.test.ts
+++ b/packages/harness/__tests__/session-registry.test.ts
@@ -630,6 +630,40 @@ describe('SessionRegistry', () => {
       vi.useRealTimers();
     });
 
+    it('isClosingOut is true when abort signal fires during closeout', () => {
+      vi.useFakeTimers();
+      const onCloseout = vi.fn();
+      registry.setCloseoutHandler(onCloseout);
+
+      const abort = new AbortController();
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+
+      // Advance to closeout
+      vi.advanceTimersByTime(DETACHED_TTL_MS - CLOSEOUT_LEAD_MS + 100);
+      expect(registry.isClosingOut('client-1')).toBe(true);
+
+      // Listen for the abort signal and capture closingOut state at that moment
+      let closingOutDuringAbort: boolean | undefined;
+      abort.signal.addEventListener('abort', () => {
+        closingOutDuringAbort = registry.isClosingOut('client-1');
+      });
+
+      // Advance through closeout timeout — triggers abort()
+      vi.advanceTimersByTime(CLOSEOUT_TIMEOUT_MS + 100);
+      expect(abort.signal.aborted).toBe(true);
+      // The listener must see isClosingOut=true so it can distinguish abandoned vs closed
+      expect(closingOutDuringAbort).toBe(true);
+
+      vi.useRealTimers();
+    });
+
     it('falls back to direct abort when no closeout handler is set', () => {
       vi.useFakeTimers();
 

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -293,8 +293,10 @@ export class SessionRegistry {
     const session = this.sessions.get(clientId);
     if (session) session.observers.clear();
     this.clearDetachTimer(clientId);
+    this.clearCloseoutTimer(clientId);
     this.sessions.delete(clientId);
     this.attached.delete(clientId);
+    this.closingOut.delete(clientId);
   }
 
   /**

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -142,7 +142,8 @@ export class SessionRegistry {
         // Phase 2: hard abort after CLOSEOUT_TIMEOUT_MS
         const abortTimer = setTimeout(() => {
           this.closeoutTimers.delete(clientId);
-          this.closingOut.delete(clientId);
+          // Don't delete closingOut here — abort() will do it AFTER
+          // firing the abort signal, so listeners can check isClosingOut().
           if (this.sessions.has(clientId) && !this.attached.has(clientId)) {
             log.info(`closeout timeout for ${clientId}, aborting`);
             this.abort(clientId);
@@ -275,11 +276,13 @@ export class SessionRegistry {
 
     this.clearDetachTimer(clientId);
     this.clearCloseoutTimer(clientId);
-    this.closingOut.delete(clientId);
+    // Fire abort signal BEFORE clearing closingOut — abort listeners
+    // check isClosingOut() to distinguish 'abandoned' vs 'closed' status.
     session.abortController.abort();
     session.observers.clear();
     this.sessions.delete(clientId);
     this.attached.delete(clientId);
+    this.closingOut.delete(clientId);
   }
 
   /**


### PR DESCRIPTION
## Summary

- abort() deleted from closingOut before calling abortController.abort(), so abort signal listeners could never observe isClosingOut()=true
- This meant closeoutSession always reported status 'closed', never 'abandoned'
- Reorder: fire the signal first, then clean up

## Test plan

- [x] Added test verifying isClosingOut()=true during abort signal

Made with [Cursor](https://cursor.com)