### PR TITLE
feat: capacitor phase 4 — status bar, safe area, push notifications

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content, viewport-fit=cover"
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/frontend/ios/App/CapApp-SPM/Package.swift
+++ b/frontend/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,20 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.1"),
+        .package(name: "CapacitorApp", path: "../../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorPushNotifications", path: "../../../../node_modules/@capacitor/push-notifications"),
+        .package(name: "CapacitorStatusBar", path: "../../../../node_modules/@capacitor/status-bar")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar")
             ]
         )
     ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.1",
+    "@capacitor/push-notifications": "^8.0.3",
+    "@capacitor/status-bar": "^8.0.2",
     "@mitzo/client": "*",
     "@mitzo/protocol": "*",
     "@opentelemetry/api": "^1.9.1",

--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -10,6 +10,7 @@
 import { createMitzoStore } from '@mitzo/client';
 import { apiFetch, getWsChatUrl } from './lib/api-fetch';
 import { registerCapacitorLifecycle, configureStatusBar } from './lib/capacitor';
+import { initPushNotifications } from './lib/push';
 
 export const clientStore = createMitzoStore({
   transport: {
@@ -27,6 +28,9 @@ registerCapacitorLifecycle(() => clientStore.getState().forceReconnect());
 
 // Configure native status bar appearance (no-op in browser)
 configureStatusBar();
+
+// Register for push notifications (no-op in browser)
+initPushNotifications();
 
 // Expose on window for console debugging during testing
 if (typeof window !== 'undefined') {

--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -9,7 +9,7 @@
 
 import { createMitzoStore } from '@mitzo/client';
 import { apiFetch, getWsChatUrl } from './lib/api-fetch';
-import { registerCapacitorLifecycle } from './lib/capacitor';
+import { registerCapacitorLifecycle, configureStatusBar } from './lib/capacitor';
 
 export const clientStore = createMitzoStore({
   transport: {
@@ -24,6 +24,9 @@ export const clientStore = createMitzoStore({
 
 // Wire Capacitor app lifecycle → force WS reconnect on resume (no-op in browser)
 registerCapacitorLifecycle(() => clientStore.getState().forceReconnect());
+
+// Configure native status bar appearance (no-op in browser)
+configureStatusBar();
 
 // Expose on window for console debugging during testing
 if (typeof window !== 'undefined') {

--- a/frontend/src/hooks/__tests__/useCalendarData.test.ts
+++ b/frontend/src/hooks/__tests__/useCalendarData.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, cleanup } from '@testing-library/react';
+
+vi.mock('../../lib/api-fetch', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../../lib/api-fetch';
 import { useCalendarData } from '../useCalendarData';
 
 const MOCK_DATA = {
@@ -44,18 +50,15 @@ const MOCK_DATA = {
 };
 
 beforeEach(() => {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve(MOCK_DATA),
-    }),
-  );
+  vi.clearAllMocks();
+  vi.mocked(apiFetch).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(MOCK_DATA),
+  } as Response);
 });
 
 afterEach(() => {
   cleanup();
-  vi.restoreAllMocks();
 });
 
 describe('useCalendarData', () => {
@@ -71,7 +74,7 @@ describe('useCalendarData', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.events).toHaveLength(2);
     expect(result.current.sprints).toHaveLength(1);
-    expect(fetch).toHaveBeenCalledWith('/api/calendar?date=2026-04-10&days=7');
+    expect(apiFetch).toHaveBeenCalledWith('/api/calendar?date=2026-04-10&days=7');
   });
 
   it('passes days parameter to API', async () => {
@@ -81,7 +84,7 @@ describe('useCalendarData', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    expect(fetch).toHaveBeenCalledWith('/api/calendar?date=2026-04-10&days=3');
+    expect(apiFetch).toHaveBeenCalledWith('/api/calendar?date=2026-04-10&days=3');
     expect(result.current.events).toHaveLength(2);
   });
 
@@ -94,7 +97,7 @@ describe('useCalendarData', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).toHaveBeenCalledTimes(1);
 
     rerender({ date: '2026-04-11' });
 
@@ -102,19 +105,16 @@ describe('useCalendarData', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenLastCalledWith('/api/calendar?date=2026-04-11&days=7');
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(apiFetch).toHaveBeenLastCalledWith('/api/calendar?date=2026-04-11&days=7');
   });
 
   it('handles non-ok HTTP responses as errors', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 401,
-        json: () => Promise.resolve({ error: 'Unauthorized' }),
-      }),
-    );
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ error: 'Unauthorized' }),
+    } as Response);
 
     const { result } = renderHook(() => useCalendarData('2026-04-10'));
 
