### PR TITLE
fix(ui): progress session leak + cleanups

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -147,13 +147,7 @@ export function ChatArea({
                 if (block.blockType === 'tool_use') {
                   const progress = block.toolId ? progressByToolId?.[block.toolId] : undefined;
                   if (progress) {
-                    return (
-                      <ProgressWidget
-                        key={block.blockId}
-                        progressId={progress.progressId}
-                        items={progress.items}
-                      />
-                    );
+                    return <ProgressWidget key={block.blockId} items={progress.items} />;
                   }
                   return <ToolPill key={block.blockId} block={block} />;
                 }
@@ -180,13 +174,7 @@ export function ChatArea({
               if (block.blockType === 'tool_use') {
                 const progress = block.toolId ? progressByToolId?.[block.toolId] : undefined;
                 if (progress) {
-                  return (
-                    <ProgressWidget
-                      key={block.blockId}
-                      progressId={progress.progressId}
-                      items={progress.items}
-                    />
-                  );
+                  return <ProgressWidget key={block.blockId} items={progress.items} />;
                 }
                 return <ToolPill key={block.blockId} block={block} />;
               }

--- a/frontend/src/components/ProgressWidget.tsx
+++ b/frontend/src/components/ProgressWidget.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import type { ProgressItem } from '@mitzo/protocol';
 
 interface Props {
-  progressId: string;
   items: ProgressItem[];
 }
 
@@ -18,7 +17,7 @@ export function ProgressWidget({ items }: Props) {
   const doneCount = items.filter((i) => i.status === 'done').length;
   const total = items.length;
   const activeItem = items.find((i) => i.status === 'in_progress');
-  const allDone = doneCount === total;
+  const allDone = total > 0 && doneCount === total;
   const pct = total > 0 ? (doneCount / total) * 100 : 0;
 
   return (

--- a/frontend/src/hooks/useProgress.ts
+++ b/frontend/src/hooks/useProgress.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { useMitzoStore } from '@mitzo/client/hooks';
+import type { ProgressBlock } from '@mitzo/protocol';
+
+/** Derives a toolId → ProgressBlock lookup from the progress store slice. */
+export function useProgressByToolId(): Record<string, ProgressBlock> {
+  const toolIndex = useMitzoStore((s) => s.progress.toolIndex);
+  const blocks = useMitzoStore((s) => s.progress.blocks);
+
+  return useMemo(() => {
+    const map: Record<string, ProgressBlock> = {};
+    for (const [toolId, progressId] of Object.entries(toolIndex)) {
+      const block = blocks[progressId];
+      if (block) map[toolId] = block;
+    }
+    return map;
+  }, [toolIndex, blocks]);
+}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
@@ -9,6 +9,7 @@ import { LAST_SESSION_KEY } from '../lib/constants';
 import { getPreferredModel, setPreferredModel } from '../lib/model-preference';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
+import { useProgressByToolId } from '../hooks/useProgress';
 import { onKeyboardToggle } from '../lib/keyboard';
 import type { ImageAttachment } from '../types/chat';
 
@@ -50,18 +51,7 @@ export function ChatView() {
   const pendingSession = useMitzoStore((s) => s.pendingSession);
   const clearPendingSession = useMitzoStore((s) => s.clearPendingSession);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
-  const progressToolIndex = useMitzoStore((s) => s.progress.toolIndex);
-  const progressBlocks = useMitzoStore((s) => s.progress.blocks);
-
-  // Derive toolId → ProgressBlock lookup for ChatArea
-  const progressByToolId = useMemo(() => {
-    const map: Record<string, (typeof progressBlocks)[string]> = {};
-    for (const [toolId, progressId] of Object.entries(progressToolIndex)) {
-      const block = progressBlocks[progressId];
-      if (block) map[toolId] = block;
-    }
-    return map;
-  }, [progressToolIndex, progressBlocks]);
+  const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
 

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { apiFetch } from '../lib/api-fetch';
 import { DesktopShell } from '../components/DesktopShell';
@@ -15,6 +15,7 @@ import { LAST_SESSION_KEY } from '../lib/constants';
 import { getPreferredModel, setPreferredModel } from '../lib/model-preference';
 import { useVoice } from '../hooks/useVoice';
 import { useAutoSpeak } from '../hooks/useAutoSpeak';
+import { useProgressByToolId } from '../hooks/useProgress';
 import type { FileRoot } from '../components/FileBrowserPanel';
 import type { ContextBlockEntry } from '../components/ContextPicker';
 import type { ImageAttachment } from '../types/chat';
@@ -67,17 +68,7 @@ export function DesktopChatView() {
   const storeSetModel = useMitzoStore((s) => s.setModel);
   const storeDispatchMessages = useMitzoStore((s) => s.dispatchMessages);
   const storeFetchSessionMeta = useMitzoStore((s) => s.fetchSessionMeta);
-  const progressToolIndex = useMitzoStore((s) => s.progress.toolIndex);
-  const progressBlocks = useMitzoStore((s) => s.progress.blocks);
-
-  const progressByToolId = useMemo(() => {
-    const map: Record<string, (typeof progressBlocks)[string]> = {};
-    for (const [toolId, progressId] of Object.entries(progressToolIndex)) {
-      const block = progressBlocks[progressId];
-      if (block) map[toolId] = block;
-    }
-    return map;
-  }, [progressToolIndex, progressBlocks]);
+  const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -236,6 +236,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         messages: INITIAL_MESSAGES_STATE,
         permissions: INITIAL_PERMISSIONS_STATE,
         tokens: INITIAL_TOKENS_STATE,
+        progress: INITIAL_PROGRESS_STATE,
       }));
 
       // v2: send switch_session for token hydration + server-side active tracking
@@ -265,6 +266,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         sessions: { ...get().sessions, active: null },
         messages: INITIAL_MESSAGES_STATE,
         permissions: INITIAL_PERMISSIONS_STATE,
+        progress: INITIAL_PROGRESS_STATE,
       });
     },
 


### PR DESCRIPTION
## Summary
Addresses Centaur review findings from #275:

- **Critical**: Progress state (`blocks`, `toolIndex`) now resets on `switchSession()` and `newSession()`, preventing stale progress data from leaking across sessions
- Remove unused `progressId` prop from `ProgressWidget` (both finished and streaming sections of `ChatArea`)
- Add empty-items guard (`total > 0 && doneCount === total`)
- Extract shared `useProgressByToolId()` hook — deduplicates identical derivation logic in `ChatView` and `DesktopChatView`

## Test plan
- [ ] Switch between sessions — progress widget should not carry over
- [ ] Start new chat — no stale progress items visible
- [ ] Build passes (`tsc --noEmit`, `npm run build:all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)