### PR TITLE
fix(client): guard stopGeneration and respondToPermission against null sessionId

### DIFF
--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -477,7 +477,7 @@ describe('stopGeneration', () => {
     expect(stop!.sessionId).toBe('test-session');
   });
 
-  it('sends stop with null sessionId during first turn before session_id arrives', () => {
+  it('does not send stop before session_id arrives', () => {
     const store = createReadyStore();
     store.getState().sendMessage('hello');
 
@@ -485,8 +485,7 @@ describe('stopGeneration', () => {
 
     const sent = lastWs.parsedSent();
     const stop = sent.find((m) => m.type === 'stop');
-    expect(stop).toBeDefined();
-    expect(stop!.sessionId).toBeNull();
+    expect(stop).toBeUndefined();
   });
 });
 
@@ -519,7 +518,7 @@ describe('respondToPermission', () => {
 });
 
 describe('respondToPermission — first turn edge case', () => {
-  it('sends permission_response with null sessionId when no session is active', () => {
+  it('sends permission_response without sessionId when no session is active', () => {
     const store = createReadyStore();
     store.getState().sendMessage('hello');
 
@@ -537,7 +536,7 @@ describe('respondToPermission — first turn edge case', () => {
     const sent = lastWs.parsedSent();
     const response = sent.find((m) => m.type === 'permission_response');
     expect(response).toBeDefined();
-    expect(response!.sessionId).toBeNull();
+    expect(response).not.toHaveProperty('sessionId');
     expect(response!.permId).toBe('perm-1');
     expect(response!.decision).toBe('once');
   });

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -284,16 +284,17 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     stopGeneration() {
+      if (!parserState.currentSessionId) return;
       connection.send({
         type: 'stop',
-        sessionId: parserState.currentSessionId ?? null,
+        sessionId: parserState.currentSessionId,
       });
     },
 
     respondToPermission(permId: string, decision: 'once' | 'always' | 'deny') {
       connection.send({
         type: 'permission_response',
-        sessionId: parserState.currentSessionId ?? null,
+        ...(parserState.currentSessionId ? { sessionId: parserState.currentSessionId } : {}),
         permId,
         decision,
       });

--- a/packages/protocol/src/ws-schemas-v2.ts
+++ b/packages/protocol/src/ws-schemas-v2.ts
@@ -89,7 +89,7 @@ export const V2StopMessage = z.object({
 
 export const V2PermissionResponseMessage = z.object({
   type: z.literal('permission_response'),
-  sessionId: z.string().min(1),
+  sessionId: z.string().min(1).optional(),
   permId: z.string(),
   decision: z.enum(['once', 'always', 'deny']).optional(),
 });


### PR DESCRIPTION
## Summary

- `stopGeneration` sent `sessionId: null` which `V2StopMessage` rejects (requires non-empty string). Guard with early return — can't stop what we can't find.
- `respondToPermission` had the same issue but server resolves by `permId` not `sessionId`. Made `sessionId` optional in `V2PermissionResponseMessage` schema so first-turn permission responses work.

Found by Centaur review on #230.

## Test plan

- [x] Updated test: stopGeneration before session_id is a no-op (not null send)
- [x] Updated test: respondToPermission omits sessionId field instead of sending null
- [x] All 339 schema/handler tests pass
- [x] All 118 store tests pass

Made with [Cursor](https://cursor.com)