### PR TITLE
feat(ui): in-session agent progress widget

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -5,6 +5,7 @@ import { ToolPill } from './ToolPill';
 import { ToolGroup } from './ToolGroup';
 import { ContextBlock } from './ContextBlock';
 import { PermissionBanner } from './PermissionBanner';
+import { ProgressWidget } from './ProgressWidget';
 import { groupBlocks } from '../lib/groupMessages';
 import { SCROLL_NEAR_BOTTOM_PX } from '../lib/constants';
 import type {
@@ -13,6 +14,7 @@ import type {
   StreamingMessage,
   PermissionRequest,
 } from '../types/chat';
+import type { ProgressBlock } from '@mitzo/protocol';
 
 export interface ChatAreaProps {
   messages: FinishedMessage[];
@@ -28,6 +30,8 @@ export interface ChatAreaProps {
   scrollRef?: React.RefObject<HTMLDivElement | null>;
   /** Boot context for sessions started from inbox/todo items */
   sessionContext?: string | null;
+  /** Progress blocks indexed by toolId for rendering ProgressWidget on TodoWrite blocks */
+  progressByToolId?: Record<string, ProgressBlock>;
 }
 
 export function ChatArea({
@@ -38,6 +42,7 @@ export function ChatArea({
   onPermissionRespond,
   scrollRef: externalScrollRef,
   sessionContext,
+  progressByToolId,
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
@@ -64,14 +69,20 @@ export function ChatArea({
     }
   }, [messages, current, scrollRef]);
 
+  // Set of toolIds that have progress data (excluded from tool grouping).
+  const progressToolIds = useMemo(
+    () => new Set(Object.keys(progressByToolId ?? {})),
+    [progressByToolId],
+  );
+
   // Group blocks per finished assistant turn for tool collapsing.
   const groupedMessages = useMemo(
     () =>
       messages.map((msg) => ({
         msg,
-        grouped: msg.role === 'assistant' ? groupBlocks(msg.blocks) : null,
+        grouped: msg.role === 'assistant' ? groupBlocks(msg.blocks, progressToolIds) : null,
       })),
-    [messages],
+    [messages, progressToolIds],
   );
 
   const touchStart = useRef<{ x: number; y: number } | null>(null);
@@ -134,6 +145,16 @@ export function ChatArea({
                   return <ThinkingBlock key={block.blockId} block={block} />;
                 }
                 if (block.blockType === 'tool_use') {
+                  const progress = block.toolId ? progressByToolId?.[block.toolId] : undefined;
+                  if (progress) {
+                    return (
+                      <ProgressWidget
+                        key={block.blockId}
+                        progressId={progress.progressId}
+                        items={progress.items}
+                      />
+                    );
+                  }
                   return <ToolPill key={block.blockId} block={block} />;
                 }
                 return (
@@ -157,6 +178,16 @@ export function ChatArea({
                 return <ThinkingBlock key={block.blockId} block={block} streaming />;
               }
               if (block.blockType === 'tool_use') {
+                const progress = block.toolId ? progressByToolId?.[block.toolId] : undefined;
+                if (progress) {
+                  return (
+                    <ProgressWidget
+                      key={block.blockId}
+                      progressId={progress.progressId}
+                      items={progress.items}
+                    />
+                  );
+                }
                 return <ToolPill key={block.blockId} block={block} />;
               }
               return <TextBubble key={block.blockId} content={block.content ?? ''} streaming />;

--- a/frontend/src/components/ProgressWidget.tsx
+++ b/frontend/src/components/ProgressWidget.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import type { ProgressItem } from '@mitzo/protocol';
+
+interface Props {
+  progressId: string;
+  items: ProgressItem[];
+}
+
+const STATUS_ICONS: Record<ProgressItem['status'], string> = {
+  done: '\u2713',
+  in_progress: '\u25C9',
+  pending: '\u25CB',
+};
+
+export function ProgressWidget({ items }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  const doneCount = items.filter((i) => i.status === 'done').length;
+  const total = items.length;
+  const activeItem = items.find((i) => i.status === 'in_progress');
+  const allDone = doneCount === total;
+  const pct = total > 0 ? (doneCount / total) * 100 : 0;
+
+  return (
+    <div className={`progress-widget ${allDone ? 'progress-widget--done' : ''}`}>
+      <button className="progress-widget-header" onClick={() => setExpanded((e) => !e)}>
+        <div className="progress-widget-bar">
+          <div
+            className="progress-widget-bar-fill"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="progress-widget-count">
+          {doneCount}/{total}
+        </span>
+        {activeItem && (
+          <span className="progress-widget-active">
+            <span className="progress-widget-pulse" />
+            {activeItem.title}
+          </span>
+        )}
+        {allDone && !activeItem && (
+          <span className="progress-widget-active progress-widget-active--done">
+            All tasks complete
+          </span>
+        )}
+        <span className="progress-widget-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
+      </button>
+      {expanded && (
+        <div className="progress-widget-list">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className={`progress-widget-item ${item.status === 'done' ? 'progress-widget-item--done' : ''} ${item.status === 'in_progress' ? 'progress-widget-item--active' : ''}`}
+            >
+              <span
+                className={`progress-widget-icon ${item.status === 'in_progress' ? 'progress-widget-icon--pulse' : ''}`}
+              >
+                {STATUS_ICONS[item.status]}
+              </span>
+              <span className="progress-widget-title">{item.title}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProgressWidget.tsx
+++ b/frontend/src/components/ProgressWidget.tsx
@@ -25,10 +25,7 @@ export function ProgressWidget({ items }: Props) {
     <div className={`progress-widget ${allDone ? 'progress-widget--done' : ''}`}>
       <button className="progress-widget-header" onClick={() => setExpanded((e) => !e)}>
         <div className="progress-widget-bar">
-          <div
-            className="progress-widget-bar-fill"
-            style={{ width: `${pct}%` }}
-          />
+          <div className="progress-widget-bar-fill" style={{ width: `${pct}%` }} />
         </div>
         <span className="progress-widget-count">
           {doneCount}/{total}

--- a/frontend/src/lib/groupMessages.ts
+++ b/frontend/src/lib/groupMessages.ts
@@ -5,7 +5,15 @@ export type GroupedBlock =
   | { type: 'block'; block: FinishedBlock }
   | { type: 'tool-group'; tools: FinishedBlock[]; key: string };
 
-export function groupBlocks(blocks: FinishedBlock[]): GroupedBlock[] {
+/**
+ * Group consecutive tool_use blocks into collapsible ToolGroups.
+ * Blocks whose toolId appears in `progressToolIds` are excluded from grouping
+ * (they render as ProgressWidget and should always be visible).
+ */
+export function groupBlocks(
+  blocks: FinishedBlock[],
+  progressToolIds?: Set<string>,
+): GroupedBlock[] {
   if (!Array.isArray(blocks)) return [];
   const result: GroupedBlock[] = [];
   let toolBuffer: FinishedBlock[] = [];
@@ -26,7 +34,13 @@ export function groupBlocks(blocks: FinishedBlock[]): GroupedBlock[] {
 
   for (const block of blocks) {
     if (block.blockType === 'tool_use') {
-      toolBuffer.push(block);
+      // Progress-augmented blocks break the tool buffer (never grouped)
+      if (block.toolId && progressToolIds?.has(block.toolId)) {
+        flushTools();
+        result.push({ type: 'block', block });
+      } else {
+        toolBuffer.push(block);
+      }
     } else {
       flushTools();
       result.push({ type: 'block', block });

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
@@ -50,6 +50,18 @@ export function ChatView() {
   const pendingSession = useMitzoStore((s) => s.pendingSession);
   const clearPendingSession = useMitzoStore((s) => s.clearPendingSession);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
+  const progressToolIndex = useMitzoStore((s) => s.progress.toolIndex);
+  const progressBlocks = useMitzoStore((s) => s.progress.blocks);
+
+  // Derive toolId → ProgressBlock lookup for ChatArea
+  const progressByToolId = useMemo(() => {
+    const map: Record<string, (typeof progressBlocks)[string]> = {};
+    for (const [toolId, progressId] of Object.entries(progressToolIndex)) {
+      const block = progressBlocks[progressId];
+      if (block) map[toolId] = block;
+    }
+    return map;
+  }, [progressToolIndex, progressBlocks]);
 
   const connected = connection.status === 'connected';
 
@@ -261,6 +273,7 @@ export function ChatView() {
         onPermissionRespond={handlePermission}
         scrollRef={scrollRef}
         sessionContext={sessionContext}
+        progressByToolId={progressByToolId}
       />
 
       <ChatInput

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { apiFetch } from '../lib/api-fetch';
 import { DesktopShell } from '../components/DesktopShell';
@@ -67,6 +67,17 @@ export function DesktopChatView() {
   const storeSetModel = useMitzoStore((s) => s.setModel);
   const storeDispatchMessages = useMitzoStore((s) => s.dispatchMessages);
   const storeFetchSessionMeta = useMitzoStore((s) => s.fetchSessionMeta);
+  const progressToolIndex = useMitzoStore((s) => s.progress.toolIndex);
+  const progressBlocks = useMitzoStore((s) => s.progress.blocks);
+
+  const progressByToolId = useMemo(() => {
+    const map: Record<string, (typeof progressBlocks)[string]> = {};
+    for (const [toolId, progressId] of Object.entries(progressToolIndex)) {
+      const block = progressBlocks[progressId];
+      if (block) map[toolId] = block;
+    }
+    return map;
+  }, [progressToolIndex, progressBlocks]);
 
   const connected = connection.status === 'connected';
 
@@ -271,6 +282,7 @@ export function DesktopChatView() {
             permission={messages.permission}
             onPermissionRespond={handlePermission}
             scrollRef={scrollRef}
+            progressByToolId={progressByToolId}
           />
           <ScrollFab scrollRef={scrollRef} />
           <ChatInput

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -112,6 +112,7 @@ function createMockStore() {
       turnIndex: 0,
       numCompactions: 0,
     },
+    progress: { blocks: {}, toolIndex: {} },
     sendError: null,
     dispatchMessages: vi.fn(),
     switchSession: vi.fn().mockResolvedValue(undefined),

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2167,6 +2167,150 @@ textarea:focus {
   flex-shrink: 0;
 }
 
+/* ===== Progress Widget ===== */
+
+.progress-widget {
+  align-self: flex-start;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.progress-widget-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.6rem;
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  font-family: inherit;
+  min-width: 0;
+}
+
+.progress-widget-header:active {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.progress-widget-bar {
+  width: 40px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--border);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.progress-widget-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--success);
+  transition: width 0.3s ease;
+}
+
+.progress-widget-count {
+  font-weight: 600;
+  color: var(--text);
+  font-size: var(--text-xxs);
+  flex-shrink: 0;
+}
+
+.progress-widget-active {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-dim);
+  font-size: var(--text-xxs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.progress-widget-active--done {
+  color: var(--success);
+}
+
+.progress-widget-pulse {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex-shrink: 0;
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+.progress-widget-chevron {
+  color: var(--text-dim);
+  font-size: 0.6rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.progress-widget-list {
+  padding: 0 0.6rem 0.45rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.progress-widget-item {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: var(--text-xxs);
+  color: var(--text);
+}
+
+.progress-widget-item--done {
+  opacity: 0.5;
+}
+
+.progress-widget-item--done .progress-widget-title {
+  text-decoration: line-through;
+}
+
+.progress-widget-icon {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  width: 1rem;
+  text-align: center;
+}
+
+.progress-widget-item--done .progress-widget-icon {
+  color: var(--success);
+}
+
+.progress-widget-item--active .progress-widget-icon {
+  color: var(--text);
+}
+
+.progress-widget-icon--pulse {
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+.progress-widget-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-widget--done .progress-widget-header {
+  opacity: 0.6;
+}
+
+.progress-widget--done:hover .progress-widget-header,
+.progress-widget--done:active .progress-widget-header {
+  opacity: 1;
+}
+
 /* ===== Permission Banner ===== */
 
 .perm-banner {

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -1,5 +1,6 @@
 import type { BlockType, FinishedBlock, ToolTier, RawToolInput } from './chat';
 import type { Task } from './task';
+import type { ProgressItem, ProgressItemStatus } from '@mitzo/protocol';
 
 interface ClientIdMsg {
   type: 'client_id';
@@ -229,7 +230,35 @@ export type ServerMessage =
   | TaskUpdatedMsg
   | TaskDeletedMsg
   | TokenUpdateMsg
-  | LoopStatusMsg;
+  | LoopStatusMsg
+  | ProgressStartMsg
+  | ProgressUpdateMsg
+  | ProgressReplaceMsg;
+
+export interface ProgressStartMsg {
+  type: 'progress_start';
+  v: 2;
+  messageId: string;
+  progressId: string;
+  sourceToolId?: string;
+  items: ProgressItem[];
+}
+
+export interface ProgressUpdateMsg {
+  type: 'progress_update';
+  v: 2;
+  progressId: string;
+  itemId: string;
+  status: ProgressItemStatus;
+}
+
+export interface ProgressReplaceMsg {
+  type: 'progress_replace';
+  v: 2;
+  progressId: string;
+  sourceToolId?: string;
+  items: ProgressItem[];
+}
 
 export interface InboxUpdatedMsg {
   type: 'inbox_updated';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -29,6 +29,8 @@ export type { TodosState, TodoItem, TodoSource, TodoContextHints } from './slice
 export type { ConfigState, ContextBlockEntry, SkillMetadata } from './slices/config.js';
 export type { TokensState } from './slices/tokens.js';
 export { INITIAL_TOKENS_STATE, DEFAULT_CONTEXT_CEILING } from './slices/tokens.js';
+export type { ProgressState, ProgressUpdate } from './slices/progress.js';
+export { INITIAL_PROGRESS_STATE, applyProgressUpdate } from './slices/progress.js';
 
 // Protocol parser
 export { parseServerMessage } from './protocol-parser.js';

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -20,6 +20,8 @@ import type { MessagesAction } from './slices/messages.js';
 import type { WsMsg } from './server-messages.js';
 import type { Task, LoopStatus } from './slices/tasks.js';
 import type { TokensState } from './slices/tokens.js';
+import type { ProgressUpdate } from './slices/progress.js';
+import type { ProgressItem, ProgressItemStatus } from '@mitzo/protocol';
 
 // ─── Callback interface ──────────────────────────────────────────────────────
 
@@ -83,6 +85,9 @@ export interface ParseResult {
 
   /** Token usage update, if any. */
   tokensUpdate?: Partial<TokensState>;
+
+  /** Progress tracking update, if any. */
+  progressUpdate?: ProgressUpdate;
 
   /** Inbox refresh signal. */
   inboxRefresh?: boolean;
@@ -379,6 +384,35 @@ export function parseServerMessage(
       result.tokensUpdate = tu;
       break;
     }
+
+    // Progress tracking messages
+    case 'progress_start':
+      result.progressUpdate = {
+        type: 'start',
+        progressId: msg.progressId as string,
+        messageId: msg.messageId as string,
+        sourceToolId: msg.sourceToolId as string | undefined,
+        items: msg.items as ProgressItem[],
+      };
+      break;
+
+    case 'progress_update':
+      result.progressUpdate = {
+        type: 'update',
+        progressId: msg.progressId as string,
+        itemId: msg.itemId as string,
+        status: msg.status as ProgressItemStatus,
+      };
+      break;
+
+    case 'progress_replace':
+      result.progressUpdate = {
+        type: 'replace',
+        progressId: msg.progressId as string,
+        sourceToolId: msg.sourceToolId as string | undefined,
+        items: msg.items as ProgressItem[],
+      };
+      break;
 
     case 'inbox_updated':
       result.inboxRefresh = true;

--- a/packages/client/src/slices/progress.ts
+++ b/packages/client/src/slices/progress.ts
@@ -1,0 +1,105 @@
+/**
+ * Progress slice — tracks in-session agent progress from TodoWrite interception.
+ *
+ * Separate from messages (async updates) and tasks (persistent orchestration).
+ * The ProgressWidget reads from this slice to render inline progress.
+ */
+
+import type { ProgressItem, ProgressItemStatus, ProgressBlock } from '@mitzo/protocol';
+
+export type { ProgressItem, ProgressItemStatus, ProgressBlock };
+
+export interface ProgressState {
+  /** Map from progressId to current progress block. */
+  blocks: Record<string, ProgressBlock>;
+  /** Map from sourceToolId to progressId (for ChatArea lookup). */
+  toolIndex: Record<string, string>;
+}
+
+export const INITIAL_PROGRESS_STATE: ProgressState = {
+  blocks: {},
+  toolIndex: {},
+};
+
+// ─── Update types ───────────────────────────────────────────────────────────
+
+export type ProgressUpdate =
+  | {
+      type: 'start';
+      progressId: string;
+      messageId: string;
+      sourceToolId?: string;
+      items: ProgressItem[];
+    }
+  | {
+      type: 'update';
+      progressId: string;
+      itemId: string;
+      status: ProgressItemStatus;
+    }
+  | {
+      type: 'replace';
+      progressId: string;
+      sourceToolId?: string;
+      items: ProgressItem[];
+    };
+
+// ─── Reducer ────────────────────────────────────────────────────────────────
+
+export function applyProgressUpdate(
+  state: ProgressState,
+  update: ProgressUpdate,
+): ProgressState {
+  switch (update.type) {
+    case 'start': {
+      const block: ProgressBlock = {
+        progressId: update.progressId,
+        items: update.items,
+        sourceToolId: update.sourceToolId,
+      };
+      const toolIndex = { ...state.toolIndex };
+      if (update.sourceToolId) {
+        toolIndex[update.sourceToolId] = update.progressId;
+      }
+      return {
+        blocks: { ...state.blocks, [update.progressId]: block },
+        toolIndex,
+      };
+    }
+
+    case 'update': {
+      const existing = state.blocks[update.progressId];
+      if (!existing) return state;
+      const items = existing.items.map((item) =>
+        item.id === update.itemId ? { ...item, status: update.status } : item,
+      );
+      return {
+        ...state,
+        blocks: {
+          ...state.blocks,
+          [update.progressId]: { ...existing, items },
+        },
+      };
+    }
+
+    case 'replace': {
+      const existing = state.blocks[update.progressId];
+      if (!existing) return state;
+      const toolIndex = { ...state.toolIndex };
+      if (update.sourceToolId) {
+        toolIndex[update.sourceToolId] = update.progressId;
+      }
+      return {
+        blocks: {
+          ...state.blocks,
+          [update.progressId]: {
+            ...existing,
+            items: update.items,
+            sourceToolId: update.sourceToolId ?? existing.sourceToolId,
+          },
+        },
+        toolIndex,
+      };
+    }
+  }
+}

--- a/packages/client/src/slices/progress.ts
+++ b/packages/client/src/slices/progress.ts
@@ -46,10 +46,7 @@ export type ProgressUpdate =
 
 // ─── Reducer ────────────────────────────────────────────────────────────────
 
-export function applyProgressUpdate(
-  state: ProgressState,
-  update: ProgressUpdate,
-): ProgressState {
+export function applyProgressUpdate(state: ProgressState, update: ProgressUpdate): ProgressState {
   switch (update.type) {
     case 'start': {
       const block: ProgressBlock = {

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -30,6 +30,8 @@ import { INITIAL_CONFIG_STATE } from './slices/config.js';
 import type { ConfigState } from './slices/config.js';
 import { INITIAL_TOKENS_STATE } from './slices/tokens.js';
 import type { TokensState } from './slices/tokens.js';
+import { INITIAL_PROGRESS_STATE, applyProgressUpdate } from './slices/progress.js';
+import type { ProgressState } from './slices/progress.js';
 import { parseServerMessage } from './protocol-parser.js';
 import type { ProtocolParserState, ProtocolCallbacks } from './protocol-parser.js';
 import type { WsMsg } from './server-messages.js';
@@ -66,6 +68,7 @@ export interface MitzoStoreState {
   todos: TodosState;
   config: ConfigState;
   tokens: TokensState;
+  progress: ProgressState;
 
   // Error state
   sendError: string | null;
@@ -213,6 +216,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     todos: INITIAL_TODOS_STATE,
     config: INITIAL_CONFIG_STATE,
     tokens: INITIAL_TOKENS_STATE,
+    progress: INITIAL_PROGRESS_STATE,
     sendError: null,
     pendingSession: null,
 
@@ -711,6 +715,12 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
           }));
           break;
       }
+    }
+
+    if (result.progressUpdate) {
+      store.setState((s) => ({
+        progress: applyProgressUpdate(s.progress, result.progressUpdate!),
+      }));
     }
 
     if (result.tokensUpdate) {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -19,6 +19,9 @@ export type {
   SessionMeta,
   SessionSearchResult,
   EventStoreLogger,
+  ProgressItemStatus,
+  ProgressItem,
+  ProgressBlock,
 } from './types.js';
 
 // Constants

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -161,3 +161,19 @@ export interface SessionMeta {
   createdAt: number;
   updatedAt: number;
 }
+
+// --- Progress tracking (in-session agent progress) ---
+
+export type ProgressItemStatus = 'pending' | 'in_progress' | 'done';
+
+export interface ProgressItem {
+  id: string;
+  title: string;
+  status: ProgressItemStatus;
+}
+
+export interface ProgressBlock {
+  progressId: string;
+  items: ProgressItem[];
+  sourceToolId?: string;
+}

--- a/server/progress-tracker.ts
+++ b/server/progress-tracker.ts
@@ -61,11 +61,7 @@ export class ProgressTracker {
    * Handle a TodoWrite tool call. Returns progress events to emit, or empty
    * array if the input is not a valid TodoWrite payload.
    */
-  handleTodoWrite(
-    messageId: string,
-    toolId: string,
-    inputBuf: string,
-  ): ProgressEvent[] {
+  handleTodoWrite(messageId: string, toolId: string, inputBuf: string): ProgressEvent[] {
     let input: TodoWriteInput;
     try {
       input = JSON.parse(inputBuf);
@@ -99,8 +95,7 @@ export class ProgressTracker {
     // If the list structure changed (different length or different IDs/titles),
     // emit a full replace.
     const structureChanged =
-      items.length !== prev.length ||
-      items.some((item, i) => item.title !== prev[i].title);
+      items.length !== prev.length || items.some((item, i) => item.title !== prev[i].title);
 
     if (structureChanged) {
       this.previousItems = items;

--- a/server/progress-tracker.ts
+++ b/server/progress-tracker.ts
@@ -1,0 +1,139 @@
+/**
+ * Progress tracker — intercepts TodoWrite tool calls and emits structured
+ * progress events for the frontend ProgressWidget.
+ *
+ * Observe-only: TodoWrite still reaches the SDK normally. This module
+ * watches the tool input, diffs against previous state, and produces
+ * sideband WS events (progress_start, progress_update, progress_replace).
+ */
+
+import type { ProgressItem, ProgressItemStatus } from '@mitzo/protocol';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface TodoWriteItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  activeForm?: string;
+}
+
+interface TodoWriteInput {
+  todos: TodoWriteItem[];
+}
+
+export interface ProgressEvent {
+  type: 'progress_start' | 'progress_update' | 'progress_replace';
+  [key: string]: unknown;
+}
+
+// ─── Status mapping ─────────────────────────────────────────────────────────
+
+function mapStatus(todoStatus: TodoWriteItem['status']): ProgressItemStatus {
+  switch (todoStatus) {
+    case 'completed':
+      return 'done';
+    case 'in_progress':
+      return 'in_progress';
+    default:
+      return 'pending';
+  }
+}
+
+function toProgressItems(todos: TodoWriteItem[]): ProgressItem[] {
+  return todos.map((t, i) => ({
+    id: String(i),
+    title: t.content,
+    status: mapStatus(t.status),
+  }));
+}
+
+// ─── Tracker ────────────────────────────────────────────────────────────────
+
+/**
+ * Session-scoped progress tracker. Create one per query-loop invocation.
+ * Tracks previous TodoWrite state to emit minimal delta events.
+ */
+export class ProgressTracker {
+  private previousItems: ProgressItem[] | null = null;
+  private progressId: string | null = null;
+
+  /**
+   * Handle a TodoWrite tool call. Returns progress events to emit, or empty
+   * array if the input is not a valid TodoWrite payload.
+   */
+  handleTodoWrite(
+    messageId: string,
+    toolId: string,
+    inputBuf: string,
+  ): ProgressEvent[] {
+    let input: TodoWriteInput;
+    try {
+      input = JSON.parse(inputBuf);
+    } catch {
+      return [];
+    }
+
+    if (!input.todos || !Array.isArray(input.todos)) return [];
+
+    const items = toProgressItems(input.todos);
+    const events: ProgressEvent[] = [];
+
+    if (!this.progressId) {
+      // First TodoWrite call in this session turn
+      this.progressId = `prog-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      this.previousItems = items;
+      events.push({
+        type: 'progress_start',
+        v: 2,
+        messageId,
+        progressId: this.progressId,
+        sourceToolId: toolId,
+        items,
+      });
+      return events;
+    }
+
+    // Subsequent call — check if we can emit deltas or need a full replace
+    const prev = this.previousItems!;
+
+    // If the list structure changed (different length or different IDs/titles),
+    // emit a full replace.
+    const structureChanged =
+      items.length !== prev.length ||
+      items.some((item, i) => item.title !== prev[i].title);
+
+    if (structureChanged) {
+      this.previousItems = items;
+      events.push({
+        type: 'progress_replace',
+        v: 2,
+        progressId: this.progressId,
+        sourceToolId: toolId,
+        items,
+      });
+      return events;
+    }
+
+    // Same structure — emit individual status updates
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].status !== prev[i].status) {
+        events.push({
+          type: 'progress_update',
+          v: 2,
+          progressId: this.progressId,
+          itemId: items[i].id,
+          status: items[i].status,
+        });
+      }
+    }
+
+    this.previousItems = items;
+    return events;
+  }
+
+  /** Reset tracker state (call on message_start). */
+  reset(): void {
+    this.previousItems = null;
+    this.progressId = null;
+  }
+}

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -18,6 +18,7 @@ import { NOTIFY_SNIPPET_MAX_CHARS } from './constants.js';
 import { createGoal, reportUsage, deriveGoalTitle } from './goal-client.js';
 import { tracer } from './tracing.js';
 import { SpanStatusCode } from '@opentelemetry/api';
+import { ProgressTracker } from './progress-tracker.js';
 const log = createLogger('query-loop');
 
 /** Send data via transport, guarding on isOpen(). */
@@ -134,6 +135,9 @@ export async function runQueryLoop(
     number,
     { name: string; id: string; inputBuf: string; blockId: string }
   >();
+
+  // Progress tracker — intercepts TodoWrite calls, emits structured events.
+  const progressTracker = new ProgressTracker();
 
   // Map content block index → blockId for all block types.
   const blockIdByIndex = new Map<number, string>();
@@ -451,6 +455,7 @@ export async function runQueryLoop(
             forceFlushPendingMessage(currentSession);
             toolInputBuffers.clear();
             blockIdByIndex.clear();
+            progressTracker.reset();
             blockCounter = 0;
             openBlockCount = 0;
             // Use API message ID if available, otherwise generate one.
@@ -650,6 +655,18 @@ export async function runQueryLoop(
                   ...(rawInput ? { rawInput } : {}),
                 }),
               );
+
+              // Intercept TodoWrite — emit structured progress events
+              if (toolEntry.name === 'TodoWrite' && currentMessageId) {
+                const progressEvents = progressTracker.handleTodoWrite(
+                  currentMessageId,
+                  toolEntry.id,
+                  toolEntry.inputBuf,
+                );
+                for (const pe of progressEvents) {
+                  emit(pe);
+                }
+              }
             } else if (blockId) {
               // Text or thinking block — mark done in snapshot.
               const block = currentSession.currentSnapshot?.blocks.find(


### PR DESCRIPTION
## Summary
- Intercepts TodoWrite tool calls server-side, emits structured progress events (progress_start/update/replace) as sideband WS messages
- Renders inline expandable ProgressWidget in chat instead of raw ToolPill for TodoWrite blocks — live progress bar, status icons, animated check-offs
- Phase 1 of agent progress system; bridges to Task Board orchestration in Phase 2

## Changes
- **Protocol**: `ProgressItem`, `ProgressBlock`, `ProgressItemStatus` types
- **Server**: `ProgressTracker` module + query-loop interception at `content_block_stop`
- **Client**: progress store slice + protocol parser for 3 new WS message types
- **Frontend**: `ProgressWidget` component, `ChatArea` integration, `groupBlocks` exclusion
- Both mobile (`ChatView`) and desktop (`DesktopChatView`) wired

## Test plan
- [ ] Trigger a multi-step task in Mitzo that uses TodoWrite
- [ ] Verify ProgressWidget renders inline instead of ToolPill
- [ ] Check progress bar animates as steps complete
- [ ] Tap to expand/collapse checklist on mobile
- [ ] Verify widget is NOT collapsed into ToolGroup when surrounded by other tools
- [ ] Confirm TodoWrite still works normally for Claude (no SDK breakage)
- [ ] Type-check passes after full workspace build

🤖 Generated with [Claude Code](https://claude.com/claude-code)