### PR TITLE
fix(chat): preserve primary worktree on session cleanup

### DIFF
--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import type { ManagedSession } from '@mitzo/harness';
 
 describe('chat module exports', () => {
   it('exports expected functions', async () => {
@@ -50,5 +51,66 @@ describe('getMessages', () => {
     const messages = await getMessages('nonexistent-session-id');
     expect(Array.isArray(messages)).toBe(true);
     expect(messages.length).toBe(0);
+  });
+});
+
+describe('cleanupSessionWorktrees', () => {
+  it('skips primary worktree and only removes secondaries', async () => {
+    const { removeWorktree } = await import('../worktree.js');
+    vi.spyOn(await import('../worktree.js'), 'removeWorktree').mockImplementation(() => {});
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['centaur', { path: '/projects/centaur/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    // Primary should be preserved in the map
+    expect(session.worktreePaths.has('primary')).toBe(true);
+    expect(session.worktreePaths.get('primary')?.wtId).toBe('abc');
+
+    // Secondary entries should be removed from the map
+    expect(session.worktreePaths.has('mitzo')).toBe(false);
+    expect(session.worktreePaths.has('centaur')).toBe(false);
+    expect(session.worktreePaths.size).toBe(1);
+
+    vi.restoreAllMocks();
+  });
+
+  it('handles session with only primary worktree', async () => {
+    vi.spyOn(await import('../worktree.js'), 'removeWorktree').mockImplementation(() => {});
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    expect(session.worktreePaths.has('primary')).toBe(true);
+    expect(session.worktreePaths.size).toBe(1);
+
+    vi.restoreAllMocks();
+  });
+
+  it('handles session with no worktrees', async () => {
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map(),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    expect(session.worktreePaths.size).toBe(0);
   });
 });

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -56,7 +56,6 @@ describe('getMessages', () => {
 
 describe('cleanupSessionWorktrees', () => {
   it('skips primary worktree and only removes secondaries', async () => {
-    const { removeWorktree } = await import('../worktree.js');
     vi.spyOn(await import('../worktree.js'), 'removeWorktree').mockImplementation(() => {});
 
     const { cleanupSessionWorktrees } = await import('../chat.js');

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ManagedSession } from '@mitzo/harness';
+
+vi.mock('../worktree.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, removeWorktree: vi.fn() };
+});
+
+vi.mock('../repo-config.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    loadRepoConfig: vi.fn(actual.loadRepoConfig as (...args: unknown[]) => unknown),
+  };
+});
 
 describe('chat module exports', () => {
   it('exports expected functions', async () => {
@@ -55,8 +68,23 @@ describe('getMessages', () => {
 });
 
 describe('cleanupSessionWorktrees', () => {
+  let removeWorktreeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const worktreeMod = await import('../worktree.js');
+    removeWorktreeMock = worktreeMod.removeWorktree as ReturnType<typeof vi.fn>;
+    removeWorktreeMock.mockReset();
+  });
+
   it('skips primary worktree and only removes secondaries', async () => {
-    vi.spyOn(await import('../worktree.js'), 'removeWorktree').mockImplementation(() => {});
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo', centaur: '/projects/centaur' },
+    });
+
+    // Force getRepoConfig TTL cache to expire so our mock is picked up
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10_000;
 
     const { cleanupSessionWorktrees } = await import('../chat.js');
 
@@ -70,34 +98,43 @@ describe('cleanupSessionWorktrees', () => {
 
     cleanupSessionWorktrees(session);
 
-    // Primary should be preserved in the map
+    expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
+    expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/projects/centaur');
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(2);
+
     expect(session.worktreePaths.has('primary')).toBe(true);
     expect(session.worktreePaths.get('primary')?.wtId).toBe('abc');
 
-    // Secondary entries should be removed from the map
     expect(session.worktreePaths.has('mitzo')).toBe(false);
     expect(session.worktreePaths.has('centaur')).toBe(false);
     expect(session.worktreePaths.size).toBe(1);
 
+    Date.now = realNow;
     vi.restoreAllMocks();
   });
 
   it('handles session with only primary worktree', async () => {
-    vi.spyOn(await import('../worktree.js'), 'removeWorktree').mockImplementation(() => {});
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: {},
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10_000;
 
     const { cleanupSessionWorktrees } = await import('../chat.js');
 
     const session = {
-      worktreePaths: new Map([
-        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
-      ]),
+      worktreePaths: new Map([['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }]]),
     } as unknown as ManagedSession;
 
     cleanupSessionWorktrees(session);
 
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
     expect(session.worktreePaths.has('primary')).toBe(true);
     expect(session.worktreePaths.size).toBe(1);
 
+    Date.now = realNow;
     vi.restoreAllMocks();
   });
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -741,9 +741,6 @@ export function cleanupSessionWorktrees(
 ): void {
   const config = getRepoConfig();
   for (const [repoName, { wtId }] of session.worktreePaths) {
-    // Skip the primary worktree — it must persist for session resume.
-    // The SDK encodes conversation data by CWD path, so removing the
-    // primary worktree breaks resume. Stale GC handles its lifecycle.
     if (repoName === 'primary') continue;
     const repoPath = config.repos[repoName];
     if (!repoPath) continue;
@@ -756,7 +753,6 @@ export function cleanupSessionWorktrees(
       });
     }
   }
-  // Remove only secondary entries; keep primary for resume.
   const primary = session.worktreePaths.get('primary');
   session.worktreePaths.clear();
   if (primary) session.worktreePaths.set('primary', primary);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -447,10 +447,14 @@ export async function startChat(
           cwd: baseCwd,
         });
       } else {
-        log.warn('resume: original CWD no longer exists, falling back to BASE_REPO', {
+        // The worktree directory was cleaned up, but the SDK encodes
+        // conversation data by CWD path. Re-create the directory so
+        // the SDK can find the conversation using the original path.
+        mkdirSync(sessionMeta.cwd, { recursive: true });
+        baseCwd = sessionMeta.cwd;
+        log.info('resume: re-created original CWD directory for SDK path encoding', {
           sessionId: options.resume,
-          originalCwd: sessionMeta.cwd,
-          fallback: BASE_REPO,
+          cwd: baseCwd,
         });
       }
     }
@@ -597,8 +601,9 @@ export async function startChat(
     if (failedSession) cleanupSessionWorktrees(failedSession);
     registry.abort(clientId);
   } finally {
-    // Clean up secondary worktrees after query loop ends (session may already
-    // be removed from registry, so use the captured reference).
+    // Clean up secondary worktrees after query loop ends. Primary worktree is
+    // preserved for resume; stale GC handles its lifecycle. Session may already
+    // be removed from registry, so use the captured reference.
     cleanupSessionWorktrees(session);
   }
 }
@@ -720,14 +725,21 @@ export async function interruptChat(
 // --- Session management ---
 
 /**
- * Best-effort cleanup of all worktrees for a session (primary + secondary).
- * Worktree directories are removed but branches are preserved for PRs.
+ * Best-effort cleanup of secondary worktrees for a session.
+ * Primary worktree is preserved — the SDK encodes conversation data by CWD
+ * path, so removing it breaks resume. Stale GC handles primary lifecycle.
+ * Branches are always preserved for PRs.
  */
-function cleanupSessionWorktrees(session: import('./session-registry.js').ManagedSession): void {
+export function cleanupSessionWorktrees(
+  session: import('./session-registry.js').ManagedSession,
+): void {
   const config = getRepoConfig();
   for (const [repoName, { wtId }] of session.worktreePaths) {
-    // For 'primary', use BASE_REPO; for secondary repos, look up in config
-    const repoPath = repoName === 'primary' ? BASE_REPO : config.repos[repoName];
+    // Skip the primary worktree — it must persist for session resume.
+    // The SDK encodes conversation data by CWD path, so removing the
+    // primary worktree breaks resume. Stale GC handles its lifecycle.
+    if (repoName === 'primary') continue;
+    const repoPath = config.repos[repoName];
     if (!repoPath) continue;
     try {
       removeWorktree(wtId, repoPath);
@@ -738,7 +750,10 @@ function cleanupSessionWorktrees(session: import('./session-registry.js').Manage
       });
     }
   }
+  // Remove only secondary entries; keep primary for resume.
+  const primary = session.worktreePaths.get('primary');
   session.worktreePaths.clear();
+  if (primary) session.worktreePaths.set('primary', primary);
 }
 
 const CLOSEOUT_PROMPT = `This session is closing in 10 minutes due to inactivity.


### PR DESCRIPTION
## Summary

- **Primary worktree no longer deleted on query loop end or stop** — `cleanupSessionWorktrees` now skips the `'primary'` entry, only removing secondary repo worktrees. Stale GC (96h TTL) handles primary lifecycle.
- **Resume CWD re-creates missing directory** instead of falling back to BASE_REPO — the SDK encodes conversation data by CWD path, so a different CWD means "No conversation found" / "Session expired".

## Root cause

Every `startChat` call cleaned up ALL worktrees (including primary) in its `finally` block. On resume, the original CWD no longer existed, the fallback to BASE_REPO produced a different SDK project encoding, and the SDK returned "No conversation found".

## Test plan

- [x] New unit tests for `cleanupSessionWorktrees` — verifies primary is preserved, secondaries removed
- [x] Existing tests pass (`npx vitest run server/__tests__/chat.test.ts`)
- [ ] Manual: send multiple messages in a Mitzo session — no more "Session expired" on follow-up messages
- [ ] Manual: stop a session mid-response, then send another message — session resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)