### PR TITLE
fix: mobile WS reconnect — prevent event loss on iOS background/resume

### DIFF
--- a/packages/client/__tests__/connection.test.ts
+++ b/packages/client/__tests__/connection.test.ts
@@ -341,5 +341,36 @@ describe('MitzoConnection', () => {
       openWithHandshake(conn);
       conn.disconnect();
     });
+
+    it('defuses old WS handlers so delayed onclose does not trash new connection', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      const received: Record<string, unknown>[] = [];
+      conn.onMessage((msg) => received.push(msg));
+      const oldWs = openWithHandshake(conn);
+
+      // Simulate iOS silent death — heartbeat detects it
+      oldWs.readyState = 3;
+      vi.advanceTimersByTime(5_000);
+
+      // A new WS was created
+      const newWs = lastWs!;
+      expect(newWs).not.toBe(oldWs);
+
+      // Old WS handlers should be nulled (defused)
+      expect(oldWs.onclose).toBeNull();
+      expect(oldWs.onmessage).toBeNull();
+      expect(oldWs.onerror).toBeNull();
+
+      // Complete handshake on new WS
+      newWs.simulateOpen();
+      newWs.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+      expect(conn.isConnected()).toBe(true);
+
+      // Connection should still be connected via new WS
+      expect(conn.getConnectionId()).toBe('conn-2');
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -850,3 +850,112 @@ describe('task CRUD actions', () => {
     );
   });
 });
