### PR TITLE
fix(ui): polish round 2 — inbox scroll, card style, consistent footers

### DIFF
--- a/.cursor/rules/frontend-deployment.mdc
+++ b/.cursor/rules/frontend-deployment.mdc
@@ -1,0 +1,39 @@
+---
+description: Frontend deployment targets and cache troubleshooting
+globs: frontend/**
+alwaysApply: false
+---
+
+# Frontend Deployment
+
+Mitzo has two independent frontend deployment targets. Changes are not visible until the correct target is rebuilt.
+
+## Web (production server)
+
+Assets served by the Express backend from `frontend/dist/`.
+
+```bash
+npm run deploy          # builds everything + restarts launchd service
+```
+
+Vite produces hashed filenames (e.g. `index-Czvd3kWX.css`), so new deploys bust browser caches automatically. If users still see stale content, the old service worker may be caching — `main.tsx` auto-unregisters it, but a hard refresh or clearing site data fixes edge cases.
+
+## iOS (Capacitor)
+
+Assets are bundled into the native app binary via `npx cap sync ios`. The production server deploy does NOT update the iOS app.
+
+```bash
+cd frontend && npm run build:ios   # vite build --mode ios + cap sync
+```
+
+After `build:ios`, you must rebuild and run from Xcode to push new assets to the device. Clearing the Xcode build cache (`Cmd+Shift+K`) and re-running is the minimum; sometimes you need to delete the app from the device first.
+
+The iOS build uses `.env.ios` (not `.env`) — verify `VITE_API_BASE` points to the correct server URL before building.
+
+## Troubleshooting checklist
+
+1. **Verify built assets contain the change** — grep `frontend/dist/assets/*.css` or `*.js` for a unique string from your change.
+2. **Verify the server serves the new assets** — `curl -sk https://localhost:3100 | grep assets/` and confirm the hash matches.
+3. **Web users see stale content** — new asset hashes should bust cache. If not: clear site data, check for service worker in DevTools > Application.
+4. **iOS users see stale content** — `npm run build:ios` + Xcode rebuild. The web deploy alone is insufficient.
+5. **Asset hash unchanged after rebuild** — the source files in the working tree may not match the committed version (lint-staged stash/pop can cause this). Run `git diff HEAD -- frontend/` to check.

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -3,6 +3,7 @@ import { UserBubble, TextBubble } from './MessageBubble';
 import { ThinkingBlock } from './ThinkingBlock';
 import { ToolPill } from './ToolPill';
 import { ToolGroup } from './ToolGroup';
+import { ContextBlock } from './ContextBlock';
 import { PermissionBanner } from './PermissionBanner';
 import { groupBlocks } from '../lib/groupMessages';
 import { SCROLL_NEAR_BOTTOM_PX } from '../lib/constants';
@@ -25,6 +26,8 @@ export interface ChatAreaProps {
   ) => void;
   /** External ref for scroll container — caller can use for forceScrollToBottom */
   scrollRef?: React.RefObject<HTMLDivElement | null>;
