### PR TITLE
feat: draft prompt persistence + fast session loading

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -17,6 +17,7 @@ import { impactMedium } from '../lib/haptics';
 import { TokenBar } from './TokenBar';
 import type { UseVoiceReturn } from '../hooks/useVoice';
 import type { TokensState as TokenState } from '@mitzo/client';
+import { useDraft } from '../hooks/useDraft';
 
 interface Props {
   onSend: (text: string, images?: ImageAttachment[], contextBlocks?: string[]) => boolean;
@@ -50,7 +51,7 @@ export function ChatInput({
   externalContextBlocks,
   tokenState,
 }: Props) {
-  const [text, setText] = useState(initialText || '');
+  const [text, setText, clearDraft] = useDraft(sessionId, initialText);
   const [images, setImages] = useState<ImageAttachment[]>([]);
   const [showSlashPicker, setShowSlashPicker] = useState(false);
   const [showContextPicker, setShowContextPicker] = useState(false);
@@ -75,7 +76,6 @@ export function ChatInput({
   useEffect(() => {
     if (initialText && !initialApplied.current) {
       initialApplied.current = true;
-      setText(initialText);
       requestAnimationFrame(() => {
         autoResize();
         textareaRef.current?.focus();
@@ -114,7 +114,7 @@ export function ChatInput({
     );
     if (sent) {
       impactMedium();
-      setText('');
+      clearDraft();
       setImages([]);
       if (!useExternal) setContextBlocks([]);
       requestAnimationFrame(() => {
@@ -201,7 +201,7 @@ export function ChatInput({
       images.length > 0 ? images : undefined,
       activeContextBlocks.length > 0 ? activeContextBlocks : undefined,
     );
-    setText('');
+    clearDraft();
     setImages([]);
     if (!useExternal) setContextBlocks([]);
     requestAnimationFrame(() => {

--- a/frontend/src/hooks/__tests__/useDraft.test.ts
+++ b/frontend/src/hooks/__tests__/useDraft.test.ts
@@ -78,4 +78,24 @@ describe('useDraft', () => {
     const { result } = renderHook(() => useDraft(undefined));
     expect(result.current[0]).toBe('unsent prompt');
   });
+
+  it('migrates draft when sessionId changes from undefined to a real ID', () => {
+    vi.useFakeTimers();
+    localStorage.setItem('mitzo-draft-new', 'draft in progress');
+    const { result, rerender } = renderHook(({ id }: { id: string | undefined }) => useDraft(id), {
+      initialProps: { id: undefined as string | undefined },
+    });
+
+    expect(result.current[0]).toBe('draft in progress');
+
+    // Simulate the session getting assigned a real ID
+    rerender({ id: 'sess-real' });
+
+    // Draft should have migrated to the new key
+    expect(localStorage.getItem('mitzo-draft-sess-real')).toBe('draft in progress');
+    // Old key should be removed
+    expect(localStorage.getItem('mitzo-draft-new')).toBeNull();
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/hooks/__tests__/useDraft.test.ts
+++ b/frontend/src/hooks/__tests__/useDraft.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDraft } from '../useDraft';
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('useDraft', () => {
+  it('initializes with empty string when no draft exists', () => {
+    const { result } = renderHook(() => useDraft('sess-1'));
+    expect(result.current[0]).toBe('');
+  });
+
+  it('uses initialText when provided', () => {
+    const { result } = renderHook(() => useDraft('sess-1', 'hello'));
+    expect(result.current[0]).toBe('hello');
+  });
+
+  it('restores draft from localStorage', () => {
+    localStorage.setItem('mitzo-draft-sess-2', 'saved draft');
+    const { result } = renderHook(() => useDraft('sess-2'));
+    expect(result.current[0]).toBe('saved draft');
+  });
+
+  it('prefers initialText over saved draft', () => {
+    localStorage.setItem('mitzo-draft-sess-3', 'old draft');
+    const { result } = renderHook(() => useDraft('sess-3', 'new text'));
+    expect(result.current[0]).toBe('new text');
+  });
+
+  it('persists text to localStorage after debounce', async () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useDraft('sess-4'));
+
+    act(() => result.current[1]('work in progress'));
+    // Not yet saved
+    expect(localStorage.getItem('mitzo-draft-sess-4')).toBeNull();
+
+    // Advance past debounce
+    act(() => vi.advanceTimersByTime(500));
+    expect(localStorage.getItem('mitzo-draft-sess-4')).toBe('work in progress');
+
+    vi.useRealTimers();
+  });
+
+  it('clears draft from state and localStorage', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('mitzo-draft-sess-5', 'draft');
+    const { result } = renderHook(() => useDraft('sess-5'));
+
+    expect(result.current[0]).toBe('draft');
+
+    act(() => result.current[2]()); // clearDraft
+    expect(result.current[0]).toBe('');
+    expect(localStorage.getItem('mitzo-draft-sess-5')).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('removes localStorage entry when text is emptied', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem('mitzo-draft-sess-6', 'old');
+    const { result } = renderHook(() => useDraft('sess-6'));
+
+    act(() => result.current[1](''));
+    act(() => vi.advanceTimersByTime(500));
+    expect(localStorage.getItem('mitzo-draft-sess-6')).toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it('uses "new" key when sessionId is undefined', () => {
+    localStorage.setItem('mitzo-draft-new', 'unsent prompt');
+    const { result } = renderHook(() => useDraft(undefined));
+    expect(result.current[0]).toBe('unsent prompt');
+  });
+});

--- a/frontend/src/hooks/useDraft.ts
+++ b/frontend/src/hooks/useDraft.ts
@@ -1,4 +1,11 @@
-import { type Dispatch, type SetStateAction, useState, useEffect, useRef, useCallback } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+} from 'react';
 
 const KEY_PREFIX = 'mitzo-draft-';
 const DEBOUNCE_MS = 400;

--- a/frontend/src/hooks/useDraft.ts
+++ b/frontend/src/hooks/useDraft.ts
@@ -14,10 +14,7 @@ function draftKey(sessionId: string | undefined): string {
   return `${KEY_PREFIX}${sessionId ?? 'new'}`;
 }
 
-/**
- * Persists draft prompt text to localStorage per session.
- * Returns [text, setText, clearDraft].
- */
+/** Persists draft prompt text to localStorage per session. */
 export function useDraft(
   sessionId: string | undefined,
   initialText?: string,
@@ -33,6 +30,7 @@ export function useDraft(
 
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const sessionRef = useRef(sessionId);
+  const mountedRef = useRef(false);
 
   // When sessionId changes (e.g. new session gets assigned an ID),
   // migrate draft from old key and load any existing draft for new key.
@@ -63,8 +61,12 @@ export function useDraft(
     }
   }, [sessionId]);
 
-  // Debounced save to localStorage on text change
+  // Debounced save to localStorage on text change (skip initial render)
   useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       try {

--- a/frontend/src/hooks/useDraft.ts
+++ b/frontend/src/hooks/useDraft.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { type Dispatch, type SetStateAction, useState, useEffect, useRef, useCallback } from 'react';
 
 const KEY_PREFIX = 'mitzo-draft-';
 const DEBOUNCE_MS = 400;
@@ -14,7 +14,7 @@ function draftKey(sessionId: string | undefined): string {
 export function useDraft(
   sessionId: string | undefined,
   initialText?: string,
-): [string, (val: string) => void, () => void] {
+): [string, Dispatch<SetStateAction<string>>, () => void] {
   const [text, setTextRaw] = useState(() => {
     if (initialText) return initialText;
     try {
@@ -24,7 +24,7 @@ export function useDraft(
     }
   });
 
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const sessionRef = useRef(sessionId);
 
   // When sessionId changes (e.g. new session gets assigned an ID),

--- a/frontend/src/hooks/useDraft.ts
+++ b/frontend/src/hooks/useDraft.ts
@@ -1,0 +1,88 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const KEY_PREFIX = 'mitzo-draft-';
+const DEBOUNCE_MS = 400;
+
+function draftKey(sessionId: string | undefined): string {
+  return `${KEY_PREFIX}${sessionId ?? 'new'}`;
+}
+
+/**
+ * Persists draft prompt text to localStorage per session.
+ * Returns [text, setText, clearDraft].
+ */
+export function useDraft(
+  sessionId: string | undefined,
+  initialText?: string,
+): [string, (val: string) => void, () => void] {
+  const [text, setTextRaw] = useState(() => {
+    if (initialText) return initialText;
+    try {
+      return localStorage.getItem(draftKey(sessionId)) ?? '';
+    } catch {
+      return '';
+    }
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const sessionRef = useRef(sessionId);
+
+  // When sessionId changes (e.g. new session gets assigned an ID),
+  // migrate draft from old key and load any existing draft for new key.
+  useEffect(() => {
+    const prev = sessionRef.current;
+    sessionRef.current = sessionId;
+    if (prev === sessionId) return;
+
+    // If we had a draft under the old key, migrate it
+    const oldKey = draftKey(prev);
+    const newKey = draftKey(sessionId);
+    try {
+      const existing = localStorage.getItem(newKey);
+      if (existing) {
+        // New session already has a draft — use it
+        setTextRaw(existing);
+      } else {
+        // Migrate from old key
+        const old = localStorage.getItem(oldKey);
+        if (old) {
+          localStorage.setItem(newKey, old);
+          // Don't change text state — it's the same draft, just moved
+        }
+      }
+      localStorage.removeItem(oldKey);
+    } catch {
+      // localStorage unavailable — ignore
+    }
+  }, [sessionId]);
+
+  // Debounced save to localStorage on text change
+  useEffect(() => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      try {
+        const key = draftKey(sessionRef.current);
+        if (text) {
+          localStorage.setItem(key, text);
+        } else {
+          localStorage.removeItem(key);
+        }
+      } catch {
+        // localStorage full or unavailable — ignore
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timerRef.current);
+  }, [text]);
+
+  const clearDraft = useCallback(() => {
+    setTextRaw('');
+    try {
+      localStorage.removeItem(draftKey(sessionRef.current));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return [text, setTextRaw, clearDraft];
+}

--- a/packages/protocol/__tests__/event-store.test.ts
+++ b/packages/protocol/__tests__/event-store.test.ts
@@ -209,6 +209,36 @@ describe('EventStore', () => {
       expect(session!.wtId).toBe('wt-session-123');
       expect(session!.mode).toBe('agent');
     });
+
+    it('uses explicit updatedAt on UPDATE instead of auto-generated', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Initial' });
+      const explicitTs = 1700000000000;
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Updated', updatedAt: explicitTs });
+
+      const session = store.getSession('sess-1');
+      expect(session!.updatedAt).toBe(explicitTs);
+    });
+
+    it('uses explicit createdAt on INSERT', () => {
+      const explicitTs = 1600000000000;
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Backdated', createdAt: explicitTs });
+
+      const session = store.getSession('sess-1');
+      expect(session!.createdAt).toBe(explicitTs);
+    });
+
+    it('auto-generates timestamps when explicit values are omitted', () => {
+      const before = Date.now();
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Auto' });
+      const after = Date.now();
+
+      const session = store.getSession('sess-1');
+      // createdAt and updatedAt should be auto-generated within a reasonable range
+      expect(session!.createdAt).toBeGreaterThanOrEqual(before - 1000);
+      expect(session!.createdAt).toBeLessThanOrEqual(after + 1000);
+      expect(session!.updatedAt).toBeGreaterThanOrEqual(before - 1000);
+      expect(session!.updatedAt).toBeLessThanOrEqual(after + 1000);
+    });
   });
 
   describe('getSession', () => {

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -265,7 +265,17 @@ export class EventStore {
         ...values,
       );
     } else {
-      const cols = ['session_id', 'summary', 'branch', 'cwd', 'mode', 'is_active', 'initial_prompt', 'wt_id', 'goal_id'];
+      const cols = [
+        'session_id',
+        'summary',
+        'branch',
+        'cwd',
+        'mode',
+        'is_active',
+        'initial_prompt',
+        'wt_id',
+        'goal_id',
+      ];
       const vals: unknown[] = [
         meta.sessionId,
         meta.summary ?? null,
@@ -286,7 +296,9 @@ export class EventStore {
         vals.push(meta.createdAt);
       }
       const placeholders = cols.map(() => '?').join(', ');
-      this.db!.prepare(`INSERT INTO sessions (${cols.join(', ')}) VALUES (${placeholders})`).run(...vals);
+      this.db!.prepare(`INSERT INTO sessions (${cols.join(', ')}) VALUES (${placeholders})`).run(
+        ...vals,
+      );
     }
   }
 

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -254,15 +254,19 @@ export class EventStore {
         fields.push('wt_id = ?');
         values.push(meta.wtId);
       }
-      fields.push("updated_at = unixepoch('now', 'subsec') * 1000");
+      if (meta.updatedAt !== undefined) {
+        fields.push('updated_at = ?');
+        values.push(meta.updatedAt);
+      } else {
+        fields.push("updated_at = unixepoch('now', 'subsec') * 1000");
+      }
       values.push(meta.sessionId);
       this.db!.prepare(`UPDATE sessions SET ${fields.join(', ')} WHERE session_id = ?`).run(
         ...values,
       );
     } else {
-      this.db!.prepare(
-        'INSERT INTO sessions (session_id, summary, branch, cwd, mode, is_active, initial_prompt, wt_id, goal_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
-      ).run(
+      const cols = ['session_id', 'summary', 'branch', 'cwd', 'mode', 'is_active', 'initial_prompt', 'wt_id', 'goal_id'];
+      const vals: unknown[] = [
         meta.sessionId,
         meta.summary ?? null,
         meta.branch ?? null,
@@ -272,7 +276,17 @@ export class EventStore {
         meta.initialPrompt ?? null,
         meta.wtId ?? null,
         meta.goalId ?? null,
-      );
+      ];
+      if (meta.updatedAt !== undefined) {
+        cols.push('updated_at');
+        vals.push(meta.updatedAt);
+      }
+      if (meta.createdAt !== undefined) {
+        cols.push('created_at');
+        vals.push(meta.createdAt);
+      }
+      const placeholders = cols.map(() => '?').join(', ');
+      this.db!.prepare(`INSERT INTO sessions (${cols.join(', ')}) VALUES (${placeholders})`).run(...vals);
     }
   }
 

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -18,6 +18,11 @@ vi.mock('../chat.js', () => {
       sessions: [{ id: 's1', summary: 'Test', lastModified: 1 }],
       hasMore: false,
     }),
+    getSessionsCached: vi.fn().mockReturnValue({
+      sessions: [{ id: 's1', summary: 'Test', lastModified: 1 }],
+      hasMore: false,
+    }),
+    reconcileSessionsBackground: vi.fn(),
     getMessages: vi.fn().mockResolvedValue([{ messageId: 'm1', role: 'assistant', blocks: [] }]),
     renameSessionById: vi.fn().mockResolvedValue(undefined),
     hideSession: vi.fn(),
@@ -344,21 +349,27 @@ describe('session routes', () => {
     expect(typeof res.body.hasMore).toBe('boolean');
   });
 
-  it('GET /api/sessions — passes offset and limit query params', async () => {
-    const { getSessions } = await import('../chat.js');
+  it('GET /api/sessions — uses cached path by default', async () => {
+    const { getSessionsCached } = await import('../chat.js');
     await request(app).get('/api/sessions?offset=5&limit=10').set('Cookie', authCookie);
-    expect(getSessions).toHaveBeenCalledWith(5, 10);
+    expect(getSessionsCached).toHaveBeenCalledWith(5, 10);
   });
 
   it('GET /api/sessions — clamps invalid offset and limit', async () => {
-    const { getSessions } = await import('../chat.js');
+    const { getSessionsCached } = await import('../chat.js');
     await request(app).get('/api/sessions?offset=-1&limit=999').set('Cookie', authCookie);
-    expect(getSessions).toHaveBeenCalledWith(0, 100);
+    expect(getSessionsCached).toHaveBeenCalledWith(0, 100);
   });
 
   it('GET /api/sessions — uses defaults when no params', async () => {
-    const { getSessions } = await import('../chat.js');
+    const { getSessionsCached } = await import('../chat.js');
     await request(app).get('/api/sessions').set('Cookie', authCookie);
+    expect(getSessionsCached).toHaveBeenCalledWith(0, 20);
+  });
+
+  it('GET /api/sessions?full=1 — uses filesystem scan', async () => {
+    const { getSessions } = await import('../chat.js');
+    await request(app).get('/api/sessions?full=1').set('Cookie', authCookie);
     expect(getSessions).toHaveBeenCalledWith(0, 20);
   });
 

--- a/server/__tests__/session-cache.test.ts
+++ b/server/__tests__/session-cache.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockListSessions = vi.fn().mockResolvedValue([]);
+const mockUpsertSession = vi.fn();
+const mockGetSession = vi.fn();
+const mockListSessionsMeta = vi.fn().mockReturnValue([]);
+const mockGetKnownSessionIds = vi.fn().mockReturnValue(new Set());
+
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+  listSessions: (...args: unknown[]) => mockListSessions(...args),
+  getSessionInfo: vi.fn().mockResolvedValue(undefined),
+  getSessionMessages: vi.fn().mockResolvedValue([]),
+  renameSession: vi.fn(),
+}));
+
+const mockEventStore = {
+  upsertSession: mockUpsertSession,
+  getSession: mockGetSession,
+  getKnownSessionIds: mockGetKnownSessionIds,
+  listSessions: mockListSessionsMeta,
+  listSessionsLimited: vi.fn().mockReturnValue([]),
+  getEventsAfter: vi.fn().mockReturnValue([]),
+  getSessionEvents: vi.fn().mockReturnValue([]),
+  markSessionInactive: vi.fn(),
+  hideSession: vi.fn(),
+  incrementPromptCount: vi.fn().mockReturnValue(1),
+  recordUsage: vi.fn(),
+  markManuallyRenamed: vi.fn(),
+  append: vi.fn().mockReturnValue(1),
+};
+
+class FakeEventStore {
+  constructor() {
+    return mockEventStore;
+  }
+}
+
+vi.mock('@mitzo/protocol/event-store', () => ({
+  EventStore: FakeEventStore,
+}));
+
+vi.mock('../repo-config.js', () => ({
+  loadRepoConfig: vi.fn().mockReturnValue({ repos: {}, roots: [] }),
+}));
+
+vi.mock('../mcp-config.js', () => ({
+  loadMcpServers: vi.fn().mockReturnValue({}),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getSessionsCached', () => {
+  it('returns sessions that have turns', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-1',
+        summary: 'Active session',
+        numTurns: 5,
+        promptCount: 3,
+        isActive: false,
+        updatedAt: 1000,
+        branch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions, hasMore } = getSessionsCached();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-1');
+    expect(sessions[0].summary).toBe('Active session');
+    expect(hasMore).toBe(false);
+  });
+
+  it('hides sessions with numTurns=0, promptCount=0, and !isActive', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-unused',
+        summary: 'Unused',
+        numTurns: 0,
+        promptCount: 0,
+        isActive: false,
+        updatedAt: 1000,
+        branch: null,
+        cwd: null,
+      },
+      {
+        sessionId: 'sess-used',
+        summary: 'Used',
+        numTurns: 1,
+        promptCount: 1,
+        isActive: false,
+        updatedAt: 2000,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-used');
+  });
+
+  it('keeps active sessions even with zero turns', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-active',
+        summary: 'Just started',
+        numTurns: 0,
+        promptCount: 0,
+        isActive: true,
+        updatedAt: 1000,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-active');
+  });
+
+  it('keeps sessions with promptCount > 0 even if numTurns=0', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-prompted',
+        summary: 'Has prompts',
+        numTurns: 0,
+        promptCount: 2,
+        isActive: false,
+        updatedAt: 1000,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-prompted');
+  });
+
+  it('respects offset and limit for pagination', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-1',
+        summary: 'First',
+        numTurns: 1,
+        promptCount: 1,
+        isActive: false,
+        updatedAt: 3000,
+        branch: null,
+        cwd: null,
+      },
+      {
+        sessionId: 'sess-2',
+        summary: 'Second',
+        numTurns: 1,
+        promptCount: 1,
+        isActive: false,
+        updatedAt: 2000,
+        branch: null,
+        cwd: null,
+      },
+      {
+        sessionId: 'sess-3',
+        summary: 'Third',
+        numTurns: 1,
+        promptCount: 1,
+        isActive: false,
+        updatedAt: 1000,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions, hasMore } = getSessionsCached(0, 2);
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].id).toBe('sess-1');
+    expect(sessions[1].id).toBe('sess-2');
+    expect(hasMore).toBe(true);
+  });
+
+  it('maps SessionMeta fields to API shape', async () => {
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-mapped',
+        summary: 'Mapped session',
+        numTurns: 3,
+        promptCount: 2,
+        isActive: true,
+        updatedAt: 5000,
+        branch: 'feat/test',
+        cwd: '/projects/bar',
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions[0]).toEqual({
+      id: 'sess-mapped',
+      summary: 'Mapped session',
+      lastModified: 5000,
+      branch: 'feat/test',
+      cwd: '/projects/bar',
+    });
+  });
+});
+
+describe('syncSessionTimestamps', () => {
+  it('inserts new sessions from filesystem into EventStore', async () => {
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-new',
+        summary: 'New from FS',
+        lastModified: 10000,
+        gitBranch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+    mockGetSession.mockReturnValue(null);
+
+    const { syncSessionTimestamps } = await import('../chat.js');
+    await syncSessionTimestamps();
+
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-new',
+        summary: 'New from FS',
+        isActive: false,
+      }),
+    );
+  });
+
+  it('syncs timestamp when drift exceeds 60s', async () => {
+    const now = Date.now();
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-drifted',
+        summary: 'Drifted',
+        lastModified: now,
+        gitBranch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+    mockGetSession.mockReturnValue({
+      sessionId: 'sess-drifted',
+      summary: 'Old summary',
+      updatedAt: now - 120_000, // 2 minutes drift
+      manuallyRenamed: false,
+    });
+
+    const { syncSessionTimestamps } = await import('../chat.js');
+    await syncSessionTimestamps();
+
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-drifted',
+        updatedAt: now,
+        summary: 'Drifted',
+      }),
+    );
+  });
+
+  it('preserves manually renamed summary during timestamp sync', async () => {
+    const now = Date.now();
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-renamed',
+        summary: 'FS summary',
+        lastModified: now,
+        gitBranch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+    mockGetSession.mockReturnValue({
+      sessionId: 'sess-renamed',
+      summary: 'User-chosen name',
+      updatedAt: now - 120_000,
+      manuallyRenamed: true,
+    });
+
+    const { syncSessionTimestamps } = await import('../chat.js');
+    await syncSessionTimestamps();
+
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-renamed',
+        updatedAt: now,
+        summary: undefined, // preserves existing summary by passing undefined
+      }),
+    );
+  });
+
+  it('skips sessions with timestamp drift under 60s', async () => {
+    const now = Date.now();
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-ok',
+        summary: 'Fine',
+        lastModified: now,
+        gitBranch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+    mockGetSession.mockReturnValue({
+      sessionId: 'sess-ok',
+      summary: 'Fine',
+      updatedAt: now - 30_000, // Only 30s drift
+      manuallyRenamed: false,
+    });
+
+    const { syncSessionTimestamps } = await import('../chat.js');
+    await syncSessionTimestamps();
+
+    expect(mockUpsertSession).not.toHaveBeenCalled();
+  });
+
+  it('skips hidden sessions', async () => {
+    mockListSessions.mockResolvedValue([
+      {
+        sessionId: 'sess-hidden',
+        summary: 'Hidden',
+        lastModified: 10000,
+        gitBranch: 'main',
+        cwd: '/projects/foo',
+      },
+    ]);
+    mockGetSession.mockReturnValue(null);
+
+    const { hideSession, syncSessionTimestamps } = await import('../chat.js');
+    hideSession('sess-hidden');
+    await syncSessionTimestamps();
+
+    expect(mockUpsertSession).not.toHaveBeenCalled();
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -746,7 +746,7 @@ app.get('/api/sessions', async (req, res) => {
     const { sessions, hasMore } = await getSessions(offset, limit);
     res.json({ sessions: annotate(sessions), hasMore });
   } catch (err) {
-    console.error('GET /api/sessions failed:', err);
+    log.error('GET /api/sessions failed', { error: err });
     res.status(500).json({ error: 'Failed to list sessions' });
   }
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -705,19 +705,18 @@ app.get('/api/sessions/active', (_req, res) => {
   res.json(registry.getActiveSessions());
 });
 
-app.get('/api/sessions', (req, res) => {
+app.get('/api/sessions', async (req, res) => {
   const offset = Math.max(0, parseInt(req.query.offset as string) || 0);
   const limit = Math.min(Math.max(1, parseInt(req.query.limit as string) || 20), 100);
   const full = req.query.full === '1';
 
-  // Fast path: serve from EventStore (SQLite, <1ms) unless ?full=1
-  if (!full) {
-    const { sessions, hasMore } = getSessionsCached(offset, limit);
+  /** Annotate raw session list with live-status and token metadata. */
+  function annotate(sessions: Array<{ id: string; [k: string]: unknown }>) {
     const activeMap = new Map<string, { attached: boolean }>();
     for (const s of registry.getActiveSessions()) {
       if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
     }
-    const annotated = sessions.map((s) => {
+    return sessions.map((s) => {
       const live = activeMap.get(s.id);
       const meta = eventStore.getSession(s.id);
       return {
@@ -730,34 +729,26 @@ app.get('/api/sessions', (req, res) => {
         numTurns: meta?.numTurns,
       };
     });
-    res.json({ sessions: annotated, hasMore });
-
-    // Background: reconcile with filesystem so EventStore stays fresh
-    if (offset === 0) reconcileSessionsBackground();
-    return;
   }
 
-  // Full path: filesystem scan (original behavior, for ?full=1)
-  getSessions(offset, limit).then(({ sessions, hasMore }) => {
-    const activeMap = new Map<string, { attached: boolean }>();
-    for (const s of registry.getActiveSessions()) {
-      if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
+  try {
+    if (!full) {
+      // Fast path: serve from EventStore (SQLite, <1ms)
+      const { sessions, hasMore } = getSessionsCached(offset, limit);
+      res.json({ sessions: annotate(sessions), hasMore });
+
+      // Background: reconcile with filesystem so EventStore stays fresh
+      if (offset === 0) reconcileSessionsBackground();
+      return;
     }
-    const annotated = sessions.map((s) => {
-      const live = activeMap.get(s.id);
-      const meta = eventStore.getSession(s.id);
-      return {
-        ...s,
-        isActive: !!live,
-        isAttached: live?.attached ?? false,
-        totalTokens: meta
-          ? meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens
-          : undefined,
-        numTurns: meta?.numTurns,
-      };
-    });
-    res.json({ sessions: annotated, hasMore });
-  });
+
+    // Full path: filesystem scan (original behavior, for ?full=1)
+    const { sessions, hasMore } = await getSessions(offset, limit);
+    res.json({ sessions: annotate(sessions), hasMore });
+  } catch (err) {
+    console.error('GET /api/sessions failed:', err);
+    res.status(500).json({ error: 'Failed to list sessions' });
+  }
 });
 
 app.get('/api/sessions/:id/messages', async (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,8 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { login, authMiddleware, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
 import {
   getSessions,
+  getSessionsCached,
+  reconcileSessionsBackground,
   getMessages,
   hideSession,
   clearHiddenSessions,
@@ -703,28 +705,59 @@ app.get('/api/sessions/active', (_req, res) => {
   res.json(registry.getActiveSessions());
 });
 
-app.get('/api/sessions', async (req, res) => {
+app.get('/api/sessions', (req, res) => {
   const offset = Math.max(0, parseInt(req.query.offset as string) || 0);
   const limit = Math.min(Math.max(1, parseInt(req.query.limit as string) || 20), 100);
-  const { sessions, hasMore } = await getSessions(offset, limit);
-  const activeMap = new Map<string, { attached: boolean }>();
-  for (const s of registry.getActiveSessions()) {
-    if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
+  const full = req.query.full === '1';
+
+  // Fast path: serve from EventStore (SQLite, <1ms) unless ?full=1
+  if (!full) {
+    const { sessions, hasMore } = getSessionsCached(offset, limit);
+    const activeMap = new Map<string, { attached: boolean }>();
+    for (const s of registry.getActiveSessions()) {
+      if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
+    }
+    const annotated = sessions.map((s) => {
+      const live = activeMap.get(s.id);
+      const meta = eventStore.getSession(s.id);
+      return {
+        ...s,
+        isActive: !!live,
+        isAttached: live?.attached ?? false,
+        totalTokens: meta
+          ? meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens
+          : undefined,
+        numTurns: meta?.numTurns,
+      };
+    });
+    res.json({ sessions: annotated, hasMore });
+
+    // Background: reconcile with filesystem so EventStore stays fresh
+    if (offset === 0) reconcileSessionsBackground();
+    return;
   }
-  const annotated = sessions.map((s) => {
-    const live = activeMap.get(s.id);
-    const meta = eventStore.getSession(s.id);
-    return {
-      ...s,
-      isActive: !!live,
-      isAttached: live?.attached ?? false,
-      totalTokens: meta
-        ? meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens
-        : undefined,
-      numTurns: meta?.numTurns,
-    };
+
+  // Full path: filesystem scan (original behavior, for ?full=1)
+  getSessions(offset, limit).then(({ sessions, hasMore }) => {
+    const activeMap = new Map<string, { attached: boolean }>();
+    for (const s of registry.getActiveSessions()) {
+      if (s.sessionId) activeMap.set(s.sessionId, { attached: s.attached });
+    }
+    const annotated = sessions.map((s) => {
+      const live = activeMap.get(s.id);
+      const meta = eventStore.getSession(s.id);
+      return {
+        ...s,
+        isActive: !!live,
+        isAttached: live?.attached ?? false,
+        totalTokens: meta
+          ? meta.inputTokens + meta.outputTokens + meta.cacheReadTokens + meta.cacheCreationTokens
+          : undefined,
+        numTurns: meta?.numTurns,
+      };
+    });
+    res.json({ sessions: annotated, hasMore });
   });
-  res.json({ sessions: annotated, hasMore });
 });
 
 app.get('/api/sessions/:id/messages', async (req, res) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1018,7 +1018,9 @@ export function reconcileSessionsBackground(): void {
   _reconciling = true;
   syncSessionTimestamps()
     .catch(() => {})
-    .finally(() => { _reconciling = false; });
+    .finally(() => {
+      _reconciling = false;
+    });
 }
 
 /**
@@ -1026,7 +1028,10 @@ export function reconcileSessionsBackground(): void {
  * for all sessions to match their actual lastModified time.
  */
 async function syncSessionTimestamps(): Promise<void> {
-  const seen = new Map<string, { lastModified: number; summary: string; branch?: string; cwd?: string }>();
+  const seen = new Map<
+    string,
+    { lastModified: number; summary: string; branch?: string; cwd?: string }
+  >();
   const fetchLimit = 250;
   for (const dir of getSessionDirs()) {
     try {
@@ -1069,7 +1074,7 @@ async function syncSessionTimestamps(): Promise<void> {
       eventStore.upsertSession({
         sessionId,
         updatedAt: entry.lastModified,
-        summary: existing.manuallyRenamed ? undefined : (entry.summary || undefined),
+        summary: existing.manuallyRenamed ? undefined : entry.summary || undefined,
         branch: entry.branch ?? undefined,
       });
       synced++;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -964,6 +964,8 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
         cwd: entry.cwd ?? (BASE_REPO || null),
         branch: entry.branch ?? null,
         isActive: false,
+        updatedAt: entry.lastModified,
+        createdAt: entry.lastModified,
       });
       reconciledCount++;
     }
@@ -984,7 +986,13 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
  * Returns the same shape as getSessions() for API compatibility.
  */
 export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
-  const all = eventStore.listSessions();
+  const all = eventStore.listSessions().filter((m) => {
+    // Hide sessions that were never used through Mitzo (e.g. automated
+    // code review sessions discovered from filesystem).  Active sessions
+    // always show regardless of turn count.
+    if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) return false;
+    return true;
+  });
   const page = all.slice(offset, offset + limit);
   const hasMore = all.length > offset + limit;
   return {
@@ -1001,11 +1009,75 @@ export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
 
 /**
  * Background reconciliation: scan filesystem for sessions the EventStore
- * doesn't know about (e.g. created by external agents or after a restart).
+ * doesn't know about and sync timestamps from the filesystem.
  * Call fire-and-forget after serving cached results.
  */
+let _reconciling = false;
 export function reconcileSessionsBackground(): void {
-  getSessions(0, 200).catch(() => {});
+  if (_reconciling) return;
+  _reconciling = true;
+  syncSessionTimestamps()
+    .catch(() => {})
+    .finally(() => { _reconciling = false; });
+}
+
+/**
+ * Full timestamp sync: scan filesystem and update EventStore timestamps
+ * for all sessions to match their actual lastModified time.
+ */
+async function syncSessionTimestamps(): Promise<void> {
+  const seen = new Map<string, { lastModified: number; summary: string; branch?: string; cwd?: string }>();
+  const fetchLimit = 250;
+  for (const dir of getSessionDirs()) {
+    try {
+      const sessions = await listSessions({ dir, limit: fetchLimit, includeWorktrees: true });
+      for (const s of sessions) {
+        if (hiddenSessionIds.has(s.sessionId)) continue;
+        const existing = seen.get(s.sessionId);
+        if (!existing || s.lastModified > existing.lastModified) {
+          seen.set(s.sessionId, {
+            lastModified: s.lastModified,
+            summary: s.summary,
+            branch: s.gitBranch,
+            cwd: s.cwd || undefined,
+          });
+        }
+      }
+    } catch {
+      // Expected when session dir doesn't exist
+    }
+  }
+
+  let synced = 0;
+  for (const [sessionId, entry] of seen) {
+    const existing = eventStore.getSession(sessionId);
+    if (!existing) {
+      // New session — insert with correct timestamp
+      eventStore.upsertSession({
+        sessionId,
+        summary: entry.summary || null,
+        cwd: entry.cwd ?? (BASE_REPO || null),
+        branch: entry.branch ?? null,
+        isActive: false,
+        updatedAt: entry.lastModified,
+        createdAt: entry.lastModified,
+      });
+      synced++;
+    } else if (Math.abs(existing.updatedAt - entry.lastModified) > 60_000) {
+      // Timestamp drifted from filesystem — sync it back.
+      // Preserves summary from EventStore if it was manually renamed.
+      eventStore.upsertSession({
+        sessionId,
+        updatedAt: entry.lastModified,
+        summary: existing.manuallyRenamed ? undefined : (entry.summary || undefined),
+        branch: entry.branch ?? undefined,
+      });
+      synced++;
+    }
+  }
+  if (synced > 0) {
+    log.info('reconciled session timestamps', { synced, total: seen.size });
+  }
 }
 
 /**

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -980,6 +980,35 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
 }
 
 /**
+ * Fast session listing from EventStore (SQLite) — no filesystem scan.
+ * Returns the same shape as getSessions() for API compatibility.
+ */
+export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
+  const all = eventStore.listSessions();
+  const page = all.slice(offset, offset + limit);
+  const hasMore = all.length > offset + limit;
+  return {
+    sessions: page.map((m) => ({
+      id: m.sessionId,
+      summary: m.summary ?? '',
+      lastModified: m.updatedAt,
+      branch: m.branch ?? undefined,
+      cwd: m.cwd ?? undefined,
+    })),
+    hasMore,
+  };
+}
+
+/**
+ * Background reconciliation: scan filesystem for sessions the EventStore
+ * doesn't know about (e.g. created by external agents or after a restart).
+ * Call fire-and-forget after serving cached results.
+ */
+export function reconcileSessionsBackground(): void {
+  getSessions(0, 200).catch(() => {});
+}
+
+/**
  * Look up a single session by ID via the Claude SDK.
  * Used as a fallback when the EventStore doesn't have the session yet
  * (e.g. orphaned by a restart or created externally). If found, backfills

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -990,6 +990,8 @@ export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
     // Hide sessions that were never used through Mitzo (e.g. automated
     // code review sessions discovered from filesystem).  Active sessions
     // always show regardless of turn count.
+    // Note: new sessions are created with is_active=1 by default (see EventStore
+    // schema), so a brand-new session will never be filtered out here.
     if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) return false;
     return true;
   });
@@ -1031,7 +1033,7 @@ export function reconcileSessionsBackground(): void {
  * Full timestamp sync: scan filesystem and update EventStore timestamps
  * for all sessions to match their actual lastModified time.
  */
-async function syncSessionTimestamps(): Promise<void> {
+export async function syncSessionTimestamps(): Promise<void> {
   const seen = new Map<
     string,
     { lastModified: number; summary: string; branch?: string; cwd?: string }

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1012,6 +1012,10 @@ export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
  * doesn't know about and sync timestamps from the filesystem.
  * Call fire-and-forget after serving cached results.
  */
+// Guard against concurrent reconciliation runs. While `_reconciling` is true,
+// subsequent page-1 loads that call reconcileSessionsBackground() are no-ops.
+// This is safe because the in-flight sync will pick up any changes, and the
+// next page-1 request after it completes will trigger a fresh reconciliation.
 let _reconciling = false;
 export function reconcileSessionsBackground(): void {
   if (_reconciling) return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,7 @@ import {
   eventStore,
   getRepoConfig,
   setConnectionRegistry,
+  reconcileSessionsBackground,
 } from './chat.js';
 import { cleanupStaleWorktrees } from './worktree.js';
 import { HEARTBEAT_INTERVAL_MS, PORT_DEFAULT, SHUTDOWN_GRACE_MS } from './constants.js';
@@ -764,6 +765,8 @@ checkPort(PORT).then((inUse) => {
   server.listen(PORT, () => {
     const protocol = USE_TLS ? 'https' : 'http';
     log.info(`Chat Agent running on ${protocol}://localhost:${PORT}${USE_TLS ? ' (TLS)' : ''}`);
+    // Eagerly reconcile sessions so the first /api/sessions request is fast and accurate.
+    reconcileSessionsBackground();
     // Clean up stale worktrees across all repos.
     // Dirty worktrees (uncommitted work) are flagged in the mgmt inbox.
     const inboxDir = BASE_REPO ? join(BASE_REPO, 'mgmt_lib', 'inbox') : undefined;


### PR DESCRIPTION
## Summary
- **Draft prompt persistence** — ChatInput drafts are saved to localStorage per session (debounced 400ms). Navigate away, come back, draft is still there. Cleared on send/interrupt.
- **Fast session loading** — Home Screen now serves sessions from EventStore (SQLite, <1ms) instead of filesystem scanning on every load. Background reconciliation keeps the cache fresh. `?full=1` falls back to filesystem scan.
- **Timestamp reconciliation** — EventStore upsertSession now preserves original timestamps. Startup reconciliation syncs filesystem timestamps eagerly so first page load is accurate.
- **Filter non-Mitzo sessions** — Sessions with 0 turns/prompts (e.g. automated code review sessions) are hidden from the session list.

## Test plan
- [x] `useDraft` hook: 8 tests covering restore, save, clear, migration, undefined sessionId
- [x] Existing ChatInput tests: 25 tests pass (no regressions)
- [x] Route tests: 66 tests pass (updated for cached path + new `?full=1` test)
- [x] Full suite: 1945/1947 pass (2 pre-existing flaky timeouts)
- [x] Manual test on mobile via Tailscale — sessions load with correct timestamps, drafts persist across navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)