### PR TITLE
fix(ui): polish bundle — message CSS, logo, button, quick actions, inbox

### DIFF
--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -6,6 +6,7 @@ import { useLongPress } from '../hooks/useLongPress';
 import { computeSwipeState, REVEAL_WIDTH } from '../lib/swipe-reveal';
 import { selectionChanged } from '../lib/haptics';
 import { EmptyState } from '../components/EmptyState';
+import { MitzoLogo } from '../components/MitzoLogo';
 import { useSessionList } from '../hooks/useSessionList';
 import type { QuickAction } from '../hooks/useSessionList';
 import { formatTokens } from '../lib/formatTokens';
@@ -225,6 +226,17 @@ export function SessionList() {
     loadMore,
   } = useSessionList();
 
+  const [quickOpen, setQuickOpen] = useState(
+    () => localStorage.getItem('mitzo:quickActionsOpen') !== 'false',
+  );
+
+  function toggleQuickActions() {
+    setQuickOpen((prev) => {
+      localStorage.setItem('mitzo:quickActionsOpen', String(!prev));
+      return !prev;
+    });
+  }
+
   function handleDeployAction() {
     const deploy = quickActions.find((a) => a.label === 'Deploy Mitzo');
     if (deploy) handleQuickAction(deploy);
@@ -243,7 +255,10 @@ export function SessionList() {
   return (
     <div className="session-list-page">
       <header className="session-list-header">
-        <h1>Mitzo</h1>
+        <div className="session-list-header-title">
+          <MitzoLogo />
+          <h1>Mitzo</h1>
+        </div>
         <div className="session-list-header-actions">
           <button
             className="check-update-btn"
@@ -279,19 +294,31 @@ export function SessionList() {
         <BriefingCard />
 
         {quickActions.length > 0 && (
-          <div className="quick-list">
-            {quickActions.map((action) => (
-              <button
-                key={action.label}
-                type="button"
-                className="quick-row"
-                onClick={() => handleQuickAction(action)}
+          <div className="quick-section">
+            <button className="quick-section-toggle" onClick={toggleQuickActions}>
+              <span>Quick Actions</span>
+              <span
+                className={`quick-section-chevron${quickOpen ? ' quick-section-chevron--open' : ''}`}
               >
-                <span className="quick-row-label">{action.label}</span>
-                <span className="quick-row-desc">{action.desc}</span>
-                <span className="quick-row-chevron">&rsaquo;</span>
-              </button>
-            ))}
+                ›
+              </span>
+            </button>
+            {quickOpen && (
+              <div className="quick-list">
+                {quickActions.map((action) => (
+                  <button
+                    key={action.label}
+                    type="button"
+                    className="quick-row"
+                    onClick={() => handleQuickAction(action)}
+                  >
+                    <span className="quick-row-label">{action.label}</span>
+                    <span className="quick-row-desc">{action.desc}</span>
+                    <span className="quick-row-chevron">&rsaquo;</span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -405,6 +405,12 @@ textarea:focus {
   flex-shrink: 0;
 }
 
+.session-list-header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .session-list-header h1 {
   font-size: var(--text-xl);
   font-weight: 700;
@@ -472,21 +478,54 @@ textarea:focus {
 
 .hero-chat-btn {
   width: 100%;
-  padding: var(--space-4);
+  padding: var(--space-3);
   font-size: var(--text-base);
   font-weight: 600;
   border-radius: 14px;
-  background: var(--accent);
-  color: #fff;
-  border: none;
+  background: transparent;
+  color: var(--accent);
+  border: 1.5px solid var(--accent);
   margin-bottom: var(--space-5);
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
-  transition: background 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .hero-chat-btn:active {
-  background: var(--accent-hover);
+  background: rgba(108, 99, 255, 0.12);
+  color: #fff;
+}
+
+.quick-section {
+  margin-bottom: var(--space-5);
+}
+
+.quick-section-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-2) 0;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.quick-section-chevron {
+  display: inline-block;
+  font-size: var(--text-base);
+  transition: transform 0.2s;
+  transform: rotate(0deg);
+}
+
+.quick-section-chevron--open {
+  transform: rotate(90deg);
 }
 
 .quick-list {
@@ -495,7 +534,6 @@ textarea:focus {
   background: var(--surface);
   border-radius: 12px;
   overflow: hidden;
-  margin-bottom: var(--space-5);
 }
 
 .quick-row {
@@ -864,16 +902,16 @@ textarea:focus {
 
 .inbox-filter-pill {
   flex-shrink: 0;
-  padding: 0.35rem 0.75rem;
+  padding: 0.5rem 1rem;
   border-radius: 999px;
   border: 1px solid var(--border);
   background: transparent;
   color: var(--text-dim);
-  font-size: 0.78rem;
+  font-size: 0.88rem;
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.5rem;
 }
 .inbox-filter-pill--active {
   background: var(--accent);
@@ -881,7 +919,7 @@ textarea:focus {
   border-color: var(--accent);
 }
 .inbox-filter-count {
-  font-size: 0.68rem;
+  font-size: 0.78rem;
   opacity: 0.7;
 }
 .inbox-filter-pill--active .inbox-filter-count {
@@ -1040,6 +1078,11 @@ textarea:focus {
 
 .inbox-btn-discard {
   background: var(--danger);
+  color: #fff;
+}
+
+.inbox-btn-session {
+  background: var(--accent, #6366f1);
   color: #fff;
 }
 
@@ -1508,15 +1551,64 @@ textarea:focus {
   color: var(--success);
 }
 
-.msg-bubble-copy {
+.msg-bubble-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
   opacity: 0;
   transition: opacity 0.15s;
-  margin-top: var(--space-1);
-  align-self: flex-end;
+  justify-content: flex-end;
 }
 
-.msg-bubble--assistant:hover .msg-bubble-copy {
+.msg-bubble--assistant:hover .msg-bubble-footer {
   opacity: 1;
+}
+
+.msg-bubble-footer--user {
+  opacity: 1;
+}
+
+.msg-bubble-footer--user .msg-bubble-copy {
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.msg-bubble-group--user:hover .msg-bubble-footer--user .msg-bubble-copy {
+  opacity: 1;
+}
+
+.msg-bubble-copy {
+  flex-shrink: 0;
+}
+
+.msg-bubble-copy--user {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.msg-bubble-copy--user:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.msg-bubble-group--user {
+  display: flex;
+  flex-direction: column;
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.msg-timestamp {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+.msg-timestamp--user {
+  align-self: flex-end;
+  margin-top: 2px;
+  margin-right: var(--space-1);
 }
 
 .code-block-wrapper {
@@ -1538,8 +1630,12 @@ textarea:focus {
 }
 
 @media (hover: none) {
-  .msg-bubble-copy {
-    opacity: 0.5;
+  .msg-bubble-footer,
+  .msg-bubble-footer--user {
+    opacity: 1;
+  }
+  .msg-bubble-footer--user .msg-bubble-copy {
+    opacity: 0.7;
   }
   .code-block-copy {
     opacity: 0.5;
@@ -1805,6 +1901,71 @@ textarea:focus {
 }
 
 .thinking-block-text {
+  font-family: var(--code-font);
+  font-size: var(--text-xxs);
+  line-height: 1.4;
+  color: var(--text-dim);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 40vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0;
+  opacity: 0.7;
+}
+
+/* ===== Context Block (session boot context) ===== */
+
+.context-block {
+  align-self: flex-start;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+  border-left: 3px solid var(--accent, #6366f1);
+}
+
+.context-block-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  touch-action: manipulation;
+  padding: 0.3rem 0.6rem;
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+  color: var(--accent, #6366f1);
+  font-size: var(--text-xs);
+  font-family: inherit;
+  font-style: italic;
+  min-width: 0;
+}
+
+.context-block-header:active {
+  background: rgba(99, 102, 241, 0.05);
+}
+
+.context-block-label {
+  color: var(--accent, #6366f1);
+  font-size: var(--text-xxs);
+  font-style: italic;
+}
+
+.context-block-chevron {
+  margin-left: auto;
+  font-size: 0.6rem;
+  color: var(--accent, #6366f1);
+  font-style: normal;
+}
+
+.context-block-content {
+  padding: 0.4rem 0.6rem;
+  background: var(--code-bg);
+  border-radius: 0 0 6px 6px;
+}
+
+.context-block-text {
   font-family: var(--code-font);
   font-size: var(--text-xxs);
   line-height: 1.4;
@@ -3521,6 +3682,30 @@ textarea:focus {
 .todo-card:hover .todo-card-add-child,
 .todo-card:active .todo-card-add-child,
 .todo-card-add-child:active {
+  opacity: 1;
+}
+
+.todo-card-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.todo-card-session-btn {
+  background: none;
+  border: 1px solid var(--accent, #6366f1);
+  color: var(--accent, #6366f1);
+  font-size: var(--text-2xs);
+  padding: 2px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.todo-card:hover .todo-card-session-btn,
+.todo-card:active .todo-card-session-btn,
+.todo-card-session-btn:active {
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary

- Restore full message footer/timestamp/copy CSS from the redesign commit (`0b39765`) that was lost during merge conflicts — fixes misaligned timestamps and copy buttons in chat
- Add `MitzoLogo` to the session list (home screen) header
- Restyle the New Chat hero button as a ghost/outlined button (transparent bg, accent border) instead of a solid purple slab
- Make quick actions collapsible with a toggle header and `localStorage` persistence
- Enlarge inbox filter pills (padding, font-size, gap) for better touch targets

## Test plan

- [ ] Verify message timestamps and copy buttons are properly aligned in both user and assistant bubbles
- [ ] Verify the Mitzo logo appears in the home screen header and navigates to `/` on tap
- [ ] Verify New Chat button renders as ghost/outlined (not solid purple)
- [ ] Verify quick actions section can be collapsed/expanded and remembers state across page loads
- [ ] Verify inbox filter pills are larger and easier to tap on mobile

Made with [Cursor](https://cursor.com)