### PR TITLE
fix(infra): fix Loki crash on startup with retention enabled

### DIFF
--- a/infra/loki-config.yaml
+++ b/infra/loki-config.yaml
@@ -28,6 +28,10 @@ storage_config:
 compactor:
   working_directory: /loki/data/compactor
   retention_enabled: true
+  delete_request_store: filesystem
+
+analytics:
+  reporting_enabled: false
 
 limits_config:
   retention_period: 720h


### PR DESCRIPTION
## Summary
- Add required `delete_request_store: filesystem` to Loki compactor config — Loki 3.4.x made this mandatory when `retention_enabled: true`, causing the container to crash on startup with exit code 1.
- Disable `analytics.reporting_enabled` to stop noisy telemetry timeout spam to `stats.grafana.org` every ~20 seconds.

## Test plan
- [x] `podman compose up -d` — all three containers (jaeger, loki, grafana) start and stay up
- [x] Loki logs show clean startup with no config validation errors

Made with [Cursor](https://cursor.com)