+
+describe('foreground recovery', () => {
+  it('re-fetches messages when store has active session but no messages', async () => {
+    const transport = mockTransport();
+    const restoredMessages = [
+      { messageId: 'msg-1', role: 'assistant', blocks: [], isStreaming: false },
+    ];
+    // Mock all fetch calls to return messages for /messages endpoints
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(restoredMessages),
+        text: () => Promise.resolve(''),
+      }),
+    );
+    const store = createReadyStore(transport);
+
+    // Set an active session with no messages (simulates iOS page eviction)
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+    }));
+
+    // Simulate _foreground event
+    lastWs.simulateMessage({ type: '_foreground' });
+
+    // Wait for the async fetch to resolve
+    await vi.waitFor(() => {
+      expect(store.getState().messages.messages.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('skips re-fetch when messages already exist', async () => {
+    const transport = mockTransport();
+    const store = createReadyStore(transport);
+
+    // Set active session AND existing messages
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+      messages: {
+        ...s.messages,
+        messages: [{ role: 'assistant', blocks: [], isStreaming: false } as never],
+      },
+    }));
+
+    // Clear fetch call count from handshake
+    (transport.fetch as ReturnType<typeof vi.fn>).mockClear();
+
+    lastWs.simulateMessage({ type: '_foreground' });
+
+    // Give any potential async a chance to fire
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Should NOT have fetched session messages
+    const fetchCalls = (transport.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const sessionMsgCalls = fetchCalls.filter(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('/messages'),
+    );
+    expect(sessionMsgCalls).toHaveLength(0);
+  });
+
+  it('does not clobber messages that arrived between fetch start and resolve', async () => {
+    const transport = mockTransport();
+    let resolveFetch!: (v: unknown) => void;
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/messages')) {
+        return new Promise((r) => {
+          resolveFetch = r;
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(''),
+      });
+    });
+    const store = createReadyStore(transport);
+
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+    }));
+
+    // Trigger foreground — fetch starts but hasn't resolved yet
+    lastWs.simulateMessage({ type: '_foreground' });
+
+    // Meanwhile, live data arrives and populates the store
+    store.setState((s) => ({
+      messages: {
+        ...s.messages,
+        messages: [{ role: 'assistant', blocks: [], isStreaming: false } as never],
+      },
+    }));
+
+    // Now the fetch resolves with stale data
+    resolveFetch({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { role: 'assistant', blocks: [{ type: 'text', text: 'stale' }], isStreaming: false },
+          { role: 'assistant', blocks: [{ type: 'text', text: 'stale2' }], isStreaming: false },
+        ]),
+      text: () => Promise.resolve(''),
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Store should still have the 1 live message, not the 2 stale ones
+    expect(store.getState().messages.messages).toHaveLength(1);
+  });
+});

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -108,6 +108,19 @@ export class MitzoConnection {
 
   // ─── Internal ──────────────────────────────────────────────────────────────
 
+  /**
+   * Detach handlers from the old WS so its delayed onclose can't overwrite
+   * `this.ws` / `this._connected` after a new WS has been created.
+   */
+  private defuseOldWs(): void {
+    if (this.ws) {
+      this.ws.onclose = null;
+      this.ws.onmessage = null;
+      this.ws.onerror = null;
+      this.ws = null;
+    }
+  }
+
   private doConnect(): void {
     if (
       this.ws?.readyState === WS_READY_STATE.OPEN ||
@@ -200,7 +213,7 @@ export class MitzoConnection {
     if (typeof globalThis.setInterval === 'undefined') return;
     this.heartbeatTimer = setInterval(() => {
       if (this.ws && this.ws.readyState !== WS_READY_STATE.OPEN && !this.reconnectTimer) {
-        this.ws = null;
+        this.defuseOldWs();
         this._connected = false;
         this.listener?.({ type: '_close' });
         this.doConnect();
@@ -221,6 +234,9 @@ export class MitzoConnection {
     this.boundOnVisibility = () => {
       if (document.visibilityState === 'visible') {
         this.checkAndReconnect();
+        // Notify the store so it can re-hydrate messages if the page was
+        // evicted from memory (iOS bfcache discard) and state was lost.
+        this.listener?.({ type: '_foreground' });
       }
     };
 
@@ -247,7 +263,7 @@ export class MitzoConnection {
   checkAndReconnect(): void {
     if (!this.ws || this.ws.readyState !== WS_READY_STATE.OPEN) {
       if (this.reconnectTimer) return;
-      this.ws = null;
+      this.defuseOldWs();
       this._connected = false;
       this.listener?.({ type: '_close' });
       this.doConnect();

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -571,7 +571,11 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
               }
             }
           })
-          .catch(() => {});
+          .catch((err) => {
+            if (typeof console !== 'undefined') {
+              console.warn('[mitzo] foreground recovery fetch failed', err);
+            }
+          });
       }
       return;
     }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -552,6 +552,30 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
   };
 
   function wsListener(msg: Record<string, unknown>) {
+    // Foreground recovery: when the page becomes visible again (iOS may have
+    // evicted it from memory, losing in-memory state), re-fetch messages from
+    // the REST API if we have an active session but no messages in the store.
+    if (msg.type === '_foreground') {
+      const { sessions, messages: msgs } = store.getState();
+      if (sessions.active && msgs.messages.length === 0 && !msgs.current) {
+        api
+          .getSessionMessages(sessions.active)
+          .then((restored) => {
+            if (Array.isArray(restored) && restored.length > 0) {
+              // Only restore if store is still empty (avoid clobbering live data)
+              const current = store.getState().messages;
+              if (current.messages.length === 0 && !current.current) {
+                store.setState((s) => ({
+                  messages: messagesReducer(s.messages, { type: 'RESTORE', messages: restored }),
+                }));
+              }
+            }
+          })
+          .catch(() => {});
+      }
+      return;
+    }
+
     const eventSessionId = msg.sessionId as string | undefined;
 
     // Session-scoped event filtering for multiplexed v2 connections:

--- a/packages/harness/src/connection-registry.ts
+++ b/packages/harness/src/connection-registry.ts
@@ -84,6 +84,17 @@ export class ConnectionRegistry {
   }
 
   /**
+   * Check if at least one open connection is watching the given session.
+   * Short-circuits on the first match — no array allocation.
+   */
+  hasOpenWatchers(sessionId: string): boolean {
+    for (const conn of this.connections.values()) {
+      if (conn.watchedSessions.has(sessionId) && conn.transport.isOpen()) return true;
+    }
+    return false;
+  }
+
+  /**
    * Send a message to all open connections watching a session.
    * Catches send errors to prevent one failing transport from
    * aborting the broadcast loop.

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -1296,6 +1296,69 @@ describe('runQueryLoop', () => {
       // session_end should reach v2Transport via connRegistry in the finally block
       expect(v2Transport.sent.some((m) => m.type === 'session_end')).toBe(true);
     });
+
+    it('delivers events to a NEW connection after WS reconnect (old connection gone)', async () => {
+      const connRegistry = new ConnectionRegistry();
+      const oldTransport = fakeTransport();
+      const newTransport = fakeTransport();
+
+      // Simulate initial v2 connection
+      connRegistry.register(clientId, oldTransport);
+      connRegistry.watch(clientId, 'sess-recon');
+      connRegistry.setActive(clientId, 'sess-recon');
+
+      // Pre-set sessionId (session already resolved from previous turn)
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-recon';
+
+      // Simulate WS disconnect: old connection removed from connRegistry
+      connRegistry.remove(clientId);
+
+      // Simulate WS reconnect: new connection with different ID watches the session
+      const newConnId = 'conn-new-after-reconnect';
+      connRegistry.register(newConnId, newTransport);
+      connRegistry.watch(newConnId, 'sess-recon');
+      connRegistry.setActive(newConnId, 'sess-recon');
+
+      // Query loop still uses the OLD clientId (closed over at start)
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-recon' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'hello after reconnect' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-recon' },
+        { type: 'result', session_id: 'sess-recon' },
+      ];
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId, // OLD clientId — no longer in connRegistry
+        registry,
+        abortController,
+        undefined,
+        undefined,
+        { connRegistry },
+      );
+
+      // The NEW transport should receive events via broadcast
+      // (even though the query loop's clientId is no longer in connRegistry)
+      expect(newTransport.sent.some((m) => m.type === 'message_start')).toBe(true);
+      expect(newTransport.sent.some((m) => m.type === 'block_delta')).toBe(true);
+      expect(newTransport.sent.some((m) => m.type === 'session_end')).toBe(true);
+
+      // Old transport should NOT receive anything (it was removed)
+      expect(oldTransport.sent).toHaveLength(0);
+    });
   });
 
   describe('onSessionResolved callback', () => {

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -28,7 +28,14 @@ vi.mock('../skill-policy.js', () => ({
   clearSkillPolicy: vi.fn(),
 }));
 
-import { startChat, interruptChat, sendToChat, isActive, discoverSession } from '../chat.js';
+import {
+  startChat,
+  interruptChat,
+  sendToChat,
+  isActive,
+  reattachChat,
+  discoverSession,
+} from '../chat.js';
 import { setSkillPolicy } from '../skill-policy.js';
 import { resolveSlashCommand } from '../slash-commands.js';
 
@@ -213,6 +220,47 @@ describe('handleReconnect', () => {
     expect(summary!.sessions).toEqual([
       expect.objectContaining({ sessionId: 'sess-1', replayed: 0 }),
     ]);
+  });
+
+  it('reattaches detached session on reconnect', () => {
+    (reattachChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    // Session is active but detached (WS died while query loop running)
+    ctx.sessionRegistry.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
+    ctx.sessionRegistry.isActive.mockReturnValue(true);
+    ctx.sessionRegistry.isAttached.mockReturnValue(false);
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    expect(reattachChat).toHaveBeenCalledWith('old-conn', transport);
+  });
+
+  it('does not reattach if session is already attached', () => {
+    (reattachChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    ctx.sessionRegistry.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
+    ctx.sessionRegistry.isActive.mockReturnValue(true);
+    ctx.sessionRegistry.isAttached.mockReturnValue(true); // already attached
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    expect(reattachChat).not.toHaveBeenCalled();
   });
 });
 
@@ -458,6 +506,66 @@ describe('handleSendV2 auto-watch', () => {
     expect(conn).toBeDefined();
     expect(conn!.watchedSessions.has('sess-new')).toBe(true);
     expect(conn!.activeSession).toBe('sess-new');
+  });
+});
+
+// ─── handleSendV2 reattach on send ──────────────────────────────────────────
+
+describe('handleSendV2 reattach', () => {
+  it('reattaches detached session before sending to active driver', () => {
+    (reattachChat as ReturnType<typeof vi.fn>).mockClear();
+    (isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-driver', session: {} });
+    sessionReg.isActive.mockReturnValue(true);
+    sessionReg.isAttached.mockReturnValue(false); // detached
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: 'sess-1', prompt: 'hi', clientMsgId: 'cmsg-1' },
+      ctx,
+    );
+
+    expect(reattachChat).toHaveBeenCalledWith('old-driver', transport);
+    expect(sendToChat).toHaveBeenCalled();
+
+    // Restore default
+    (isActive as ReturnType<typeof vi.fn>).mockReturnValue(false);
+  });
+
+  it('skips reattach when session is already attached', () => {
+    (reattachChat as ReturnType<typeof vi.fn>).mockClear();
+    (isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-driver', session: {} });
+    sessionReg.isActive.mockReturnValue(true);
+    sessionReg.isAttached.mockReturnValue(true); // already attached
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: 'sess-1', prompt: 'hi', clientMsgId: 'cmsg-1' },
+      ctx,
+    );
+
+    expect(reattachChat).not.toHaveBeenCalled();
+
+    (isActive as ReturnType<typeof vi.fn>).mockReturnValue(false);
   });
 });
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -32,11 +32,12 @@ import {
   startChat,
   interruptChat,
   sendToChat,
+  stopChat,
   isActive,
   reattachChat,
   discoverSession,
 } from '../chat.js';
-import { setSkillPolicy } from '../skill-policy.js';
+import { setSkillPolicy, clearSkillPolicy } from '../skill-policy.js';
 import { resolveSlashCommand } from '../slash-commands.js';
 
 import {
@@ -51,6 +52,7 @@ import {
   handleStopV2,
   handlePermissionResponseV2,
   isHelloHandshake,
+  dispatchV2Message,
   type V2HandlerContext,
 } from '../ws-handler-v2.js';
 import { NativeCommandRegistry } from '../native-commands.js';
@@ -678,6 +680,21 @@ describe('handleStopV2', () => {
     const ctx = createContext();
     expect(() => handleStopV2('c1', { type: 'stop', sessionId: 'nope' }, ctx)).not.toThrow();
   });
+
+  it('calls stopChat with correct clientId when session is found', () => {
+    (stopChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+
+    handleStopV2('c1', { type: 'stop', sessionId: 'sess-1' }, ctx);
+
+    expect(stopChat).toHaveBeenCalledWith('driver-1');
+  });
 });
 
 // ─── handlePermissionResponseV2 ──────────────────────────────────────────────
@@ -685,7 +702,6 @@ describe('handleStopV2', () => {
 describe('handlePermissionResponseV2', () => {
   it('calls resolvePending with correct args', () => {
     const ctx = createContext();
-    // resolvePending is imported from permissions.js — we just verify no throw
     expect(() =>
       handlePermissionResponseV2(
         'c1',
@@ -693,5 +709,689 @@ describe('handlePermissionResponseV2', () => {
         ctx,
       ),
     ).not.toThrow();
+  });
+
+  it('defaults decision to deny when not provided', () => {
+    const ctx = createContext();
+    expect(() =>
+      handlePermissionResponseV2(
+        'c1',
+        {
+          type: 'permission_response',
+          sessionId: 'sess-1',
+          permId: 'p2',
+          decision: undefined as unknown as 'once',
+        },
+        ctx,
+      ),
+    ).not.toThrow();
+  });
+});
+
+// ─── handleReconnect — running status ───────────────────────────────────────
+
+describe('handleReconnect running status', () => {
+  it('reports running=true when session has an active driver', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1' });
+    sessionReg.isActive.mockReturnValue(true);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    const summary = transport.sent.find((m) => m.type === 'reconnected') as {
+      sessions: Array<{ sessionId: string; running: boolean }>;
+    };
+    expect(summary.sessions[0].running).toBe(true);
+  });
+
+  it('reports running=false when session has no active driver', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1' });
+    sessionReg.isActive.mockReturnValue(false);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    const summary = transport.sent.find((m) => m.type === 'reconnected') as {
+      sessions: Array<{ sessionId: string; running: boolean }>;
+    };
+    expect(summary.sessions[0].running).toBe(false);
+  });
+
+  it('reports running=false when session is not in registry', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'unknown-sess', lastSeq: 0 }] },
+      ctx,
+    );
+
+    const summary = transport.sent.find((m) => m.type === 'reconnected') as {
+      sessions: Array<{ sessionId: string; running: boolean }>;
+    };
+    expect(summary.sessions[0].running).toBe(false);
+  });
+
+  it('handles mixed running states across multiple sessions', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId
+      .mockReturnValueOnce({ clientId: 'driver-1' })
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({ clientId: 'driver-3' });
+    sessionReg.isActive.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleReconnect(
+      'c1',
+      {
+        type: 'reconnect',
+        sessions: [
+          { sessionId: 'sess-1', lastSeq: 0 },
+          { sessionId: 'sess-2', lastSeq: 0 },
+          { sessionId: 'sess-3', lastSeq: 0 },
+        ],
+      },
+      ctx,
+    );
+
+    const summary = transport.sent.find((m) => m.type === 'reconnected') as {
+      sessions: Array<{ sessionId: string; running: boolean }>;
+    };
+    expect(summary.sessions).toHaveLength(3);
+    expect(summary.sessions[0]).toEqual(
+      expect.objectContaining({ sessionId: 'sess-1', running: true }),
+    );
+    expect(summary.sessions[1]).toEqual(
+      expect.objectContaining({ sessionId: 'sess-2', running: false }),
+    );
+    expect(summary.sessions[2]).toEqual(
+      expect.objectContaining({ sessionId: 'sess-3', running: false }),
+    );
+  });
+
+  it('replays multiple events in sequence order', () => {
+    const eventStore = mockEventStore();
+    eventStore.getEventsAfter.mockReturnValue([
+      {
+        seq: 3,
+        sessionId: 'sess-1',
+        type: 'block_delta',
+        payload: { v: 2, type: 'block_delta', delta: 'first', sessionId: 'sess-1' },
+      },
+      {
+        seq: 4,
+        sessionId: 'sess-1',
+        type: 'block_delta',
+        payload: { v: 2, type: 'block_delta', delta: 'second', sessionId: 'sess-1' },
+      },
+      {
+        seq: 5,
+        sessionId: 'sess-1',
+        type: 'turn_end',
+        payload: { v: 2, type: 'turn_end', sessionId: 'sess-1' },
+      },
+    ]);
+
+    const ctx = createContext({
+      eventStore: eventStore as unknown as V2HandlerContext['eventStore'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 2 }] },
+      ctx,
+    );
+
+    const replayed = transport.sent.filter((m) => m.seq !== undefined);
+    expect(replayed).toHaveLength(3);
+    expect(replayed[0].seq).toBe(3);
+    expect(replayed[1].seq).toBe(4);
+    expect(replayed[2].seq).toBe(5);
+  });
+});
+
+// ─── handleSendV2 — routing paths ──────────────────────────────────────────
+
+describe('handleSendV2 routing', () => {
+  it('sends to active driver on the active path', () => {
+    (sendToChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+    (isActive as ReturnType<typeof vi.fn>).mockReturnValueOnce(true);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: 'sess-1', prompt: 'hello', clientMsgId: 'cmsg-1' },
+      ctx,
+    );
+
+    expect(sendToChat).toHaveBeenCalledWith('driver-1', 'hello', undefined, undefined, 'cmsg-1');
+    expect(ctx.connRegistry.get('c1')!.watchedSessions.has('sess-1')).toBe(true);
+    expect(ctx.connRegistry.get('c1')!.activeSession).toBe('sess-1');
+  });
+
+  it('sends error on resolution error', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      type: 'error',
+      message: 'Unknown command /foo',
+    });
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: null, prompt: '/foo', clientMsgId: 'e1' },
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({ type: 'error', error: 'Unknown command /foo' }),
+    );
+    expect(startChat).not.toHaveBeenCalled();
+  });
+
+  it('returns early for native commands without calling startChat', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      type: 'native',
+      name: 'test-cmd',
+      arguments: '',
+    });
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: null, prompt: '/test-cmd', clientMsgId: 'h1' },
+      ctx,
+    );
+
+    // Native commands short-circuit — startChat should NOT be called
+    expect(startChat).not.toHaveBeenCalled();
+  });
+
+  it('sends skill_invoked event for skill commands', () => {
+    // Reset resolveSlashCommand to plain first, then set skill for this test
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReset();
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      type: 'skill',
+      name: 'commit',
+      renderedPrompt: 'Create a commit...',
+      allowedTools: ['Bash'],
+      arguments: '-m "test"',
+    });
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      {
+        type: 'send' as const,
+        sessionId: null,
+        prompt: '/commit -m "test"',
+        clientMsgId: 's1',
+      },
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({
+        type: 'skill_invoked',
+        v: 2,
+        name: 'commit',
+        arguments: '-m "test"',
+      }),
+    );
+    expect(startChat).toHaveBeenCalledTimes(1);
+
+    // Restore default
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValue({ type: 'plain' });
+  });
+
+  it('sends error message on exception', () => {
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReset();
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('Kaboom');
+    });
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: null, prompt: 'hi', clientMsgId: 'x1' },
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({ type: 'error', error: 'Kaboom' }),
+    );
+
+    // Restore default
+    (resolveSlashCommand as ReturnType<typeof vi.fn>).mockReturnValue({ type: 'plain' });
+  });
+
+  it('validates cwd via isAllowedPath', () => {
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      {
+        type: 'send' as const,
+        sessionId: null,
+        prompt: 'hi',
+        clientMsgId: 'cwd1',
+        cwd: '/some/valid/path',
+      },
+      ctx,
+    );
+
+    expect(startChat).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─── handleSendV2 — skill policy clearing ──────────────────────────────────
+
+describe('handleSendV2 skill policy clearing', () => {
+  it('calls clearSkillPolicy when no skill is invoked', () => {
+    (clearSkillPolicy as ReturnType<typeof vi.fn>).mockClear();
+    (startChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleSendV2(
+      'c1',
+      transport,
+      { type: 'send' as const, sessionId: null, prompt: 'plain text', clientMsgId: 'cp1' },
+      ctx,
+    );
+
+    expect(clearSkillPolicy).toHaveBeenCalledWith(expect.anything(), expect.any(String));
+  });
+});
+
+// ─── handleSwitchSession — token fields ────────────────────────────────────
+
+describe('handleSwitchSession token fields', () => {
+  it('includes all token fields in session_switched response', async () => {
+    const eventStore = mockEventStore();
+    eventStore.getSession.mockReturnValue({
+      sessionId: 'sess-tokens',
+      mode: 'code',
+      cwd: '/projects/bar',
+      branch: 'develop',
+      wtId: null,
+      inputTokens: 5000,
+      outputTokens: 2000,
+      cacheReadTokens: 1500,
+      cacheCreationTokens: 300,
+      totalCostUsd: 0.12,
+    });
+
+    const ctx = createContext({
+      eventStore: eventStore as unknown as V2HandlerContext['eventStore'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await handleSwitchSession('c1', { type: 'switch_session', sessionId: 'sess-tokens' }, ctx);
+
+    const resp = transport.sent[0];
+    expect(resp).toHaveProperty('tokens');
+    const tokens = (resp as { tokens: Record<string, unknown> }).tokens;
+    expect(tokens).toEqual({
+      input: 5000,
+      output: 2000,
+      cacheRead: 1500,
+      cacheCreation: 300,
+      costUsd: 0.12,
+    });
+  });
+});
+
+// ─── handleSetModeV2 — broadcast to multiple watchers ──────────────────────
+
+describe('handleSetModeV2 broadcast', () => {
+  it('broadcasts mode_changed to multiple watchers', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport1 = mockTransport();
+    const transport2 = mockTransport();
+    ctx.connRegistry.register('c1', transport1);
+    ctx.connRegistry.register('c2', transport2);
+    ctx.connRegistry.watch('c1', 'sess-1');
+    ctx.connRegistry.watch('c2', 'sess-1');
+
+    handleSetModeV2('c1', { type: 'set_mode', sessionId: 'sess-1', mode: 'ask' }, ctx);
+
+    expect(transport1.sent.some((m) => m.type === 'mode_changed' && m.mode === 'ask')).toBe(true);
+    expect(transport2.sent.some((m) => m.type === 'mode_changed' && m.mode === 'ask')).toBe(true);
+  });
+});
+
+// ─── handleWatch / handleUnwatch — edge cases ──────────────────────────────
+
+describe('handleWatch edge cases', () => {
+  it('watching the same session twice is idempotent', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleWatch('c1', { type: 'watch', sessionId: 'sess-1' }, ctx);
+    handleWatch('c1', { type: 'watch', sessionId: 'sess-1' }, ctx);
+
+    expect(ctx.connRegistry.get('c1')!.watchedSessions.has('sess-1')).toBe(true);
+    expect(transport.sent.filter((m) => m.type === 'watched')).toHaveLength(2);
+  });
+
+  it('unwatching a session not watched is harmless', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleUnwatch('c1', { type: 'unwatch', sessionId: 'never-watched' }, ctx);
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({ type: 'unwatched', sessionId: 'never-watched' }),
+    );
+  });
+
+  it('can watch multiple sessions on the same connection', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleWatch('c1', { type: 'watch', sessionId: 'sess-1' }, ctx);
+    handleWatch('c1', { type: 'watch', sessionId: 'sess-2' }, ctx);
+    handleWatch('c1', { type: 'watch', sessionId: 'sess-3' }, ctx);
+
+    const conn = ctx.connRegistry.get('c1')!;
+    expect(conn.watchedSessions.has('sess-1')).toBe(true);
+    expect(conn.watchedSessions.has('sess-2')).toBe(true);
+    expect(conn.watchedSessions.has('sess-3')).toBe(true);
+  });
+});
+
+// ─── handleHello — edge cases ──────────────────────────────────────────────
+
+describe('handleHello edge cases', () => {
+  it('returns the provided connectionId', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+
+    const id = handleHello('unique-conn-42', transport, ctx);
+
+    expect(id).toBe('unique-conn-42');
+  });
+
+  it('welcome message includes protocolVersion 2', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+
+    handleHello('c1', transport, ctx);
+
+    expect(transport.sent[0]).toEqual(
+      expect.objectContaining({
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'c1',
+      }),
+    );
+  });
+});
+
+// ─── dispatchV2Message ─────────────────────────────────────────────────────
+
+describe('dispatchV2Message', () => {
+  it('ignores malformed JSON', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message('c1', transport, 'not json{{{', ctx);
+
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it('ignores unrecognized message types', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message('c1', transport, JSON.stringify({ type: 'unknown_type' }), ctx);
+
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it('ignores duplicate hello messages', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({ type: 'hello', protocolVersion: 2 }),
+      ctx,
+    );
+
+    expect(transport.sent).toHaveLength(0);
+  });
+
+  it('routes watch messages correctly', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({ type: 'watch', sessionId: 'sess-1' }),
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({ type: 'watched', sessionId: 'sess-1' }),
+    );
+  });
+
+  it('routes unwatch messages correctly', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+    ctx.connRegistry.watch('c1', 'sess-1');
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({ type: 'unwatch', sessionId: 'sess-1' }),
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(
+      expect.objectContaining({ type: 'unwatched', sessionId: 'sess-1' }),
+    );
+  });
+
+  it('routes stop messages correctly', async () => {
+    (stopChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({ type: 'stop', sessionId: 'sess-1' }),
+      ctx,
+    );
+
+    expect(stopChat).toHaveBeenCalledWith('driver-1');
+  });
+
+  it('routes reconnect messages and produces reconnected summary', async () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({
+        type: 'reconnect',
+        sessions: [{ sessionId: 'sess-1', lastSeq: 0 }],
+      }),
+      ctx,
+    );
+
+    expect(transport.sent).toContainEqual(expect.objectContaining({ type: 'reconnected' }));
+  });
+
+  it('routes set_mode messages correctly', async () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+    ctx.connRegistry.watch('c1', 'sess-1');
+
+    await dispatchV2Message(
+      'c1',
+      transport,
+      JSON.stringify({ type: 'set_mode', sessionId: 'sess-1', mode: 'agent' }),
+      ctx,
+    );
+
+    expect(sessionReg.setMode).toHaveBeenCalledWith('driver-1', 'agent');
+    expect(transport.sent.some((m) => m.type === 'mode_changed')).toBe(true);
+  });
+});
+
+// ─── handleInterruptV2 — images and contextBlocks forwarding ───────────────
+
+describe('handleInterruptV2 forwarding', () => {
+  it('forwards images and contextBlocks to interruptChat', () => {
+    (interruptChat as ReturnType<typeof vi.fn>).mockClear();
+
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'driver-1', session: {} });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    const images = [{ data: 'base64img', mediaType: 'image/png' as const }];
+    const contextBlocks = ['some context block'];
+
+    handleInterruptV2(
+      'c1',
+      transport,
+      {
+        type: 'interrupt',
+        sessionId: 'sess-1',
+        prompt: 'new direction',
+        clientMsgId: 'i3',
+        images,
+        contextBlocks,
+      },
+      ctx,
+    );
+
+    expect(interruptChat).toHaveBeenCalledWith(
+      'driver-1',
+      'new direction',
+      images,
+      contextBlocks,
+      'i3',
+    );
+  });
+
+  it('does not watch or activate when session is not found', () => {
+    const ctx = createContext();
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    handleInterruptV2(
+      'c1',
+      transport,
+      { type: 'interrupt', sessionId: 'ghost', prompt: 'x', clientMsgId: 'i4' },
+      ctx,
+    );
+
+    const conn = ctx.connRegistry.get('c1')!;
+    expect(conn.watchedSessions.size).toBe(0);
+    expect(conn.activeSession).toBeNull();
   });
 });

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -225,14 +225,16 @@ describe('handleReconnect', () => {
   it('reattaches detached session on reconnect', () => {
     (reattachChat as ReturnType<typeof vi.fn>).mockClear();
 
-    const ctx = createContext();
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
+    sessionReg.isActive.mockReturnValue(true);
+    sessionReg.isAttached.mockReturnValue(false);
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
-
-    // Session is active but detached (WS died while query loop running)
-    ctx.sessionRegistry.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
-    ctx.sessionRegistry.isActive.mockReturnValue(true);
-    ctx.sessionRegistry.isAttached.mockReturnValue(false);
 
     handleReconnect(
       'c1',
@@ -246,13 +248,16 @@ describe('handleReconnect', () => {
   it('does not reattach if session is already attached', () => {
     (reattachChat as ReturnType<typeof vi.fn>).mockClear();
 
-    const ctx = createContext();
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
+    sessionReg.isActive.mockReturnValue(true);
+    sessionReg.isAttached.mockReturnValue(true); // already attached
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
     const transport = mockTransport();
     ctx.connRegistry.register('c1', transport);
-
-    ctx.sessionRegistry.findBySessionId.mockReturnValue({ clientId: 'old-conn' });
-    ctx.sessionRegistry.isActive.mockReturnValue(true);
-    ctx.sessionRegistry.isAttached.mockReturnValue(true); // already attached
 
     handleReconnect(
       'c1',

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -8,6 +8,7 @@ vi.mock('../chat.js', () => ({
   interruptChat: vi.fn(),
   stopChat: vi.fn(),
   isActive: vi.fn().mockReturnValue(false),
+  reattachChat: vi.fn().mockReturnValue(true),
   BASE_REPO: '/tmp/test-repo',
   discoverSession: vi.fn().mockResolvedValue(null),
 }));
@@ -73,6 +74,8 @@ function mockSessionRegistry() {
     findBySessionId: vi.fn().mockReturnValue(null),
     setMode: vi.fn(),
     isActive: vi.fn().mockReturnValue(false),
+    isAttached: vi.fn().mockReturnValue(true),
+    reattach: vi.fn().mockReturnValue(true),
     entries: vi.fn(() => new Map().entries()),
   };
 }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -81,9 +81,11 @@ function sendOrBuffer(
     }
   }
 
-  // v2 path: deliver via ConnectionRegistry when clientId is a registered v2
-  // connection AND sessionId is resolved (broadcast needs a session target).
-  if (connRegistry?.get(clientId) && sessionId) {
+  // v2 path: deliver via ConnectionRegistry when there are open connections
+  // watching this session. Uses sessionId-based fan-out instead of checking
+  // whether the originating clientId is still registered — after a WS
+  // reconnect the original connection is gone but new ones may be watching.
+  if (sessionId && connRegistry?.hasOpenWatchers(sessionId)) {
     connRegistry.broadcast(sessionId, enriched);
     return;
   }
@@ -399,8 +401,14 @@ export async function runQueryLoop(
         }
 
         emit(v2('session_end', { sessionId: msg.session_id, usage: usageData }));
-        if (connRegistry?.get(clientId)) {
-          connRegistry.setActive(clientId, null);
+        const resultSid = (msg.session_id as string) || currentSession.sessionId;
+        if (resultSid && connRegistry?.hasOpenWatchers(resultSid)) {
+          for (const { connectionId: cid } of connRegistry.getConnectionsWatching(
+            resultSid,
+            true,
+          )) {
+            connRegistry.setActive(cid, null);
+          }
         }
         if (!registry.isAttached(clientId)) {
           const snippet = extractSnippet(snapshotBlocks, NOTIFY_SNIPPET_MAX_CHARS);
@@ -669,14 +677,18 @@ export async function runQueryLoop(
       finalSession.currentSnapshot = null;
       if (!doneSent) {
         const endMsg = v2('session_end', { sessionId: finalSession.sessionId });
-        if (connRegistry?.get(clientId) && finalSession.sessionId) {
-          connRegistry.broadcast(finalSession.sessionId, endMsg);
+        const sid = finalSession.sessionId;
+        if (sid && connRegistry?.hasOpenWatchers(sid)) {
+          connRegistry.broadcast(sid, endMsg);
         } else {
           send(finalSession.transport, endMsg);
           broadcastToObservers(finalSession.observers, endMsg);
         }
-        if (connRegistry?.get(clientId)) {
-          connRegistry.setActive(clientId, null);
+        if (sid && connRegistry?.hasOpenWatchers(sid)) {
+          // Clear active session on all watching connections
+          for (const { connectionId: cid } of connRegistry.getConnectionsWatching(sid, true)) {
+            connRegistry.setActive(cid, null);
+          }
         }
       }
       registry.remove(clientId);

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -407,7 +407,10 @@ export async function runQueryLoop(
             resultSid,
             true,
           )) {
-            connRegistry.setActive(cid, null);
+            const conn = connRegistry.get(cid);
+            if (conn?.activeSession === resultSid) {
+              connRegistry.setActive(cid, null);
+            }
           }
         }
         if (!registry.isAttached(clientId)) {
@@ -685,9 +688,12 @@ export async function runQueryLoop(
           broadcastToObservers(finalSession.observers, endMsg);
         }
         if (sid && connRegistry?.hasOpenWatchers(sid)) {
-          // Clear active session on all watching connections
+          // Clear active session only on connections whose active is this session
           for (const { connectionId: cid } of connRegistry.getConnectionsWatching(sid, true)) {
-            connRegistry.setActive(cid, null);
+            const conn = connRegistry.get(cid);
+            if (conn?.activeSession === sid) {
+              connRegistry.setActive(cid, null);
+            }
           }
         }
       }

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -41,6 +41,7 @@ import {
   interruptChat,
   stopChat,
   isActive,
+  reattachChat,
   BASE_REPO,
   discoverSession,
 } from './chat.js';
@@ -118,9 +119,23 @@ export function handleReconnect(
         } as Record<string, unknown>);
       }
 
-      // Check if session has an active driver in the SessionRegistry
+      // Check if session has an active driver in the SessionRegistry.
+      // If the driver is still running but was detached by the old WS close,
+      // reattach it with the new connection's transport so future events
+      // from the query loop can be delivered via the v1 fallback path.
       const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
       const running = found ? ctx.sessionRegistry.isActive(found.clientId) : false;
+      if (found && running && !ctx.sessionRegistry.isAttached(found.clientId)) {
+        const conn = ctx.connRegistry.get(connectionId);
+        if (conn) {
+          ctx.sessionRegistry.reattach(found.clientId, conn.transport);
+          log.info('reattached detached session on reconnect', {
+            connectionId,
+            sessionId: entry.sessionId,
+            clientId: found.clientId,
+          });
+        }
+      }
 
       summaries.push({
         sessionId: entry.sessionId,
@@ -312,6 +327,17 @@ export function handleSendV2(
       // Resume existing session
       const found = ctx.sessionRegistry.findBySessionId(sessionId);
       if (found && isActive(found.clientId)) {
+        // Reattach if session was detached by a previous WS disconnect.
+        // This updates the session's transport to the current connection
+        // so the v1 fallback path in sendOrBuffer can still deliver events.
+        if (!ctx.sessionRegistry.isAttached(found.clientId)) {
+          reattachChat(found.clientId, transport);
+          log.info('reattached detached session on send', {
+            connectionId,
+            sessionId,
+            clientId: found.clientId,
+          });
+        }
         applySkillPolicy(found.clientId);
         sendToChat(found.clientId, prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
         ctx.connRegistry.watch(connectionId, sessionId);

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -128,7 +128,7 @@ export function handleReconnect(
       if (found && running && !ctx.sessionRegistry.isAttached(found.clientId)) {
         const conn = ctx.connRegistry.get(connectionId);
         if (conn) {
-          ctx.sessionRegistry.reattach(found.clientId, conn.transport);
+          reattachChat(found.clientId, conn.transport);
           log.info('reattached detached session on reconnect', {
             connectionId,
             sessionId: entry.sessionId,


### PR DESCRIPTION
## Summary

- **Server**: `sendOrBuffer` now gates v2 broadcast on `hasOpenWatchers(sessionId)` instead of checking the originating `clientId` — after a WS reconnect the old connection is gone but new ones may be watching. Also reattaches detached sessions on reconnect and on send.
- **Client**: `defuseOldWs()` nulls all handlers on the old WebSocket before creating a new one, so the stale `onclose` can't overwrite `this.ws` / `this._connected` and cause cascading reconnect cycles.
- **Client**: Foreground recovery — on `visibilitychange → visible`, if the store has an active session but no messages (iOS evicted the page), re-fetches from the REST API.

## Root cause

iOS Safari kills WebSocket connections when the app is backgrounded. Three things then go wrong:

1. The query loop's closed-over `clientId` no longer exists in `ConnectionRegistry` → events silently dropped
2. `checkAndReconnect()` replaces the WS but the old socket's `onclose` fires later, setting `this.ws = null` and `_connected = false` on the **new** connection — causing duplicate reconnect cycles
3. If iOS fully evicts the page from memory, the in-memory Zustand store and `seqBySession` map are lost — no reconnect replay happens and messages vanish

## Test plan

- [x] Send a message on mobile, switch away, come back — response visible without pull-to-refresh
- [x] Second prompt in same session displays correctly
- [ ] Desktop/Safari — no regression on normal WS lifecycle
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)