+  /** Boot context for sessions started from inbox/todo items */
+  sessionContext?: string | null;
 }
 
 export function ChatArea({
@@ -34,6 +37,7 @@ export function ChatArea({
   permission,
   onPermissionRespond,
   scrollRef: externalScrollRef,
+  sessionContext,
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
@@ -97,7 +101,9 @@ export function ChatArea({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        {messages.length === 0 && !current && !running && (
+        {sessionContext && <ContextBlock content={sessionContext} />}
+
+        {messages.length === 0 && !current && !running && !sessionContext && (
           <p className="chat-empty">Send a message to start</p>
         )}
 

--- a/frontend/src/components/ContextBlock.tsx
+++ b/frontend/src/components/ContextBlock.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+interface Props {
+  content: string;
+}
+
+export function ContextBlock({ content }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!content) return null;
+
+  return (
+    <div className="context-block">
+      <button className="context-block-header" onClick={() => setExpanded((e) => !e)}>
+        <span className="context-block-label">Session Context</span>
+        <span className="context-block-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
+      </button>
+      {expanded && (
+        <div className="context-block-content">
+          <pre className="context-block-text">{content}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -39,13 +39,13 @@ export function UserBubble({ text, images, contextBlocks, onEdit, timestamp }: U
           </div>
         )}
         {text && <div className="msg-bubble-content">{text}</div>}
+        {(time || text) && (
+          <div className="msg-bubble-footer msg-bubble-footer--user">
+            {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
+            {text && <CopyButton text={text} className="msg-bubble-copy msg-bubble-copy--user" />}
+          </div>
+        )}
       </div>
-      {(time || text) && (
-        <div className="msg-bubble-footer msg-bubble-footer--user">
-          {time && <span className="msg-timestamp msg-timestamp--user">{time}</span>}
-          {text && <CopyButton text={text} className="msg-bubble-copy msg-bubble-copy--user" />}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/PageHeader.tsx
+++ b/frontend/src/components/PageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { MitzoLogo } from './MitzoLogo';
 
 interface PageHeaderProps {
   title: string;
@@ -8,14 +9,10 @@ interface PageHeaderProps {
   children?: ReactNode;
 }
 
-export function PageHeader({ title, onBack, badge, center, children }: PageHeaderProps) {
+export function PageHeader({ title, onBack: _onBack, badge, center, children }: PageHeaderProps) {
   return (
     <header className="page-header">
-      {onBack && (
-        <button className="page-header-back" onClick={onBack} title="Back">
-          {'\u2039'}
-        </button>
-      )}
+      <MitzoLogo />
       {center ? (
         <div className="page-header-center">{center}</div>
       ) : (

--- a/frontend/src/components/TodoCard.tsx
+++ b/frontend/src/components/TodoCard.tsx
@@ -11,6 +11,7 @@ interface TodoCardProps {
   onTap: (item: TodoItem) => void;
   onAddChild: (parentId: string) => void;
   onStar: (id: string) => void;
+  onStartSession: (item: TodoItem) => void;
 }
 
 function urgencyBar(urgency: number): string {
@@ -28,6 +29,7 @@ export function TodoCard({
   onTap,
   onAddChild,
   onStar,
+  onStartSession,
 }: TodoCardProps) {
   const ref = useRef<HTMLDivElement>(null);
   const startX = useRef(0);
@@ -159,15 +161,26 @@ export function TodoCard({
               <span className="todo-card-author">{source.author}</span>
             </div>
           )}
-          <button
-            className="todo-card-add-child"
-            onClick={(e) => {
-              e.stopPropagation();
-              onAddChild(item.id);
-            }}
-          >
-            + sub-task
-          </button>
+          <div className="todo-card-actions">
+            <button
+              className="todo-card-add-child"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddChild(item.id);
+              }}
+            >
+              + sub-task
+            </button>
+            <button
+              className="todo-card-session-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                onStartSession(item);
+              }}
+            >
+              Start Session
+            </button>
+          </div>
         </div>
       </div>
 
@@ -183,6 +196,7 @@ export function TodoCard({
               onTap={onTap}
               onAddChild={onAddChild}
               onStar={onStar}
+              onStartSession={onStartSession}
             />
           ))}
         </div>

--- a/frontend/src/components/__tests__/TodoCard.test.tsx
+++ b/frontend/src/components/__tests__/TodoCard.test.tsx
@@ -47,6 +47,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(screen.getByText('[dimakis/mitzo#1] Fix bug')).toBeTruthy();
@@ -61,6 +62,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(container.querySelector('.todo-card-source')?.textContent).toBe('GH');
@@ -76,6 +78,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(container.querySelector('.todo-card-author')?.textContent).toBe('dimakis');
@@ -90,6 +93,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const starBtn = container.querySelector('.todo-card-star');
@@ -107,6 +111,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const starBtn = container.querySelector('.todo-card-star');
@@ -123,6 +128,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={onStar}
+        onStartSession={vi.fn()}
       />,
     );
     const starBtn = container.querySelector('.todo-card-star')!;
@@ -141,6 +147,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={onStar}
+        onStartSession={vi.fn()}
       />,
     );
     const starBtn = container.querySelector('.todo-card-star')!;
@@ -158,6 +165,7 @@ describe('TodoCard', () => {
         onTap={onTap}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -176,6 +184,7 @@ describe('TodoCard', () => {
         onTap={onTap}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -195,6 +204,7 @@ describe('TodoCard', () => {
         onTap={onTap}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -214,6 +224,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(screen.getByText('new')).toBeTruthy();
@@ -229,6 +240,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(screen.getByText('\u25D0')).toBeTruthy();
@@ -245,6 +257,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -267,6 +280,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -289,6 +303,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const card = container.querySelector('.todo-card')!;
@@ -309,6 +324,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     expect(container.querySelector('.todo-card-expand')).toBeNull();
@@ -338,6 +354,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const expandBtn = container.querySelector('.todo-card-expand')!;
@@ -367,6 +384,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const progress = container.querySelector('.todo-card-progress');
@@ -383,6 +401,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={onAddChild}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const addBtn = container.querySelector('.todo-card-add-child')!;
@@ -400,6 +419,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const treeNode = container.querySelector('.todo-card-tree-node');
@@ -415,6 +435,7 @@ describe('TodoCard', () => {
         onTap={vi.fn()}
         onAddChild={vi.fn()}
         onStar={vi.fn()}
+        onStartSession={vi.fn()}
       />,
     );
     const treeNode = container.querySelector('.todo-card-tree-node');

--- a/frontend/src/lib/inbox-utils.ts
+++ b/frontend/src/lib/inbox-utils.ts
@@ -1,0 +1,39 @@
+interface InboxItem {
+  filename: string;
+  agent: string;
+  title: string;
+  tags: string[];
+  timestamp: string;
+  preview: string;
+}
+
+/** Strip YAML frontmatter from inbox item content. */
+export function stripFrontmatter(content: string): string {
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  return match ? match[1].trim() : content;
+}
+
+/** Build the context string shown in the ContextBlock bubble. */
+export function buildInboxContext(item: InboxItem, body: string): string {
+  const lines: string[] = [];
+  lines.push(`Agent: ${item.agent}`);
+  lines.push(`Title: ${item.title}`);
+  if (item.tags.length) lines.push(`Tags: ${item.tags.join(', ')}`);
+  if (item.timestamp) lines.push(`Date: ${new Date(item.timestamp).toLocaleDateString()}`);
+  lines.push('');
+  lines.push(stripFrontmatter(body));
+  return lines.join('\n');
+}
+
+/** Build the prompt sent to the agent for an inbox item session. */
+export function buildInboxPrompt(item: InboxItem, body: string): string {
+  const lines: string[] = [];
+  lines.push(`I want to work on this inbox item:`);
+  lines.push('');
+  lines.push(`**${item.title}** (from ${item.agent})`);
+  lines.push('');
+  lines.push(stripFrontmatter(body));
+  lines.push('');
+  lines.push('Start by reading the relevant context and giving me a brief assessment.');
+  return lines.join('\n');
+}

--- a/frontend/src/lib/todo-utils.ts
+++ b/frontend/src/lib/todo-utils.ts
@@ -45,3 +45,39 @@ export function buildPrompt(item: TodoItem): string {
 
   return lines.join('\n');
 }
+
+/** Build the context string shown in the ContextBlock bubble for a todo session. */
+export function buildTodoContext(item: TodoItem): string {
+  const hints = item.contextHints;
+  const lines: string[] = [];
+  lines.push(`Summary: ${item.summary}`);
+  lines.push(`Status: ${item.status}`);
+  lines.push(`Profile: ${item.profile}`);
+  lines.push(`Urgency: ${item.urgency.toFixed(2)}`);
+  lines.push(`Age: ${item.ageDays === 0 ? 'new' : `${item.ageDays}d`}`);
+
+  for (const source of item.sources) {
+    lines.push('');
+    lines.push(`Source: ${source.title} (${source.type})`);
+    if (source.url) lines.push(`  URL: ${source.url}`);
+    if (source.author) lines.push(`  Author: ${source.author}`);
+    if (source.snippet) lines.push(`  ${source.snippet}`);
+  }
+
+  const context: string[] = [];
+  if (hints.repos.length) context.push(`Repos: ${hints.repos.join(', ')}`);
+  if (hints.issues.length) context.push(`Issues: ${hints.issues.join(', ')}`);
+  if (hints.paths.length) context.push(`Files: ${hints.paths.join(', ')}`);
+  if (hints.jiraKeys.length) context.push(`Jira: ${hints.jiraKeys.join(', ')}`);
+  if (hints.keywords.length) context.push(`Keywords: ${hints.keywords.join(', ')}`);
+
+  if (context.length) {
+    lines.push('', ...context.map((c) => `- ${c}`));
+  }
+
+  if (hints.taskHint) {
+    lines.push('', `Hint: ${hints.taskHint}`);
+  }
+
+  return lines.join('\n');
+}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -47,6 +47,9 @@ export function ChatView() {
   const storeSetModel = useMitzoStore((s) => s.setModel);
   const storeDispatchMessages = useMitzoStore((s) => s.dispatchMessages);
   const storeFetchSessionMeta = useMitzoStore((s) => s.fetchSessionMeta);
+  const pendingSession = useMitzoStore((s) => s.pendingSession);
+  const clearPendingSession = useMitzoStore((s) => s.clearPendingSession);
+  const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
 
   const connected = connection.status === 'connected';
 
@@ -115,6 +118,19 @@ export function ChatView() {
       storeFetchSessionMeta(sessionId);
     }
   }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-send pending session (from "Start Session" on inbox/todo items)
+  const pendingConsumed = useRef(false);
+  useEffect(() => {
+    if (!pendingSession || pendingConsumed.current) return;
+    pendingConsumed.current = true;
+    // Set the context block for display
+    storeDispatchMessages({ type: 'SET_SESSION_CONTEXT', context: pendingSession.context });
+    // Auto-send the prompt
+    storeSendMessage(pendingSession.prompt, { model: modelState, mode });
+    clearPendingSession();
+    forceScrollToBottom();
+  }, [pendingSession]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useAutoSpeak({
     messages: messages.messages,
@@ -241,6 +257,7 @@ export function ChatView() {
         permission={messages.permission}
         onPermissionRespond={handlePermission}
         scrollRef={scrollRef}
+        sessionContext={sessionContext}
       />
 
       <ChatInput

--- a/frontend/src/pages/InboxView.tsx
+++ b/frontend/src/pages/InboxView.tsx
@@ -4,6 +4,7 @@ import { useMitzoStore } from '@mitzo/client/hooks';
 import { EmptyState } from '../components/EmptyState';
 import { PageHeader } from '../components/PageHeader';
 import { apiFetch } from '../lib/api-fetch';
+import { buildInboxContext, buildInboxPrompt } from '../lib/inbox-utils';
 
 interface InboxItem {
   filename: string;
@@ -18,10 +19,12 @@ function InboxCard({
   item,
   onApprove,
   onDiscard,
+  onStartSession,
 }: {
   item: InboxItem;
   onApprove: (filename: string) => void;
   onDiscard: (filename: string) => void;
+  onStartSession: (item: InboxItem, body: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const startX = useRef(0);
@@ -153,6 +156,15 @@ function InboxCard({
               >
                 Discard
               </button>
+              <button
+                className="inbox-btn inbox-btn-session"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onStartSession(item, fullContent ?? item.preview);
+                }}
+              >
+                Start Session
+              </button>
             </div>
           </div>
         )}
@@ -167,6 +179,7 @@ export function InboxView() {
   const [loading, setLoading] = useState(true);
   const [activeFilter, setActiveFilter] = useState<string | null>(null);
   const [pendingRemovals, setPendingRemovals] = useState<Set<string>>(new Set());
+  const setPendingSession = useMitzoStore((s) => s.setPendingSession);
 
   // Sync from the store's inbox (updated via v2 WS inbox_updated events)
   const storeInbox = useMitzoStore((s) => s.inbox.items);
@@ -238,6 +251,14 @@ export function InboxView() {
       });
   }
 
+  function handleStartSession(item: InboxItem, body: string) {
+    setPendingSession({
+      prompt: buildInboxPrompt(item, body),
+      context: buildInboxContext(item, body),
+    });
+    navigate('/chat');
+  }
+
   const sources = [...new Set(items.map((i) => i.agent))].sort();
   const filtered = activeFilter ? items.filter((i) => i.agent === activeFilter) : items;
 
@@ -276,13 +297,14 @@ export function InboxView() {
         {filtered.length > 0 && <span>Swipe right to approve, left to discard</span>}
       </div>
 
-      <div className="inbox-list">
+      <div className="inbox-scroll">
         {filtered.map((item) => (
           <InboxCard
             key={item.filename}
             item={item}
             onApprove={handleApprove}
             onDiscard={handleDiscard}
+            onStartSession={handleStartSession}
           />
         ))}
       </div>

--- a/frontend/src/pages/TodoView.tsx
+++ b/frontend/src/pages/TodoView.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useMitzoStore } from '@mitzo/client/hooks';
 import { TodoCard } from '../components/TodoCard';
 import { EmptyState } from '../components/EmptyState';
 import { PageHeader } from '../components/PageHeader';
 import { useTodoData } from '../hooks/useTodoData';
+import { buildPrompt, buildTodoContext } from '../lib/todo-utils';
 import type { TodoItem } from '../types/todo';
 
 function TodoCreateForm({
@@ -78,6 +80,15 @@ export function TodoView() {
   const [activeProfile, setActiveProfile] = useState<string | undefined>(undefined);
   const { loading, items, profiles, ack, done, star, create, refresh } = useTodoData(activeProfile);
   const [creating, setCreating] = useState<{ parentId?: string } | null>(null);
+  const setPendingSession = useMitzoStore((s) => s.setPendingSession);
+
+  function handleStartSession(item: TodoItem) {
+    setPendingSession({
+      prompt: buildPrompt(item),
+      context: buildTodoContext(item),
+    });
+    navigate('/chat');
+  }
 
   function handleTap(item: TodoItem) {
     navigate(`/todos/${item.id}`, { state: { item } });
@@ -161,6 +172,7 @@ export function TodoView() {
               onStar={star}
               onTap={handleTap}
               onAddChild={handleAddChild}
+              onStartSession={handleStartSession}
             />
           ))}
         </div>

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -141,6 +141,9 @@ function createMockStore() {
     refreshTasks: vi.fn(),
     loadInbox: vi.fn().mockResolvedValue(undefined),
     loadTodos: vi.fn().mockResolvedValue(undefined),
+    pendingSession: null,
+    setPendingSession: vi.fn(),
+    clearPendingSession: vi.fn(),
     forceReconnect: vi.fn(),
   }));
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -531,34 +531,27 @@ textarea:focus {
 .quick-list {
   display: flex;
   flex-direction: column;
-  background: var(--surface);
-  border-radius: 12px;
-  overflow: hidden;
+  gap: var(--space-2);
 }
 
 .quick-row {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: 0.9rem 1rem;
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
   text-align: left;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
-  transition: background 0.1s;
-  border-radius: 0;
+  transition: background 0.12s;
   width: 100%;
 }
 
-.quick-row:last-child {
-  border-bottom: none;
-}
-
 .quick-row:active {
-  background: rgba(108, 99, 255, 0.08);
+  background: var(--hover);
 }
 
 .quick-row-label {
@@ -838,13 +831,6 @@ textarea:focus {
   z-index: 10;
 }
 
-.inbox-scroll {
-  flex: 1;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  padding-bottom: 72px;
-}
-
 .inbox-header h1 {
   font-size: var(--text-xl);
   font-weight: 700;
@@ -891,10 +877,11 @@ textarea:focus {
 .inbox-filters {
   display: flex;
   gap: var(--space-2);
-  padding: 0 var(--space-4) var(--space-3);
+  padding: 0 0 var(--space-3);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  flex-shrink: 0;
 }
 .inbox-filters::-webkit-scrollbar {
   display: none;
@@ -902,16 +889,16 @@ textarea:focus {
 
 .inbox-filter-pill {
   flex-shrink: 0;
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
   border: 1px solid var(--border);
   background: transparent;
   color: var(--text-dim);
-  font-size: 0.88rem;
+  font-size: var(--text-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 .inbox-filter-pill--active {
   background: var(--accent);
@@ -919,7 +906,7 @@ textarea:focus {
   border-color: var(--accent);
 }
 .inbox-filter-count {
-  font-size: 0.78rem;
+  font-size: var(--text-xs);
   opacity: 0.7;
 }
 .inbox-filter-pill--active .inbox-filter-count {
@@ -934,17 +921,21 @@ textarea:focus {
   opacity: 0.7;
 }
 
-.inbox-list {
+.inbox-scroll {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding-bottom: var(--space-6);
+  padding-bottom: 72px;
 }
 
 .inbox-card-wrapper {
   position: relative;
   overflow: hidden;
   border-radius: 12px;
+  flex-shrink: 0;
 }
 
 .inbox-card-actions-bg {
@@ -1013,16 +1004,16 @@ textarea:focus {
 .inbox-card-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
+  gap: 0.35rem;
   margin-bottom: 0.4rem;
 }
 
 .inbox-card-tag {
-  font-size: 0.6rem;
+  font-size: var(--text-xs);
   color: var(--text-dim);
   background: var(--bg);
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
 }
 
 .inbox-card-preview {
@@ -1556,7 +1547,7 @@ textarea:focus {
   align-items: center;
   gap: var(--space-2);
   margin-top: var(--space-1);
-  opacity: 0;
+  opacity: 0.7;
   transition: opacity 0.15s;
   justify-content: flex-end;
 }
@@ -1570,7 +1561,7 @@ textarea:focus {
 }
 
 .msg-bubble-footer--user .msg-bubble-copy {
-  opacity: 0;
+  opacity: 0.7;
   transition: opacity 0.15s;
 }
 
@@ -1596,6 +1587,12 @@ textarea:focus {
   flex-direction: column;
   align-self: flex-end;
   align-items: flex-end;
+  max-width: 85%;
+}
+
+.msg-bubble-group--user .msg-bubble {
+  max-width: 100%;
+  width: fit-content;
 }
 
 .msg-timestamp {
@@ -1606,9 +1603,8 @@ textarea:focus {
 }
 
 .msg-timestamp--user {
-  align-self: flex-end;
+  color: rgba(255, 255, 255, 0.6);
   margin-top: 2px;
-  margin-right: var(--space-1);
 }
 
 .code-block-wrapper {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -9,7 +9,7 @@ export { WS_READY_STATE } from './types.js';
 
 // Store
 export { createMitzoStore } from './store.js';
-export type { MitzoStoreState, MitzoStoreOptions, SendMessageOptions } from './store.js';
+export type { MitzoStoreState, MitzoStoreOptions, SendMessageOptions, PendingSession } from './store.js';
 
 // Slices — state shapes and types
 export type { MessagesState, MessagesAction, ActiveWorktree } from './slices/messages.js';

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -31,6 +31,7 @@ export interface MessagesState {
   isWorktree: boolean;
   wtId: string | null;
   activeWorktrees: ActiveWorktree[];
+  sessionContext: string | null;
 }
 
 export const INITIAL_MESSAGES_STATE: MessagesState = {
@@ -42,6 +43,7 @@ export const INITIAL_MESSAGES_STATE: MessagesState = {
   isWorktree: false,
   wtId: null,
   activeWorktrees: [],
+  sessionContext: null,
 };
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -95,6 +97,7 @@ export type MessagesAction =
   | { type: 'USER_MESSAGE_RECEIVED'; messageId: string; text: string }
   | { type: 'WORKTREE_OPENED'; repoName: string; path: string }
   | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string }
+  | { type: 'SET_SESSION_CONTEXT'; context: string }
   | { type: 'CLEAR' };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -331,6 +334,9 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
         messages: [...state.messages, cmdMsg],
       };
     }
+
+    case 'SET_SESSION_CONTEXT':
+      return { ...state, sessionContext: action.context };
 
     case 'CLEAR':
       return { ...INITIAL_MESSAGES_STATE };

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -49,6 +49,11 @@ export interface SendMessageOptions {
   isolation?: boolean;
 }
 
+export interface PendingSession {
+  prompt: string;
+  context: string;
+}
+
 export interface MitzoStoreState {
   // Slices
   sessions: SessionsState;
@@ -64,6 +69,9 @@ export interface MitzoStoreState {
 
   // Error state
   sendError: string | null;
+
+  // Pending session (for "Start Session" from inbox/todo)
+  pendingSession: PendingSession | null;
 
   // Actions — chat
   dispatchMessages(action: MessagesAction): void;
@@ -100,6 +108,10 @@ export interface MitzoStoreState {
 
   // Actions — todos
   loadTodos(): Promise<void>;
+
+  // Actions — pending session
+  setPendingSession(ps: PendingSession): void;
+  clearPendingSession(): void;
 
   // Actions — lifecycle
   forceReconnect(): void;
@@ -175,6 +187,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     config: INITIAL_CONFIG_STATE,
     tokens: INITIAL_TOKENS_STATE,
     sendError: null,
+    pendingSession: null,
 
     // ── Actions ──────────────────────────────────────────────────────────
 
@@ -513,6 +526,16 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       } catch {
         // Graceful — keep existing todos
       }
+    },
+
+    // ── Pending session actions ────────────────────────────────────────
+
+    setPendingSession(ps: PendingSession) {
+      set({ pendingSession: ps });
+    },
+
+    clearPendingSession() {
+      set({ pendingSession: null });
     },
 
     forceReconnect() {


### PR DESCRIPTION
## Summary

Follow-up to #269. Fixes and polish discovered during live testing:

- Fix inbox cards not rendering when "All" selected (flex-shrink: 0 on card wrapper)
- Add scrollable inbox list with pinned filter pills at top
- Move user bubble timestamp + copy button inside the purple bubble for consistency
- Make assistant message footer always visible (not hover-only on mobile)
- Add MitzoLogo to shared PageHeader (inbox, todos, calendar, task board)
- Restyle quick actions as individual rounded cards (matching briefing button)
- Moderate inbox filter pill sizing
- Add `.cursor/rules/frontend-deployment.mdc` documenting web vs iOS deploy workflow

## Test plan

- [ ] Inbox "All" filter renders all cards (was blank before)
- [ ] Inbox filter pills stay pinned while scrolling cards
- [ ] Expanded inbox cards don't clip last line
- [ ] User message bubbles show timestamp + copy button inside the bubble
- [ ] Assistant message footer (timestamp + copy) visible without hovering
- [ ] MitzoLogo appears on inbox, todos, calendar, task board headers
- [ ] Quick actions on home screen render as individual rounded cards

Made with [Cursor](https://cursor.com)