### PR TITLE
fix: IPv6 DNS workaround + user message copy button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ frontend/ios/local.xcconfig
 mcp-server/build/
 certs/
 logs/
+.DS_Store
+.claude/worktrees/
+.cursor/worktrees/
+frontend/ios/App/App.xcworkspace/
+**/xcshareddata/swiftpm/Package.resolved

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -34,10 +34,12 @@ export function UserBubble({ text, images, contextBlocks, timestamp }: UserBubbl
         )}
         {text && <div className="msg-bubble-content">{text}</div>}
       </div>
-      <div className="msg-bubble-footer msg-bubble-footer--user">
-        {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
-        {text && <CopyButton text={text} className="msg-bubble-copy msg-bubble-copy--user" />}
-      </div>
+      {(time || text) && (
+        <div className="msg-bubble-footer msg-bubble-footer--user">
+          {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
+          {text && <CopyButton text={text} className="msg-bubble-copy msg-bubble-copy--user" />}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -34,7 +34,10 @@ export function UserBubble({ text, images, contextBlocks, timestamp }: UserBubbl
         )}
         {text && <div className="msg-bubble-content">{text}</div>}
       </div>
-      {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
+      <div className="msg-bubble-footer msg-bubble-footer--user">
+        {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
+        {text && <CopyButton text={text} className="msg-bubble-copy msg-bubble-copy--user" />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1627,6 +1627,9 @@ textarea:focus {
   .msg-bubble-footer--user {
     opacity: 1;
   }
+  .msg-bubble-footer--user .msg-bubble-copy {
+    opacity: 0.7;
+  }
   .code-block-copy {
     opacity: 0.5;
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1559,11 +1559,15 @@ textarea:focus {
 }
 
 .msg-bubble-footer--user {
-  opacity: 0;
-  justify-content: flex-end;
+  opacity: 1;
 }
 
-.msg-bubble-group--user:hover .msg-bubble-footer--user {
+.msg-bubble-footer--user .msg-bubble-copy {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.msg-bubble-group--user:hover .msg-bubble-footer--user .msg-bubble-copy {
   opacity: 1;
 }
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1558,8 +1558,26 @@ textarea:focus {
   opacity: 1;
 }
 
+.msg-bubble-footer--user {
+  opacity: 0;
+  justify-content: flex-end;
+}
+
+.msg-bubble-group--user:hover .msg-bubble-footer--user {
+  opacity: 1;
+}
+
 .msg-bubble-copy {
   flex-shrink: 0;
+}
+
+.msg-bubble-copy--user {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.msg-bubble-copy--user:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .msg-bubble-group--user {
@@ -1601,7 +1619,8 @@ textarea:focus {
 }
 
 @media (hover: none) {
-  .msg-bubble-footer {
+  .msg-bubble-footer,
+  .msg-bubble-footer--user {
     opacity: 1;
   }
   .code-block-copy {

--- a/ipv4-preload.cjs
+++ b/ipv4-preload.cjs
@@ -8,8 +8,10 @@
 'use strict';
 
 const dns = require('dns');
-const origLookup = dns.lookup;
 
+dns.setDefaultResultOrder('ipv4first');
+
+const origLookup = dns.lookup;
 dns.lookup = function patchedLookup(hostname, options, callback) {
   if (typeof options === 'function') {
     callback = options;
@@ -25,4 +27,18 @@ dns.lookup = function patchedLookup(hostname, options, callback) {
   }
 
   return origLookup.call(dns, hostname, options, callback);
+};
+
+const origPromiseLookup = dns.promises.lookup;
+dns.promises.lookup = function patchedPromiseLookup(hostname, options) {
+  if (typeof options === 'number') {
+    options = { family: options };
+  }
+  if (!options) options = {};
+
+  if (!options.family) {
+    options = { ...options, family: 4 };
+  }
+
+  return origPromiseLookup.call(dns.promises, hostname, options);
 };

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -319,6 +319,69 @@ describe('sendMessage', () => {
     const newSends = lastWs.sent.slice(sentBefore).map((s) => JSON.parse(s));
     expect(newSends).toContainEqual(expect.objectContaining({ type: 'send', prompt: 'second' }));
   });
+
+  it('queues second message as pendingSend while first turn is active', () => {
+    const store = createReadyStore();
+
+    store.getState().sendMessage('first');
+    lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-pend' });
+
+    const sentBefore = lastWs.sent.length;
+    store.getState().sendMessage('second');
+
+    // Second message should be queued, not immediately sent
+    const immediateSends = lastWs.sent
+      .slice(sentBefore)
+      .filter((s) => JSON.parse(s).type === 'send');
+    expect(immediateSends).toHaveLength(0);
+
+    // But the optimistic user message should appear in the store
+    const userMsgs = store.getState().messages.messages.filter((m) => m.role === 'user');
+    expect(userMsgs).toHaveLength(2);
+  });
+
+  it('cancels pending timeout when session_end arrives in time', () => {
+    vi.useFakeTimers();
+    try {
+      const store = createMitzoStore(makeOptions());
+      lastWs.completeHandshake();
+
+      store.getState().sendMessage('first');
+      lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-ok' });
+
+      store.getState().sendMessage('second');
+      lastWs.simulateMessage({ type: 'session_end', sessionId: 'sess-ok' });
+
+      const sentAfterEnd = lastWs.sent.length;
+      vi.advanceTimersByTime(6_000);
+
+      expect(lastWs.sent.length).toBe(sentAfterEnd);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels pending timeout on newSession', () => {
+    vi.useFakeTimers();
+    try {
+      const store = createMitzoStore(makeOptions());
+      lastWs.completeHandshake();
+
+      store.getState().sendMessage('first');
+      lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-new' });
+
+      store.getState().sendMessage('second');
+      const sentBefore = lastWs.sent.length;
+
+      store.getState().newSession();
+      vi.advanceTimersByTime(6_000);
+
+      const flushed = lastWs.sent.slice(sentBefore).filter((s) => JSON.parse(s).type === 'send');
+      expect(flushed).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('WS → store wiring', () => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -10,7 +10,6 @@ import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'fs';
 import { join, resolve, dirname } from 'path';
-import { fileURLToPath } from 'url';
 import { randomBytes } from 'crypto';
 import { homedir } from 'os';
 import { createWorktree, removeWorktree } from './worktree.js';
@@ -123,7 +122,7 @@ function send(transport: SessionTransport, data: Record<string, unknown>) {
   if (transport.isOpen()) transport.send(data);
 }
 
-const IPV4_PRELOAD = join(dirname(fileURLToPath(import.meta.url)), 'ipv4-preload.cjs');
+const IPV4_PRELOAD = join(process.cwd(), 'ipv4-preload.cjs');
 
 function sdkEnv(): Record<string, string> {
   const env = { ...process.env } as Record<string, string>;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -10,6 +10,7 @@ import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { execFileSync } from 'child_process';
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'fs';
 import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { randomBytes } from 'crypto';
 import { homedir } from 'os';
 import { createWorktree, removeWorktree } from './worktree.js';
@@ -122,11 +123,23 @@ function send(transport: SessionTransport, data: Record<string, unknown>) {
   if (transport.isOpen()) transport.send(data);
 }
 
+const IPV4_PRELOAD = join(dirname(fileURLToPath(import.meta.url)), 'ipv4-preload.cjs');
+
 function sdkEnv(): Record<string, string> {
   const env = { ...process.env } as Record<string, string>;
   env.CLAUDE_CODE_USE_VERTEX = process.env.CLAUDE_CODE_USE_VERTEX || '1';
   env.ANTHROPIC_VERTEX_PROJECT_ID = process.env.ANTHROPIC_VERTEX_PROJECT_ID || '';
   env.CLOUD_ML_REGION = process.env.CLOUD_ML_REGION || 'us-east5';
+
+  // Force IPv4-only DNS in the spawned CLI process. Undici's bundled
+  // autoSelectFamily ignores --dns-result-order, so we patch dns.lookup
+  // via a preload script to always resolve IPv4.
+  const nodeOpts = env.NODE_OPTIONS || '';
+  if (!nodeOpts.includes('ipv4-preload')) {
+    env.NODE_OPTIONS = nodeOpts
+      ? `${nodeOpts} --require=${IPV4_PRELOAD}`
+      : `--require=${IPV4_PRELOAD}`;
+  }
 
   const existingPath = env.PATH || '/usr/bin:/bin:/usr/local/bin';
   const venvPaths = getRepoConfig().resolvedVenvPaths;
@@ -422,15 +435,25 @@ export async function startChat(
   // The SDK stores conversation data under ~/.claude/projects/<encoded-cwd>/,
   // so we must use the same CWD the session was created with — otherwise the
   // SDK can't find the conversation and returns "No conversation found".
+  // If the original CWD was a worktree that's been cleaned up, fall back to
+  // BASE_REPO — the SDK will still find the conversation via the encoded path.
   let baseCwd = options.cwd || BASE_REPO;
   if (options.resume && !options.cwd) {
     const sessionMeta = eventStore.getSession(options.resume);
     if (sessionMeta?.cwd) {
-      baseCwd = sessionMeta.cwd;
-      log.info('resume: using original session CWD', {
-        sessionId: options.resume,
-        cwd: baseCwd,
-      });
+      if (existsSync(sessionMeta.cwd)) {
+        baseCwd = sessionMeta.cwd;
+        log.info('resume: using original session CWD', {
+          sessionId: options.resume,
+          cwd: baseCwd,
+        });
+      } else {
+        log.warn('resume: original CWD no longer exists, falling back to BASE_REPO', {
+          sessionId: options.resume,
+          originalCwd: sessionMeta.cwd,
+          fallback: BASE_REPO,
+        });
+      }
     }
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,10 @@
 import 'dotenv/config';
+import dns from 'node:dns';
+
+// Force IPv4-first DNS resolution. Works around undici's broken happy-eyeballs
+// (RFC 8305) that fails to fall back from IPv6 on networks with Tailscale ULA.
+dns.setDefaultResultOrder('ipv4first');
+
 import './tracing.js';
 import { existsSync, readFileSync } from 'fs';
 import { createServer } from 'http';

--- a/server/ipv4-preload.cjs
+++ b/server/ipv4-preload.cjs
@@ -1,0 +1,28 @@
+// Preload script that forces dns.lookup to prefer IPv4.
+// Loaded via NODE_OPTIONS=--require=<this file> before the Agent SDK cli.js starts.
+//
+// Works around a known undici bug where autoSelectFamily (RFC 8305) fails to
+// fall back from IPv6 when EHOSTUNREACH is returned on networks with a
+// Tailscale IPv6 ULA address but no routable IPv6 to Google's OAuth servers.
+// See: https://github.com/nodejs/node/issues/48145
+'use strict';
+
+const dns = require('dns');
+const origLookup = dns.lookup;
+
+dns.lookup = function patchedLookup(hostname, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  if (typeof options === 'number') {
+    options = { family: options };
+  }
+  if (!options) options = {};
+
+  if (!options.family) {
+    options = { ...options, family: 4 };
+  }
+
+  return origLookup.call(dns, hostname, options, callback);
+};


### PR DESCRIPTION
## Summary

- **IPv6 DNS fix**: Force IPv4-only DNS resolution for the SDK child process via a preload script (`ipv4-preload.cjs`) that patches `dns.lookup`. Undici's bundled `autoSelectFamily` fails to fall back from IPv6 on networks with Tailscale ULA — this makes Mitzo self-sufficient without the unbound DNS workaround. Also sets `dns.setDefaultResultOrder('ipv4first')` in the server process itself. Filed upstream: anthropics/claude-agent-sdk-typescript#294
- **User copy button**: User message bubbles had no copy button. Added `CopyButton` to `UserBubble` with white/semi-transparent styling that contrasts against the accent background. Always visible on touch devices (iOS).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All tests pass (1346)
- [ ] Verify copy button visible on user messages (PWA + iOS)
- [ ] Verify chat works after Mitzo server restart (IPv6 fix active, unbound optional)


Made with [Cursor](https://cursor.com)