### PR TITLE
chore: stop tracking .env.ios (already gitignored)

### DIFF
--- a/frontend/.env.ios
+++ b/frontend/.env.ios
@@ -1,2 +1,0 @@
-VITE_API_BASE_URL=https://YOUR_HOST:3100
-VITE_OTEL_ENDPOINT=http://localhost:4318


### PR DESCRIPTION
The file was committed before the gitignore rule existed. This removes it from tracking so machine-specific Tailnet hostnames don't get pushed.

Made with [Cursor](https://cursor.com)