### PR TITLE
fix(auto-rename): trigger session naming on initial prompt

### DIFF
--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -828,15 +828,62 @@ describe('runQueryLoop', () => {
         'Hello, this is my first message',
       );
 
-      // Initial prompt is stored on session metadata, not as an event
+      // Initial prompt is stored on session metadata
       const session = store.getSession('sess-ip');
       expect(session).toBeTruthy();
       expect(session!.initialPrompt).toBe('Hello, this is my first message');
 
-      // No user_message event should be in the event stream
+      // Initial prompt is also stored as a user_message event for auto-rename
       const stored = store.getSessionEvents('sess-ip');
       const userMsgEvents = stored.filter((e) => e.type === 'user_message');
-      expect(userMsgEvents).toHaveLength(0);
+      expect(userMsgEvents).toHaveLength(1);
+      expect(userMsgEvents[0].payload.text).toBe('Hello, this is my first message');
+    });
+
+    it('calls onInitialPrompt callback when initial prompt is registered', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-cb' },
+        { type: 'result', session_id: 'sess-cb' },
+      ];
+
+      const onInitialPrompt = vi.fn();
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        store,
+        'trigger callback please',
+        { onInitialPrompt },
+      );
+
+      expect(onInitialPrompt).toHaveBeenCalledWith('sess-cb');
+      expect(onInitialPrompt).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onInitialPrompt when there is no initial prompt', async () => {
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-no-ip';
+
+      const events: Record<string, unknown>[] = [
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-no-ip' },
+        { type: 'result', session_id: 'sess-no-ip' },
+      ];
+
+      const onInitialPrompt = vi.fn();
+
+      await runQueryLoop(
+        eventStream(events),
+        clientId,
+        registry,
+        abortController,
+        store,
+        undefined,
+        { onInitialPrompt },
+      );
+
+      expect(onInitialPrompt).not.toHaveBeenCalled();
     });
 
     it('persists follow-up user_message from sendToChat in the event store', async () => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -566,7 +566,7 @@ export async function startChat(
         connRegistry: _connRegistry ?? undefined,
         onSessionResolved: options.onSessionResolved,
         onInitialPrompt: (sessionId: string) => {
-          tryAutoRename(sessionId, clientId).catch(() => {});
+          tryAutoRename(sessionId, clientId).catch(() => { /* errors logged internally */ });
         },
       },
     );

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -566,7 +566,9 @@ export async function startChat(
         connRegistry: _connRegistry ?? undefined,
         onSessionResolved: options.onSessionResolved,
         onInitialPrompt: (sessionId: string) => {
-          tryAutoRename(sessionId, clientId).catch(() => { /* errors logged internally */ });
+          tryAutoRename(sessionId, clientId).catch(() => {
+            /* errors logged internally */
+          });
         },
       },
     );

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -565,6 +565,9 @@ export async function startChat(
       {
         connRegistry: _connRegistry ?? undefined,
         onSessionResolved: options.onSessionResolved,
+        onInitialPrompt: (sessionId: string) => {
+          tryAutoRename(sessionId, clientId).catch(() => {});
+        },
       },
     );
   } catch (err: unknown) {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -309,9 +309,7 @@ export async function runQueryLoop(
                 messageId: `umsg-${Date.now()}-init`,
                 text: initialPrompt,
               });
-              // Count the initial prompt for auto-rename tracking
-              store.incrementPromptCount(resolvedSessionId);
-              // Trigger auto-rename on prompt 1 (immediate naming)
+              // Trigger auto-rename — tryAutoRename handles the increment
               onInitialPrompt?.(resolvedSessionId);
             }
           }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -108,6 +108,8 @@ function v2(type: string, rest: Record<string, unknown> = {}): Record<string, un
 export interface QueryLoopOptions {
   connRegistry?: ConnectionRegistry;
   onSessionResolved?: (sessionId: string) => void;
+  /** Called after the initial prompt is registered, enabling auto-rename on prompt 1. */
+  onInitialPrompt?: (sessionId: string) => void;
 }
 
 export async function runQueryLoop(
@@ -121,6 +123,7 @@ export async function runQueryLoop(
 ) {
   const connRegistry = options?.connRegistry;
   const onSessionResolved = options?.onSessionResolved;
+  const onInitialPrompt = options?.onInitialPrompt;
   // Tool input buffers keyed by content block index (reset per message_start).
   const toolInputBuffers = new Map<
     number,
@@ -297,8 +300,19 @@ export async function runQueryLoop(
               ...(initialPrompt ? { initialPrompt } : {}),
             });
             if (initialPrompt) {
+              // Store the initial prompt as a user_message event so
+              // extractRecentPrompts() can find it for auto-rename.
+              store.append(resolvedSessionId, 'user_message', {
+                v: 2,
+                type: 'user_message',
+                ts: Date.now(),
+                messageId: `umsg-${Date.now()}-init`,
+                text: initialPrompt,
+              });
               // Count the initial prompt for auto-rename tracking
               store.incrementPromptCount(resolvedSessionId);
+              // Trigger auto-rename on prompt 1 (immediate naming)
+              onInitialPrompt?.(resolvedSessionId);
             }
           }
 

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -302,11 +302,12 @@ export async function runQueryLoop(
             if (initialPrompt) {
               // Store the initial prompt as a user_message event so
               // extractRecentPrompts() can find it for auto-rename.
+              const now = Date.now();
               store.append(resolvedSessionId, 'user_message', {
                 v: 2,
                 type: 'user_message',
-                ts: Date.now(),
-                messageId: `umsg-${Date.now()}-init`,
+                ts: now,
+                messageId: `umsg-${now}-init`,
                 text: initialPrompt,
               });
               // Trigger auto-rename — tryAutoRename handles the increment


### PR DESCRIPTION
## Summary

- **Bug:** `tryAutoRename` was only called from `sendToChat()` (follow-up messages), never for the initial prompt processed in `runQueryLoop()`. The prompt count was incremented to 1 but no rename attempt was made, so sessions stayed "Untitled" until the 4th message (count 4 is the first to pass `shouldAutoRename` after the skip zone at 2-3).
- **Fix:** Store the initial prompt as a `user_message` event (so `extractRecentPrompts()` has content to work with) and add an `onInitialPrompt` callback that fires `tryAutoRename` when the session ID resolves.
- **Result:** Sessions get named immediately after the first assistant response, not after the 4th user message.

## Test plan

- [x] Existing auto-rename tests pass (62/62)
- [x] Updated test: initial prompt now stored as `user_message` event
- [x] New test: `onInitialPrompt` callback fires with session ID
- [x] New test: callback does not fire when no initial prompt (resume case)
- [ ] Manual: start a new Mitzo session, verify it gets named after the first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)