### PR TITLE
fix(ui): swap blue theme tokens for neutral dark

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -5,24 +5,24 @@
 }
 
 :root {
-  --bg: #0f0f1a;
-  --surface: #1a1a2e;
-  --border: #2a2a3e;
+  --bg: #111113;
+  --surface: #1a1a1c;
+  --border: #2a2a2c;
   --text: #e0e0e0;
-  --text-dim: #8888aa;
+  --text-dim: #888888;
   --accent: #6c63ff;
   --accent-hover: #5a52e0;
   --danger: #f44336;
   --success: #4caf50;
-  --code-bg: #141425;
+  --code-bg: #0e0e10;
   --code-font: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
 
-  /* Previously undefined — now explicit */
-  --bg-secondary: #161628;
-  --text-secondary: #8888aa;
+  --bg-secondary: #151517;
+  --text-secondary: #888888;
   --hover: rgba(108, 99, 255, 0.1);
   --active: rgba(108, 99, 255, 0.2);
   --warning: #ff9800;
+  --shadow: rgba(0, 0, 0, 0.3);
 
   /* Type scale */
   --text-2xs: 0.65rem;


### PR DESCRIPTION
Replaces the blue-tinted dark theme (#0f0f1a) with neutral dark (#111113) across all CSS variables.

Made with [Cursor](https://cursor.com)