### PR TITLE
fix(server): per-session clientId in v2 to fix active dots

### DIFF
--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -451,7 +451,8 @@ describe('handleSetModeV2', () => {
 // ─── handleSendV2 auto-watch ─────────────────────────────────────────────────
 
 describe('handleSendV2 auto-watch', () => {
-  it('watches + activates the session on the resume path', () => {
+  it('watches + activates the session on the resume path with composite clientId', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
     const sessionReg = mockSessionRegistry();
     // findBySessionId returns a result but isActive returns false → resume path
     sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-driver', session: {} });
@@ -463,9 +464,6 @@ describe('handleSendV2 auto-watch', () => {
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
 
-    // We can't fully test startChat without mocking the Agent SDK, but we can
-    // verify that watch + setActive are called before startChat. The resume
-    // path should ensure the connection is watching the session.
     handleSendV2(
       'c1',
       transport,
@@ -482,9 +480,13 @@ describe('handleSendV2 auto-watch', () => {
     expect(conn).toBeDefined();
     expect(conn!.watchedSessions.has('sess-resume')).toBe(true);
     expect(conn!.activeSession).toBe('sess-resume');
+
+    // startChat should receive composite clientId (connectionId:sessionId)
+    const callArgs = (startChat as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[1]).toBe('c1:sess-resume');
   });
 
-  it('passes onSessionResolved callback to startChat on the create path', () => {
+  it('passes onSessionResolved callback and uses unique composite clientId on create path', () => {
     (startChat as ReturnType<typeof vi.fn>).mockClear();
     const ctx = createContext();
     const transport = mockTransport();
@@ -506,6 +508,10 @@ describe('handleSendV2 auto-watch', () => {
     const callArgs = (startChat as ReturnType<typeof vi.fn>).mock.calls[0];
     const options = callArgs[3];
     expect(options.onSessionResolved).toBeTypeOf('function');
+
+    // clientId should be composite: connectionId:new-<uuid>
+    const clientId = callArgs[1] as string;
+    expect(clientId).toMatch(/^c1:new-[0-9a-f]{8}$/);
 
     // Simulate the callback firing — should watch + activate
     options.onSessionResolved('sess-new');
@@ -622,6 +628,43 @@ describe('handleSendV2 skill policy', () => {
       undefined,
       'cmsg-sp',
     );
+  });
+
+  it('calls setSkillPolicy with composite clientId on resume path', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+    (setSkillPolicy as ReturnType<typeof vi.fn>).mockClear();
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      type: 'skill',
+      name: 'test-skill',
+      renderedPrompt: 'rendered prompt',
+      allowedTools: ['Read'],
+      arguments: '',
+    });
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-driver', session: {} });
+    sessionReg.isActive.mockReturnValue(false);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      {
+        type: 'send' as const,
+        sessionId: 'sess-resume',
+        prompt: '/test-skill',
+        clientMsgId: 'cmsg-sp2',
+      },
+      ctx,
+    );
+
+    // Resume path uses composite clientId
+    expect(setSkillPolicy).toHaveBeenCalledWith(expect.anything(), 'c1:sess-resume', ['Read']);
   });
 });
 

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -347,11 +347,14 @@ export function handleSendV2(
         return;
       }
 
-      // Session exists in store but no active driver — start with resume
+      // Session exists in store but no active driver — start with resume.
+      // Use a per-session clientId so multiple sessions from the same v2
+      // connection each get their own registry entry (prevents overwrites).
+      const sessionClientId = `${connectionId}:${sessionId}`;
       ctx.connRegistry.watch(connectionId, sessionId);
       ctx.connRegistry.setActive(connectionId, sessionId);
       span.setAttribute('routing.decision', 'resume');
-      startChat(transport, connectionId, prompt, {
+      startChat(transport, sessionClientId, prompt, {
         resume: sessionId,
         cwd: msg.cwd,
         model: msg.model,
@@ -361,17 +364,17 @@ export function handleSendV2(
         contextBlocks: msg.contextBlocks,
         clientMsgId: msg.clientMsgId,
       });
-      // startChat registers under connectionId — safe to apply now
-      applySkillPolicy(connectionId);
+      applySkillPolicy(sessionClientId);
     } else {
-      // null sessionId — new session. Supply onSessionResolved so the
-      // connection auto-watches once the SDK resolves the session ID.
+      // null sessionId — new session. Use a unique clientId so concurrent
+      // new-session starts don't collide in the registry.
+      const newClientId = `${connectionId}:new-${Date.now()}`;
       span.setAttribute('routing.decision', 'create');
       const onSessionResolved = (resolvedId: string) => {
         ctx.connRegistry.watch(connectionId, resolvedId);
         ctx.connRegistry.setActive(connectionId, resolvedId);
       };
-      startChat(transport, connectionId, prompt, {
+      startChat(transport, newClientId, prompt, {
         cwd: msg.cwd,
         model: msg.model,
         extraTools: msg.extraTools,
@@ -381,8 +384,7 @@ export function handleSendV2(
         clientMsgId: msg.clientMsgId,
         onSessionResolved,
       });
-      // startChat registers under connectionId — safe to apply now
-      applySkillPolicy(connectionId);
+      applySkillPolicy(newClientId);
     }
 
     span.setStatus({ code: SpanStatusCode.OK });

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -32,6 +32,7 @@ type StopMsg = z.infer<typeof V2StopMessage>;
 type InterruptMsg = z.infer<typeof V2InterruptMessage>;
 type PermissionMsg = z.infer<typeof V2PermissionResponseMessage>;
 type SetModeMsg = z.infer<typeof V2SetModeMessage>;
+import { randomUUID } from 'crypto';
 import { tracer } from './tracing.js';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { resolvePending } from './permissions.js';
@@ -368,13 +369,13 @@ export function handleSendV2(
     } else {
       // null sessionId — new session. Use a unique clientId so concurrent
       // new-session starts don't collide in the registry.
-      const newClientId = `${connectionId}:new-${Date.now()}`;
+      const sessionClientId = `${connectionId}:new-${randomUUID().slice(0, 8)}`;
       span.setAttribute('routing.decision', 'create');
       const onSessionResolved = (resolvedId: string) => {
         ctx.connRegistry.watch(connectionId, resolvedId);
         ctx.connRegistry.setActive(connectionId, resolvedId);
       };
-      startChat(transport, newClientId, prompt, {
+      startChat(transport, sessionClientId, prompt, {
         cwd: msg.cwd,
         model: msg.model,
         extraTools: msg.extraTools,
@@ -384,7 +385,7 @@ export function handleSendV2(
         clientMsgId: msg.clientMsgId,
         onSessionResolved,
       });
-      applySkillPolicy(newClientId);
+      applySkillPolicy(sessionClientId);
     }
 
     span.setStatus({ code: SpanStatusCode.OK });


### PR DESCRIPTION
## Summary

- `handleSendV2` was passing the shared `connectionId` as `clientId` to `startChat`, causing `registry.register()` to overwrite the previous session when the user switched between sessions on the same v2 connection
- `getActiveSessions()` returned at most one session per connection, so the home screen active dots were broken (no dots showed)
- Generate unique per-session keys (`connectionId:sessionId` for resume, `connectionId:new-<ts>` for create) so each session gets its own registry entry
- All downstream lookups use `findBySessionId()` which searches by sessionId, not clientId, so they remain correct

## Test plan

- [x] All 121 ws-handler-v2 tests pass
- [x] All 1700+ relevant server tests pass
- [ ] Deploy and verify active dots appear on mobile home screen for multiple concurrent sessions
- [ ] Verify dots show green (attached) during active query and orange (detached) after WS reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)