### PR TITLE
fix(ws): allow session takeover when owner connection is gone

### DIFF
--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -381,8 +381,9 @@ export function handleSendV2(
         const ownerConnection = getOwnerConnection(found.clientId);
         const isOwner = ownerConnection === connectionId;
         const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
+        const ownerGone = !ctx.connRegistry.get(ownerConnection);
 
-        if (!isOwner && !isDetached) {
+        if (!isOwner && !isDetached && !ownerGone) {
           // Session is actively driven by another connection — reject.
           transport.send({
             type: 'error',
@@ -495,8 +496,9 @@ export function handleInterruptV2(
     const ownerConnection = getOwnerConnection(found.clientId);
     const isOwner = ownerConnection === connectionId;
     const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
+    const ownerGone = !ctx.connRegistry.get(ownerConnection);
 
-    if (!isOwner && !isDetached) {
+    if (!isOwner && !isDetached && !ownerGone) {
       transport.send({
         type: 'error',
         error: 'Session is active on another device',


### PR DESCRIPTION
## Summary

- After a server restart or reconnect race, the ownership guard rejected messages with "Session is active on another device" because the `connectionId` changed but the old owner connection was already gone.
- Adds `ownerGone` check to both send paths — if the original owner connection no longer exists in the registry, allow the new connection to take over instead of rejecting.

## Test plan

- [x] Verified on production: phone could not send to existing session after server restart, now works
- [ ] CI passes


Made with [Cursor](https://cursor.com)