### PR TITLE
feat(skills): add /land-pr bundled skill for PR merge lifecycle

### DIFF
--- a/server/__tests__/bundled-skills.test.ts
+++ b/server/__tests__/bundled-skills.test.ts
@@ -12,9 +12,16 @@ describe('bundled skills', () => {
   const registry = new SkillRegistry({ bundledDir: SKILLS_DIR });
   const skills = registry.list();
 
-  it('discovers all five bundled skills', () => {
+  it('discovers all six bundled skills', () => {
     const names = skills.map((s) => s.name).sort();
-    expect(names).toEqual(['person', 'pr-review', 'review-response', 'risk-scan', 'simplify']);
+    expect(names).toEqual([
+      'land-pr',
+      'person',
+      'pr-review',
+      'review-response',
+      'risk-scan',
+      'simplify',
+    ]);
   });
 
   it('has unique names', () => {
@@ -134,6 +141,31 @@ describe('bundled skills', () => {
     expect(body).toBeDefined();
     expect(body).toContain('$ARGUMENTS');
     expect(body).toContain('command_center/context/people');
+  });
+
+  it('/land-pr includes Bash for gh CLI and git access', () => {
+    const landPr = skills.find((s) => s.name === 'land-pr');
+    expect(landPr).toBeDefined();
+    expect(landPr!.allowedTools).toBeDefined();
+    expect(landPr!.allowedTools).toContain('Bash');
+    expect(landPr!.allowedTools).toContain('Read');
+    expect(landPr!.allowedTools).toContain('Grep');
+    expect(landPr!.allowedTools).toContain('Edit');
+  });
+
+  it('/land-pr is a mutating skill', () => {
+    const landPr = skills.find((s) => s.name === 'land-pr');
+    expect(landPr).toBeDefined();
+    expect(landPr!.mutating).toBe(true);
+  });
+
+  it('/land-pr body references the PR lifecycle phases', () => {
+    const body = registry.getBody('land-pr')!;
+    expect(body).toBeDefined();
+    expect(body).toContain('$ARGUMENTS');
+    expect(body.toLowerCase()).toContain('ci');
+    expect(body.toLowerCase()).toContain('review');
+    expect(body.toLowerCase()).toContain('merge');
   });
 
   it('all bundled skills are scoped as bundled', () => {

--- a/skills/land-pr/SKILL.md
+++ b/skills/land-pr/SKILL.md
@@ -1,0 +1,70 @@
+---
+description: Shepherd a PR from open to merged — CI fixes, review cycles, final merge
+mutating: true
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+---
+
+Land PR $ARGUMENTS through the full merge lifecycle.
+
+If `$ARGUMENTS` is a PR number, use it directly. Otherwise detect the current branch's open PR with `gh pr view --json number,url,statusCheckRollup,reviews,headRefName`.
+
+## Lifecycle
+
+Repeat this cycle until the PR is merged:
+
+### 1. Ensure CI is green
+
+```bash
+gh pr checks <number> --watch
+```
+
+If any check fails:
+
+1. `gh run view <run-id> --log-failed` to get the failure.
+2. Fix the issue locally.
+3. Commit and push. Wait for CI to go green before proceeding.
+
+### 2. Await review
+
+Check for pending reviews:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/reviews
+gh api repos/{owner}/{repo}/pulls/<number>/comments
+```
+
+If no reviews yet, stop and tell the user — nothing to act on until a reviewer responds.
+
+### 3. Address review findings
+
+For every review comment:
+
+1. **Read** the referenced code and understand the full context.
+2. **Fix** — the default action. Only push back if investigation proves the finding is factually wrong.
+3. **Commit and push** the fixes as a cohesive commit.
+
+### 4. Return to step 1
+
+After addressing a review round, CI must pass again before the next review. Two approved review rounds with green CI means the PR is ready.
+
+### 5. Merge
+
+When CI is green and reviews are approved:
+
+```bash
+gh pr merge <number> --squash --delete-branch
+```
+
+Report the merge result to the user.
+
+## Principles
+
+- Never merge with failing CI. Fix it first.
+- Never dismiss review findings without evidence. Default is to fix.
+- Each review round is: green CI → address comments → green CI → next round.
+- Keep the user informed at each phase transition.


### PR DESCRIPTION
## Summary

- Adds `/land-pr` as a bundled skill that shepherds a PR from open to merged through the repeating cycle: green CI → address review comments → green CI → next review round → merge.
- Mutating skill with `Bash`, `Read`, `Edit`, `Grep`, `Glob` in allowed-tools — it runs `gh` CLI, reads code, and pushes fixes.
- Updates bundled-skills test to expect 6 skills and adds `/land-pr`-specific assertions (mutating flag, allowed-tools, lifecycle keywords).

## Test plan

- [x] `bundled-skills.test.ts` — discovers 6 skills, validates `/land-pr` metadata and body
- [x] All 4443 skill-related tests pass (registry, rendering, native commands, bundled)
- [ ] CI passes on this branch


Made with [Cursor](https://cursor.com)