### PR TITLE
fix(test): increase timeout for flaky abort test in hook-bridge

### DIFF
--- a/server/__tests__/hook-bridge.test.ts
+++ b/server/__tests__/hook-bridge.test.ts
@@ -204,7 +204,7 @@ describe('createCommandCallback', () => {
     });
   });
 
-  it('returns empty object when aborted', async () => {
+  it('returns empty object when aborted', { timeout: 15000 }, async () => {
     const controller = new AbortController();
     // sleep command that we'll abort immediately
     const cb = createCommandCallback('sleep 10', TEST_DIR, 10000);


### PR DESCRIPTION
## Summary

- The `returns empty object when aborted` test in `hook-bridge.test.ts` spawns a `sleep 10` command with a 10s callback timeout, but vitest's default test timeout is 5s. The abort races with the test timeout on slower CI runners, causing consistent failures.
- Increases the test timeout to 15s so the abort has time to complete.

## Test plan

- [x] This test was failing on every CI run for PRs #259 and #263
- [ ] CI passes on this branch


Made with [Cursor](https://cursor.com)