@@ -128,7 +128,7 @@ describe('useCalendarData', () => {
   });
 
   it('handles fetch errors gracefully', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')));
+    vi.mocked(apiFetch).mockRejectedValue(new Error('Network error'));
 
     const { result } = renderHook(() => useCalendarData('2026-04-10'));
 

--- a/frontend/src/hooks/__tests__/useSessionList.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionList.test.ts
@@ -6,25 +6,30 @@ vi.mock('../../lib/rename-session', () => ({
   renameSession: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../lib/api-fetch', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../../lib/api-fetch';
 import { useSessionList } from '../useSessionList';
 
-const mockFetch = vi.fn();
-
 beforeEach(() => {
-  mockFetch.mockReset();
-  vi.stubGlobal('fetch', mockFetch);
+  vi.mocked(apiFetch).mockReset();
 
   // Default: all fetches succeed with empty data
-  mockFetch.mockImplementation((url: string) => {
-    if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
-    if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
-    if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-    return Promise.resolve({ json: () => Promise.resolve({}) });
+  vi.mocked(apiFetch).mockImplementation((url: string) => {
+    if (url === '/api/sessions')
+      return Promise.resolve({ json: () => Promise.resolve([]) }) as Promise<Response>;
+    if (url === '/api/config')
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+    if (url === '/api/version')
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+    return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
   });
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('useSessionList', () => {
@@ -35,12 +40,14 @@ describe('useSessionList', () => {
 
   it('fetches sessions on mount', async () => {
     const sessions = [{ id: 'abc', summary: 'Test', lastModified: Date.now() }];
-    mockFetch.mockImplementation((url: string) => {
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
       if (url === '/api/sessions')
-        return Promise.resolve({ json: () => Promise.resolve(sessions) });
-      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+        return Promise.resolve({ json: () => Promise.resolve(sessions) }) as Promise<Response>;
+      if (url === '/api/config')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      if (url === '/api/version')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
     });
 
     const { result } = renderHook(() => useSessionList());
@@ -57,12 +64,14 @@ describe('useSessionList', () => {
       { id: 'a', summary: 'A', lastModified: Date.now() },
       { id: 'b', summary: 'B', lastModified: Date.now() },
     ];
-    mockFetch.mockImplementation((url: string) => {
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
       if (url === '/api/sessions')
-        return Promise.resolve({ json: () => Promise.resolve(sessions) });
-      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+        return Promise.resolve({ json: () => Promise.resolve(sessions) }) as Promise<Response>;
+      if (url === '/api/config')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      if (url === '/api/version')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
     });
 
     const { result } = renderHook(() => useSessionList());
@@ -74,17 +83,19 @@ describe('useSessionList', () => {
 
     expect(result.current.sessions).toHaveLength(1);
     expect(result.current.sessions[0].id).toBe('b');
-    expect(mockFetch).toHaveBeenCalledWith('/api/sessions/a', { method: 'DELETE' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/sessions/a', { method: 'DELETE' });
   });
 
   it('clearAll empties sessions and calls DELETE', async () => {
     const sessions = [{ id: 'a', summary: 'A', lastModified: Date.now() }];
-    mockFetch.mockImplementation((url: string) => {
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
       if (url === '/api/sessions')
-        return Promise.resolve({ json: () => Promise.resolve(sessions) });
-      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+        return Promise.resolve({ json: () => Promise.resolve(sessions) }) as Promise<Response>;
+      if (url === '/api/config')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      if (url === '/api/version')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
     });
 
     const { result } = renderHook(() => useSessionList());
@@ -95,17 +106,19 @@ describe('useSessionList', () => {
     });
 
     expect(result.current.sessions).toHaveLength(0);
-    expect(mockFetch).toHaveBeenCalledWith('/api/sessions', { method: 'DELETE' });
+    expect(apiFetch).toHaveBeenCalledWith('/api/sessions', { method: 'DELETE' });
   });
 
   it('handleRename does optimistic update', async () => {
     const sessions = [{ id: 'a', summary: 'Old', lastModified: Date.now() }];
-    mockFetch.mockImplementation((url: string) => {
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
       if (url === '/api/sessions')
-        return Promise.resolve({ json: () => Promise.resolve(sessions) });
-      if (url === '/api/config') return Promise.resolve({ json: () => Promise.resolve({}) });
-      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+        return Promise.resolve({ json: () => Promise.resolve(sessions) }) as Promise<Response>;
+      if (url === '/api/config')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      if (url === '/api/version')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
     });
 
     const { result } = renderHook(() => useSessionList());
@@ -119,14 +132,16 @@ describe('useSessionList', () => {
   });
 
   it('builds quick actions from config', async () => {
-    mockFetch.mockImplementation((url: string) => {
-      if (url === '/api/sessions') return Promise.resolve({ json: () => Promise.resolve([]) });
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
+      if (url === '/api/sessions')
+        return Promise.resolve({ json: () => Promise.resolve([]) }) as Promise<Response>;
       if (url === '/api/config')
         return Promise.resolve({
           json: () => Promise.resolve({ quickActions: [{ label: 'Test', desc: 'Test action' }] }),
-        });
-      if (url === '/api/version') return Promise.resolve({ json: () => Promise.resolve({}) });
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+        }) as Promise<Response>;
+      if (url === '/api/version')
+        return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
+      return Promise.resolve({ json: () => Promise.resolve({}) }) as Promise<Response>;
     });
 
     const { result } = renderHook(() => useSessionList());

--- a/frontend/src/hooks/__tests__/useTodoData.test.ts
+++ b/frontend/src/hooks/__tests__/useTodoData.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+
+vi.mock('../../lib/api-fetch', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../../lib/api-fetch';
 import { useTodoData } from '../useTodoData';
 
 const mockItems = [
@@ -44,7 +50,8 @@ const mockResponse = {
 };
 
 beforeEach(() => {
-  vi.spyOn(global, 'fetch').mockResolvedValue({
+  vi.clearAllMocks();
+  vi.mocked(apiFetch).mockResolvedValue({
     ok: true,
     json: () => Promise.resolve(mockResponse),
   } as Response);
@@ -64,7 +71,7 @@ describe('useTodoData', () => {
 
     expect(result.current.items).toHaveLength(1);
     expect(result.current.profiles).toEqual(['centaur', 'work', 'personal']);
-    expect(fetch).toHaveBeenCalledWith('/api/todos');
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos');
   });
 
   it('fetches with profile filter', async () => {
@@ -72,11 +79,11 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(fetch).toHaveBeenCalledWith('/api/todos?profile=centaur');
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos?profile=centaur');
   });
 
   it('handles fetch errors gracefully', async () => {
-    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+    vi.mocked(apiFetch).mockRejectedValue(new Error('Network error'));
 
     const { result } = renderHook(() => useTodoData());
 
@@ -91,7 +98,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -101,7 +108,7 @@ describe('useTodoData', () => {
     });
 
     expect(result.current.items).toHaveLength(0);
-    expect(fetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'ack' }),
@@ -113,7 +120,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -130,7 +137,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -140,7 +147,7 @@ describe('useTodoData', () => {
     });
 
     expect(result.current.items).toHaveLength(0);
-    expect(fetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'snooze', days: 5 }),
@@ -151,14 +158,14 @@ describe('useTodoData', () => {
     const { result } = renderHook(() => useTodoData());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).toHaveBeenCalledTimes(1);
 
     act(() => {
       result.current.refresh();
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(apiFetch).toHaveBeenCalledTimes(2);
   });
 
   it('handles network error in performAction gracefully', async () => {
@@ -166,7 +173,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error('Network error'));
 
     await act(async () => {
       await result.current.ack('abc123');
@@ -180,9 +187,9 @@ describe('useTodoData', () => {
     const { result } = renderHook(() => useTodoData());
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).toHaveBeenCalledTimes(1);
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -191,7 +198,7 @@ describe('useTodoData', () => {
       await result.current.create('New task', 'work');
     });
 
-    expect(fetch).toHaveBeenCalledWith('/api/todos', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ summary: 'New task', profile: 'work' }),
@@ -203,7 +210,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -212,7 +219,7 @@ describe('useTodoData', () => {
       await result.current.create('Sub task', 'work', 'parent-123');
     });
 
-    expect(fetch).toHaveBeenCalledWith('/api/todos', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ summary: 'Sub task', profile: 'work', parentId: 'parent-123' }),
@@ -224,7 +231,7 @@ describe('useTodoData', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error('Network error'));
 
     await act(async () => {
       await result.current.create('New task', 'work');
@@ -240,7 +247,7 @@ describe('useTodoData', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.items[0].starred).toBe(false);
 
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -259,7 +266,7 @@ describe('useTodoData', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     // First star: item is unstarred, so action should be 'star'
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -268,14 +275,14 @@ describe('useTodoData', () => {
       await result.current.star('abc123');
     });
 
-    expect(fetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'star' }),
     });
 
     // Second star: item is now starred, so action should be 'unstar'
-    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+    vi.mocked(apiFetch).mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ ok: true }),
     } as Response);
@@ -284,7 +291,7 @@ describe('useTodoData', () => {
       await result.current.star('abc123');
     });
 
-    expect(fetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
+    expect(apiFetch).toHaveBeenCalledWith('/api/todos/abc123/action', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'unstar' }),
@@ -297,7 +304,7 @@ describe('useTodoData', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.items[0].starred).toBe(false);
 
-    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+    vi.mocked(apiFetch).mockRejectedValueOnce(new Error('Network error'));
 
     await act(async () => {
       await result.current.star('abc123');

--- a/frontend/src/lib/__tests__/capacitor.test.ts
+++ b/frontend/src/lib/__tests__/capacitor.test.ts
@@ -18,9 +18,22 @@ vi.mock('@capacitor/app', () => ({
   },
 }));
 
+// Mock @capacitor/status-bar
+vi.mock('@capacitor/status-bar', () => ({
+  StatusBar: {
+    setStyle: vi.fn().mockResolvedValue(undefined),
+    setBackgroundColor: vi.fn().mockResolvedValue(undefined),
+  },
+  Style: {
+    Dark: 'DARK',
+    Light: 'LIGHT',
+  },
+}));
+
 import { Capacitor } from '@capacitor/core';
 import { App } from '@capacitor/app';
-import { isCapacitor, registerCapacitorLifecycle } from '../capacitor';
+import { StatusBar, Style } from '@capacitor/status-bar';
+import { isCapacitor, registerCapacitorLifecycle, configureStatusBar } from '../capacitor';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -72,5 +85,27 @@ describe('registerCapacitorLifecycle', () => {
     // Simulate app going to background
     listeners['appStateChange']({ isActive: false });
     expect(onResume).not.toHaveBeenCalled();
+  });
+});
+
+describe('configureStatusBar', () => {
+  it('no-ops in browser environment', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    await configureStatusBar();
+    expect(StatusBar.setStyle).not.toHaveBeenCalled();
+  });
+
+  it('sets dark style (light text) on native platform', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await configureStatusBar();
+    expect(StatusBar.setStyle).toHaveBeenCalledWith({ style: Style.Dark });
+  });
+
+  it('sets background color on native platform', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await configureStatusBar();
+    expect(StatusBar.setBackgroundColor).toHaveBeenCalledWith({
+      color: '#0f0f1a',
+    });
   });
 });

--- a/frontend/src/lib/__tests__/push.test.ts
+++ b/frontend/src/lib/__tests__/push.test.ts
@@ -29,20 +29,22 @@ vi.mock('../api-fetch', () => ({
 import { Capacitor } from '@capacitor/core';
 import { PushNotifications } from '@capacitor/push-notifications';
 import { apiFetch } from '../api-fetch';
-import { initPushNotifications } from '../push';
+import { initPushNotifications, _resetForTest } from '../push';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  _resetForTest();
   Object.keys(pushListeners).forEach((k) => delete pushListeners[k]);
   // Restore default mock returns after clearAllMocks resets them
   vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({ receive: 'granted' });
   vi.mocked(PushNotifications.register).mockResolvedValue(undefined);
-  vi.mocked(PushNotifications.addListener).mockImplementation(
-    (event: string, cb: (data: unknown) => void) => {
-      pushListeners[event] = cb;
-      return Promise.resolve() as ReturnType<typeof PushNotifications.addListener>;
-    },
-  );
+  vi.mocked(PushNotifications.addListener).mockImplementation(((
+    event: string,
+    cb: (data: unknown) => void,
+  ) => {
+    pushListeners[event] = cb;
+    return Promise.resolve({ remove: vi.fn() });
+  }) as typeof PushNotifications.addListener);
 });
 
 describe('initPushNotifications', () => {

--- a/frontend/src/lib/__tests__/push.test.ts
+++ b/frontend/src/lib/__tests__/push.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @capacitor/core
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => false),
+  },
+}));
+
+// Mock @capacitor/push-notifications — capture listeners
+const pushListeners: Record<string, (data: unknown) => void> = {};
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    requestPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+    register: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn((event: string, cb: (data: unknown) => void) => {
+      pushListeners[event] = cb;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+// Mock api-fetch
+vi.mock('../api-fetch', () => ({
+  apiFetch: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+import { Capacitor } from '@capacitor/core';
+import { PushNotifications } from '@capacitor/push-notifications';
+import { apiFetch } from '../api-fetch';
+import { initPushNotifications } from '../push';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.keys(pushListeners).forEach((k) => delete pushListeners[k]);
+  // Restore default mock returns after clearAllMocks resets them
+  vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({ receive: 'granted' });
+  vi.mocked(PushNotifications.register).mockResolvedValue(undefined);
+  vi.mocked(PushNotifications.addListener).mockImplementation(
+    (event: string, cb: (data: unknown) => void) => {
+      pushListeners[event] = cb;
+      return Promise.resolve() as ReturnType<typeof PushNotifications.addListener>;
+    },
+  );
+});
+
+describe('initPushNotifications', () => {
+  it('no-ops in browser environment', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    await initPushNotifications();
+    expect(PushNotifications.requestPermissions).not.toHaveBeenCalled();
+  });
+
+  it('requests permissions on native platform', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await initPushNotifications();
+    expect(PushNotifications.requestPermissions).toHaveBeenCalled();
+  });
+
+  it('calls register after permission granted', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await initPushNotifications();
+    expect(PushNotifications.register).toHaveBeenCalled();
+  });
+
+  it('does not register when permission denied', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(PushNotifications.requestPermissions).mockResolvedValue({
+      receive: 'denied',
+    });
+    await initPushNotifications();
+    expect(PushNotifications.register).not.toHaveBeenCalled();
+  });
+
+  it('registers device token with server on registration event', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await initPushNotifications();
+
+    // Simulate registration success
+    pushListeners['registration']({ value: 'device-token-xyz' });
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/push/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: 'device-token-xyz' }),
+    });
+  });
+
+  it('registers listeners for push events', async () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    await initPushNotifications();
+
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      'registration',
+      expect.any(Function),
+    );
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      'registrationError',
+      expect.any(Function),
+    );
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      'pushNotificationReceived',
+      expect.any(Function),
+    );
+    expect(PushNotifications.addListener).toHaveBeenCalledWith(
+      'pushNotificationActionPerformed',
+      expect.any(Function),
+    );
+  });
+});

--- a/frontend/src/lib/capacitor.ts
+++ b/frontend/src/lib/capacitor.ts
@@ -1,11 +1,4 @@
-/**
- * Capacitor-specific lifecycle integration.
- *
- * When running as a native iOS app, registers appStateChange listener
- * to force a WebSocket reconnect check on resume. The callback directly
- * invokes MitzoConnection.checkAndReconnect() via the store rather than
- * relying on synthetic DOM events.
- */
+// Capacitor-specific lifecycle integration for native iOS.
 
 import { Capacitor } from '@capacitor/core';
 import { App } from '@capacitor/app';
@@ -15,15 +8,7 @@ export function isCapacitor(): boolean {
   return Capacitor.isNativePlatform();
 }
 
-/**
- * Register Capacitor app lifecycle events. When the app returns to the
- * foreground, calls the provided callback to force a WebSocket reconnect
- * check. This directly invokes MitzoConnection.checkAndReconnect() rather
- * than relying on synthetic visibilitychange events (which won't update
- * the read-only document.visibilityState property).
- *
- * Call once at app startup. No-op in browser environments.
- */
+/** Register app lifecycle events. Calls onResume on foreground return. No-op in browser. */
 export function registerCapacitorLifecycle(onResume: () => void): void {
   if (!isCapacitor()) return;
 
@@ -32,12 +17,7 @@ export function registerCapacitorLifecycle(onResume: () => void): void {
   });
 }
 
-/**
- * Configure the native status bar appearance. Sets light text on the dark
- * app background (#0f0f1a) so the status bar blends with the UI.
- *
- * No-op in browser environments.
- */
+/** Configure native status bar — light text on dark background. No-op in browser. */
 export async function configureStatusBar(): Promise<void> {
   if (!isCapacitor()) return;
 

--- a/frontend/src/lib/capacitor.ts
+++ b/frontend/src/lib/capacitor.ts
@@ -9,6 +9,7 @@
 
 import { Capacitor } from '@capacitor/core';
 import { App } from '@capacitor/app';
+import { StatusBar, Style } from '@capacitor/status-bar';
 
 export function isCapacitor(): boolean {
   return Capacitor.isNativePlatform();
@@ -29,4 +30,17 @@ export function registerCapacitorLifecycle(onResume: () => void): void {
   App.addListener('appStateChange', ({ isActive }) => {
     if (isActive) onResume();
   });
+}
+
+/**
+ * Configure the native status bar appearance. Sets light text on the dark
+ * app background (#0f0f1a) so the status bar blends with the UI.
+ *
+ * No-op in browser environments.
+ */
+export async function configureStatusBar(): Promise<void> {
+  if (!isCapacitor()) return;
+
+  await StatusBar.setStyle({ style: Style.Dark });
+  await StatusBar.setBackgroundColor({ color: '#0f0f1a' });
 }

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -1,0 +1,48 @@
+/**
+ * Push notification integration for Capacitor iOS.
+ *
+ * Requests notification permissions, registers the device token with
+ * the Mitzo server, and handles incoming push notifications.
+ *
+ * No-op in browser environments.
+ */
+
+import { Capacitor } from '@capacitor/core';
+import { PushNotifications } from '@capacitor/push-notifications';
+import { apiFetch } from './api-fetch';
+
+export async function initPushNotifications(): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return;
+
+  const permission = await PushNotifications.requestPermissions();
+  if (permission.receive !== 'granted') return;
+
+  // Register listeners before calling register()
+  await PushNotifications.addListener('registration', (token) => {
+    apiFetch('/api/push/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: (token as { value: string }).value }),
+    });
+  });
+
+  await PushNotifications.addListener('registrationError', (error) => {
+    console.error('Push registration failed:', error);
+  });
+
+  await PushNotifications.addListener('pushNotificationReceived', (_notification) => {
+    // Foreground notification — the app is already open, so no action needed.
+    // The WS connection handles live updates.
+  });
+
+  await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
+    // User tapped a notification — navigate to the relevant session
+    const data = (action as { notification: { data: Record<string, string> } }).notification.data;
+    if (data?.sessionId) {
+      window.location.hash = '';
+      window.location.pathname = `/chat/${data.sessionId}`;
+    }
+  });
+
+  await PushNotifications.register();
+}

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -6,6 +6,11 @@ import { apiFetch } from './api-fetch';
 
 let initialized = false;
 
+/** @internal test-only — reset the init guard */
+export function _resetForTest(): void {
+  initialized = false;
+}
+
 export async function initPushNotifications(): Promise<void> {
   if (!Capacitor.isNativePlatform() || initialized) return;
   initialized = true;

--- a/frontend/src/lib/push.ts
+++ b/frontend/src/lib/push.ts
@@ -1,23 +1,18 @@
-/**
- * Push notification integration for Capacitor iOS.
- *
- * Requests notification permissions, registers the device token with
- * the Mitzo server, and handles incoming push notifications.
- *
- * No-op in browser environments.
- */
+// Push notification integration for Capacitor iOS. No-op in browser.
 
 import { Capacitor } from '@capacitor/core';
 import { PushNotifications } from '@capacitor/push-notifications';
 import { apiFetch } from './api-fetch';
 
+let initialized = false;
+
 export async function initPushNotifications(): Promise<void> {
-  if (!Capacitor.isNativePlatform()) return;
+  if (!Capacitor.isNativePlatform() || initialized) return;
+  initialized = true;
 
   const permission = await PushNotifications.requestPermissions();
   if (permission.receive !== 'granted') return;
 
-  // Register listeners before calling register()
   await PushNotifications.addListener('registration', (token) => {
     apiFetch('/api/push/register', {
       method: 'POST',
@@ -31,16 +26,13 @@ export async function initPushNotifications(): Promise<void> {
   });
 
   await PushNotifications.addListener('pushNotificationReceived', (_notification) => {
-    // Foreground notification — the app is already open, so no action needed.
-    // The WS connection handles live updates.
+    // Foreground — WS handles live updates, no action needed
   });
 
   await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
-    // User tapped a notification — navigate to the relevant session
     const data = (action as { notification: { data: Record<string, string> } }).notification.data;
     if (data?.sessionId) {
-      window.location.hash = '';
-      window.location.pathname = `/chat/${data.sessionId}`;
+      window.location.href = `/chat/${data.sessionId}`;
     }
   });
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -57,6 +57,9 @@ body {
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 a {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@opentelemetry/resources": "^2.6.1",
         "@opentelemetry/sdk-trace-node": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@parse/node-apn": "^8.1.0",
         "better-sqlite3": "^12.8.0",
         "contexgin": "github:dimakis/contexgin#52fe1c7",
         "cookie-parser": "^1.4.7",
@@ -68,9 +69,9 @@
       "name": "mitzo-frontend",
       "dependencies": {
         "@capacitor/app": "^8.1.0",
-        "@capacitor/cli": "^8.3.1",
         "@capacitor/core": "^8.3.1",
-        "@capacitor/ios": "^8.3.1",
+        "@capacitor/push-notifications": "^8.0.3",
+        "@capacitor/status-bar": "^8.0.2",
         "@mitzo/client": "*",
         "@mitzo/protocol": "*",
         "@opentelemetry/api": "^1.9.1",
@@ -89,6 +90,8 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@capacitor/cli": "^8.3.1",
+        "@capacitor/ios": "^8.3.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -571,6 +574,7 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.1.tgz",
       "integrity": "sha512-1sPGW4THTDfR6YjXwZ0jM7oAfAtciPOHN00qs/3sNAQx1kKrrEYSfDPwCm1/xlAgi0OeL69SiRfw314Ans+1sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/cli-framework-output": "^2.2.8",
@@ -603,6 +607,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -621,9 +626,28 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.1.tgz",
       "integrity": "sha512-BEhLyYYHWJLib4mpaPMaaylbC8meqgxbNYwQJH2svsSLW7yo/hFie+Zoo66a44XnqcMd2tvmAuzimWunXZi/xA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/push-notifications": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-8.0.3.tgz",
+      "integrity": "sha512-jmBBoJvOzmzem8YoO9dQJBPFiM1bksTNAoV7yksCBN10BybAOtmBF19vFPt/jr2KGAirnPZz0ne2X0OH/rRGtg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -2049,6 +2073,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/@ionic/cli-framework-output/-/cli-framework-output-2.2.8.tgz",
       "integrity": "sha512-TshtaFQsovB4NWRBydbNFawql6yul7d5bMiW1WYYf17hd99V6xdDdk3vtF51bw6sLkxON3bDQpWsnUc9/hVo3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-terminal": "2.3.5",
@@ -2063,6 +2088,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@ionic/utils-array/-/utils-array-2.1.6.tgz",
       "integrity": "sha512-0JZ1Zkp3wURnv8oq6Qt7fMPo5MpjbLoUoa9Bu2Q4PJuSDWM8H8gwF3dQO7VTeUj3/0o1IB1wGkFWZZYgUXZMUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -2076,6 +2102,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@ionic/utils-fs/-/utils-fs-3.1.7.tgz",
       "integrity": "sha512-2EknRvMVfhnyhL1VhFkSLa5gOcycK91VnjfrTB0kbqkTFCOXyXgVLI5whzq7SLrgD9t1aqos3lMMQyVzaQ5gVA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.0",
@@ -2091,6 +2118,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "at-least-node": "^1.0.0",
@@ -2106,6 +2134,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@ionic/utils-object/-/utils-object-2.1.6.tgz",
       "integrity": "sha512-vCl7sl6JjBHFw99CuAqHljYJpcE88YaH2ZW4ELiC/Zwxl5tiwn4kbdP/gxi2OT3MQb1vOtgAmSNRtusvgxI8ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -2119,6 +2148,7 @@
       "version": "2.1.12",
       "resolved": "https://registry.npmjs.org/@ionic/utils-process/-/utils-process-2.1.12.tgz",
       "integrity": "sha512-Jqkgyq7zBs/v/J3YvKtQQiIcxfJyplPgECMWgdO0E1fKrrH8EF0QGHNJ9mJCn6PYe2UtHNS8JJf5G21e09DfYg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-object": "2.1.6",
@@ -2136,12 +2166,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@ionic/utils-stream": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@ionic/utils-stream/-/utils-stream-3.1.7.tgz",
       "integrity": "sha512-eSELBE7NWNFIHTbTC2jiMvh1ABKGIpGdUIvARsNPMNQhxJB3wpwdiVnoBoTYp+5a6UUIww4Kpg7v6S7iTctH1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
@@ -2155,6 +2187,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@ionic/utils-subprocess/-/utils-subprocess-3.0.1.tgz",
       "integrity": "sha512-cT4te3AQQPeIM9WCwIg8ohroJ8TjsYaMb2G4ZEgv9YzeDqHZ4JpeIKqG2SoaA3GmVQ3sOfhPM6Ox9sxphV/d1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-array": "2.1.6",
@@ -2174,6 +2207,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@ionic/utils-terminal/-/utils-terminal-2.3.5.tgz",
       "integrity": "sha512-3cKScz9Jx2/Pr9ijj1OzGlBDfcmx7OMVBt4+P1uRR0SSW4cm1/y3Mo4OY3lfkuaYifMNBW8Wz6lQHbs1bihr7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/slice-ansi": "^4.0.0",
@@ -2194,6 +2228,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2203,6 +2238,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2212,12 +2248,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@ionic/utils-terminal/node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2235,6 +2273,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -2249,6 +2288,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2261,6 +2301,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -2278,6 +2319,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -2941,6 +2983,21 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@parse/node-apn": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.1.0.tgz",
+      "integrity": "sha512-LowcdkKPDikbbzIr3zwEdoFW5wfEbbTzpYQeen3S8kKLePG0AQK586Li+OLC7bonyLmlk//Yk3smHZOLSV6TZA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.4.3",
+        "jsonwebtoken": "9.0.3",
+        "node-forge": "1.4.0",
+        "verror": "1.10.1"
+      },
+      "engines": {
+        "node": "20 || 22 || 24"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -3668,6 +3725,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
       "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3801,6 +3859,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/superagent": {
@@ -4269,6 +4328,7 @@
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
       "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4409,6 +4469,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4456,6 +4517,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4470,6 +4540,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4486,6 +4557,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
@@ -4578,6 +4650,7 @@
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
       "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
@@ -4670,6 +4743,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
       "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -4763,6 +4837,7 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5044,6 +5119,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5056,6 +5132,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5234,6 +5311,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5445,6 +5528,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5594,6 +5678,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/elementtree/-/elementtree-0.1.7.tgz",
       "integrity": "sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "sax": "1.1.4"
@@ -5606,6 +5691,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5643,6 +5729,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6172,6 +6259,15 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-copy": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
@@ -6226,6 +6322,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -6434,6 +6531,7 @@
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
       "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6608,6 +6706,7 @@
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
       "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -6638,6 +6737,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6647,6 +6747,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6659,6 +6760,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -6741,6 +6843,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/gtoken": {
@@ -7122,6 +7225,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
       "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -7196,6 +7300,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -7323,6 +7428,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -7511,12 +7617,35 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jwa": {
@@ -7554,6 +7683,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7652,6 +7782,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -7671,6 +7837,12 @@
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -7779,6 +7951,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -8835,6 +9008,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8844,6 +9018,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -8896,6 +9071,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/native-run/-/native-run-2.0.3.tgz",
       "integrity": "sha512-U1PllBuzW5d1gfan+88L+Hky2eZx+9gv3Pf6rNBxKbORxi7boHzqiA6QFGSnqMem4j0A9tZ08NMIs5+0m/VS1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ionic/utils-fs": "^3.1.7",
@@ -8987,6 +9163,15 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -9076,6 +9261,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
@@ -9143,6 +9329,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -9247,6 +9434,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -9276,6 +9464,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -9396,6 +9585,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -9568,6 +9758,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
       "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -9581,6 +9772,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10054,6 +10246,7 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
       "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "glob": "^13.0.3",
@@ -10179,6 +10372,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
       "integrity": "sha512-5f3k2PbGGp+YtKJjOItpg3P99IMD84E4HOvcfleTb5joCHNXYLsR9yWFPOYGgaeMPDubQILTCMdsFb2OMeOjtg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/saxes": {
@@ -10457,6 +10651,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/slice-ansi": {
@@ -10743,6 +10938,7 @@
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -10787,6 +10983,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10796,6 +10993,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10817,6 +11015,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "3"
@@ -10937,6 +11136,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -11204,6 +11404,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -11222,6 +11423,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11303,6 +11505,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/vfile": {
@@ -12169,6 +12385,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -12182,6 +12399,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -12191,6 +12409,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
@@ -12317,6 +12536,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-trace-node": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@parse/node-apn": "^8.1.0",
     "better-sqlite3": "^12.8.0",
     "contexgin": "github:dimakis/contexgin#52fe1c7",
     "cookie-parser": "^1.4.7",

--- a/server/__tests__/apns.test.ts
+++ b/server/__tests__/apns.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+
+const TEST_DIR = join(tmpdir(), `mitzo-apns-test-${process.pid}`);
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('device token store', () => {
+  // Dynamic import to get fresh module state per test
+  async function loadModule() {
+    // Reset module registry for fresh imports
+    vi.resetModules();
+    const mod = await import('../apns.js');
+    mod.setTokenStorePath(join(TEST_DIR, 'device-tokens.json'));
+    return mod;
+  }
+
+  it('registers a device token', async () => {
+    const { registerToken, getTokens } = await loadModule();
+    registerToken('token-abc-123');
+    expect(getTokens()).toEqual(['token-abc-123']);
+  });
+
+  it('deduplicates identical tokens', async () => {
+    const { registerToken, getTokens } = await loadModule();
+    registerToken('token-abc-123');
+    registerToken('token-abc-123');
+    expect(getTokens()).toEqual(['token-abc-123']);
+  });
+
+  it('stores multiple tokens', async () => {
+    const { registerToken, getTokens } = await loadModule();
+    registerToken('token-1');
+    registerToken('token-2');
+    expect(getTokens()).toEqual(['token-1', 'token-2']);
+  });
+
+  it('removes a token', async () => {
+    const { registerToken, removeToken, getTokens } = await loadModule();
+    registerToken('token-1');
+    registerToken('token-2');
+    removeToken('token-1');
+    expect(getTokens()).toEqual(['token-2']);
+  });
+
+  it('removing non-existent token is a no-op', async () => {
+    const { removeToken, getTokens } = await loadModule();
+    removeToken('nonexistent');
+    expect(getTokens()).toEqual([]);
+  });
+
+  it('persists tokens to disk', async () => {
+    const { registerToken, setTokenStorePath } = await loadModule();
+    const filePath = join(TEST_DIR, 'device-tokens.json');
+    setTokenStorePath(filePath);
+    registerToken('persisted-token');
+    expect(existsSync(filePath)).toBe(true);
+    const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+    expect(data).toEqual(['persisted-token']);
+  });
+
+  it('loads tokens from disk on init', async () => {
+    const filePath = join(TEST_DIR, 'preload-tokens.json');
+    writeFileSync(filePath, JSON.stringify(['preloaded-1', 'preloaded-2']));
+
+    vi.resetModules();
+    const mod = await import('../apns.js');
+    mod.setTokenStorePath(filePath);
+    expect(mod.getTokens()).toEqual(['preloaded-1', 'preloaded-2']);
+  });
+});
+
+describe('isConfigured', () => {
+  it('returns false when no APNs key is set', async () => {
+    vi.resetModules();
+    delete process.env.APNS_KEY_PATH;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_TEAM_ID;
+    const { isConfigured } = await import('../apns.js');
+    expect(isConfigured()).toBe(false);
+  });
+
+  it('returns true when all APNs env vars are set', async () => {
+    vi.resetModules();
+    process.env.APNS_KEY_PATH = '/path/to/key.p8';
+    process.env.APNS_KEY_ID = 'KEYID123';
+    process.env.APNS_TEAM_ID = 'TEAMID456';
+    process.env.APNS_BUNDLE_ID = 'com.mitzo.app';
+    const { isConfigured } = await import('../apns.js');
+    expect(isConfigured()).toBe(true);
+    delete process.env.APNS_KEY_PATH;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_TEAM_ID;
+    delete process.env.APNS_BUNDLE_ID;
+  });
+});
+
+describe('sendPush', () => {
+  it('is a no-op when not configured', async () => {
+    vi.resetModules();
+    delete process.env.APNS_KEY_PATH;
+    const { sendPush } = await import('../apns.js');
+    // Should not throw
+    await expect(sendPush('Test', 'Body')).resolves.toBeUndefined();
+  });
+});

--- a/server/__tests__/push-routes.test.ts
+++ b/server/__tests__/push-routes.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import request from 'supertest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const TEST_REPO = join(tmpdir(), `mitzo-push-test-${process.pid}`);
+
+vi.mock('../chat.js', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join: pjoin } = require('path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir: ptmpdir } = require('os');
+  const repo = pjoin(ptmpdir(), `mitzo-push-test-${process.pid}`);
+  return {
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
+    getMessages: vi.fn().mockResolvedValue([]),
+    renameSessionById: vi.fn(),
+    hideSession: vi.fn(),
+    clearHiddenSessions: vi.fn(),
+    BASE_REPO: repo,
+    getRepoConfig: vi.fn(() => ({
+      quickActions: [],
+      allowedPaths: [],
+      roots: [],
+      resolvedVenvPaths: [],
+      toolTierOverrides: {},
+      inboxPath: '',
+      resolvedInboxPath: '',
+      repos: {},
+      contextBlocks: {},
+    })),
+    getMcpServerNames: vi.fn().mockReturnValue([]),
+    AVAILABLE_MODELS: [],
+    registry: {
+      get: vi.fn(),
+      getActiveSessions: vi.fn().mockReturnValue([]),
+    },
+    setTaskStore: vi.fn(),
+    eventStore: {
+      append: vi.fn(),
+      getEventsAfter: vi.fn().mockReturnValue([]),
+      getSession: vi.fn().mockReturnValue(null),
+    },
+  };
+});
+
+let app: Express;
+let authCookie: string;
+
+beforeAll(async () => {
+  mkdirSync(TEST_REPO, { recursive: true });
+  mkdirSync(join(TEST_REPO, '.mitzo'), { recursive: true });
+  process.env.BASE_REPO = TEST_REPO;
+
+  const mod = await import('../app.js');
+  app = mod.app;
+
+  // Login to get auth cookie
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ passphrase: process.env.AUTH_PASSPHRASE });
+  const cookies = loginRes.headers['set-cookie'];
+  authCookie = Array.isArray(cookies) ? cookies[0] : cookies;
+});
+
+afterAll(() => {
+  rmSync(TEST_REPO, { recursive: true, force: true });
+});
+
+describe('POST /api/push/register', () => {
+  it('registers a device token', async () => {
+    const res = await request(app)
+      .post('/api/push/register')
+      .set('Cookie', authCookie)
+      .send({ token: 'device-token-abc123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects missing token', async () => {
+    const res = await request(app).post('/api/push/register').set('Cookie', authCookie).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('token is required');
+  });
+
+  it('rejects non-string token', async () => {
+    const res = await request(app)
+      .post('/api/push/register')
+      .set('Cookie', authCookie)
+      .send({ token: 12345 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app)
+      .post('/api/push/register')
+      .send({ token: 'device-token-abc123' });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/push/register', () => {
+  it('removes a registered device token', async () => {
+    // Register first
+    await request(app)
+      .post('/api/push/register')
+      .set('Cookie', authCookie)
+      .send({ token: 'token-to-remove' });
+
+    const res = await request(app)
+      .delete('/api/push/register')
+      .set('Cookie', authCookie)
+      .send({ token: 'token-to-remove' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('returns 200 even for non-existent token (idempotent)', async () => {
+    const res = await request(app)
+      .delete('/api/push/register')
+      .set('Cookie', authCookie)
+      .send({ token: 'nonexistent-token' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).delete('/api/push/register').send({ token: 'some-token' });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/server/apns.ts
+++ b/server/apns.ts
@@ -1,0 +1,159 @@
+/**
+ * APNs push notification module.
+ *
+ * Manages device token registration and sends push notifications via
+ * Apple Push Notification service. Tokens are persisted to a JSON file
+ * in the Mitzo data directory.
+ *
+ * Required env vars for sending:
+ *   APNS_KEY_PATH  — path to .p8 key file
+ *   APNS_KEY_ID    — key ID from App Store Connect
+ *   APNS_TEAM_ID   — Apple Developer team ID
+ *   APNS_BUNDLE_ID — app bundle ID (default: com.mitzo.app)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { createLogger } from '@mitzo/harness';
+
+const log = createLogger('apns');
+
+const APNS_KEY_PATH = process.env.APNS_KEY_PATH;
+const APNS_KEY_ID = process.env.APNS_KEY_ID;
+const APNS_TEAM_ID = process.env.APNS_TEAM_ID;
+const APNS_BUNDLE_ID = process.env.APNS_BUNDLE_ID || 'com.mitzo.app';
+
+let tokens: string[] = [];
+let tokenStorePath: string | null = null;
+
+export function isConfigured(): boolean {
+  return !!(APNS_KEY_PATH && APNS_KEY_ID && APNS_TEAM_ID);
+}
+
+/** Set the file path for persisting device tokens and load any existing tokens. */
+export function setTokenStorePath(path: string): void {
+  tokenStorePath = path;
+  if (existsSync(path)) {
+    try {
+      tokens = JSON.parse(readFileSync(path, 'utf-8'));
+    } catch {
+      tokens = [];
+    }
+  }
+}
+
+function persist(): void {
+  if (!tokenStorePath) return;
+  try {
+    writeFileSync(tokenStorePath, JSON.stringify(tokens));
+  } catch (err: unknown) {
+    log.error('failed to persist device tokens', {
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+  }
+}
+
+export function registerToken(token: string): void {
+  if (!tokens.includes(token)) {
+    tokens.push(token);
+    persist();
+  }
+}
+
+export function removeToken(token: string): void {
+  const idx = tokens.indexOf(token);
+  if (idx !== -1) {
+    tokens.splice(idx, 1);
+    persist();
+  }
+}
+
+export function getTokens(): string[] {
+  return [...tokens];
+}
+
+let apnProvider: import('@parse/node-apn').Provider | null = null;
+
+function getProvider(): import('@parse/node-apn').Provider | null {
+  if (apnProvider) return apnProvider;
+  if (!isConfigured()) return null;
+
+  try {
+    // Dynamic import to avoid requiring the module when not configured
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const apn = require('@parse/node-apn');
+    apnProvider = new apn.Provider({
+      token: {
+        key: APNS_KEY_PATH!,
+        keyId: APNS_KEY_ID!,
+        teamId: APNS_TEAM_ID!,
+      },
+      production: true,
+    });
+    return apnProvider;
+  } catch (err: unknown) {
+    log.error('failed to initialize APNs provider', {
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+    return null;
+  }
+}
+
+/** Send a push notification to all registered devices. */
+export async function sendPush(
+  title: string,
+  body: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  const provider = getProvider();
+  if (!provider || tokens.length === 0) return;
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const apn = require('@parse/node-apn');
+    const notification = new apn.Notification();
+    notification.alert = { title, body };
+    notification.topic = APNS_BUNDLE_ID;
+    notification.sound = 'default';
+    notification.badge = 1;
+    if (data) notification.payload = data;
+
+    const result = await provider.send(notification, tokens);
+
+    // Remove any invalid tokens
+    for (const failure of result.failed) {
+      if (failure.status === '410' || failure.response?.reason === 'Unregistered') {
+        removeToken(failure.device);
+        log.info('removed unregistered device token', { device: failure.device });
+      }
+    }
+  } catch (err: unknown) {
+    log.error('failed to send push notification', {
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+  }
+}
+
+export async function sendTurnCompleteNotification(
+  sessionId?: string,
+  snippet?: string,
+): Promise<void> {
+  await sendPush('Mitzo: Agent replied', snippet || 'The agent has finished its turn.', {
+    type: 'turn_complete',
+    sessionId,
+  });
+}
+
+export async function sendPermissionNotification(
+  toolName: string,
+  toolInput: string,
+  permId: string,
+  sessionId?: string,
+): Promise<void> {
+  const truncated = toolInput.length > 100 ? toolInput.slice(0, 100) + '...' : toolInput;
+  await sendPush(`Mitzo: ${toolName}`, truncated, {
+    type: 'permission_request',
+    toolName,
+    permId,
+    sessionId,
+  });
+}

--- a/server/apns.ts
+++ b/server/apns.ts
@@ -109,7 +109,7 @@ export async function sendPush(
 
     // Remove any invalid tokens
     for (const failure of result.failed) {
-      if (failure.status === '410' || failure.response?.reason === 'Unregistered') {
+      if (String(failure.status) === '410' || failure.response?.reason === 'Unregistered') {
         removeToken(failure.device);
         log.info('removed unregistered device token', { device: failure.device });
       }

--- a/server/apns.ts
+++ b/server/apns.ts
@@ -1,19 +1,10 @@
-/**
- * APNs push notification module.
- *
- * Manages device token registration and sends push notifications via
- * Apple Push Notification service. Tokens are persisted to a JSON file
- * in the Mitzo data directory.
- *
- * Required env vars for sending:
- *   APNS_KEY_PATH  — path to .p8 key file
- *   APNS_KEY_ID    — key ID from App Store Connect
- *   APNS_TEAM_ID   — Apple Developer team ID
- *   APNS_BUNDLE_ID — app bundle ID (default: com.mitzo.app)
- */
+// APNs push notification module — token registration and delivery via Apple Push Notification service.
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { createRequire } from 'module';
 import { createLogger } from '@mitzo/harness';
+
+const require = createRequire(import.meta.url);
 
 const log = createLogger('apns');
 
@@ -78,8 +69,6 @@ function getProvider(): import('@parse/node-apn').Provider | null {
   if (!isConfigured()) return null;
 
   try {
-    // Dynamic import to avoid requiring the module when not configured
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const apn = require('@parse/node-apn');
     apnProvider = new apn.Provider({
       token: {
@@ -108,7 +97,6 @@ export async function sendPush(
   if (!provider || tokens.length === 0) return;
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const apn = require('@parse/node-apn');
     const notification = new apn.Notification();
     notification.alert = { title, body };
@@ -139,21 +127,6 @@ export async function sendTurnCompleteNotification(
 ): Promise<void> {
   await sendPush('Mitzo: Agent replied', snippet || 'The agent has finished its turn.', {
     type: 'turn_complete',
-    sessionId,
-  });
-}
-
-export async function sendPermissionNotification(
-  toolName: string,
-  toolInput: string,
-  permId: string,
-  sessionId?: string,
-): Promise<void> {
-  const truncated = toolInput.length > 100 ? toolInput.slice(0, 100) + '...' : toolInput;
-  await sendPush(`Mitzo: ${toolName}`, truncated, {
-    type: 'permission_request',
-    toolName,
-    permId,
     sessionId,
   });
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -57,6 +57,7 @@ import {
   discardInboxItem,
   createInboxItem,
 } from './inbox.js';
+import { registerToken, removeToken, setTokenStorePath } from './apns.js';
 import { SkillRegistry } from './skills.js';
 
 import { mkdirSync } from 'fs';
@@ -202,6 +203,7 @@ try {
 }
 export const taskStore = new TaskStore(join(mitzoDir, 'tasks.db'));
 setTaskStore(taskStore);
+setTokenStorePath(join(mitzoDir, 'device-tokens.json'));
 
 export function setUpdateBroadcast(fn: () => void) {
   onUpdateAvailable = fn;
@@ -1024,6 +1026,28 @@ app.delete('/api/inbox/:filename', (req, res) => {
   }
   res.json({ ok: true });
   broadcastInboxUpdate();
+});
+
+// --- Push notification device token registration ---
+
+app.post('/api/push/register', (req, res) => {
+  const { token } = req.body || {};
+  if (!token || typeof token !== 'string') {
+    res.status(400).json({ error: 'token is required' });
+    return;
+  }
+  registerToken(token);
+  res.json({ ok: true });
+});
+
+app.delete('/api/push/register', (req, res) => {
+  const { token } = req.body || {};
+  if (!token || typeof token !== 'string') {
+    res.status(400).json({ error: 'token is required' });
+    return;
+  }
+  removeToken(token);
+  res.json({ ok: true });
 });
 
 // --- Calendar API ---

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -12,6 +12,7 @@ import type { EventStore } from './event-store.js';
 import { updateSessionSdkId } from './session-index.js';
 import { sendTurnCompleteNotification as ntfyTurnComplete } from './notify.js';
 import { sendTurnCompleteNotification as pushoverTurnComplete } from './pushover.js';
+import { sendTurnCompleteNotification as apnsTurnComplete } from './apns.js';
 import { extractSnippet } from './notification-helpers.js';
 import { NOTIFY_SNIPPET_MAX_CHARS } from './constants.js';
 import { createGoal, reportUsage, deriveGoalTitle } from './goal-client.js';
@@ -418,6 +419,7 @@ export async function runQueryLoop(
           const sid = (msg.session_id as string) || currentSession.sessionId;
           ntfyTurnComplete(sid, snippet).catch(() => {});
           pushoverTurnComplete(sid, snippet).catch(() => {});
+          apnsTurnComplete(sid, snippet).catch(() => {});
         }
       } else if (msg.type === 'stream_event') {
         const evt = msg.event as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary

- **Status bar styling**: `@capacitor/status-bar` integration — dark style (light text) with app background color, configured at startup via `configureStatusBar()`. No-op in browser.
- **Safe area insets**: `viewport-fit=cover` in index.html + `env(safe-area-inset-*)` on body for notch/Dynamic Island clearance. Bottom insets already handled by tab bar.
- **APNs push notifications**: Server-side `apns.ts` module with device token management (JSON file persistence), APNs provider via `@parse/node-apn`, and `sendTurnCompleteNotification` wired into query-loop alongside ntfy/Pushover. Fires when agent finishes and client is detached (backgrounded).
- **Push registration routes**: `POST/DELETE /api/push/register` for device token CRUD from native clients.
- **Frontend push integration**: `@capacitor/push-notifications` — permission request, token registration, foreground handling, tap-to-navigate. Wired into `client-store.ts`.
- **Test fixes**: Updated `useCalendarData`, `useTodoData`, `useSessionList` tests to mock `apiFetch` instead of `fetch` (broken by capacitor PR migration).

## Setup required for push

1. Generate APNs key (.p8) in App Store Connect > Keys
2. Set env vars: `APNS_KEY_PATH`, `APNS_KEY_ID`, `APNS_TEAM_ID`
3. Enable Push Notifications capability in Xcode

## Test plan

- [ ] `npm test` passes (new tests: capacitor, push, apns, push-routes + fixed hook tests)
- [ ] Browser regression: status bar and push init are no-ops, no behavior change
- [ ] Capacitor build: `npm run build:ios && npx cap sync ios` succeeds with 3 plugins
- [ ] Status bar renders with light text on dark background in simulator
- [ ] Safe area clearance visible on notched devices (Dynamic Island, notch)
- [ ] Push permission prompt appears on first launch
- [ ] Device token registered with server on permission grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)