### PR TITLE
feat(task-board): workflow layer with stage types, signals, and templates

### DIFF
--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -82,7 +82,8 @@ export function TaskNode({
         )}
         {task.retryCount > 0 && (
           <span className="task-node-retry" title={`Retry ${task.retryCount}/${task.maxRetries}`}>
-            {'\u21BB'}{task.retryCount}
+            {'\u21BB'}
+            {task.retryCount}
           </span>
         )}
         <div className="task-node-actions">

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Task, TaskStatus } from '../types/task';
+import type { Task, TaskStatus, StageType } from '../types/task';
 
 const STATUS_ICONS: Record<TaskStatus, string> = {
   pending: '\u25CB', // ○
@@ -9,6 +9,12 @@ const STATUS_ICONS: Record<TaskStatus, string> = {
   blocked: '\u2298', // ⊘
   skipped: '\u2014', // —
   failed: '\u2717', // ✗
+};
+
+const STAGE_LABELS: Record<StageType, string> = {
+  agent_work: '',
+  wait_for_signal: 'signal',
+  human_review: 'review',
 };
 
 const NEXT_STATUS: Record<TaskStatus, TaskStatus> = {
@@ -69,6 +75,16 @@ export function TaskNode({
         >
           {task.title}
         </span>
+        {task.stageType && STAGE_LABELS[task.stageType] && (
+          <span className={`task-node-stage task-node-stage--${task.stageType}`}>
+            {STAGE_LABELS[task.stageType]}
+          </span>
+        )}
+        {task.retryCount > 0 && (
+          <span className="task-node-retry" title={`Retry ${task.retryCount}/${task.maxRetries}`}>
+            {'\u21BB'}{task.retryCount}
+          </span>
+        )}
         <div className="task-node-actions">
           {task.status === 'pending_review' && onApprove && (
             <button
@@ -104,6 +120,16 @@ export function TaskNode({
           </button>
         </div>
       </div>
+      {task.artifacts && Object.keys(task.artifacts).length > 0 && expanded && (
+        <div className="task-node-artifacts">
+          {Object.entries(task.artifacts).map(([key, value]) => (
+            <div key={key} className="task-node-artifact">
+              <span className="task-node-artifact-key">{key}:</span>{' '}
+              <span className="task-node-artifact-value">{String(value)}</span>
+            </div>
+          ))}
+        </div>
+      )}
       {hasChildren && expanded && (
         <div className="task-node-children">
           {task.children.map((child) => (

--- a/frontend/src/components/WorkflowCreateForm.tsx
+++ b/frontend/src/components/WorkflowCreateForm.tsx
@@ -102,9 +102,7 @@ export function WorkflowCreateForm({ onCreated, onCancel }: WorkflowCreateFormPr
         </select>
       </div>
 
-      {selected?.description && (
-        <p className="workflow-create-desc">{selected.description}</p>
-      )}
+      {selected?.description && <p className="workflow-create-desc">{selected.description}</p>}
 
       <div className="workflow-create-field">
         <label htmlFor="wf-title">Title</label>

--- a/frontend/src/components/WorkflowCreateForm.tsx
+++ b/frontend/src/components/WorkflowCreateForm.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from 'react';
+import { apiFetch } from '../lib/api-fetch';
+
+interface TemplateVariable {
+  description: string;
+  default?: string;
+}
+
+interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  variables: Record<string, TemplateVariable> | null;
+}
+
+interface WorkflowCreateFormProps {
+  onCreated: () => void;
+  onCancel: () => void;
+}
+
+export function WorkflowCreateForm({ onCreated, onCancel }: WorkflowCreateFormProps) {
+  const [templates, setTemplates] = useState<WorkflowTemplate[]>([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [title, setTitle] = useState('');
+  const [variables, setVariables] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiFetch('/api/templates')
+      .then((r) => r.json())
+      .then((data: WorkflowTemplate[]) => {
+        setTemplates(data);
+        if (data.length > 0) {
+          setSelectedId(data[0].id);
+          initVars(data[0]);
+        }
+      })
+      .catch(() => setError('Failed to load templates'));
+  }, []);
+
+  function initVars(tmpl: WorkflowTemplate) {
+    const vars: Record<string, string> = {};
+    if (tmpl.variables) {
+      for (const [key, v] of Object.entries(tmpl.variables)) {
+        vars[key] = v.default ?? '';
+      }
+    }
+    setVariables(vars);
+    setTitle(`${tmpl.name}`);
+  }
+
+  function handleTemplateChange(id: string) {
+    setSelectedId(id);
+    const tmpl = templates.find((t) => t.id === id);
+    if (tmpl) initVars(tmpl);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!selectedId || !title.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await apiFetch('/api/workflows/instantiate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          templateId: selectedId,
+          title: title.trim(),
+          variables,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error((data as { error?: string }).error || `HTTP ${res.status}`);
+      }
+      onCreated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create workflow');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const selected = templates.find((t) => t.id === selectedId);
+
+  return (
+    <form className="workflow-create-form" onSubmit={handleSubmit}>
+      <div className="workflow-create-field">
+        <label htmlFor="wf-template">Template</label>
+        <select
+          id="wf-template"
+          value={selectedId}
+          onChange={(e) => handleTemplateChange(e.target.value)}
+        >
+          {templates.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {selected?.description && (
+        <p className="workflow-create-desc">{selected.description}</p>
+      )}
+
+      <div className="workflow-create-field">
+        <label htmlFor="wf-title">Title</label>
+        <input
+          id="wf-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Workflow title"
+        />
+      </div>
+
+      {selected?.variables &&
+        Object.entries(selected.variables).map(([key, v]) => (
+          <div className="workflow-create-field" key={key}>
+            <label htmlFor={`wf-var-${key}`}>{key}</label>
+            <input
+              id={`wf-var-${key}`}
+              value={variables[key] ?? ''}
+              onChange={(e) => setVariables((prev) => ({ ...prev, [key]: e.target.value }))}
+              placeholder={v.description}
+            />
+          </div>
+        ))}
+
+      {error && <p className="workflow-create-error">{error}</p>}
+
+      <div className="task-create-actions">
+        <button type="submit" className="task-create-submit" disabled={submitting || !title.trim()}>
+          {submitting ? 'Creating...' : 'Create Workflow'}
+        </button>
+        <button type="button" className="task-create-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -28,6 +28,12 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     createdAt: Date.now(),
     updatedAt: Date.now(),
     completedAt: null,
+    stageType: null,
+    gateConfig: null,
+    artifacts: null,
+    retryCount: 0,
+    maxRetries: 0,
+    templateId: null,
     children: [],
     ...overrides,
   };

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TaskNode } from '../components/TaskNode';
 import { TaskCreateForm } from '../components/TaskCreateForm';
+import { WorkflowCreateForm } from '../components/WorkflowCreateForm';
 import { LoopControls } from '../components/LoopControls';
 import { EmptyState } from '../components/EmptyState';
 import { useTaskBoard } from '../hooks/useTaskBoard';
@@ -27,6 +28,7 @@ export function TaskBoard() {
     refresh,
   } = useTaskBoard();
   const [creating, setCreating] = useState<{ parentId?: string } | null>(null);
+  const [creatingWorkflow, setCreatingWorkflow] = useState(false);
 
   function handleStatusChange(id: string, status: TaskStatus) {
     updateTask(id, { status });
@@ -64,6 +66,13 @@ export function TaskBoard() {
         >
           +
         </button>
+        <button
+          className="task-board-add-btn"
+          onClick={() => setCreatingWorkflow(true)}
+          title="New workflow"
+        >
+          {'\u2699'}
+        </button>
         <button className="task-board-refresh" onClick={refresh} title="Refresh">
           &#x21bb;
         </button>
@@ -85,6 +94,16 @@ export function TaskBoard() {
           parentId={creating.parentId}
           onCreate={handleCreate}
           onCancel={() => setCreating(null)}
+        />
+      )}
+
+      {creatingWorkflow && (
+        <WorkflowCreateForm
+          onCreated={() => {
+            setCreatingWorkflow(false);
+            refresh();
+          }}
+          onCancel={() => setCreatingWorkflow(false)}
         />
       )}
 

--- a/frontend/src/pages/__tests__/TaskBoard.test.tsx
+++ b/frontend/src/pages/__tests__/TaskBoard.test.tsx
@@ -29,6 +29,12 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     createdAt: Date.now(),
     updatedAt: Date.now(),
     completedAt: null,
+    stageType: null,
+    gateConfig: null,
+    artifacts: null,
+    retryCount: 0,
+    maxRetries: 0,
+    templateId: null,
     children: [],
     ...overrides,
   };

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -4211,6 +4211,59 @@ textarea:focus {
   border-color: var(--text-dim);
 }
 
+/* ── Workflow Create Form ────────────────────────────── */
+
+.workflow-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  margin: var(--space-2) 0;
+  background: var(--surface);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.workflow-create-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.workflow-create-field label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.workflow-create-field select,
+.workflow-create-field input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: var(--space-2) var(--space-3);
+  color: var(--text);
+  font-size: var(--text-md);
+  outline: none;
+}
+
+.workflow-create-field select:focus,
+.workflow-create-field input:focus {
+  border-color: var(--accent);
+}
+
+.workflow-create-desc {
+  font-size: var(--text-sm);
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.workflow-create-error {
+  font-size: var(--text-sm);
+  color: var(--error);
+}
+
 /* ── Loop Controls ────────────────────────────────────── */
 
 .loop-controls {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -4102,6 +4102,48 @@ textarea:focus {
   border-left: 1px solid var(--border);
 }
 
+.task-node-stage {
+  font-size: 0.65rem;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-left: var(--space-1);
+}
+
+.task-node-stage--wait_for_signal {
+  background: color-mix(in srgb, var(--warning) 20%, transparent);
+  color: var(--warning);
+}
+
+.task-node-stage--human_review {
+  background: color-mix(in srgb, var(--info, #8b5cf6) 20%, transparent);
+  color: var(--info, #8b5cf6);
+}
+
+.task-node-retry {
+  font-size: 0.7rem;
+  color: var(--warning);
+  margin-left: var(--space-1);
+}
+
+.task-node-artifacts {
+  padding: var(--space-1) var(--space-2);
+  margin-left: var(--space-3);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.task-node-artifact {
+  margin-bottom: 2px;
+}
+
+.task-node-artifact-key {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
 /* ── Task Create Form ───────────────────────────────────── */
 
 .task-create-form {

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -9,6 +9,8 @@ export type TaskStatus =
 
 export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
 
+export type StageType = 'agent_work' | 'wait_for_signal' | 'human_review';
+
 export interface LoopStatus {
   state: 'idle' | 'running' | 'paused';
   goalId: string | null;
@@ -37,5 +39,11 @@ export interface Task {
   createdAt: number;
   updatedAt: number;
   completedAt: number | null;
+  stageType: StageType | null;
+  gateConfig: Record<string, unknown> | null;
+  artifacts: Record<string, unknown> | null;
+  retryCount: number;
+  maxRetries: number;
+  templateId: string | null;
   children: Task[];
 }

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/dsaridak/tools/mitzo/node_modules

--- a/packages/client/src/slices/tasks.ts
+++ b/packages/client/src/slices/tasks.ts
@@ -9,6 +9,8 @@ export type TaskStatus =
 
 export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
 
+export type StageType = 'agent_work' | 'wait_for_signal' | 'human_review';
+
 export interface Task {
   id: string;
   parentId: string | null;
@@ -28,6 +30,12 @@ export interface Task {
   createdAt: number;
   updatedAt: number;
   completedAt: number | null;
+  stageType: StageType | null;
+  gateConfig: Record<string, unknown> | null;
+  artifacts: Record<string, unknown> | null;
+  retryCount: number;
+  maxRetries: number;
+  templateId: string | null;
   children: Task[];
 }
 

--- a/server/__tests__/signal-processor.test.ts
+++ b/server/__tests__/signal-processor.test.ts
@@ -3,18 +3,18 @@ import { join } from 'path';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { TaskStore } from '../task-store.js';
-import { SignalProcessor, type GateResult } from '../signal-processor.js';
+import { SignalProcessor } from '../signal-processor.js';
 
 const TEST_DIR = join(tmpdir(), `mitzo-signal-test-${process.pid}`);
 
 let store: TaskStore;
 let processor: SignalProcessor;
-let onResolved: ReturnType<typeof vi.fn>;
+let onResolved: ReturnType<typeof vi.fn<(taskId: string) => void>>;
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
   store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
-  onResolved = vi.fn();
+  onResolved = vi.fn<(taskId: string) => void>();
   processor = new SignalProcessor(store, onResolved);
 });
 

--- a/server/__tests__/signal-processor.test.ts
+++ b/server/__tests__/signal-processor.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { TaskStore } from '../task-store.js';
+import { SignalProcessor, type GateResult } from '../signal-processor.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-signal-test-${process.pid}`);
+
+let store: TaskStore;
+let processor: SignalProcessor;
+let onResolved: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  store = new TaskStore(join(TEST_DIR, `tasks-${Date.now()}.db`));
+  onResolved = vi.fn();
+  processor = new SignalProcessor(store, onResolved);
+});
+
+afterEach(() => {
+  processor.unwatchAll();
+  store.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('SignalProcessor', () => {
+  it('watches and resolves a signal manually', () => {
+    const goal = store.create({ title: 'Goal' });
+    const task = store.create({
+      title: 'Wait for CI',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+    });
+    store.update(task.id, { status: 'active' });
+
+    processor.watch(task.id, task.gateConfig!);
+    expect(processor.isWatching(task.id)).toBe(true);
+
+    processor.resolveSignal(task.id, { status: 'pass', artifacts: { ci: 'green' } });
+
+    const updated = store.get(task.id);
+    expect(updated!.status).toBe('done');
+    expect(updated!.artifacts).toEqual({ ci: 'green' });
+    expect(onResolved).toHaveBeenCalledWith(task.id);
+    expect(processor.isWatching(task.id)).toBe(false);
+  });
+
+  it('resolves a signal with failure and no retries → failed', () => {
+    const goal = store.create({ title: 'Goal' });
+    const task = store.create({
+      title: 'CI check',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      maxRetries: 0,
+    });
+    store.update(task.id, { status: 'active' });
+
+    processor.watch(task.id, task.gateConfig!);
+    processor.resolveSignal(task.id, { status: 'fail' });
+
+    const updated = store.get(task.id);
+    expect(updated!.status).toBe('failed');
+    expect(onResolved).toHaveBeenCalledWith(task.id);
+  });
+
+  it('retries when max_retries > retry_count and resets preceding sibling', () => {
+    const goal = store.create({ title: 'Goal' });
+    const agentTask = store.create({
+      title: 'Fix code',
+      parentId: goal.id,
+      stageType: 'agent_work',
+      priority: 2,
+    });
+    store.update(agentTask.id, { status: 'done', summary: 'Fixed things' });
+
+    const signalTask = store.create({
+      title: 'Wait for CI',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      maxRetries: 3,
+      priority: 1,
+    });
+    store.update(signalTask.id, { status: 'active' });
+
+    processor.watch(signalTask.id, signalTask.gateConfig!);
+    processor.resolveSignal(signalTask.id, { status: 'fail', artifacts: { error: 'tests failed' } });
+
+    const updatedSignal = store.get(signalTask.id);
+    expect(updatedSignal!.status).toBe('pending');
+    expect(updatedSignal!.retryCount).toBe(1);
+
+    // Preceding agent_work sibling should be reset to pending
+    const updatedAgent = store.get(agentTask.id);
+    expect(updatedAgent!.status).toBe('pending');
+
+    expect(onResolved).toHaveBeenCalledWith(signalTask.id);
+  });
+
+  it('fails after exhausting retries', () => {
+    const goal = store.create({ title: 'Goal' });
+    const task = store.create({
+      title: 'CI check',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      maxRetries: 2,
+    });
+    // Simulate already retried twice
+    store.update(task.id, { status: 'active', retryCount: 2 });
+
+    processor.watch(task.id, task.gateConfig!);
+    processor.resolveSignal(task.id, { status: 'fail' });
+
+    const updated = store.get(task.id);
+    expect(updated!.status).toBe('failed');
+  });
+
+  it('unwatches a signal', () => {
+    const goal = store.create({ title: 'Goal' });
+    const task = store.create({
+      title: 'Wait',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'human_approval' },
+    });
+    store.update(task.id, { status: 'active' });
+
+    processor.watch(task.id, task.gateConfig!);
+    expect(processor.isWatching(task.id)).toBe(true);
+
+    processor.unwatch(task.id);
+    expect(processor.isWatching(task.id)).toBe(false);
+  });
+
+  it('unwatchAll clears everything', () => {
+    const goal = store.create({ title: 'Goal' });
+    const t1 = store.create({ title: 'W1', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'human_approval' } });
+    const t2 = store.create({ title: 'W2', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'human_approval' } });
+    store.update(t1.id, { status: 'active' });
+    store.update(t2.id, { status: 'active' });
+
+    processor.watch(t1.id, t1.gateConfig!);
+    processor.watch(t2.id, t2.gateConfig!);
+    expect(processor.isWatching(t1.id)).toBe(true);
+    expect(processor.isWatching(t2.id)).toBe(true);
+
+    processor.unwatchAll();
+    expect(processor.isWatching(t1.id)).toBe(false);
+    expect(processor.isWatching(t2.id)).toBe(false);
+  });
+
+  it('stores failure artifacts in annotations on retry', () => {
+    const goal = store.create({ title: 'Goal' });
+    const agent = store.create({ title: 'Agent work', parentId: goal.id, stageType: 'agent_work', priority: 2 });
+    store.update(agent.id, { status: 'done', summary: 'Done' });
+
+    const signal = store.create({
+      title: 'CI',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      maxRetries: 3,
+      priority: 1,
+    });
+    store.update(signal.id, { status: 'active' });
+
+    processor.watch(signal.id, signal.gateConfig!);
+    processor.resolveSignal(signal.id, { status: 'fail', artifacts: { failed_checks: ['lint', 'test'] } });
+
+    const updated = store.get(signal.id);
+    expect(updated!.annotations).toHaveLength(1);
+    expect(updated!.annotations[0]).toContain('retry_0');
+    expect(updated!.annotations[0]).toContain('lint');
+  });
+});

--- a/server/__tests__/signal-processor.test.ts
+++ b/server/__tests__/signal-processor.test.ts
@@ -91,7 +91,10 @@ describe('SignalProcessor', () => {
     store.update(signalTask.id, { status: 'active' });
 
     processor.watch(signalTask.id, signalTask.gateConfig!);
-    processor.resolveSignal(signalTask.id, { status: 'fail', artifacts: { error: 'tests failed' } });
+    processor.resolveSignal(signalTask.id, {
+      status: 'fail',
+      artifacts: { error: 'tests failed' },
+    });
 
     const updatedSignal = store.get(signalTask.id);
     expect(updatedSignal!.status).toBe('pending');
@@ -142,8 +145,18 @@ describe('SignalProcessor', () => {
 
   it('unwatchAll clears everything', () => {
     const goal = store.create({ title: 'Goal' });
-    const t1 = store.create({ title: 'W1', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'human_approval' } });
-    const t2 = store.create({ title: 'W2', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'human_approval' } });
+    const t1 = store.create({
+      title: 'W1',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'human_approval' },
+    });
+    const t2 = store.create({
+      title: 'W2',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'human_approval' },
+    });
     store.update(t1.id, { status: 'active' });
     store.update(t2.id, { status: 'active' });
 
@@ -159,7 +172,12 @@ describe('SignalProcessor', () => {
 
   it('stores failure artifacts in annotations on retry', () => {
     const goal = store.create({ title: 'Goal' });
-    const agent = store.create({ title: 'Agent work', parentId: goal.id, stageType: 'agent_work', priority: 2 });
+    const agent = store.create({
+      title: 'Agent work',
+      parentId: goal.id,
+      stageType: 'agent_work',
+      priority: 2,
+    });
     store.update(agent.id, { status: 'done', summary: 'Done' });
 
     const signal = store.create({
@@ -173,7 +191,10 @@ describe('SignalProcessor', () => {
     store.update(signal.id, { status: 'active' });
 
     processor.watch(signal.id, signal.gateConfig!);
-    processor.resolveSignal(signal.id, { status: 'fail', artifacts: { failed_checks: ['lint', 'test'] } });
+    processor.resolveSignal(signal.id, {
+      status: 'fail',
+      artifacts: { failed_checks: ['lint', 'test'] },
+    });
 
     const updated = store.get(signal.id);
     expect(updated!.annotations).toHaveLength(1);

--- a/server/__tests__/task-context.test.ts
+++ b/server/__tests__/task-context.test.ts
@@ -100,6 +100,32 @@ describe('buildTaskContextPrompt', () => {
     expect(ctx).toContain('&amp;');
     expect(ctx).toContain('&quot;quotes&quot;');
   });
+
+  it('includes sibling artifacts in context', () => {
+    const goal = store.create({ title: 'Goal' });
+    const s1 = store.create({ title: 'Create PR', parentId: goal.id, priority: 2 });
+    store.update(s1.id, {
+      status: 'done',
+      summary: 'Created PR #42',
+      artifacts: { pr_url: 'https://github.com/org/repo/pull/42' },
+    });
+    const s2 = store.create({ title: 'Check CI', parentId: goal.id, priority: 1 });
+
+    const ctx = buildTaskContextPrompt(store, s2.id)!;
+    expect(ctx).toContain('<sibling-artifacts>');
+    expect(ctx).toContain('key="pr_url"');
+    expect(ctx).toContain('https://github.com/org/repo/pull/42');
+  });
+
+  it('omits sibling-artifacts when none exist', () => {
+    const goal = store.create({ title: 'Goal' });
+    const s1 = store.create({ title: 'Step 1', parentId: goal.id, priority: 2 });
+    store.update(s1.id, { status: 'done', summary: 'Done' });
+    const s2 = store.create({ title: 'Step 2', parentId: goal.id, priority: 1 });
+
+    const ctx = buildTaskContextPrompt(store, s2.id)!;
+    expect(ctx).not.toContain('<sibling-artifacts>');
+  });
 });
 
 describe('buildTaskSystemPrompt', () => {
@@ -110,6 +136,7 @@ describe('buildTaskSystemPrompt', () => {
     expect(prompt).toContain('Task Board');
     expect(prompt).toContain('TaskSet');
     expect(prompt).toContain('TaskComplete');
+    expect(prompt).toContain('TaskArtifact');
     expect(prompt).toContain('<task-context>');
   });
 

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -415,4 +415,115 @@ describe('TaskOrchestrator', () => {
       expect(orchestrator.rejectTask(c1.id, 'nope')).toBe(false);
     });
   });
+
+  describe('stage type dispatch', () => {
+    it('wait_for_signal tasks register with signal watcher instead of agent', () => {
+      const watchSignal = vi.fn();
+      const deps = createTestDeps(store);
+      deps.watchSignal = watchSignal;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Wait for CI',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 42 },
+      });
+
+      orch.start(goal.id);
+
+      const task = store.getChildren(goal.id)[0];
+      expect(task.status).toBe('active');
+      expect(watchSignal).toHaveBeenCalledWith(task.id, { type: 'gh_ci', repo: 'org/repo', pr: 42 });
+      // Should NOT have set task context on session (no agent work)
+      expect(deps.setTaskContext).not.toHaveBeenCalled();
+    });
+
+    it('human_review tasks go to pending_review immediately', () => {
+      const deps = createTestDeps(store);
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Review design',
+        parentId: goal.id,
+        stageType: 'human_review',
+      });
+
+      orch.start(goal.id);
+
+      const task = store.getChildren(goal.id)[0];
+      expect(task.status).toBe('pending_review');
+      expect(deps.setTaskContext).not.toHaveBeenCalled();
+    });
+
+    it('agent_work tasks behave as before (assign to session)', () => {
+      const deps = createTestDeps(store);
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Do agent work',
+        parentId: goal.id,
+        stageType: 'agent_work',
+      });
+
+      orch.start(goal.id);
+
+      const task = store.getChildren(goal.id)[0];
+      expect(task.status).toBe('active');
+      expect(deps.setTaskContext).toHaveBeenCalledWith(task.id, goal.id);
+    });
+
+    it('null stageType tasks behave as agent_work (backwards compat)', () => {
+      const deps = createTestDeps(store);
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({ title: 'Legacy task', parentId: goal.id });
+
+      orch.start(goal.id);
+
+      const task = store.getChildren(goal.id)[0];
+      expect(task.status).toBe('active');
+      expect(deps.setTaskContext).toHaveBeenCalled();
+    });
+
+    it('mixed workflow: agent_work → wait_for_signal → human_review', () => {
+      const watchSignal = vi.fn();
+      const deps = createTestDeps(store);
+      deps.watchSignal = watchSignal;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Workflow Goal' });
+      const agent = store.create({ title: 'Agent step', parentId: goal.id, stageType: 'agent_work', priority: 3 });
+      const signal = store.create({ title: 'Signal step', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 }, priority: 2 });
+      const review = store.create({ title: 'Review step', parentId: goal.id, stageType: 'human_review', priority: 1 });
+
+      // Start: should pick agent_work (highest priority)
+      orch.start(goal.id);
+      expect(orch.getStatus().activeTaskId).toBe(agent.id);
+      expect(store.get(agent.id)!.status).toBe('active');
+
+      // Complete agent work → should pick wait_for_signal
+      store.update(agent.id, { status: 'done' });
+      store.cascadeStatus(agent.id);
+      orch.onTaskCompleted(agent.id);
+      expect(orch.getStatus().activeTaskId).toBe(signal.id);
+      expect(store.get(signal.id)!.status).toBe('active');
+      expect(watchSignal).toHaveBeenCalledWith(signal.id, { type: 'gh_ci', repo: 'org/repo', pr: 1 });
+
+      // Simulate signal resolved → should pick human_review
+      store.update(signal.id, { status: 'done' });
+      store.cascadeStatus(signal.id);
+      orch.onTaskCompleted(signal.id);
+      expect(orch.getStatus().activeTaskId).toBe(review.id);
+      expect(store.get(review.id)!.status).toBe('pending_review');
+
+      // Approve human review → goal done
+      orch.approveTask(review.id);
+      expect(orch.getStatus().state).toBe('idle');
+    });
+  });
 });

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -435,7 +435,11 @@ describe('TaskOrchestrator', () => {
 
       const task = store.getChildren(goal.id)[0];
       expect(task.status).toBe('active');
-      expect(watchSignal).toHaveBeenCalledWith(task.id, { type: 'gh_ci', repo: 'org/repo', pr: 42 });
+      expect(watchSignal).toHaveBeenCalledWith(task.id, {
+        type: 'gh_ci',
+        repo: 'org/repo',
+        pr: 42,
+      });
       // Should NOT have set task context on session (no agent work)
       expect(deps.setTaskContext).not.toHaveBeenCalled();
     });
@@ -497,9 +501,25 @@ describe('TaskOrchestrator', () => {
       const orch = new TaskOrchestrator(deps);
 
       const goal = store.create({ title: 'Workflow Goal' });
-      const agent = store.create({ title: 'Agent step', parentId: goal.id, stageType: 'agent_work', priority: 3 });
-      const signal = store.create({ title: 'Signal step', parentId: goal.id, stageType: 'wait_for_signal', gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 }, priority: 2 });
-      const review = store.create({ title: 'Review step', parentId: goal.id, stageType: 'human_review', priority: 1 });
+      const agent = store.create({
+        title: 'Agent step',
+        parentId: goal.id,
+        stageType: 'agent_work',
+        priority: 3,
+      });
+      const signal = store.create({
+        title: 'Signal step',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+        priority: 2,
+      });
+      const review = store.create({
+        title: 'Review step',
+        parentId: goal.id,
+        stageType: 'human_review',
+        priority: 1,
+      });
 
       // Start: should pick agent_work (highest priority)
       orch.start(goal.id);
@@ -512,7 +532,11 @@ describe('TaskOrchestrator', () => {
       orch.onTaskCompleted(agent.id);
       expect(orch.getStatus().activeTaskId).toBe(signal.id);
       expect(store.get(signal.id)!.status).toBe('active');
-      expect(watchSignal).toHaveBeenCalledWith(signal.id, { type: 'gh_ci', repo: 'org/repo', pr: 1 });
+      expect(watchSignal).toHaveBeenCalledWith(signal.id, {
+        type: 'gh_ci',
+        repo: 'org/repo',
+        pr: 1,
+      });
 
       // Simulate signal resolved → should pick human_review
       store.update(signal.id, { status: 'done' });

--- a/server/__tests__/task-store.test.ts
+++ b/server/__tests__/task-store.test.ts
@@ -432,4 +432,119 @@ describe('TaskStore', () => {
     expect(roots[0].title).toBe('Persist me');
     store2.close();
   });
+
+  // --- Workflow fields ---
+
+  it('creates a task with workflow fields', () => {
+    const task = store.create({
+      title: 'Wait for CI',
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 42 },
+      maxRetries: 3,
+      templateId: 'pr-triage',
+    });
+    expect(task.stageType).toBe('wait_for_signal');
+    expect(task.gateConfig).toEqual({ type: 'gh_ci', repo: 'org/repo', pr: 42 });
+    expect(task.maxRetries).toBe(3);
+    expect(task.retryCount).toBe(0);
+    expect(task.templateId).toBe('pr-triage');
+    expect(task.artifacts).toBeNull();
+  });
+
+  it('defaults workflow fields to null/0 for legacy tasks', () => {
+    const task = store.create({ title: 'Plain task' });
+    expect(task.stageType).toBeNull();
+    expect(task.gateConfig).toBeNull();
+    expect(task.artifacts).toBeNull();
+    expect(task.retryCount).toBe(0);
+    expect(task.maxRetries).toBe(0);
+    expect(task.templateId).toBeNull();
+  });
+
+  it('updates workflow fields', () => {
+    const task = store.create({ title: 'Updatable' });
+    const updated = store.update(task.id, {
+      stageType: 'human_review',
+      artifacts: { design_doc: '/path/to/doc.md' },
+      retryCount: 2,
+      maxRetries: 5,
+    });
+    expect(updated!.stageType).toBe('human_review');
+    expect(updated!.artifacts).toEqual({ design_doc: '/path/to/doc.md' });
+    expect(updated!.retryCount).toBe(2);
+    expect(updated!.maxRetries).toBe(5);
+  });
+
+  it('updates gate_config via update', () => {
+    const task = store.create({
+      title: 'Signal task',
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+    });
+    const updated = store.update(task.id, {
+      gateConfig: { type: 'gh_review', repo: 'org/repo', pr: 1 },
+    });
+    expect(updated!.gateConfig).toEqual({ type: 'gh_review', repo: 'org/repo', pr: 1 });
+  });
+
+  it('round-trips workflow fields through close and reopen', () => {
+    const dbPath = join(TEST_DIR, 'workflow-reopen.db');
+    const store1 = new TaskStore(dbPath);
+    store1.create({
+      title: 'Workflow task',
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 99 },
+      maxRetries: 2,
+      templateId: 'upstream-issue',
+    });
+    store1.close();
+
+    const store2 = new TaskStore(dbPath);
+    const roots = store2.listRoots();
+    expect(roots).toHaveLength(1);
+    expect(roots[0].stageType).toBe('wait_for_signal');
+    expect(roots[0].gateConfig).toEqual({ type: 'gh_ci', repo: 'org/repo', pr: 99 });
+    expect(roots[0].maxRetries).toBe(2);
+    expect(roots[0].templateId).toBe('upstream-issue');
+    store2.close();
+  });
+
+  it('migrates existing database to add workflow columns', () => {
+    // Create a DB without workflow columns, then reopen to trigger migration
+    const dbPath = join(TEST_DIR, 'migrate.db');
+    const store1 = new TaskStore(dbPath);
+    const t = store1.create({ title: 'Pre-migration task' });
+    store1.close();
+
+    // Reopen — migration should be idempotent
+    const store2 = new TaskStore(dbPath);
+    const task = store2.get(t.id);
+    expect(task!.stageType).toBeNull();
+    expect(task!.gateConfig).toBeNull();
+    expect(task!.retryCount).toBe(0);
+    expect(task!.maxRetries).toBe(0);
+    store2.close();
+  });
+
+  it('preserves workflow fields in tree assembly', () => {
+    const goal = store.create({ title: 'Goal', stageType: 'agent_work' });
+    store.create({
+      title: 'Wait step',
+      parentId: goal.id,
+      stageType: 'wait_for_signal',
+      gateConfig: { type: 'gh_ci', repo: 'test/repo', pr: 5 },
+    });
+    store.create({
+      title: 'Review step',
+      parentId: goal.id,
+      stageType: 'human_review',
+    });
+
+    const tree = store.getTree();
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children).toHaveLength(2);
+    expect(tree[0].children[0].stageType).toBe('wait_for_signal');
+    expect(tree[0].children[0].gateConfig).toEqual({ type: 'gh_ci', repo: 'test/repo', pr: 5 });
+    expect(tree[0].children[1].stageType).toBe('human_review');
+  });
 });

--- a/server/__tests__/task-tools.test.ts
+++ b/server/__tests__/task-tools.test.ts
@@ -168,7 +168,12 @@ describe('handleTaskBlock', () => {
 describe('handleTaskArtifact', () => {
   it('stores an artifact on a task', () => {
     const task = store.create({ title: 'Task' });
-    const result = handleTaskArtifact(store, task.id, 'pr_url', 'https://github.com/org/repo/pull/42');
+    const result = handleTaskArtifact(
+      store,
+      task.id,
+      'pr_url',
+      'https://github.com/org/repo/pull/42',
+    );
 
     expect(result).toContain('pr_url');
     expect(result).toContain('https://github.com/org/repo/pull/42');

--- a/server/__tests__/task-tools.test.ts
+++ b/server/__tests__/task-tools.test.ts
@@ -8,6 +8,7 @@ import {
   handleTaskComplete,
   handleTaskStatus,
   handleTaskBlock,
+  handleTaskArtifact,
 } from '../task-tools.js';
 
 const TEST_DIR = join(tmpdir(), `mitzo-task-tools-test-${process.pid}`);
@@ -160,6 +161,48 @@ describe('handleTaskBlock', () => {
   it('returns error for empty reason', () => {
     const task = store.create({ title: 'Task' });
     const result = handleTaskBlock(store, task.id, '  ');
+    expect(result).toContain('Error');
+  });
+});
+
+describe('handleTaskArtifact', () => {
+  it('stores an artifact on a task', () => {
+    const task = store.create({ title: 'Task' });
+    const result = handleTaskArtifact(store, task.id, 'pr_url', 'https://github.com/org/repo/pull/42');
+
+    expect(result).toContain('pr_url');
+    expect(result).toContain('https://github.com/org/repo/pull/42');
+
+    const updated = store.get(task.id)!;
+    expect(updated.artifacts).toEqual({ pr_url: 'https://github.com/org/repo/pull/42' });
+  });
+
+  it('merges with existing artifacts', () => {
+    const task = store.create({ title: 'Task' });
+    handleTaskArtifact(store, task.id, 'key1', 'val1');
+    handleTaskArtifact(store, task.id, 'key2', 'val2');
+
+    const updated = store.get(task.id)!;
+    expect(updated.artifacts).toEqual({ key1: 'val1', key2: 'val2' });
+  });
+
+  it('overwrites existing artifact key', () => {
+    const task = store.create({ title: 'Task' });
+    handleTaskArtifact(store, task.id, 'status', 'draft');
+    handleTaskArtifact(store, task.id, 'status', 'final');
+
+    const updated = store.get(task.id)!;
+    expect(updated.artifacts).toEqual({ status: 'final' });
+  });
+
+  it('returns error for nonexistent task', () => {
+    const result = handleTaskArtifact(store, 'nonexistent', 'key', 'val');
+    expect(result).toContain('Error');
+  });
+
+  it('returns error for empty key', () => {
+    const task = store.create({ title: 'Task' });
+    const result = handleTaskArtifact(store, task.id, '  ', 'val');
     expect(result).toContain('Error');
   });
 });

--- a/server/__tests__/workflow-templates.test.ts
+++ b/server/__tests__/workflow-templates.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { WorkflowTemplateStore, instantiateTemplate } from '../workflow-templates.js';
+import { TaskStore } from '../task-store.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-workflow-test-${process.pid}`);
+
+let templateStore: WorkflowTemplateStore;
+let taskStore: TaskStore;
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  const dbPath = join(TEST_DIR, `test-${Date.now()}.db`);
+  taskStore = new TaskStore(dbPath);
+  templateStore = new WorkflowTemplateStore(dbPath);
+});
+
+afterEach(() => {
+  templateStore.close();
+  taskStore.close();
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('WorkflowTemplateStore', () => {
+  it('creates and retrieves a template', () => {
+    const t = templateStore.create({
+      name: 'pr-triage',
+      description: 'Triage a PR',
+      stages: [
+        { title: 'Check CI', stage_type: 'agent_work' },
+        { title: 'Wait for review', stage_type: 'wait_for_signal', gate_config: { type: 'gh_review', repo: '{{repo}}', pr: '{{pr}}' } },
+      ],
+      variables: { repo: { description: 'GitHub repo' }, pr: { description: 'PR number' } },
+    });
+    expect(t.id).toBeTruthy();
+    expect(t.name).toBe('pr-triage');
+    expect(t.stages).toHaveLength(2);
+    expect(t.variables).toHaveProperty('repo');
+  });
+
+  it('lists all templates', () => {
+    templateStore.create({ name: 'a', stages: [{ title: 'Step 1', stage_type: 'agent_work' }] });
+    templateStore.create({ name: 'b', stages: [{ title: 'Step 1', stage_type: 'agent_work' }] });
+    const all = templateStore.list();
+    expect(all).toHaveLength(2);
+  });
+
+  it('gets a template by id', () => {
+    const created = templateStore.create({ name: 'test', stages: [{ title: 'S1', stage_type: 'agent_work' }] });
+    const found = templateStore.get(created.id);
+    expect(found!.name).toBe('test');
+  });
+
+  it('returns null for nonexistent template', () => {
+    expect(templateStore.get('nonexistent')).toBeNull();
+  });
+
+  it('deletes a template', () => {
+    const t = templateStore.create({ name: 'doomed', stages: [{ title: 'S', stage_type: 'agent_work' }] });
+    expect(templateStore.delete(t.id)).toBe(true);
+    expect(templateStore.get(t.id)).toBeNull();
+  });
+
+  it('rejects duplicate names', () => {
+    templateStore.create({ name: 'unique', stages: [{ title: 'S', stage_type: 'agent_work' }] });
+    expect(() => templateStore.create({ name: 'unique', stages: [{ title: 'S', stage_type: 'agent_work' }] })).toThrow();
+  });
+});
+
+describe('instantiateTemplate', () => {
+  it('creates a goal with child tasks from template', () => {
+    const tmpl = templateStore.create({
+      name: 'simple',
+      stages: [
+        { title: 'Step 1', stage_type: 'agent_work', description: 'Do work' },
+        { title: 'Step 2', stage_type: 'wait_for_signal', gate_config: { type: 'gh_ci', repo: 'org/repo', pr: 1 } },
+        { title: 'Step 3', stage_type: 'human_review' },
+      ],
+    });
+
+    const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'My Goal', {});
+    expect(goal.title).toBe('My Goal');
+    expect(goal.templateId).toBe(tmpl.id);
+    expect(goal.depth).toBe(0);
+
+    const children = taskStore.getChildren(goal.id);
+    expect(children).toHaveLength(3);
+    expect(children[0].title).toBe('Step 1');
+    expect(children[0].stageType).toBe('agent_work');
+    expect(children[0].description).toBe('Do work');
+    expect(children[1].title).toBe('Step 2');
+    expect(children[1].stageType).toBe('wait_for_signal');
+    expect(children[1].gateConfig).toEqual({ type: 'gh_ci', repo: 'org/repo', pr: 1 });
+    expect(children[2].title).toBe('Step 3');
+    expect(children[2].stageType).toBe('human_review');
+  });
+
+  it('substitutes template variables', () => {
+    const tmpl = templateStore.create({
+      name: 'parameterized',
+      stages: [
+        {
+          title: 'Check CI for PR #{{pr_number}}',
+          stage_type: 'wait_for_signal',
+          description: 'Check {{repo}} PR {{pr_number}}',
+          gate_config: { type: 'gh_ci', repo: '{{repo}}', pr: '{{pr_number}}' },
+        },
+      ],
+      variables: { repo: { description: 'Repo' }, pr_number: { description: 'PR #' } },
+    });
+
+    const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'Triage PR #42', {
+      repo: 'dimakis/mitzo',
+      pr_number: '42',
+    });
+    const children = taskStore.getChildren(goal.id);
+    expect(children[0].title).toBe('Check CI for PR #42');
+    expect(children[0].description).toBe('Check dimakis/mitzo PR 42');
+    expect(children[0].gateConfig).toEqual({ type: 'gh_ci', repo: 'dimakis/mitzo', pr: '42' });
+  });
+
+  it('sets priority to preserve stage ordering', () => {
+    const tmpl = templateStore.create({
+      name: 'ordered',
+      stages: [
+        { title: 'First', stage_type: 'agent_work' },
+        { title: 'Second', stage_type: 'agent_work' },
+        { title: 'Third', stage_type: 'agent_work' },
+      ],
+    });
+
+    const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'Ordered Goal', {});
+    const children = taskStore.getChildren(goal.id);
+    // DFS uses priority DESC so first stage needs highest priority
+    expect(children[0].title).toBe('First');
+    expect(children[0].priority).toBeGreaterThan(children[1].priority);
+    expect(children[1].priority).toBeGreaterThan(children[2].priority);
+  });
+
+  it('sets max_retries from template stage', () => {
+    const tmpl = templateStore.create({
+      name: 'retriable',
+      stages: [
+        { title: 'Flaky step', stage_type: 'agent_work', max_retries: 3 },
+      ],
+    });
+
+    const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'Retry Goal', {});
+    const children = taskStore.getChildren(goal.id);
+    expect(children[0].maxRetries).toBe(3);
+  });
+
+  it('throws for nonexistent template', () => {
+    expect(() => instantiateTemplate(taskStore, templateStore, 'nonexistent', 'Goal', {})).toThrow();
+  });
+
+  it('sets templateId on all created tasks', () => {
+    const tmpl = templateStore.create({
+      name: 'tracked',
+      stages: [
+        { title: 'S1', stage_type: 'agent_work' },
+        { title: 'S2', stage_type: 'agent_work' },
+      ],
+    });
+
+    const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'Tracked', {});
+    const children = taskStore.getChildren(goal.id);
+    expect(goal.templateId).toBe(tmpl.id);
+    expect(children[0].templateId).toBe(tmpl.id);
+    expect(children[1].templateId).toBe(tmpl.id);
+  });
+});

--- a/server/__tests__/workflow-templates.test.ts
+++ b/server/__tests__/workflow-templates.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { join } from 'path';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { WorkflowTemplateStore, instantiateTemplate, seedBuiltInTemplates } from '../workflow-templates.js';
+import {
+  WorkflowTemplateStore,
+  instantiateTemplate,
+  seedBuiltInTemplates,
+} from '../workflow-templates.js';
 import { TaskStore } from '../task-store.js';
 
 const TEST_DIR = join(tmpdir(), `mitzo-workflow-test-${process.pid}`);
@@ -34,7 +38,11 @@ describe('WorkflowTemplateStore', () => {
       description: 'Triage a PR',
       stages: [
         { title: 'Check CI', stage_type: 'agent_work' },
-        { title: 'Wait for review', stage_type: 'wait_for_signal', gate_config: { type: 'gh_review', repo: '{{repo}}', pr: '{{pr}}' } },
+        {
+          title: 'Wait for review',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_review', repo: '{{repo}}', pr: '{{pr}}' },
+        },
       ],
       variables: { repo: { description: 'GitHub repo' }, pr: { description: 'PR number' } },
     });
@@ -52,7 +60,10 @@ describe('WorkflowTemplateStore', () => {
   });
 
   it('gets a template by id', () => {
-    const created = templateStore.create({ name: 'test', stages: [{ title: 'S1', stage_type: 'agent_work' }] });
+    const created = templateStore.create({
+      name: 'test',
+      stages: [{ title: 'S1', stage_type: 'agent_work' }],
+    });
     const found = templateStore.get(created.id);
     expect(found!.name).toBe('test');
   });
@@ -62,14 +73,19 @@ describe('WorkflowTemplateStore', () => {
   });
 
   it('deletes a template', () => {
-    const t = templateStore.create({ name: 'doomed', stages: [{ title: 'S', stage_type: 'agent_work' }] });
+    const t = templateStore.create({
+      name: 'doomed',
+      stages: [{ title: 'S', stage_type: 'agent_work' }],
+    });
     expect(templateStore.delete(t.id)).toBe(true);
     expect(templateStore.get(t.id)).toBeNull();
   });
 
   it('rejects duplicate names', () => {
     templateStore.create({ name: 'unique', stages: [{ title: 'S', stage_type: 'agent_work' }] });
-    expect(() => templateStore.create({ name: 'unique', stages: [{ title: 'S', stage_type: 'agent_work' }] })).toThrow();
+    expect(() =>
+      templateStore.create({ name: 'unique', stages: [{ title: 'S', stage_type: 'agent_work' }] }),
+    ).toThrow();
   });
 });
 
@@ -79,7 +95,11 @@ describe('instantiateTemplate', () => {
       name: 'simple',
       stages: [
         { title: 'Step 1', stage_type: 'agent_work', description: 'Do work' },
-        { title: 'Step 2', stage_type: 'wait_for_signal', gate_config: { type: 'gh_ci', repo: 'org/repo', pr: 1 } },
+        {
+          title: 'Step 2',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+        },
         { title: 'Step 3', stage_type: 'human_review' },
       ],
     });
@@ -146,9 +166,7 @@ describe('instantiateTemplate', () => {
   it('sets max_retries from template stage', () => {
     const tmpl = templateStore.create({
       name: 'retriable',
-      stages: [
-        { title: 'Flaky step', stage_type: 'agent_work', max_retries: 3 },
-      ],
+      stages: [{ title: 'Flaky step', stage_type: 'agent_work', max_retries: 3 }],
     });
 
     const goal = instantiateTemplate(taskStore, templateStore, tmpl.id, 'Retry Goal', {});
@@ -157,7 +175,9 @@ describe('instantiateTemplate', () => {
   });
 
   it('throws for nonexistent template', () => {
-    expect(() => instantiateTemplate(taskStore, templateStore, 'nonexistent', 'Goal', {})).toThrow();
+    expect(() =>
+      instantiateTemplate(taskStore, templateStore, 'nonexistent', 'Goal', {}),
+    ).toThrow();
   });
 
   it('sets templateId on all created tasks', () => {

--- a/server/__tests__/workflow-templates.test.ts
+++ b/server/__tests__/workflow-templates.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { join } from 'path';
 import { mkdirSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
-import { WorkflowTemplateStore, instantiateTemplate } from '../workflow-templates.js';
+import { WorkflowTemplateStore, instantiateTemplate, seedBuiltInTemplates } from '../workflow-templates.js';
 import { TaskStore } from '../task-store.js';
 
 const TEST_DIR = join(tmpdir(), `mitzo-workflow-test-${process.pid}`);
@@ -174,5 +174,27 @@ describe('instantiateTemplate', () => {
     expect(goal.templateId).toBe(tmpl.id);
     expect(children[0].templateId).toBe(tmpl.id);
     expect(children[1].templateId).toBe(tmpl.id);
+  });
+});
+
+describe('seedBuiltInTemplates', () => {
+  it('creates pr-triage and upstream-issue templates', () => {
+    seedBuiltInTemplates(templateStore);
+    const templates = templateStore.list();
+    const names = templates.map((t) => t.name);
+    expect(names).toContain('pr-triage');
+    expect(names).toContain('upstream-issue');
+
+    const prTriage = templates.find((t) => t.name === 'pr-triage')!;
+    expect(prTriage.stages).toHaveLength(5);
+    expect(prTriage.variables).toHaveProperty('repo');
+    expect(prTriage.variables).toHaveProperty('pr');
+  });
+
+  it('is idempotent — second call does not duplicate', () => {
+    seedBuiltInTemplates(templateStore);
+    seedBuiltInTemplates(templateStore);
+    const count = templateStore.list().filter((t) => t.name === 'pr-triage').length;
+    expect(count).toBe(1);
   });
 });

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -153,6 +153,24 @@ export const WorkflowInstantiateBody = z.object({
   variables: z.record(z.string(), z.string()).default({}),
 });
 
+export const TemplateCreateBody = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  stages: z.array(
+    z.object({
+      title: z.string().min(1),
+      description: z.string().optional(),
+      stage_type: z.enum(['agent_work', 'wait_for_signal', 'human_review']),
+      gate_config: z.record(z.string(), z.unknown()).optional(),
+      max_retries: z.number().min(0).optional(),
+    }),
+  ).min(1),
+  variables: z.record(z.string(), z.object({
+    description: z.string().optional(),
+    default: z.string().optional(),
+  })).optional(),
+});
+
 export const SignalBody = z.object({
   status: z.enum(['pass', 'fail']),
   artifacts: z.record(z.string(), z.unknown()).optional(),

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -119,7 +119,7 @@ export const TaskCreateBody = z.object({
   sessionPolicy: z.enum(['reuse', 'spawn', 'auto']).optional(),
   annotations: z.array(z.string()).optional(),
   stageType: z.enum(['agent_work', 'wait_for_signal', 'human_review']).optional(),
-  gateConfig: z.record(z.unknown()).optional(),
+  gateConfig: z.record(z.string(), z.unknown()).optional(),
   maxRetries: z.number().min(0).optional(),
   templateId: z.string().optional(),
 });
@@ -136,8 +136,8 @@ export const TaskUpdateBody = z.object({
   summary: z.string().optional(),
   requiresApproval: z.boolean().optional(),
   stageType: z.enum(['agent_work', 'wait_for_signal', 'human_review']).optional(),
-  gateConfig: z.record(z.unknown()).optional(),
-  artifacts: z.record(z.unknown()).optional(),
+  gateConfig: z.record(z.string(), z.unknown()).optional(),
+  artifacts: z.record(z.string(), z.unknown()).optional(),
   retryCount: z.number().min(0).optional(),
   maxRetries: z.number().min(0).optional(),
 });
@@ -150,10 +150,10 @@ export const LoopStartBody = z.object({
 export const WorkflowInstantiateBody = z.object({
   templateId: z.string().min(1),
   title: z.string().min(1),
-  variables: z.record(z.string()).default({}),
+  variables: z.record(z.string(), z.string()).default({}),
 });
 
 export const SignalBody = z.object({
   status: z.enum(['pass', 'fail']),
-  artifacts: z.record(z.unknown()).optional(),
+  artifacts: z.record(z.string(), z.unknown()).optional(),
 });

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -156,19 +156,26 @@ export const WorkflowInstantiateBody = z.object({
 export const TemplateCreateBody = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
-  stages: z.array(
-    z.object({
-      title: z.string().min(1),
-      description: z.string().optional(),
-      stage_type: z.enum(['agent_work', 'wait_for_signal', 'human_review']),
-      gate_config: z.record(z.string(), z.unknown()).optional(),
-      max_retries: z.number().min(0).optional(),
-    }),
-  ).min(1),
-  variables: z.record(z.string(), z.object({
-    description: z.string().optional(),
-    default: z.string().optional(),
-  })).optional(),
+  stages: z
+    .array(
+      z.object({
+        title: z.string().min(1),
+        description: z.string().optional(),
+        stage_type: z.enum(['agent_work', 'wait_for_signal', 'human_review']),
+        gate_config: z.record(z.string(), z.unknown()).optional(),
+        max_retries: z.number().min(0).optional(),
+      }),
+    )
+    .min(1),
+  variables: z
+    .record(
+      z.string(),
+      z.object({
+        description: z.string().optional(),
+        default: z.string().optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const SignalBody = z.object({

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -118,6 +118,10 @@ export const TaskCreateBody = z.object({
   priority: z.number().optional(),
   sessionPolicy: z.enum(['reuse', 'spawn', 'auto']).optional(),
   annotations: z.array(z.string()).optional(),
+  stageType: z.enum(['agent_work', 'wait_for_signal', 'human_review']).optional(),
+  gateConfig: z.record(z.unknown()).optional(),
+  maxRetries: z.number().min(0).optional(),
+  templateId: z.string().optional(),
 });
 
 export const TaskUpdateBody = z.object({
@@ -131,9 +135,25 @@ export const TaskUpdateBody = z.object({
   annotations: z.array(z.string()).optional(),
   summary: z.string().optional(),
   requiresApproval: z.boolean().optional(),
+  stageType: z.enum(['agent_work', 'wait_for_signal', 'human_review']).optional(),
+  gateConfig: z.record(z.unknown()).optional(),
+  artifacts: z.record(z.unknown()).optional(),
+  retryCount: z.number().min(0).optional(),
+  maxRetries: z.number().min(0).optional(),
 });
 
 export const LoopStartBody = z.object({
   goalId: z.string().min(1),
   specMode: z.boolean().optional(),
+});
+
+export const WorkflowInstantiateBody = z.object({
+  templateId: z.string().min(1),
+  title: z.string().min(1),
+  variables: z.record(z.string()).default({}),
+});
+
+export const SignalBody = z.object({
+  status: z.enum(['pass', 'fail']),
+  artifacts: z.record(z.unknown()).optional(),
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -57,10 +57,11 @@ import {
   TaskUpdateBody,
   LoopStartBody,
   WorkflowInstantiateBody,
+  TemplateCreateBody,
   SignalBody,
 } from './api-schemas.js';
 import type { TaskOrchestrator } from './task-orchestrator.js';
-import type { WorkflowTemplateStore } from './workflow-templates.js';
+import type { WorkflowTemplateStore, TemplateCreateInput } from './workflow-templates.js';
 import { instantiateTemplate } from './workflow-templates.js';
 import type { SignalProcessor } from './signal-processor.js';
 import {
@@ -677,7 +678,7 @@ app.get('/api/templates', (_req, res) => {
     res.status(503).json({ error: 'Template store not initialized' });
     return;
   }
-  res.json({ templates: templateStore.list() });
+  res.json(templateStore.list());
 });
 
 app.get('/api/templates/:id', (req, res) => {
@@ -691,6 +692,20 @@ app.get('/api/templates/:id', (req, res) => {
     return;
   }
   res.json({ template: tmpl });
+});
+
+app.post('/api/templates', (req, res) => {
+  if (!templateStore) {
+    res.status(503).json({ error: 'Template store not initialized' });
+    return;
+  }
+  const body = TemplateCreateBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+  const tmpl = templateStore.create(body.data as TemplateCreateInput);
+  res.status(201).json(tmpl);
 });
 
 app.delete('/api/templates/:id', (req, res) => {
@@ -747,6 +762,14 @@ app.post('/api/tasks/:id/signal', (req, res) => {
   const task = taskStore.get(req.params.id);
   if (!task) {
     res.status(404).json({ error: 'Task not found' });
+    return;
+  }
+  if (task.stageType !== 'wait_for_signal') {
+    res.status(400).json({ error: 'Task is not a wait_for_signal stage' });
+    return;
+  }
+  if (task.status !== 'active') {
+    res.status(400).json({ error: `Task is ${task.status}, not active` });
     return;
   }
   signalProcessor.resolveSignal(req.params.id, {

--- a/server/app.ts
+++ b/server/app.ts
@@ -41,6 +41,7 @@ import {
   handleTaskComplete,
   handleTaskStatus,
   handleTaskBlock,
+  handleTaskArtifact,
 } from './task-tools.js';
 import { setTaskStore } from './chat.js';
 import {
@@ -55,8 +56,12 @@ import {
   TaskCreateBody,
   TaskUpdateBody,
   LoopStartBody,
+  WorkflowInstantiateBody,
+  SignalBody,
 } from './api-schemas.js';
 import type { TaskOrchestrator } from './task-orchestrator.js';
+import type { WorkflowTemplateStore } from './workflow-templates.js';
+import type { SignalProcessor } from './signal-processor.js';
 import {
   listInboxItems,
   readInboxItem,
@@ -195,9 +200,19 @@ let onUpdateAvailable: (() => void) | null = null;
 let onInboxUpdated: (() => void) | null = null;
 let onTaskBroadcast: ((event: Record<string, unknown>) => void) | null = null;
 let orchestrator: TaskOrchestrator | null = null;
+let templateStore: WorkflowTemplateStore | null = null;
+let signalProcessor: SignalProcessor | null = null;
 
 export function setOrchestrator(o: TaskOrchestrator): void {
   orchestrator = o;
+}
+
+export function setTemplateStore(ts: WorkflowTemplateStore): void {
+  templateStore = ts;
+}
+
+export function setSignalProcessor(sp: SignalProcessor): void {
+  signalProcessor = sp;
 }
 
 // --- Task store ---
@@ -532,6 +547,24 @@ app.post('/api/internal/task-tools/block', (req, res) => {
   });
 });
 
+app.post('/api/internal/task-tools/artifact', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  const taskId = resolveTaskContext(req);
+  if (!taskId) {
+    res.status(400).json({ error: 'No active task context' });
+    return;
+  }
+  const result = handleTaskArtifact(taskStore, taskId, req.body.key ?? '', req.body.value ?? '');
+  res.json({ result });
+  onTaskBroadcast?.({
+    type: 'task_state',
+    tasks: taskStore.getTree(),
+  });
+});
+
 // --- Loop orchestrator API ---
 
 app.get('/api/loop/status', (req, res) => {
@@ -634,6 +667,94 @@ app.post('/api/loop/spec/reject', (_req, res) => {
     return;
   }
   res.json(orchestrator.rejectSpec());
+});
+
+// --- Workflow Templates ---
+
+app.get('/api/templates', (_req, res) => {
+  if (!templateStore) {
+    res.status(503).json({ error: 'Template store not initialized' });
+    return;
+  }
+  res.json({ templates: templateStore.list() });
+});
+
+app.get('/api/templates/:id', (req, res) => {
+  if (!templateStore) {
+    res.status(503).json({ error: 'Template store not initialized' });
+    return;
+  }
+  const tmpl = templateStore.get(req.params.id);
+  if (!tmpl) {
+    res.status(404).json({ error: 'Template not found' });
+    return;
+  }
+  res.json({ template: tmpl });
+});
+
+app.delete('/api/templates/:id', (req, res) => {
+  if (!templateStore) {
+    res.status(503).json({ error: 'Template store not initialized' });
+    return;
+  }
+  const ok = templateStore.delete(req.params.id);
+  if (!ok) {
+    res.status(404).json({ error: 'Template not found' });
+    return;
+  }
+  res.json({ ok: true });
+});
+
+app.post('/api/workflows/instantiate', (req, res) => {
+  if (!templateStore) {
+    res.status(503).json({ error: 'Template store not initialized' });
+    return;
+  }
+  const body = WorkflowInstantiateBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+  try {
+    const { instantiateTemplate } = require('./workflow-templates.js');
+    const goal = instantiateTemplate(
+      taskStore,
+      templateStore,
+      body.data.templateId,
+      body.data.title,
+      body.data.variables,
+    );
+    res.status(201).json({ task: goal });
+    onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    res.status(400).json({ error: message });
+  }
+});
+
+// --- Signal injection ---
+
+app.post('/api/tasks/:id/signal', (req, res) => {
+  if (!signalProcessor) {
+    res.status(503).json({ error: 'Signal processor not initialized' });
+    return;
+  }
+  const body = SignalBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+  const task = taskStore.get(req.params.id);
+  if (!task) {
+    res.status(404).json({ error: 'Task not found' });
+    return;
+  }
+  signalProcessor.resolveSignal(req.params.id, {
+    status: body.data.status,
+    artifacts: body.data.artifacts,
+  });
+  res.json({ ok: true });
+  onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
 });
 
 app.post('/api/auth/login', loginLimiter, async (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -61,6 +61,7 @@ import {
 } from './api-schemas.js';
 import type { TaskOrchestrator } from './task-orchestrator.js';
 import type { WorkflowTemplateStore } from './workflow-templates.js';
+import { instantiateTemplate } from './workflow-templates.js';
 import type { SignalProcessor } from './signal-processor.js';
 import {
   listInboxItems,
@@ -74,7 +75,7 @@ import { SkillRegistry } from './skills.js';
 
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
-import { TaskStore } from './task-store.js';
+import { TaskStore, type TaskCreateInput, type TaskUpdateInput } from './task-store.js';
 
 const log = createLogger('server');
 
@@ -426,7 +427,7 @@ app.post('/api/tasks', (req, res) => {
     return;
   }
   try {
-    const task = taskStore.create(body.data);
+    const task = taskStore.create(body.data as TaskCreateInput);
     res.status(201).json({ task });
     // Broadcast full tree so child tasks appear correctly in all clients
     onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
@@ -451,7 +452,7 @@ app.patch('/api/tasks/:id', (req, res) => {
     res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
     return;
   }
-  const task = taskStore.update(req.params.id, body.data);
+  const task = taskStore.update(req.params.id, body.data as TaskUpdateInput);
   if (!task) {
     res.status(404).json({ error: 'Task not found' });
     return;
@@ -716,7 +717,6 @@ app.post('/api/workflows/instantiate', (req, res) => {
     return;
   }
   try {
-    const { instantiateTemplate } = require('./workflow-templates.js');
     const goal = instantiateTemplate(
       taskStore,
       templateStore,

--- a/server/index.ts
+++ b/server/index.ts
@@ -112,7 +112,7 @@ setTaskBroadcast((event) => {
 });
 
 // --- Workflow layer ---
-const wfTemplateStore = new WorkflowTemplateStore(join(BASE_REPO, '.mitzo', 'tasks.db'));
+const wfTemplateStore = new WorkflowTemplateStore(taskStore.getDatabase());
 seedBuiltInTemplates(wfTemplateStore);
 setTemplateStore(wfTemplateStore);
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,7 +42,7 @@ import {
   yapperWsProxy,
   taskStore,
 } from './app.js';
-import { WorkflowTemplateStore } from './workflow-templates.js';
+import { WorkflowTemplateStore, seedBuiltInTemplates } from './workflow-templates.js';
 import { SignalProcessor } from './signal-processor.js';
 import { TaskOrchestrator } from './task-orchestrator.js';
 import { IncomingWsMessage } from './ws-schemas.js';
@@ -113,6 +113,7 @@ setTaskBroadcast((event) => {
 
 // --- Workflow layer ---
 const wfTemplateStore = new WorkflowTemplateStore(join(BASE_REPO, '.mitzo', 'tasks.db'));
+seedBuiltInTemplates(wfTemplateStore);
 setTemplateStore(wfTemplateStore);
 
 // SignalProcessor + orchestrator have a circular dep: signal resolution triggers tick(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,8 @@ import {
   setInboxBroadcast,
   setTaskBroadcast,
   setOrchestrator,
+  setTemplateStore,
+  setSignalProcessor,
   runUpdateCheck,
   buildSkillRegistry,
   NATIVE_COMMAND_NAMES,
@@ -40,6 +42,8 @@ import {
   yapperWsProxy,
   taskStore,
 } from './app.js';
+import { WorkflowTemplateStore } from './workflow-templates.js';
+import { SignalProcessor } from './signal-processor.js';
 import { TaskOrchestrator } from './task-orchestrator.js';
 import { IncomingWsMessage } from './ws-schemas.js';
 import { resolvePending } from './permissions.js';
@@ -107,9 +111,22 @@ setTaskBroadcast((event) => {
   connRegistry.broadcastAll(event as Record<string, unknown>);
 });
 
+// --- Workflow layer ---
+const wfTemplateStore = new WorkflowTemplateStore(join(BASE_REPO, '.mitzo', 'tasks.db'));
+setTemplateStore(wfTemplateStore);
+
+// SignalProcessor + orchestrator have a circular dep: signal resolution triggers tick(),
+// tick() registers watches. Break the cycle with a late-bound callback.
+let orchestratorRef: TaskOrchestrator | null = null;
+const signalProc = new SignalProcessor(taskStore, () => {
+  orchestratorRef?.tick();
+});
+setSignalProcessor(signalProc);
+
 // --- Task Orchestrator ---
 const orchestrator = new TaskOrchestrator({
   store: taskStore,
+  watchSignal: (taskId, gateConfig) => signalProc.watch(taskId, gateConfig),
   getClientId: () => {
     // Find the first registered client (reuse-only for Phase 2)
     for (const [clientId] of registry.entries()) {
@@ -161,6 +178,7 @@ const orchestrator = new TaskOrchestrator({
     return ids;
   },
 });
+orchestratorRef = orchestrator;
 setOrchestrator(orchestrator);
 
 server.on('upgrade', async (req, socket, head) => {
@@ -743,6 +761,8 @@ function handleChatWs(
 function shutdown(signal: string) {
   log.info(`${signal} received — shutting down gracefully`);
   server.close();
+  signalProc.unwatchAll();
+  wfTemplateStore.close();
   registry.dispose();
   for (const client of wss.clients) {
     client.close(1001, 'Server shutting down');

--- a/server/signal-processor.ts
+++ b/server/signal-processor.ts
@@ -122,10 +122,7 @@ export class SignalProcessor {
   }
 
   /** Handle a failed gate — retry or mark failed. */
-  private handleFailure(
-    taskId: string,
-    artifacts?: Record<string, unknown>,
-  ): void {
+  private handleFailure(taskId: string, artifacts?: Record<string, unknown>): void {
     const task = this.store.get(taskId);
     if (!task) return;
 
@@ -203,9 +200,13 @@ export async function checkGate(config: GateConfig): Promise<GateResult> {
 async function checkGhCi(config: { repo: string; pr: number | string }): Promise<GateResult> {
   try {
     const { stdout } = await execFileAsync('gh', [
-      'pr', 'checks', String(config.pr),
-      '--repo', config.repo,
-      '--json', 'state,name',
+      'pr',
+      'checks',
+      String(config.pr),
+      '--repo',
+      config.repo,
+      '--json',
+      'state,name',
     ]);
     const checks = JSON.parse(stdout) as Array<{ state: string; name: string }>;
     if (checks.length === 0) return { resolved: false, status: 'fail' };
@@ -218,7 +219,11 @@ async function checkGhCi(config: { repo: string; pr: number | string }): Promise
     }
     if (anyFailed) {
       const failed = checks.filter((c) => c.state === 'FAILURE' || c.state === 'ERROR');
-      return { resolved: true, status: 'fail', artifacts: { failed_checks: failed.map((c) => c.name) } };
+      return {
+        resolved: true,
+        status: 'fail',
+        artifacts: { failed_checks: failed.map((c) => c.name) },
+      };
     }
     // Still pending
     return { resolved: false, status: 'fail' };
@@ -231,9 +236,13 @@ async function checkGhCi(config: { repo: string; pr: number | string }): Promise
 async function checkGhReview(config: { repo: string; pr: number | string }): Promise<GateResult> {
   try {
     const { stdout } = await execFileAsync('gh', [
-      'pr', 'view', String(config.pr),
-      '--repo', config.repo,
-      '--json', 'reviewDecision',
+      'pr',
+      'view',
+      String(config.pr),
+      '--repo',
+      config.repo,
+      '--json',
+      'reviewDecision',
     ]);
     const data = JSON.parse(stdout) as { reviewDecision: string };
 

--- a/server/signal-processor.ts
+++ b/server/signal-processor.ts
@@ -1,0 +1,297 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import type { TaskStore, GateConfig } from './task-store.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('signal-processor');
+const execFileAsync = promisify(execFile);
+
+export interface GateResult {
+  resolved: boolean;
+  status: 'pass' | 'fail';
+  artifacts?: Record<string, unknown>;
+}
+
+interface WatchEntry {
+  taskId: string;
+  gateConfig: GateConfig;
+  intervalId: NodeJS.Timeout | null; // null for non-polling gates (human_approval)
+}
+
+/** Default polling intervals by gate type (milliseconds). */
+const POLL_INTERVALS: Record<string, number> = {
+  gh_ci: 30_000,
+  gh_review: 60_000,
+  centaur_review: 30_000,
+  compound: 30_000,
+};
+
+/**
+ * Watches external signals for wait_for_signal tasks.
+ * Polls GitHub/Centaur status or waits for manual resolution.
+ */
+export class SignalProcessor {
+  private watches = new Map<string, WatchEntry>();
+  private store: TaskStore;
+  private onSignalResolved: (taskId: string) => void;
+
+  constructor(store: TaskStore, onSignalResolved: (taskId: string) => void) {
+    this.store = store;
+    this.onSignalResolved = onSignalResolved;
+  }
+
+  watch(taskId: string, gateConfig: GateConfig): void {
+    if (this.watches.has(taskId)) {
+      log.warn('already watching task', { taskId });
+      return;
+    }
+
+    const interval = POLL_INTERVALS[gateConfig.type];
+    let intervalId: NodeJS.Timeout | null = null;
+
+    if (interval && gateConfig.type !== 'human_approval') {
+      intervalId = setInterval(() => this.poll(taskId), interval);
+      log.info('started polling', { taskId, type: gateConfig.type, intervalMs: interval });
+    } else {
+      log.info('watching for manual signal', { taskId, type: gateConfig.type });
+    }
+
+    this.watches.set(taskId, { taskId, gateConfig, intervalId });
+  }
+
+  unwatch(taskId: string): void {
+    const entry = this.watches.get(taskId);
+    if (!entry) return;
+    if (entry.intervalId) clearInterval(entry.intervalId);
+    this.watches.delete(taskId);
+    log.info('unwatched task', { taskId });
+  }
+
+  unwatchAll(): void {
+    for (const [taskId, entry] of this.watches) {
+      if (entry.intervalId) clearInterval(entry.intervalId);
+      log.info('unwatched task', { taskId });
+    }
+    this.watches.clear();
+  }
+
+  isWatching(taskId: string): boolean {
+    return this.watches.has(taskId);
+  }
+
+  /** Manually resolve a signal (used by REST endpoint or webhook push). */
+  resolveSignal(
+    taskId: string,
+    result: { status: 'pass' | 'fail'; artifacts?: Record<string, unknown> },
+  ): void {
+    this.unwatch(taskId);
+    const task = this.store.get(taskId);
+    if (!task) {
+      log.error('resolveSignal: task not found', { taskId });
+      return;
+    }
+
+    if (result.status === 'pass') {
+      this.store.update(taskId, {
+        status: 'done',
+        summary: `Signal resolved: ${task.gateConfig?.type ?? 'unknown'} passed`,
+        artifacts: result.artifacts,
+      });
+      this.store.cascadeStatus(taskId);
+      log.info('signal passed', { taskId, type: task.gateConfig?.type });
+    } else {
+      this.handleFailure(task.id, result.artifacts);
+    }
+
+    this.onSignalResolved(taskId);
+  }
+
+  /** Poll a gate and resolve if ready. */
+  private async poll(taskId: string): Promise<void> {
+    const entry = this.watches.get(taskId);
+    if (!entry) return;
+
+    try {
+      const result = await checkGate(entry.gateConfig);
+      if (result.resolved) {
+        this.resolveSignal(taskId, { status: result.status, artifacts: result.artifacts });
+      }
+    } catch (err) {
+      log.error('poll error', { taskId, error: (err as Error).message });
+    }
+  }
+
+  /** Handle a failed gate — retry or mark failed. */
+  private handleFailure(
+    taskId: string,
+    artifacts?: Record<string, unknown>,
+  ): void {
+    const task = this.store.get(taskId);
+    if (!task) return;
+
+    if (task.maxRetries > 0 && task.retryCount < task.maxRetries) {
+      // Store failure context in annotations
+      const failAnnotation = `retry_${task.retryCount}: ${JSON.stringify(artifacts ?? {})}`;
+      const annotations = [...task.annotations, failAnnotation];
+
+      // Reset this task to pending with incremented retry count
+      this.store.update(taskId, {
+        status: 'pending',
+        retryCount: task.retryCount + 1,
+        annotations,
+      });
+
+      // Find and reset the preceding agent_work sibling so it can fix the issue
+      this.resetPrecedingSibling(task);
+
+      this.store.cascadeStatus(taskId);
+      log.info('signal failed, retrying', {
+        taskId,
+        retryCount: task.retryCount + 1,
+        maxRetries: task.maxRetries,
+      });
+    } else {
+      this.store.update(taskId, { status: 'failed', artifacts });
+      this.store.cascadeStatus(taskId);
+      log.info('signal failed, retries exhausted', { taskId });
+    }
+  }
+
+  /** Reset the most recent agent_work sibling before this task to pending. */
+  private resetPrecedingSibling(task: { id: string; parentId: string | null }): void {
+    if (!task.parentId) return;
+
+    const siblings = this.store.getChildren(task.parentId);
+    // Siblings are sorted by priority DESC — find the one just before this task
+    let found = false;
+    for (const sibling of siblings) {
+      if (sibling.id === task.id) {
+        found = true;
+        continue;
+      }
+      // After finding our task in the list, look backwards. But since sorted by priority DESC,
+      // the sibling before us has higher priority. So we need to find the last agent_work
+      // sibling before our task in the ordered list.
+    }
+
+    // Walk the list: find the agent_work sibling that comes right before this task
+    // (i.e., has higher priority = appears earlier in priority-sorted list)
+    let precedingAgent: string | null = null;
+    for (const sibling of siblings) {
+      if (sibling.id === task.id) break;
+      if (sibling.stageType === 'agent_work' || sibling.stageType === null) {
+        precedingAgent = sibling.id;
+      }
+    }
+
+    if (precedingAgent) {
+      this.store.update(precedingAgent, { status: 'pending' });
+      log.info('reset preceding sibling for retry', { taskId: task.id, siblingId: precedingAgent });
+    }
+  }
+}
+
+// --- Gate checker implementations ---
+
+export async function checkGate(config: GateConfig): Promise<GateResult> {
+  switch (config.type) {
+    case 'gh_ci':
+      return checkGhCi(config as GateConfig & { repo: string; pr: number | string });
+    case 'gh_review':
+      return checkGhReview(config as GateConfig & { repo: string; pr: number | string });
+    case 'centaur_review':
+      return checkCentaurReview(config as GateConfig & { pr_url: string });
+    case 'compound':
+      return checkCompound(config as GateConfig & { all: GateConfig[] });
+    case 'human_approval':
+      return { resolved: false, status: 'fail' }; // never auto-resolves
+    default:
+      log.warn('unknown gate type', { type: config.type });
+      return { resolved: false, status: 'fail' };
+  }
+}
+
+async function checkGhCi(config: { repo: string; pr: number | string }): Promise<GateResult> {
+  try {
+    const { stdout } = await execFileAsync('gh', [
+      'pr', 'checks', String(config.pr),
+      '--repo', config.repo,
+      '--json', 'state,name',
+    ]);
+    const checks = JSON.parse(stdout) as Array<{ state: string; name: string }>;
+    if (checks.length === 0) return { resolved: false, status: 'fail' };
+
+    const allPassed = checks.every((c) => c.state === 'SUCCESS' || c.state === 'SKIPPED');
+    const anyFailed = checks.some((c) => c.state === 'FAILURE' || c.state === 'ERROR');
+
+    if (allPassed) {
+      return { resolved: true, status: 'pass', artifacts: { checks } };
+    }
+    if (anyFailed) {
+      const failed = checks.filter((c) => c.state === 'FAILURE' || c.state === 'ERROR');
+      return { resolved: true, status: 'fail', artifacts: { failed_checks: failed.map((c) => c.name) } };
+    }
+    // Still pending
+    return { resolved: false, status: 'fail' };
+  } catch (err) {
+    log.error('gh ci check failed', { error: (err as Error).message });
+    return { resolved: false, status: 'fail' };
+  }
+}
+
+async function checkGhReview(config: { repo: string; pr: number | string }): Promise<GateResult> {
+  try {
+    const { stdout } = await execFileAsync('gh', [
+      'pr', 'view', String(config.pr),
+      '--repo', config.repo,
+      '--json', 'reviewDecision',
+    ]);
+    const data = JSON.parse(stdout) as { reviewDecision: string };
+
+    if (data.reviewDecision === 'APPROVED') {
+      return { resolved: true, status: 'pass', artifacts: { reviewDecision: 'APPROVED' } };
+    }
+    if (data.reviewDecision === 'CHANGES_REQUESTED') {
+      return { resolved: true, status: 'fail', artifacts: { reviewDecision: 'CHANGES_REQUESTED' } };
+    }
+    // REVIEW_REQUIRED or empty — not resolved yet
+    return { resolved: false, status: 'fail' };
+  } catch (err) {
+    log.error('gh review check failed', { error: (err as Error).message });
+    return { resolved: false, status: 'fail' };
+  }
+}
+
+async function checkCentaurReview(config: { pr_url: string }): Promise<GateResult> {
+  try {
+    const res = await fetch(
+      `http://localhost:8642/api/reviews?pr=${encodeURIComponent(config.pr_url)}`,
+    );
+    if (!res.ok) return { resolved: false, status: 'fail' };
+    const data = (await res.json()) as { status?: string; review?: unknown };
+
+    if (data.status === 'approved') {
+      return { resolved: true, status: 'pass', artifacts: { review: data.review } };
+    }
+    if (data.status === 'changes_requested') {
+      return { resolved: true, status: 'fail', artifacts: { review: data.review } };
+    }
+    return { resolved: false, status: 'fail' };
+  } catch {
+    // Centaur might not be running — that's fine, just not resolved
+    return { resolved: false, status: 'fail' };
+  }
+}
+
+async function checkCompound(config: { all: GateConfig[] }): Promise<GateResult> {
+  const results = await Promise.all(config.all.map((c) => checkGate(c)));
+  const allResolved = results.every((r) => r.resolved);
+  const anyFailed = results.some((r) => r.status === 'fail' && r.resolved);
+
+  if (!allResolved) return { resolved: false, status: 'fail' };
+  return {
+    resolved: true,
+    status: anyFailed ? 'fail' : 'pass',
+    artifacts: { sub_results: results },
+  };
+}

--- a/server/signal-processor.ts
+++ b/server/signal-processor.ts
@@ -162,17 +162,6 @@ export class SignalProcessor {
     if (!task.parentId) return;
 
     const siblings = this.store.getChildren(task.parentId);
-    // Siblings are sorted by priority DESC — find the one just before this task
-    let found = false;
-    for (const sibling of siblings) {
-      if (sibling.id === task.id) {
-        found = true;
-        continue;
-      }
-      // After finding our task in the list, look backwards. But since sorted by priority DESC,
-      // the sibling before us has higher priority. So we need to find the last agent_work
-      // sibling before our task in the ordered list.
-    }
 
     // Walk the list: find the agent_work sibling that comes right before this task
     // (i.e., has higher priority = appears earlier in priority-sorted list)

--- a/server/task-context.ts
+++ b/server/task-context.ts
@@ -54,19 +54,38 @@ export function buildTaskContextPrompt(store: TaskStore, taskId: string): string
       }
       lines.push('  </siblings>');
 
-      // Completed sibling summaries
+      // Completed sibling summaries and artifacts
       const completed = siblings.filter(
-        (s) => s.id !== task.id && (s.status === 'done' || s.status === 'skipped') && s.summary,
+        (s) => s.id !== task.id && (s.status === 'done' || s.status === 'skipped'),
       );
       if (completed.length > 0) {
-        lines.push('  <completed-siblings>');
-        for (const s of completed) {
-          const summary = truncate(s.summary!, SUMMARY_MAX_CHARS);
-          lines.push(`    <summary task="${escapeXml(s.title)}">`);
-          lines.push(`      ${escapeXml(summary)}`);
-          lines.push('    </summary>');
+        const withSummaries = completed.filter((s) => s.summary);
+        if (withSummaries.length > 0) {
+          lines.push('  <completed-siblings>');
+          for (const s of withSummaries) {
+            const summary = truncate(s.summary!, SUMMARY_MAX_CHARS);
+            lines.push(`    <summary task="${escapeXml(s.title)}">`);
+            lines.push(`      ${escapeXml(summary)}`);
+            lines.push('    </summary>');
+          }
+          lines.push('  </completed-siblings>');
         }
-        lines.push('  </completed-siblings>');
+
+        // Artifacts from completed siblings — available for reference
+        const withArtifacts = completed.filter(
+          (s) => s.artifacts && Object.keys(s.artifacts).length > 0,
+        );
+        if (withArtifacts.length > 0) {
+          lines.push('  <sibling-artifacts>');
+          for (const s of withArtifacts) {
+            for (const [key, value] of Object.entries(s.artifacts!)) {
+              lines.push(
+                `    <artifact task="${escapeXml(s.title)}" key="${escapeXml(key)}">${escapeXml(String(value))}</artifact>`,
+              );
+            }
+          }
+          lines.push('  </sibling-artifacts>');
+        }
       }
     }
   }
@@ -87,12 +106,13 @@ export function buildTaskSystemPrompt(store: TaskStore, taskId: string): string 
   return (
     '\n\n## Task Board\n\n' +
     'You are working on a task from the task board. ' +
-    'Use the TaskSet, TaskComplete, TaskStatus, and TaskBlock tools ' +
+    'Use the TaskSet, TaskComplete, TaskStatus, TaskBlock, and TaskArtifact tools ' +
     'to manage your work.\n\n' +
     '- Call TaskSet to decompose your task into subtasks\n' +
     '- Call TaskComplete with a summary when done\n' +
     '- Call TaskStatus to check progress\n' +
-    '- Call TaskBlock if you encounter a blocker\n\n' +
+    '- Call TaskBlock if you encounter a blocker\n' +
+    '- Call TaskArtifact to store structured output (e.g., PR URLs, file paths) for later stages\n\n' +
     context
   );
 }

--- a/server/task-mcp-server.ts
+++ b/server/task-mcp-server.ts
@@ -141,6 +141,31 @@ server.registerTool(
   },
 );
 
+server.registerTool(
+  'TaskArtifact',
+  {
+    description:
+      'Store a structured artifact (e.g., PR URL, file path) for later workflow stages. ' +
+      'Artifacts are visible to sibling tasks in the same workflow.',
+    inputSchema: {
+      key: z.string().min(1).describe('Artifact key (e.g., "pr_url", "design_doc")'),
+      value: z.string().describe('Artifact value'),
+    },
+  },
+  async ({ key, value }) => {
+    try {
+      const data = (await apiCall('POST', '/api/internal/task-tools/artifact', {
+        key,
+        value,
+      })) as { result: string };
+      return { content: [{ type: 'text' as const, text: data.result }] };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] };
+    }
+  },
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -1,4 +1,4 @@
-import type { TaskStore, Task } from './task-store.js';
+import type { TaskStore, Task, GateConfig } from './task-store.js';
 import { sendToChat } from './chat.js';
 import { createLogger } from './logger.js';
 
@@ -33,6 +33,8 @@ export interface OrchestratorDeps {
   broadcastTasks: () => void;
   /** Get active session IDs for orphan detection */
   getActiveSessionIds?: () => Set<string>;
+  /** Register a signal watch for a wait_for_signal task */
+  watchSignal?: (taskId: string, gateConfig: GateConfig) => void;
 }
 
 export class TaskOrchestrator {
@@ -286,22 +288,56 @@ export class TaskOrchestrator {
       return;
     }
 
-    // Assign task
-    this.activeTaskId = next.id;
-    this.deps.store.update(next.id, { status: 'active' });
-    this.deps.store.cascadeStatus(next.id);
+    // Dispatch based on stage type
+    const stageType = next.stageType ?? 'agent_work';
 
-    // Set task context on session
-    this.deps.setTaskContext(next.id, this.goalId);
+    switch (stageType) {
+      case 'wait_for_signal': {
+        // Set active but don't assign to agent — register with SignalProcessor
+        this.activeTaskId = next.id;
+        this.deps.store.update(next.id, { status: 'active' });
+        this.deps.store.cascadeStatus(next.id);
+        this.deps.broadcastTasks();
+        this.deps.broadcastStatus(this.getStatus());
 
-    // Broadcast updates
-    this.deps.broadcastTasks();
-    this.deps.broadcastStatus(this.getStatus());
+        if (this.deps.watchSignal && next.gateConfig) {
+          this.deps.watchSignal(next.id, next.gateConfig);
+          log.info('registered signal watch', { taskId: next.id, type: next.gateConfig.type });
+        } else {
+          log.warn('wait_for_signal task has no gate config or watchSignal not wired', {
+            taskId: next.id,
+          });
+        }
+        break;
+      }
 
-    // Send prompt to pinned agent session
-    if (this.pinnedClientId) {
-      const prompt = this.buildTaskPrompt(next);
-      sendToChat(this.pinnedClientId, prompt);
+      case 'human_review': {
+        // Go straight to pending_review — reuse existing approval flow
+        this.activeTaskId = next.id;
+        this.deps.store.update(next.id, { status: 'pending_review' });
+        this.deps.store.cascadeStatus(next.id);
+        this.deps.broadcastTasks();
+        this.deps.broadcastStatus(this.getStatus());
+        log.info('human review task awaiting approval', { taskId: next.id });
+        break;
+      }
+
+      case 'agent_work':
+      default: {
+        // Original behavior: assign to session, send prompt
+        this.activeTaskId = next.id;
+        this.deps.store.update(next.id, { status: 'active' });
+        this.deps.store.cascadeStatus(next.id);
+        this.deps.setTaskContext(next.id, this.goalId);
+        this.deps.broadcastTasks();
+        this.deps.broadcastStatus(this.getStatus());
+
+        if (this.pinnedClientId) {
+          const prompt = this.buildTaskPrompt(next);
+          sendToChat(this.pinnedClientId, prompt);
+        }
+        break;
+      }
     }
   }
 

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -201,6 +201,12 @@ function rowToTask(row: TaskRow): Task {
 export class TaskStore {
   private db: Database.Database | null;
 
+  /** Expose the underlying database for shared-connection use (e.g. WorkflowTemplateStore). */
+  getDatabase(): Database.Database {
+    if (!this.db) throw new Error('TaskStore is closed');
+    return this.db;
+  }
+
   constructor(dbPath: string) {
     const db = new Database(dbPath);
     this.db = db;

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -15,6 +15,13 @@ export type TaskStatus =
 
 export type SessionPolicy = 'reuse' | 'spawn' | 'auto';
 
+export type StageType = 'agent_work' | 'wait_for_signal' | 'human_review';
+
+export interface GateConfig {
+  type: 'gh_ci' | 'gh_review' | 'centaur_review' | 'human_approval' | 'compound';
+  [key: string]: unknown;
+}
+
 const TERMINAL_STATUSES: Set<TaskStatus> = new Set(['done', 'skipped', 'failed']);
 
 export interface Task {
@@ -36,6 +43,12 @@ export interface Task {
   createdAt: number;
   updatedAt: number;
   completedAt: number | null;
+  stageType: StageType | null;
+  gateConfig: GateConfig | null;
+  artifacts: Record<string, unknown> | null;
+  retryCount: number;
+  maxRetries: number;
+  templateId: string | null;
   children: Task[];
 }
 
@@ -46,6 +59,10 @@ export interface TaskCreateInput {
   priority?: number;
   sessionPolicy?: SessionPolicy;
   annotations?: string[];
+  stageType?: StageType;
+  gateConfig?: GateConfig;
+  maxRetries?: number;
+  templateId?: string;
 }
 
 export interface TaskUpdateInput {
@@ -57,6 +74,11 @@ export interface TaskUpdateInput {
   annotations?: string[];
   summary?: string;
   requiresApproval?: boolean;
+  stageType?: StageType;
+  gateConfig?: GateConfig;
+  artifacts?: Record<string, unknown>;
+  retryCount?: number;
+  maxRetries?: number;
 }
 
 interface TaskRow {
@@ -78,6 +100,12 @@ interface TaskRow {
   created_at: number;
   updated_at: number;
   completed_at: number | null;
+  stage_type: string | null;
+  gate_config: string | null;
+  artifacts: string | null;
+  retry_count: number;
+  max_retries: number;
+  template_id: string | null;
 }
 
 const SCHEMA = `
@@ -102,12 +130,35 @@ const SCHEMA = `
     claimed_at      REAL,
     created_at      REAL NOT NULL,
     updated_at      REAL NOT NULL,
-    completed_at    REAL
+    completed_at    REAL,
+    stage_type      TEXT DEFAULT NULL
+                    CHECK(stage_type IS NULL OR stage_type IN ('agent_work','wait_for_signal','human_review')),
+    gate_config     TEXT DEFAULT NULL,
+    artifacts       TEXT DEFAULT NULL,
+    retry_count     INTEGER NOT NULL DEFAULT 0,
+    max_retries     INTEGER NOT NULL DEFAULT 0,
+    template_id     TEXT DEFAULT NULL
   );
   CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
   CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
   CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id);
 `;
+
+const MIGRATIONS = [
+  // Migration 1: Add workflow columns to existing tasks table
+  {
+    check: "SELECT COUNT(*) as cnt FROM pragma_table_info('tasks') WHERE name = 'stage_type'",
+    sql: `
+      ALTER TABLE tasks ADD COLUMN stage_type TEXT DEFAULT NULL
+        CHECK(stage_type IS NULL OR stage_type IN ('agent_work','wait_for_signal','human_review'));
+      ALTER TABLE tasks ADD COLUMN gate_config TEXT DEFAULT NULL;
+      ALTER TABLE tasks ADD COLUMN artifacts TEXT DEFAULT NULL;
+      ALTER TABLE tasks ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE tasks ADD COLUMN max_retries INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE tasks ADD COLUMN template_id TEXT DEFAULT NULL;
+    `,
+  },
+];
 
 function rowToTask(row: TaskRow): Task {
   let annotations: string[] = [];
@@ -137,6 +188,12 @@ function rowToTask(row: TaskRow): Task {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     completedAt: row.completed_at,
+    stageType: (row.stage_type as StageType) ?? null,
+    gateConfig: row.gate_config ? JSON.parse(row.gate_config) : null,
+    artifacts: row.artifacts ? JSON.parse(row.artifacts) : null,
+    retryCount: row.retry_count ?? 0,
+    maxRetries: row.max_retries ?? 0,
+    templateId: row.template_id ?? null,
     children: [],
   };
 }
@@ -150,6 +207,7 @@ export class TaskStore {
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');
     db.exec(SCHEMA);
+    this.runMigrations(db);
     log.info('TaskStore initialized', { dbPath });
   }
 
@@ -163,6 +221,16 @@ export class TaskStore {
   private getDb(): Database.Database {
     if (!this.db) throw new Error('TaskStore is closed');
     return this.db;
+  }
+
+  private runMigrations(db: Database.Database): void {
+    for (const migration of MIGRATIONS) {
+      const row = db.prepare(migration.check).get() as { cnt: number };
+      if (row.cnt === 0) {
+        log.info('Running migration', { check: migration.check });
+        db.exec(migration.sql);
+      }
+    }
   }
 
   create(input: TaskCreateInput): Task {
@@ -182,10 +250,11 @@ export class TaskStore {
     }
 
     const annotations = input.annotations ? JSON.stringify(input.annotations) : null;
+    const gateConfig = input.gateConfig ? JSON.stringify(input.gateConfig) : null;
 
     db.prepare(
-      `INSERT INTO tasks (id, parent_id, title, description, status, session_policy, priority, depth, annotations, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO tasks (id, parent_id, title, description, status, session_policy, priority, depth, annotations, stage_type, gate_config, max_retries, template_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       id,
       input.parentId ?? null,
@@ -195,6 +264,10 @@ export class TaskStore {
       input.priority ?? 0,
       depth,
       annotations,
+      input.stageType ?? null,
+      gateConfig,
+      input.maxRetries ?? 0,
+      input.templateId ?? null,
       now,
       now,
     );
@@ -255,6 +328,26 @@ export class TaskStore {
     if (fields.requiresApproval !== undefined) {
       sets.push('requires_approval = ?');
       values.push(fields.requiresApproval ? 1 : 0);
+    }
+    if (fields.stageType !== undefined) {
+      sets.push('stage_type = ?');
+      values.push(fields.stageType);
+    }
+    if (fields.gateConfig !== undefined) {
+      sets.push('gate_config = ?');
+      values.push(JSON.stringify(fields.gateConfig));
+    }
+    if (fields.artifacts !== undefined) {
+      sets.push('artifacts = ?');
+      values.push(JSON.stringify(fields.artifacts));
+    }
+    if (fields.retryCount !== undefined) {
+      sets.push('retry_count = ?');
+      values.push(fields.retryCount);
+    }
+    if (fields.maxRetries !== undefined) {
+      sets.push('max_retries = ?');
+      values.push(fields.maxRetries);
     }
 
     if (sets.length === 0) return existing;

--- a/server/task-tools.ts
+++ b/server/task-tools.ts
@@ -121,3 +121,25 @@ export function handleTaskBlock(store: TaskStore, currentTaskId: string, reason:
 
   return `Task "${current.title}" blocked: ${reason}`;
 }
+
+/**
+ * Store a structured artifact on the current task.
+ * Artifacts are key-value pairs that persist across the workflow.
+ */
+export function handleTaskArtifact(
+  store: TaskStore,
+  currentTaskId: string,
+  key: string,
+  value: string,
+): string {
+  const current = store.get(currentTaskId);
+  if (!current) return `Error: task ${currentTaskId} not found`;
+
+  if (!key.trim()) return 'Error: artifact key is required';
+
+  const artifacts = current.artifacts ? { ...current.artifacts } : {};
+  artifacts[key] = value;
+  store.update(currentTaskId, { artifacts });
+
+  return `Artifact stored: ${key} = ${value}`;
+}

--- a/server/workflow-templates.ts
+++ b/server/workflow-templates.ts
@@ -73,20 +73,27 @@ function rowToTemplate(row: TemplateRow): WorkflowTemplate {
 
 export class WorkflowTemplateStore {
   private db: Database.Database | null;
+  private ownsDb: boolean;
 
-  constructor(dbPath: string) {
-    const db = new Database(dbPath);
-    this.db = db;
-    db.pragma('journal_mode = WAL');
-    db.exec(TEMPLATE_SCHEMA);
-    log.info('WorkflowTemplateStore initialized', { dbPath });
+  constructor(dbOrPath: string | Database.Database) {
+    if (typeof dbOrPath === 'string') {
+      const db = new Database(dbOrPath);
+      this.db = db;
+      this.ownsDb = true;
+      db.pragma('journal_mode = WAL');
+    } else {
+      this.db = dbOrPath;
+      this.ownsDb = false;
+    }
+    this.db.exec(TEMPLATE_SCHEMA);
+    log.info('WorkflowTemplateStore initialized');
   }
 
   close(): void {
-    if (this.db) {
+    if (this.db && this.ownsDb) {
       this.db.close();
-      this.db = null;
     }
+    this.db = null;
   }
 
   private getDb(): Database.Database {

--- a/server/workflow-templates.ts
+++ b/server/workflow-templates.ts
@@ -1,0 +1,198 @@
+import Database from 'better-sqlite3';
+import { randomUUID } from 'crypto';
+import type { TaskStore, StageType, GateConfig } from './task-store.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('workflow-templates');
+
+export interface TemplateStage {
+  title: string;
+  description?: string;
+  stage_type: StageType;
+  gate_config?: GateConfig;
+  max_retries?: number;
+  priority?: number;
+  requires_approval?: boolean;
+}
+
+export interface TemplateVariable {
+  description: string;
+  default?: string;
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  stages: TemplateStage[];
+  variables: Record<string, TemplateVariable> | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface TemplateCreateInput {
+  name: string;
+  description?: string;
+  stages: TemplateStage[];
+  variables?: Record<string, TemplateVariable>;
+}
+
+interface TemplateRow {
+  id: string;
+  name: string;
+  description: string | null;
+  stages: string;
+  variables: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+const TEMPLATE_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS workflow_templates (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    description TEXT,
+    stages      TEXT NOT NULL,
+    variables   TEXT,
+    created_at  REAL NOT NULL,
+    updated_at  REAL NOT NULL
+  );
+`;
+
+function rowToTemplate(row: TemplateRow): WorkflowTemplate {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    stages: JSON.parse(row.stages),
+    variables: row.variables ? JSON.parse(row.variables) : null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class WorkflowTemplateStore {
+  private db: Database.Database | null;
+
+  constructor(dbPath: string) {
+    const db = new Database(dbPath);
+    this.db = db;
+    db.pragma('journal_mode = WAL');
+    db.exec(TEMPLATE_SCHEMA);
+    log.info('WorkflowTemplateStore initialized', { dbPath });
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  private getDb(): Database.Database {
+    if (!this.db) throw new Error('WorkflowTemplateStore is closed');
+    return this.db;
+  }
+
+  create(input: TemplateCreateInput): WorkflowTemplate {
+    const id = randomUUID();
+    const now = Date.now();
+    this.getDb()
+      .prepare(
+        `INSERT INTO workflow_templates (id, name, description, stages, variables, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.name,
+        input.description ?? null,
+        JSON.stringify(input.stages),
+        input.variables ? JSON.stringify(input.variables) : null,
+        now,
+        now,
+      );
+    return this.get(id)!;
+  }
+
+  get(id: string): WorkflowTemplate | null {
+    const row = this.getDb()
+      .prepare('SELECT * FROM workflow_templates WHERE id = ?')
+      .get(id) as TemplateRow | undefined;
+    return row ? rowToTemplate(row) : null;
+  }
+
+  list(): WorkflowTemplate[] {
+    const rows = this.getDb()
+      .prepare('SELECT * FROM workflow_templates ORDER BY name ASC')
+      .all() as TemplateRow[];
+    return rows.map(rowToTemplate);
+  }
+
+  delete(id: string): boolean {
+    const result = this.getDb()
+      .prepare('DELETE FROM workflow_templates WHERE id = ?')
+      .run(id);
+    return result.changes > 0;
+  }
+}
+
+/** Replace all {{variable}} placeholders in a string. */
+function substituteVars(text: string, vars: Record<string, string>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    return key in vars ? vars[key] : match;
+  });
+}
+
+/** Deep-substitute all string values in a JSON-serializable object. */
+function substituteDeep<T>(obj: T, vars: Record<string, string>): T {
+  if (typeof obj === 'string') return substituteVars(obj, vars) as T;
+  if (Array.isArray(obj)) return obj.map((item) => substituteDeep(item, vars)) as T;
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = substituteDeep(value, vars);
+    }
+    return result as T;
+  }
+  return obj;
+}
+
+/**
+ * Instantiate a workflow template as a task tree.
+ * Creates a root goal task + child tasks for each stage.
+ */
+export function instantiateTemplate(
+  taskStore: TaskStore,
+  templateStore: WorkflowTemplateStore,
+  templateId: string,
+  goalTitle: string,
+  variables: Record<string, string>,
+) {
+  const template = templateStore.get(templateId);
+  if (!template) throw new Error(`Template not found: ${templateId}`);
+
+  // Create the root goal
+  const goal = taskStore.create({
+    title: goalTitle,
+    templateId,
+  });
+
+  // Create child tasks — priority is inverse of index so DFS picks them in order
+  // (getChildren sorts by priority DESC, so first stage gets highest priority)
+  const stageCount = template.stages.length;
+  for (let i = 0; i < stageCount; i++) {
+    const stage = substituteDeep(template.stages[i], variables);
+    taskStore.create({
+      title: stage.title,
+      description: stage.description,
+      parentId: goal.id,
+      stageType: stage.stage_type,
+      gateConfig: stage.gate_config,
+      maxRetries: stage.max_retries ?? 0,
+      priority: stageCount - i, // first stage gets highest priority
+      templateId,
+    });
+  }
+
+  return taskStore.get(goal.id)!;
+}

--- a/server/workflow-templates.ts
+++ b/server/workflow-templates.ts
@@ -122,9 +122,9 @@ export class WorkflowTemplateStore {
   }
 
   get(id: string): WorkflowTemplate | null {
-    const row = this.getDb()
-      .prepare('SELECT * FROM workflow_templates WHERE id = ?')
-      .get(id) as TemplateRow | undefined;
+    const row = this.getDb().prepare('SELECT * FROM workflow_templates WHERE id = ?').get(id) as
+      | TemplateRow
+      | undefined;
     return row ? rowToTemplate(row) : null;
   }
 
@@ -136,9 +136,7 @@ export class WorkflowTemplateStore {
   }
 
   delete(id: string): boolean {
-    const result = this.getDb()
-      .prepare('DELETE FROM workflow_templates WHERE id = ?')
-      .run(id);
+    const result = this.getDb().prepare('DELETE FROM workflow_templates WHERE id = ?').run(id);
     return result.changes > 0;
   }
 }

--- a/server/workflow-templates.ts
+++ b/server/workflow-templates.ts
@@ -196,3 +196,90 @@ export function instantiateTemplate(
 
   return taskStore.get(goal.id)!;
 }
+
+/**
+ * Seed built-in workflow templates if they don't already exist.
+ * Idempotent — safe to call on every server start.
+ */
+export function seedBuiltInTemplates(store: WorkflowTemplateStore): void {
+  const existing = new Set(store.list().map((t) => t.name));
+
+  if (!existing.has('pr-triage')) {
+    store.create({
+      name: 'pr-triage',
+      description: 'Triage a pull request: CI check, code review, feedback loop, merge readiness.',
+      stages: [
+        {
+          title: 'Check CI status and conflicts for {{repo}}#{{pr}}',
+          stage_type: 'agent_work',
+        },
+        {
+          title: 'Wait for code review on {{repo}}#{{pr}}',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_review', repo: '{{repo}}', pr: '{{pr}}' },
+        },
+        {
+          title: 'Address review feedback on {{repo}}#{{pr}}',
+          stage_type: 'agent_work',
+          max_retries: 3,
+        },
+        {
+          title: 'Verify CI green on {{repo}}#{{pr}}',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_ci', repo: '{{repo}}', pr: '{{pr}}' },
+        },
+        {
+          title: 'Merge readiness report for {{repo}}#{{pr}}',
+          stage_type: 'agent_work',
+        },
+      ],
+      variables: {
+        repo: { description: 'Repository in org/name format (e.g., dimakis/mitzo)' },
+        pr: { description: 'Pull request number' },
+      },
+    });
+    log.info('seeded built-in template: pr-triage');
+  }
+
+  if (!existing.has('upstream-issue')) {
+    store.create({
+      name: 'upstream-issue',
+      description: 'End-to-end upstream issue: design, review, implement, CI/review cycles.',
+      stages: [
+        {
+          title: 'Design implementation for {{issue}}',
+          stage_type: 'agent_work',
+        },
+        {
+          title: 'Review design',
+          stage_type: 'human_review',
+        },
+        {
+          title: 'Implement {{issue}} in {{repo}}',
+          stage_type: 'agent_work',
+        },
+        {
+          title: 'Wait for CI on {{repo}}',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_ci', repo: '{{repo}}', pr: '{{pr}}' },
+        },
+        {
+          title: 'Address review feedback',
+          stage_type: 'agent_work',
+          max_retries: 3,
+        },
+        {
+          title: 'Wait for final approval on {{repo}}#{{pr}}',
+          stage_type: 'wait_for_signal',
+          gate_config: { type: 'gh_review', repo: '{{repo}}', pr: '{{pr}}' },
+        },
+      ],
+      variables: {
+        issue: { description: 'Issue reference (e.g., upstream/repo#456)' },
+        repo: { description: 'Target repository in org/name format' },
+        pr: { description: 'Pull request number (set after PR is created)', default: '' },
+      },
+    });
+    log.info('seeded built-in template: upstream-issue');
+  }
+}


### PR DESCRIPTION
## Summary

- **Workflow stage types**: Tasks can now be `agent_work`, `wait_for_signal`, or `human_review` — the orchestrator dispatches differently for each (agent session, signal polling, or immediate pending_review)
- **SignalProcessor**: Polls external systems (GitHub CI/review via `gh` CLI, Centaur API) for gate resolution, with retry logic that resets preceding agent work stages on failure
- **Workflow templates**: Reusable multi-stage workflow definitions with Mustache-style variable substitution; CRUD endpoints + instantiation that creates a goal tree from a template
- **TaskArtifact**: New MCP tool + REST endpoint for storing structured key-value artifacts per task, injected into sibling context as `<sibling-artifacts>` XML
- **Frontend**: Stage type badges (signal/review), retry count indicator, artifacts display on TaskNode
- **Full backwards compatibility**: All new fields nullable/defaulted, existing tasks unaffected

### New files
- `server/signal-processor.ts` — gate checker + polling engine
- `server/workflow-templates.ts` — template CRUD + instantiation
- 4 new test files (132 workflow-specific tests)

### Modified
- `task-store.ts` — 6 new columns + migration
- `task-orchestrator.ts` — stage-type dispatch in `tick()`
- `task-context.ts` — sibling artifact injection
- `task-tools.ts` + `task-mcp-server.ts` — TaskArtifact tool
- `app.ts` + `index.ts` — REST endpoints + server wiring
- Frontend types + components + CSS

## Test plan

- [x] 132 workflow-specific tests pass (task-store, workflow-templates, signal-processor, task-orchestrator, task-tools, task-context)
- [x] Full test suite passes (2023/2025 — 2 pre-existing chat.test.ts timeouts)
- [ ] Built-in template seeding (PR Triage, Upstream Issue) — follow-up commit
- [ ] WorkflowCreateForm UI — follow-up commit
- [ ] End-to-end test with real PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)