### PR TITLE
feat(ui): persist queued messages across session switches

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -18,6 +18,7 @@ import { TokenBar } from './TokenBar';
 import type { UseVoiceReturn } from '../hooks/useVoice';
 import type { TokensState as TokenState } from '@mitzo/client';
 import { useDraft } from '../hooks/useDraft';
+import { useQueuedMessages } from '../hooks/useQueuedMessages';
 
 interface Props {
   onSend: (text: string, images?: ImageAttachment[], contextBlocks?: string[]) => boolean;
@@ -56,10 +57,13 @@ export function ChatInput({
   const [showSlashPicker, setShowSlashPicker] = useState(false);
   const [showContextPicker, setShowContextPicker] = useState(false);
   const [contextBlocks, setContextBlocks] = useState<string[]>([]);
-  const MAX_QUEUED = 5;
-  const [queuedMessages, setQueuedMessages] = useState<
-    { text: string; images: ImageAttachment[]; contextBlocks: string[] }[]
-  >([]);
+  const {
+    queue: queuedMessages,
+    enqueue,
+    dequeue,
+    remove: removeQueued,
+    edit: editQueued,
+  } = useQueuedMessages(sessionId);
   const useExternal = externalContextBlocks !== undefined;
   const activeContextBlocks = useExternal ? externalContextBlocks : contextBlocks;
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -95,16 +99,17 @@ export function ChatInput({
   // Auto-send next queued message when agent finishes its turn
   useEffect(() => {
     if (prevRunning.current && !running && queuedMessages.length > 0) {
-      const [q, ...rest] = queuedMessages;
-      setQueuedMessages(rest);
-      onSend(
-        q.text,
-        q.images.length > 0 ? q.images : undefined,
-        q.contextBlocks.length > 0 ? q.contextBlocks : undefined,
-      );
+      const q = dequeue();
+      if (q) {
+        onSend(
+          q.text,
+          q.images.length > 0 ? q.images : undefined,
+          q.contextBlocks.length > 0 ? q.contextBlocks : undefined,
+        );
+      }
     }
     prevRunning.current = running;
-  }, [running, queuedMessages, onSend]);
+  }, [running, queuedMessages, onSend, dequeue]);
 
   // Show/hide slash picker based on input
   // TODO: Verify picker reopens correctly on backspace after space (e.g. "/simplify " → "/simplify")
@@ -214,16 +219,13 @@ export function ChatInput({
   function handleQueue() {
     const trimmed = text.trim();
     if (!trimmed && images.length === 0) return;
-    if (queuedMessages.length >= MAX_QUEUED) return;
+    const added = enqueue({
+      text: trimmed || 'What do you see in this image?',
+      images: [...images],
+      contextBlocks: [...activeContextBlocks],
+    });
+    if (!added) return;
     impactMedium();
-    setQueuedMessages((prev) => [
-      ...prev,
-      {
-        text: trimmed || 'What do you see in this image?',
-        images: [...images],
-        contextBlocks: [...activeContextBlocks],
-      },
-    ]);
     setText('');
     setImages([]);
     if (!useExternal) setContextBlocks([]);
@@ -234,12 +236,11 @@ export function ChatInput({
   }
 
   function editQueuedMessage(index: number) {
-    const q = queuedMessages[index];
+    const q = editQueued(index);
     if (!q) return;
     setText(q.text);
     setImages(q.images);
     if (!useExternal) setContextBlocks(q.contextBlocks);
-    setQueuedMessages((prev) => prev.filter((_, i) => i !== index));
     requestAnimationFrame(() => {
       autoResize();
       textareaRef.current?.focus();
@@ -247,9 +248,9 @@ export function ChatInput({
   }
 
   function fireQueuedAsInterrupt(index: number) {
-    if (!onInterrupt || !queuedMessages[index]) return;
     const q = queuedMessages[index];
-    setQueuedMessages((prev) => prev.filter((_, i) => i !== index));
+    if (!onInterrupt || !q) return;
+    removeQueued(index);
     onInterrupt(
       q.text,
       q.images.length > 0 ? q.images : undefined,
@@ -344,7 +345,7 @@ export function ChatInput({
           </button>
           <button
             className="chat-input-queued-btn chat-input-queued-btn--clear"
-            onClick={() => setQueuedMessages((prev) => prev.filter((_, j) => j !== i))}
+            onClick={() => removeQueued(i)}
           >
             &times;
           </button>

--- a/frontend/src/hooks/__tests__/useQueuedMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useQueuedMessages.test.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useQueuedMessages, type QueuedMessage } from '../useQueuedMessages';
+
+function msg(text: string): QueuedMessage {
+  return { text, images: [], contextBlocks: [] };
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+describe('useQueuedMessages', () => {
+  it('initializes with empty queue when nothing is stored', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-1'));
+    expect(result.current.queue).toEqual([]);
+  });
+
+  it('loads queue from localStorage on init', () => {
+    localStorage.setItem(
+      'mitzo-queue-sess-2',
+      JSON.stringify([{ text: 'hello', contextBlocks: [] }]),
+    );
+    const { result } = renderHook(() => useQueuedMessages('sess-2'));
+    expect(result.current.queue).toHaveLength(1);
+    expect(result.current.queue[0].text).toBe('hello');
+    // images should be reconstructed as empty array
+    expect(result.current.queue[0].images).toEqual([]);
+  });
+
+  it('enqueues a message and persists it', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-3'));
+
+    act(() => {
+      const added = result.current.enqueue(msg('first'));
+      expect(added).toBe(true);
+    });
+
+    expect(result.current.queue).toHaveLength(1);
+    expect(result.current.queue[0].text).toBe('first');
+
+    const stored = JSON.parse(localStorage.getItem('mitzo-queue-sess-3')!);
+    expect(stored).toEqual([{ text: 'first', contextBlocks: [] }]);
+  });
+
+  it('respects maxQueued limit', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-4', 2));
+
+    act(() => result.current.enqueue(msg('one')));
+    act(() => result.current.enqueue(msg('two')));
+
+    let added: boolean = false;
+    act(() => {
+      added = result.current.enqueue(msg('three'));
+    });
+
+    expect(added).toBe(false);
+    expect(result.current.queue).toHaveLength(2);
+  });
+
+  it('dequeues the first message', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-5'));
+
+    act(() => result.current.enqueue(msg('first')));
+    act(() => result.current.enqueue(msg('second')));
+
+    let item: QueuedMessage | undefined;
+    act(() => {
+      item = result.current.dequeue();
+    });
+
+    expect(item?.text).toBe('first');
+    expect(result.current.queue).toHaveLength(1);
+    expect(result.current.queue[0].text).toBe('second');
+  });
+
+  it('dequeue returns undefined for empty queue', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-6'));
+
+    let item: QueuedMessage | undefined;
+    act(() => {
+      item = result.current.dequeue();
+    });
+
+    expect(item).toBeUndefined();
+  });
+
+  it('removes a message by index', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-7'));
+
+    act(() => result.current.enqueue(msg('a')));
+    act(() => result.current.enqueue(msg('b')));
+    act(() => result.current.enqueue(msg('c')));
+    act(() => result.current.remove(1));
+
+    expect(result.current.queue.map((q) => q.text)).toEqual(['a', 'c']);
+  });
+
+  it('edits (removes and returns) a message by index', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-8'));
+
+    act(() => result.current.enqueue(msg('x')));
+    act(() => result.current.enqueue(msg('y')));
+
+    let item: QueuedMessage | undefined;
+    act(() => {
+      item = result.current.edit(0);
+    });
+
+    expect(item?.text).toBe('x');
+    expect(result.current.queue).toHaveLength(1);
+    expect(result.current.queue[0].text).toBe('y');
+  });
+
+  it('edit returns undefined for invalid index', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-9'));
+
+    let item: QueuedMessage | undefined;
+    act(() => {
+      item = result.current.edit(5);
+    });
+
+    expect(item).toBeUndefined();
+  });
+
+  it('uses "new" key when sessionId is undefined', () => {
+    localStorage.setItem(
+      'mitzo-queue-new',
+      JSON.stringify([{ text: 'pending', contextBlocks: [] }]),
+    );
+    const { result } = renderHook(() => useQueuedMessages(undefined));
+    expect(result.current.queue[0].text).toBe('pending');
+  });
+
+  it('migrates queue when sessionId changes from undefined to real ID', () => {
+    localStorage.setItem(
+      'mitzo-queue-new',
+      JSON.stringify([{ text: 'queued', contextBlocks: ['ctx'] }]),
+    );
+    const { rerender } = renderHook(({ id }: { id: string | undefined }) => useQueuedMessages(id), {
+      initialProps: { id: undefined as string | undefined },
+    });
+
+    rerender({ id: 'sess-real' });
+
+    expect(localStorage.getItem('mitzo-queue-sess-real')).toContain('queued');
+    expect(localStorage.getItem('mitzo-queue-new')).toBeNull();
+  });
+
+  it('loads existing queue for new sessionId during migration', () => {
+    localStorage.setItem('mitzo-queue-new', JSON.stringify([{ text: 'old', contextBlocks: [] }]));
+    localStorage.setItem(
+      'mitzo-queue-sess-existing',
+      JSON.stringify([{ text: 'existing', contextBlocks: [] }]),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | undefined }) => useQueuedMessages(id),
+      { initialProps: { id: undefined as string | undefined } },
+    );
+
+    rerender({ id: 'sess-existing' });
+
+    // Should load the existing queue, not migrate the old one
+    expect(result.current.queue[0].text).toBe('existing');
+    expect(localStorage.getItem('mitzo-queue-new')).toBeNull();
+  });
+
+  it('removes localStorage entry when queue becomes empty', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-10'));
+
+    act(() => result.current.enqueue(msg('only')));
+    expect(localStorage.getItem('mitzo-queue-sess-10')).not.toBeNull();
+
+    act(() => result.current.remove(0));
+    expect(localStorage.getItem('mitzo-queue-sess-10')).toBeNull();
+  });
+
+  it('does not persist image data to localStorage', () => {
+    const { result } = renderHook(() => useQueuedMessages('sess-11'));
+
+    act(() => {
+      result.current.enqueue({
+        text: 'with image',
+        images: [
+          { data: 'base64data...', mediaType: 'image/png', preview: 'data:image/png;base64,...' },
+        ],
+        contextBlocks: [],
+      });
+    });
+
+    const stored = localStorage.getItem('mitzo-queue-sess-11')!;
+    expect(stored).not.toContain('base64data');
+    expect(stored).not.toContain('preview');
+
+    // But the in-memory queue still has the images
+    expect(result.current.queue[0].images).toHaveLength(1);
+  });
+});

--- a/frontend/src/hooks/useQueuedMessages.ts
+++ b/frontend/src/hooks/useQueuedMessages.ts
@@ -1,0 +1,128 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ImageAttachment } from '../types/chat';
+
+const KEY_PREFIX = 'mitzo-queue-';
+
+export interface QueuedMessage {
+  text: string;
+  images: ImageAttachment[];
+  contextBlocks: string[];
+}
+
+function queueKey(sessionId: string | undefined): string {
+  return `${KEY_PREFIX}${sessionId ?? 'new'}`;
+}
+
+function loadQueue(sessionId: string | undefined): QueuedMessage[] {
+  try {
+    const raw = localStorage.getItem(queueKey(sessionId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveQueue(sessionId: string | undefined, queue: QueuedMessage[]): void {
+  try {
+    const key = queueKey(sessionId);
+    if (queue.length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(queue));
+    }
+  } catch {
+    // localStorage full or unavailable — ignore
+  }
+}
+
+/** Persists queued messages to localStorage per session. */
+export function useQueuedMessages(
+  sessionId: string | undefined,
+  maxQueued: number = 5,
+): {
+  queue: QueuedMessage[];
+  enqueue: (msg: QueuedMessage) => boolean;
+  dequeue: () => QueuedMessage | undefined;
+  remove: (index: number) => void;
+  edit: (index: number) => QueuedMessage | undefined;
+  clear: () => void;
+} {
+  const [queue, setQueueRaw] = useState<QueuedMessage[]>(() => loadQueue(sessionId));
+  const sessionRef = useRef(sessionId);
+
+  // When sessionId changes, load queue for new session
+  useEffect(() => {
+    const prev = sessionRef.current;
+    sessionRef.current = sessionId;
+    if (prev === sessionId) return;
+
+    // Migrate queue from 'new' key when session gets assigned an ID
+    const oldKey = queueKey(prev);
+    const newKey = queueKey(sessionId);
+    try {
+      const existing = localStorage.getItem(newKey);
+      if (existing) {
+        setQueueRaw(JSON.parse(existing));
+      } else {
+        const old = localStorage.getItem(oldKey);
+        if (old) {
+          localStorage.setItem(newKey, old);
+          // Queue state stays the same — just moved the key
+        }
+      }
+      localStorage.removeItem(oldKey);
+    } catch {
+      // ignore
+    }
+  }, [sessionId]);
+
+  // Persist whenever queue changes
+  useEffect(() => {
+    saveQueue(sessionRef.current, queue);
+  }, [queue]);
+
+  const enqueue = useCallback(
+    (msg: QueuedMessage): boolean => {
+      let added = false;
+      setQueueRaw((prev) => {
+        if (prev.length >= maxQueued) return prev;
+        added = true;
+        return [...prev, msg];
+      });
+      return added;
+    },
+    [maxQueued],
+  );
+
+  const dequeue = useCallback((): QueuedMessage | undefined => {
+    let item: QueuedMessage | undefined;
+    setQueueRaw((prev) => {
+      if (prev.length === 0) return prev;
+      [item] = prev;
+      return prev.slice(1);
+    });
+    return item;
+  }, []);
+
+  const remove = useCallback((index: number) => {
+    setQueueRaw((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const edit = useCallback((index: number): QueuedMessage | undefined => {
+    let item: QueuedMessage | undefined;
+    setQueueRaw((prev) => {
+      item = prev[index];
+      if (!item) return prev;
+      return prev.filter((_, i) => i !== index);
+    });
+    return item;
+  }, []);
+
+  const clear = useCallback(() => {
+    setQueueRaw([]);
+  }, []);
+
+  return { queue, enqueue, dequeue, remove, edit, clear };
+}

--- a/frontend/src/hooks/useQueuedMessages.ts
+++ b/frontend/src/hooks/useQueuedMessages.ts
@@ -9,8 +9,22 @@ export interface QueuedMessage {
   contextBlocks: string[];
 }
 
+/** Stored shape omits images — base64 data is too large for localStorage. */
+interface StoredMessage {
+  text: string;
+  contextBlocks: string[];
+}
+
 function queueKey(sessionId: string | undefined): string {
   return `${KEY_PREFIX}${sessionId ?? 'new'}`;
+}
+
+function toStored(msgs: QueuedMessage[]): StoredMessage[] {
+  return msgs.map(({ text, contextBlocks }) => ({ text, contextBlocks }));
+}
+
+function fromStored(msgs: StoredMessage[]): QueuedMessage[] {
+  return msgs.map(({ text, contextBlocks }) => ({ text, contextBlocks, images: [] }));
 }
 
 function loadQueue(sessionId: string | undefined): QueuedMessage[] {
@@ -18,7 +32,7 @@ function loadQueue(sessionId: string | undefined): QueuedMessage[] {
     const raw = localStorage.getItem(queueKey(sessionId));
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    return Array.isArray(parsed) ? fromStored(parsed) : [];
   } catch {
     return [];
   }
@@ -30,7 +44,7 @@ function saveQueue(sessionId: string | undefined, queue: QueuedMessage[]): void 
     if (queue.length === 0) {
       localStorage.removeItem(key);
     } else {
-      localStorage.setItem(key, JSON.stringify(queue));
+      localStorage.setItem(key, JSON.stringify(toStored(queue)));
     }
   } catch {
     // localStorage full or unavailable — ignore
@@ -47,10 +61,15 @@ export function useQueuedMessages(
   dequeue: () => QueuedMessage | undefined;
   remove: (index: number) => void;
   edit: (index: number) => QueuedMessage | undefined;
-  clear: () => void;
 } {
   const [queue, setQueueRaw] = useState<QueuedMessage[]>(() => loadQueue(sessionId));
+  const queueRef = useRef(queue);
   const sessionRef = useRef(sessionId);
+
+  // Keep ref in sync with state
+  useEffect(() => {
+    queueRef.current = queue;
+  }, [queue]);
 
   // When sessionId changes, load queue for new session
   useEffect(() => {
@@ -64,7 +83,7 @@ export function useQueuedMessages(
     try {
       const existing = localStorage.getItem(newKey);
       if (existing) {
-        setQueueRaw(JSON.parse(existing));
+        setQueueRaw(fromStored(JSON.parse(existing)));
       } else {
         const old = localStorage.getItem(oldKey);
         if (old) {
@@ -85,24 +104,18 @@ export function useQueuedMessages(
 
   const enqueue = useCallback(
     (msg: QueuedMessage): boolean => {
-      let added = false;
-      setQueueRaw((prev) => {
-        if (prev.length >= maxQueued) return prev;
-        added = true;
-        return [...prev, msg];
-      });
-      return added;
+      if (queueRef.current.length >= maxQueued) return false;
+      setQueueRaw((prev) => [...prev, msg]);
+      return true;
     },
     [maxQueued],
   );
 
   const dequeue = useCallback((): QueuedMessage | undefined => {
-    let item: QueuedMessage | undefined;
-    setQueueRaw((prev) => {
-      if (prev.length === 0) return prev;
-      [item] = prev;
-      return prev.slice(1);
-    });
+    const current = queueRef.current;
+    if (current.length === 0) return undefined;
+    const item = current[0];
+    setQueueRaw((prev) => prev.slice(1));
     return item;
   }, []);
 
@@ -111,18 +124,11 @@ export function useQueuedMessages(
   }, []);
 
   const edit = useCallback((index: number): QueuedMessage | undefined => {
-    let item: QueuedMessage | undefined;
-    setQueueRaw((prev) => {
-      item = prev[index];
-      if (!item) return prev;
-      return prev.filter((_, i) => i !== index);
-    });
+    const item = queueRef.current[index];
+    if (!item) return undefined;
+    setQueueRaw((prev) => prev.filter((_, i) => i !== index));
     return item;
   }, []);
 
-  const clear = useCallback(() => {
-    setQueueRaw([]);
-  }, []);
-
-  return { queue, enqueue, dequeue, remove, edit, clear };
+  return { queue, enqueue, dequeue, remove, edit };
 }


### PR DESCRIPTION
## Summary
- Queued messages (typed while agent is running) were plain React state — lost on session switch
- New `useQueuedMessages` hook persists the queue to `localStorage` per session, mirroring the existing `useDraft` pattern
- Handles sessionId migration (new → assigned), quota-safe writes, and loads correct queue when switching back

## Test plan
- [ ] Queue 2-3 messages while agent is running
- [ ] Switch to a different session and back — queue should be intact
- [ ] Edit/remove/fire-as-interrupt queued messages — all operations should persist
- [ ] Refresh the page while messages are queued — they should survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)