### PR TITLE
feat(otel): fix log-to-trace correlation, add session/turn/tool spans, Grafana dashboard

### DIFF
--- a/infra/grafana/provisioning/dashboards/json/mitzo-observability.json
+++ b/infra/grafana/provisioning/dashboards/json/mitzo-observability.json
@@ -1,0 +1,182 @@
+{
+  "uid": "mitzo-observability",
+  "title": "Mitzo Observability",
+  "tags": ["mitzo"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "module",
+        "type": "query",
+        "datasource": { "type": "loki", "uid": "" },
+        "query": { "label": "module", "stream": "{app=\"mitzo\"}", "type": 1 },
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Live Log Stream",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{app=\"mitzo\", module=~\"$module\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "wrapLogMessage": true
+      }
+    },
+    {
+      "id": 2,
+      "title": "Log Volume by Level",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum by (level) (count_over_time({app=\"mitzo\"} [$__interval]))",
+          "legendFormat": "{{level}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 30,
+            "stacking": { "mode": "normal" }
+          }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "warning" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "info" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "debug" }, "properties": [{ "id": "color", "value": { "fixedColor": "gray", "mode": "fixed" } }] }
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "title": "Log Volume by Module",
+      "type": "timeseries",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "sum by (module) (count_over_time({app=\"mitzo\"} [$__interval]))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "fillOpacity": 20, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Errors",
+      "type": "logs",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 16 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{app=\"mitzo\", level=~\"error|warning\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "wrapLogMessage": true
+      }
+    },
+    {
+      "id": 5,
+      "title": "WebSocket Operations",
+      "type": "logs",
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 23 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{app=\"mitzo\", module=\"ws-v2\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "id": 6,
+      "title": "Session Lifecycle",
+      "type": "logs",
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 23 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{app=\"mitzo\", module=\"query-loop\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      }
+    },
+    {
+      "id": 7,
+      "title": "Traces — Recent Operations",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 30 },
+      "datasource": { "type": "jaeger", "uid": "jaeger" },
+      "targets": [
+        {
+          "queryType": "search",
+          "service": "mitzo",
+          "limit": 30,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Trace-Correlated Logs",
+      "description": "Log lines that carry a trace_id — click TraceID to jump to Jaeger",
+      "type": "logs",
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 38 },
+      "datasource": { "type": "loki", "uid": "" },
+      "targets": [
+        {
+          "expr": "{app=\"mitzo\"} |= \"trace_id\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "wrapLogMessage": true
+      }
+    }
+  ],
+  "schemaVersion": 39
+}

--- a/infra/grafana/provisioning/dashboards/provider.yaml
+++ b/infra/grafana/provisioning/dashboards/provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+providers:
+  - name: Mitzo
+    type: file
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/server/__tests__/with-span.test.ts
+++ b/server/__tests__/with-span.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import pino from 'pino';
+import { trace, context } from '@opentelemetry/api';
+import {
+  NodeTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+import { _buildLogger } from '../logger.js';
+
+let provider: NodeTracerProvider;
+let exporter: InMemorySpanExporter;
+let tmpDir: string;
+
+beforeAll(() => {
+  exporter = new InMemorySpanExporter();
+  provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  provider.register();
+});
+
+afterAll(async () => {
+  await provider.shutdown();
+});
+
+beforeEach(() => {
+  exporter.reset();
+  tmpDir = mkdtempSync(join(tmpdir(), 'withspan-test-'));
+});
+
+function syncDest(logFile: string) {
+  return pino.destination({ dest: logFile, sync: true, mkdir: true });
+}
+
+function readLogLines(logFile: string): Record<string, unknown>[] {
+  const raw = readFileSync(logFile, 'utf-8').trim();
+  if (!raw) return [];
+  return raw.split('\n').map((line) => JSON.parse(line));
+}
+
+function makeLogger(module: string, dest: pino.DestinationStream) {
+  const root = _buildLogger(dest);
+  const child = root.child({ module });
+  return {
+    info: (message: string, ctx?: Record<string, unknown>) => child.info(ctx ?? {}, message),
+  };
+}
+
+describe('withSpan', () => {
+  it('sets the span as active context so logger gets trace_id', async () => {
+    const { withSpan } = await import('../tracing.js');
+    const logFile = join(tmpDir, 'test.log');
+    const log = makeLogger('span-test', syncDest(logFile));
+
+    withSpan('test.op', { 'test.key': 'val' }, () => {
+      log.info('inside withSpan');
+    });
+
+    const lines = readLogLines(logFile);
+    const entry = lines.find((l) => l.msg === 'inside withSpan');
+    expect(entry).toBeDefined();
+    expect(entry!.trace_id).toBeDefined();
+    expect(typeof entry!.trace_id).toBe('string');
+    expect((entry!.trace_id as string).length).toBe(32);
+    expect(entry!.span_id).toBeDefined();
+  });
+
+  it('exports a span with correct name and attributes', async () => {
+    const { withSpan } = await import('../tracing.js');
+
+    withSpan('test.export', { 'ws.connectionId': 'conn-42' }, () => {
+      // work
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const span = spans.find((s) => s.name === 'test.export');
+    expect(span).toBeDefined();
+    expect(span!.attributes['ws.connectionId']).toBe('conn-42');
+    expect(span!.status.code).toBe(1); // SpanStatusCode.OK
+  });
+
+  it('returns the value from the callback', async () => {
+    const { withSpan } = await import('../tracing.js');
+    const result = withSpan('test.return', {}, () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('records error status and re-throws on sync exception', async () => {
+    const { withSpan } = await import('../tracing.js');
+
+    expect(() =>
+      withSpan('test.error', {}, () => {
+        throw new Error('boom');
+      }),
+    ).toThrow('boom');
+
+    const spans = exporter.getFinishedSpans();
+    const span = spans.find((s) => s.name === 'test.error');
+    expect(span).toBeDefined();
+    expect(span!.status.code).toBe(2); // ERROR
+    expect(span!.status.message).toBe('boom');
+  });
+
+  it('does not leak span context after completion', async () => {
+    const { withSpan } = await import('../tracing.js');
+
+    withSpan('test.noleak', {}, () => {
+      // inside
+    });
+
+    const activeSpan = trace.getSpan(context.active());
+    expect(activeSpan).toBeUndefined();
+  });
+});
+
+describe('withSpanAsync', () => {
+  it('sets active context for async functions', async () => {
+    const { withSpanAsync } = await import('../tracing.js');
+    const logFile = join(tmpDir, 'async.log');
+    const log = makeLogger('async-test', syncDest(logFile));
+
+    await withSpanAsync('test.async', { 'test.mode': 'async' }, async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      log.info('inside async span');
+    });
+
+    const lines = readLogLines(logFile);
+    const entry = lines.find((l) => l.msg === 'inside async span');
+    expect(entry).toBeDefined();
+    expect(entry!.trace_id).toBeDefined();
+    expect((entry!.trace_id as string).length).toBe(32);
+  });
+
+  it('records error on async rejection', async () => {
+    const { withSpanAsync } = await import('../tracing.js');
+
+    await expect(
+      withSpanAsync('test.async.error', {}, async () => {
+        throw new Error('async boom');
+      }),
+    ).rejects.toThrow('async boom');
+
+    const spans = exporter.getFinishedSpans();
+    const span = spans.find((s) => s.name === 'test.async.error');
+    expect(span).toBeDefined();
+    expect(span!.status.code).toBe(2);
+  });
+
+  it('returns the resolved value', async () => {
+    const { withSpanAsync } = await import('../tracing.js');
+    const result = await withSpanAsync('test.async.return', {}, async () => 'hello');
+    expect(result).toBe('hello');
+  });
+
+  it('inherits parent span context', async () => {
+    const { withSpan } = await import('../tracing.js');
+
+    let parentTraceId: string | undefined;
+    let childTraceId: string | undefined;
+
+    withSpan('parent', {}, (parentSpan) => {
+      parentTraceId = parentSpan.spanContext().traceId;
+      withSpan('child', {}, (childSpan) => {
+        childTraceId = childSpan.spanContext().traceId;
+      });
+    });
+
+    expect(parentTraceId).toBeDefined();
+    expect(childTraceId).toBe(parentTraceId);
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -49,6 +49,7 @@ import { capturePromptComparison } from './prompt-compare.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
 import { registerSession, updateSessionTitle, finalizeCloseout } from './session-index.js';
 import { createLogger } from './logger.js';
+import { withSpan, withSpanAsync } from './tracing.js';
 
 const log = createLogger('chat');
 
@@ -554,6 +555,34 @@ export async function startChat(
     onSessionResolved?: (sessionId: string) => void;
   },
 ) {
+  return withSpanAsync(
+    'chat.start',
+    {
+      'chat.clientId': clientId,
+      'chat.resume': options.resume ?? '',
+      'chat.mode': options.mode ?? 'agent',
+    },
+    async () => _startChatInner(transport, clientId, prompt, options),
+  );
+}
+
+async function _startChatInner(
+  transport: SessionTransport,
+  clientId: string,
+  prompt: string,
+  options: {
+    resume?: string;
+    cwd?: string;
+    model?: string;
+    extraTools?: string;
+    isolation?: boolean;
+    mode?: MitzoMode;
+    images?: Array<{ data: string; mediaType: string }>;
+    contextBlocks?: string[];
+    clientMsgId?: string;
+    onSessionResolved?: (sessionId: string) => void;
+  },
+) {
   const abortController = new AbortController();
   const mode = options.mode || 'agent';
 
@@ -818,27 +847,29 @@ export function sendToChat(
   contextBlocks?: string[],
   clientMsgId?: string,
 ): boolean {
-  const session = registry.get(clientId);
-  if (!session?.inputQueue) return false;
-  const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = clientMsgId || `umsg-${Date.now()}-send`;
-  if (session.sessionId) {
-    eventStore.append(session.sessionId, 'user_message', {
-      v: 2,
-      type: 'user_message',
-      ts: Date.now(),
-      messageId,
-      text: fullPrompt,
-    });
-    tryAutoRename(session.sessionId, clientId).catch(() => {
-      /* errors logged internally */
-    });
-  }
-  const echo = { type: 'user_message', messageId, text: fullPrompt };
-  send(session.transport, echo);
-  broadcastToObservers(session.observers, echo);
-  session.inputQueue.push(makeUserMessage(fullPrompt, 'next'));
-  return true;
+  return withSpan('chat.send', { 'chat.clientId': clientId }, () => {
+    const session = registry.get(clientId);
+    if (!session?.inputQueue) return false;
+    const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
+    const messageId = clientMsgId || `umsg-${Date.now()}-send`;
+    if (session.sessionId) {
+      eventStore.append(session.sessionId, 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId,
+        text: fullPrompt,
+      });
+      tryAutoRename(session.sessionId, clientId).catch(() => {
+        /* errors logged internally */
+      });
+    }
+    const echo = { type: 'user_message', messageId, text: fullPrompt };
+    send(session.transport, echo);
+    broadcastToObservers(session.observers, echo);
+    session.inputQueue.push(makeUserMessage(fullPrompt, 'next'));
+    return true;
+  });
 }
 
 /** Interrupt the current generation and inject a message the model sees immediately. */
@@ -849,25 +880,27 @@ export async function interruptChat(
   contextBlocks?: string[],
   clientMsgId?: string,
 ): Promise<boolean> {
-  const session = registry.get(clientId);
-  if (!session?.queryInstance || !session?.inputQueue) return false;
-  const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-  const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
-  if (session.sessionId) {
-    eventStore.append(session.sessionId, 'user_message', {
-      v: 2,
-      type: 'user_message',
-      ts: Date.now(),
-      messageId,
-      text: fullPrompt,
-    });
-  }
-  const echo = { type: 'user_message', messageId, text: fullPrompt };
-  send(session.transport, echo);
-  broadcastToObservers(session.observers, echo);
-  await session.queryInstance.interrupt();
-  session.inputQueue.push(makeUserMessage(fullPrompt, 'now'));
-  return true;
+  return withSpanAsync('chat.interrupt', { 'chat.clientId': clientId }, async () => {
+    const session = registry.get(clientId);
+    if (!session?.queryInstance || !session?.inputQueue) return false;
+    const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
+    const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
+    if (session.sessionId) {
+      eventStore.append(session.sessionId, 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId,
+        text: fullPrompt,
+      });
+    }
+    const echo = { type: 'user_message', messageId, text: fullPrompt };
+    send(session.transport, echo);
+    broadcastToObservers(session.observers, echo);
+    await session.queryInstance.interrupt();
+    session.inputQueue.push(makeUserMessage(fullPrompt, 'now'));
+    return true;
+  });
 }
 
 // --- Session management ---
@@ -915,6 +948,12 @@ Please perform session closeout:
  * still has full conversation context.
  */
 export function closeoutSession(clientId: string): void {
+  withSpan('session.closeout', { 'session.clientId': clientId }, () =>
+    _closeoutSessionInner(clientId),
+  );
+}
+
+function _closeoutSessionInner(clientId: string): void {
   const session = registry.get(clientId);
   if (!session?.inputQueue) {
     // No active session or input queue — just finalize as abandoned
@@ -964,22 +1003,34 @@ export function closeoutSession(clientId: string): void {
 registry.setCloseoutHandler(closeoutSession);
 
 export function stopChat(clientId: string) {
-  const session = registry.get(clientId);
-  if (session) {
-    cleanupSessionWorktrees(session);
-    session.inputQueue?.close();
-    session.queryInstance?.close();
-  }
-  registry.abort(clientId);
+  withSpan('session.stop', { 'session.clientId': clientId }, () => {
+    const session = registry.get(clientId);
+    if (session) {
+      cleanupSessionWorktrees(session);
+      session.inputQueue?.close();
+      session.queryInstance?.close();
+    }
+    registry.abort(clientId);
+  });
 }
 export function detachChat(clientId: string) {
-  registry.detach(clientId);
+  withSpan('session.detach', { 'session.clientId': clientId }, () => {
+    registry.detach(clientId);
+  });
 }
 export function reattachChat(clientId: string, transport: SessionTransport): boolean {
-  return registry.reattach(clientId, transport);
+  return withSpan('session.reattach', { 'session.clientId': clientId }, () => {
+    return registry.reattach(clientId, transport);
+  });
 }
 export function rekeyChat(oldClientId: string, newClientId: string): boolean {
-  return registry.rekey(oldClientId, newClientId);
+  return withSpan(
+    'session.rekey',
+    { 'session.oldClientId': oldClientId, 'session.newClientId': newClientId },
+    () => {
+      return registry.rekey(oldClientId, newClientId);
+    },
+  );
 }
 export function isActive(clientId: string): boolean {
   return registry.isActive(clientId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,9 +70,8 @@ import {
   dispatchV2Message,
   type V2HandlerContext,
 } from './ws-handler-v2.js';
-import { tracer } from './tracing.js';
+import { withSpan } from './tracing.js';
 import { contextFromTraceparent } from './trace-context.js';
-import { SpanStatusCode } from '@opentelemetry/api';
 
 const log = createLogger('server');
 
@@ -319,13 +318,14 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
       if (!found) continue;
       const session = registry.get(found.clientId);
       if (session && session.transport === transport && registry.isAttached(found.clientId)) {
-        const detachSpan = tracer.startSpan('session.detach');
-        detachSpan.setAttribute('session.sessionId', sessionId);
-        detachSpan.setAttribute('ws.connectionId', connectionId);
-        detachChat(found.clientId);
-        detachSpan.setStatus({ code: SpanStatusCode.OK });
-        detachSpan.end();
-        log.info('v2 session detached (surviving)', { connectionId, sessionId });
+        withSpan(
+          'session.detach',
+          { 'session.sessionId': sessionId, 'ws.connectionId': connectionId },
+          () => {
+            detachChat(found.clientId);
+            log.info('v2 session detached (surviving)', { connectionId, sessionId });
+          },
+        );
       }
     }
   });
@@ -443,10 +443,6 @@ function handleChatWs(
   let clientId = initialClientId;
   const transport = getTransport(ws);
 
-  const connSpan = tracer.startSpan('ws.connection', {
-    attributes: { 'ws.client_id': clientId },
-  });
-
   transport.send({ type: 'client_id', clientId });
 
   // Hydrate task board state
@@ -474,273 +470,242 @@ function handleChatWs(
       const traceparent = (parsed as Record<string, unknown>).traceparent as string | undefined;
 
       if (msg.type === 'subscribe') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.subscribe',
-          {
-            attributes: { 'ws.client_id': clientId, 'ws.session_id': msg.sessionId },
-          },
-          contextFromTraceparent(traceparent),
-        );
-        const found = registry.findBySessionId(msg.sessionId);
-        if (found && !registry.isAttached(found.clientId)) {
-          // Driver WS is dead (session detached). Promote this subscriber
-          // to the session driver so it receives direct query-loop events.
-          // Typical iOS Safari reconnect path: socket drops every 30-90s
-          // and the pool reconnects with a subscribe carrying the session ID.
-          const ok = reattachChat(found.clientId, transport);
-          if (ok) {
-            span.setAttribute('ws.subscribe.outcome', 'promoted_to_reattach');
-            const session = registry.get(found.clientId);
-            transport.send({
-              type: 'reattached',
-              clientId: found.clientId,
-              sessionId: session?.sessionId,
-              running: true,
-            });
-            if (session) {
-              const count = replayMissedEvents(session, transport, msg.lastSeq);
-              sendSnapshot(session, transport);
-              if (count > 0) {
-                log.info('subscribe-reattach replayed events', {
+          { 'ws.client_id': clientId, 'ws.session_id': msg.sessionId },
+          (span) => {
+            const found = registry.findBySessionId(msg.sessionId);
+            if (found && !registry.isAttached(found.clientId)) {
+              const ok = reattachChat(found.clientId, transport);
+              if (ok) {
+                span.setAttribute('ws.subscribe.outcome', 'promoted_to_reattach');
+                const session = registry.get(found.clientId);
+                transport.send({
+                  type: 'reattached',
+                  clientId: found.clientId,
+                  sessionId: session?.sessionId,
+                  running: true,
+                });
+                if (session) {
+                  const count = replayMissedEvents(session, transport, msg.lastSeq);
+                  sendSnapshot(session, transport);
+                  if (count > 0) {
+                    log.info('subscribe-reattach replayed events', {
+                      driverClientId: found.clientId,
+                      sessionId: msg.sessionId,
+                      count,
+                    });
+                    span.setAttribute('ws.replay.count', count);
+                  }
+                }
+                log.info('subscribe promoted to reattach (detached session)', {
+                  wsClientId: clientId,
                   driverClientId: found.clientId,
                   sessionId: msg.sessionId,
-                  count,
                 });
+              } else {
+                span.setAttribute('ws.subscribe.outcome', 'observer_fallback');
+                registry.addObserver(msg.sessionId, transport);
+                transport.send({ type: 'subscribed', sessionId: msg.sessionId, running: true });
+              }
+            } else if (found) {
+              span.setAttribute('ws.subscribe.outcome', 'observer');
+              registry.addObserver(msg.sessionId, transport);
+              transport.send({ type: 'subscribed', sessionId: msg.sessionId, running: true });
+              sendSnapshot(found.session, transport);
+              log.info('client subscribed to active session', {
+                clientId,
+                sessionId: msg.sessionId,
+              });
+            } else {
+              span.setAttribute('ws.subscribe.outcome', 'not_found');
+              transport.send({ type: 'subscribed', sessionId: msg.sessionId, running: false });
+            }
+          },
+          contextFromTraceparent(traceparent),
+        );
+      } else if (msg.type === 'reattach') {
+        withSpan(
+          'ws.reattach',
+          { 'ws.client_id': clientId, 'ws.reattach.target_client_id': msg.clientId },
+          (span) => {
+            const ok = reattachChat(msg.clientId, transport);
+            if (ok) {
+              span.setAttribute('ws.reattach.success', true);
+              clientId = msg.clientId;
+              const session = registry.get(clientId);
+              transport.send({
+                type: 'reattached',
+                clientId: msg.clientId,
+                sessionId: session?.sessionId,
+                running: true,
+              });
+              if (session) {
+                const count = replayMissedEvents(session, transport, msg.lastSeq);
+                sendSnapshot(session, transport);
                 span.setAttribute('ws.replay.count', count);
               }
+              log.info('reattached', { oldClientId: msg.clientId, newClientId: initialClientId });
+            } else {
+              span.setAttribute('ws.reattach.success', false);
+              transport.send({
+                type: 'reattach_failed',
+                clientId: msg.clientId,
+                reason: 'Session not found or already finished',
+              });
             }
-            log.info('subscribe promoted to reattach (detached session)', {
-              wsClientId: clientId,
-              driverClientId: found.clientId,
-              sessionId: msg.sessionId,
-            });
-          } else {
-            span.setAttribute('ws.subscribe.outcome', 'observer_fallback');
-            registry.addObserver(msg.sessionId, transport);
-            transport.send({
-              type: 'subscribed',
-              sessionId: msg.sessionId,
-              running: true,
-            });
-          }
-        } else if (found) {
-          span.setAttribute('ws.subscribe.outcome', 'observer');
-          registry.addObserver(msg.sessionId, transport);
-          transport.send({
-            type: 'subscribed',
-            sessionId: msg.sessionId,
-            running: true,
-          });
-          sendSnapshot(found.session, transport);
-          log.info('client subscribed to active session', {
-            clientId,
-            sessionId: msg.sessionId,
-          });
-        } else {
-          span.setAttribute('ws.subscribe.outcome', 'not_found');
-          transport.send({
-            type: 'subscribed',
-            sessionId: msg.sessionId,
-            running: false,
-          });
-        }
-        span.end();
-      } else if (msg.type === 'reattach') {
-        const span = tracer.startSpan(
-          'ws.reattach',
-          {
-            attributes: { 'ws.client_id': clientId, 'ws.reattach.target_client_id': msg.clientId },
           },
           contextFromTraceparent(traceparent),
         );
-        const ok = reattachChat(msg.clientId, transport);
-        if (ok) {
-          span.setAttribute('ws.reattach.success', true);
-          clientId = msg.clientId;
-          const session = registry.get(clientId);
-          transport.send({
-            type: 'reattached',
-            clientId: msg.clientId,
-            sessionId: session?.sessionId,
-            running: true,
-          });
-          if (session) {
-            const count = replayMissedEvents(session, transport, msg.lastSeq);
-            sendSnapshot(session, transport);
-            span.setAttribute('ws.replay.count', count);
-          }
-          log.info('reattached', { oldClientId: msg.clientId, newClientId: initialClientId });
-        } else {
-          span.setAttribute('ws.reattach.success', false);
-          transport.send({
-            type: 'reattach_failed',
-            clientId: msg.clientId,
-            reason: 'Session not found or already finished',
-          });
-        }
-        span.end();
       } else if (msg.type === 'send') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.send',
           {
-            attributes: {
-              'ws.client_id': clientId,
-              'ws.client_msg_id': msg.clientMsgId,
-              'ws.has_resume': !!msg.resume,
-            },
+            'ws.client_id': clientId,
+            'ws.client_msg_id': msg.clientMsgId ?? '',
+            'ws.has_resume': !!msg.resume,
+          },
+          (span) => {
+            const rawCwd = msg.cwd || registry.get(clientId)?.cwd || BASE_REPO;
+            const cwd = rawCwd && isAllowedPath(rawCwd) ? rawCwd : BASE_REPO;
+            const skillRegistry = buildSkillRegistry(cwd);
+            const resolution = resolveSlashCommand(msg.prompt, skillRegistry, NATIVE_COMMAND_NAMES);
+            span.setAttribute('ws.send.resolution', resolution.type);
+
+            if (resolution.type === 'native') {
+              const result = nativeCommands.execute(
+                resolution.name,
+                resolution.arguments,
+                skillRegistry,
+              );
+              if (result) {
+                transport.send({
+                  type: 'native_command_result',
+                  v: 2,
+                  command: result.command,
+                  content: result.content,
+                });
+              }
+            } else if (resolution.type === 'error') {
+              transport.send({ type: 'error', error: resolution.message });
+            } else if (resolution.type === 'skill') {
+              if (resolution.allowedTools) {
+                setSkillPolicy(registry, clientId, resolution.allowedTools);
+              } else {
+                clearSkillPolicy(registry, clientId);
+              }
+              transport.send({
+                type: 'skill_invoked',
+                v: 2,
+                name: resolution.name,
+                source: skillRegistry.get(resolution.name)?.scope || 'bundled',
+                arguments: resolution.arguments,
+                ...(resolution.collisions ? { collisions: resolution.collisions } : {}),
+              });
+              if (isActive(clientId)) {
+                sendToChat(
+                  clientId,
+                  resolution.renderedPrompt,
+                  msg.images,
+                  msg.contextBlocks,
+                  msg.clientMsgId,
+                );
+              } else if (
+                !tryRouteToActiveSession(
+                  ws,
+                  msg.resume,
+                  resolution.renderedPrompt,
+                  msg.images,
+                  msg.contextBlocks,
+                  msg.clientMsgId,
+                )
+              ) {
+                startChat(transport, clientId, resolution.renderedPrompt, {
+                  resume: msg.resume,
+                  cwd: msg.cwd,
+                  model: msg.model,
+                  extraTools: msg.extraTools,
+                  isolation: msg.isolation,
+                  mode: msg.mode,
+                  images: msg.images,
+                  contextBlocks: msg.contextBlocks,
+                  clientMsgId: msg.clientMsgId,
+                });
+              }
+            } else {
+              clearSkillPolicy(registry, clientId);
+              if (isActive(clientId)) {
+                sendToChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
+              } else if (
+                !tryRouteToActiveSession(
+                  ws,
+                  msg.resume,
+                  msg.prompt,
+                  msg.images,
+                  msg.contextBlocks,
+                  msg.clientMsgId,
+                )
+              ) {
+                startChat(transport, clientId, msg.prompt, {
+                  resume: msg.resume,
+                  cwd: msg.cwd,
+                  model: msg.model,
+                  extraTools: msg.extraTools,
+                  isolation: msg.isolation,
+                  mode: msg.mode,
+                  images: msg.images,
+                  contextBlocks: msg.contextBlocks,
+                  clientMsgId: msg.clientMsgId,
+                });
+              }
+            }
           },
           contextFromTraceparent(traceparent),
         );
-        // Resolve slash commands server-side before routing
-        const rawCwd = msg.cwd || registry.get(clientId)?.cwd || BASE_REPO;
-        const cwd = rawCwd && isAllowedPath(rawCwd) ? rawCwd : BASE_REPO;
-        const skillRegistry = buildSkillRegistry(cwd);
-        const resolution = resolveSlashCommand(msg.prompt, skillRegistry, NATIVE_COMMAND_NAMES);
-        span.setAttribute('ws.send.resolution', resolution.type);
-
-        if (resolution.type === 'native') {
-          // Native commands execute directly — never touch the SDK
-          const result = nativeCommands.execute(
-            resolution.name,
-            resolution.arguments,
-            skillRegistry,
-          );
-          if (result) {
-            transport.send({
-              type: 'native_command_result',
-              v: 2,
-              command: result.command,
-              content: result.content,
-            });
-          }
-        } else if (resolution.type === 'error') {
-          transport.send({ type: 'error', error: resolution.message });
-        } else if (resolution.type === 'skill') {
-          // Set skill policy for tool restrictions
-          if (resolution.allowedTools) {
-            setSkillPolicy(registry, clientId, resolution.allowedTools);
-          } else {
-            clearSkillPolicy(registry, clientId);
-          }
-
-          // Emit skill_invoked event for frontend badging
-          transport.send({
-            type: 'skill_invoked',
-            v: 2,
-            name: resolution.name,
-            source: skillRegistry.get(resolution.name)?.scope || 'bundled',
-            arguments: resolution.arguments,
-            ...(resolution.collisions ? { collisions: resolution.collisions } : {}),
-          });
-
-          // Pass rendered prompt through to normal chat flow
-          if (isActive(clientId)) {
-            sendToChat(
-              clientId,
-              resolution.renderedPrompt,
-              msg.images,
-              msg.contextBlocks,
-              msg.clientMsgId,
-            );
-          } else if (
-            !tryRouteToActiveSession(
-              ws,
-              msg.resume,
-              resolution.renderedPrompt,
-              msg.images,
-              msg.contextBlocks,
-              msg.clientMsgId,
-            )
-          ) {
-            startChat(transport, clientId, resolution.renderedPrompt, {
-              resume: msg.resume,
-              cwd: msg.cwd,
-              model: msg.model,
-              extraTools: msg.extraTools,
-              isolation: msg.isolation,
-              mode: msg.mode,
-              images: msg.images,
-              contextBlocks: msg.contextBlocks,
-              clientMsgId: msg.clientMsgId,
-            });
-          }
-        } else {
-          // Passthrough — plain text, no slash command
-          clearSkillPolicy(registry, clientId);
-          if (isActive(clientId)) {
-            sendToChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
-          } else if (
-            !tryRouteToActiveSession(
-              ws,
-              msg.resume,
-              msg.prompt,
-              msg.images,
-              msg.contextBlocks,
-              msg.clientMsgId,
-            )
-          ) {
-            startChat(transport, clientId, msg.prompt, {
-              resume: msg.resume,
-              cwd: msg.cwd,
-              model: msg.model,
-              extraTools: msg.extraTools,
-              isolation: msg.isolation,
-              mode: msg.mode,
-              images: msg.images,
-              contextBlocks: msg.contextBlocks,
-              clientMsgId: msg.clientMsgId,
-            });
-          }
-        }
-        span.end();
       } else if (msg.type === 'permission_response') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.permission_response',
           {
-            attributes: {
-              'ws.client_id': clientId,
-              'ws.perm_id': msg.permId,
-              'ws.decision': msg.decision || 'deny',
-            },
+            'ws.client_id': clientId,
+            'ws.perm_id': msg.permId,
+            'ws.decision': msg.decision || 'deny',
+          },
+          () => {
+            resolvePending(msg.permId, msg.decision || 'deny');
           },
           contextFromTraceparent(traceparent),
         );
-        resolvePending(msg.permId, msg.decision || 'deny');
-        span.end();
       } else if (msg.type === 'set_mode') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.set_mode',
-          {
-            attributes: { 'ws.client_id': clientId, 'ws.mode': msg.mode },
+          { 'ws.client_id': clientId, 'ws.mode': msg.mode },
+          () => {
+            registry.setMode(clientId, msg.mode);
+            const session = registry.get(clientId);
+            if (session) {
+              transport.send({ type: 'mode_changed', mode: msg.mode });
+            }
           },
           contextFromTraceparent(traceparent),
         );
-        registry.setMode(clientId, msg.mode);
-        const session = registry.get(clientId);
-        if (session) {
-          transport.send({ type: 'mode_changed', mode: msg.mode });
-        }
-        span.end();
       } else if (msg.type === 'interrupt') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.interrupt',
-          {
-            attributes: { 'ws.client_id': clientId, 'ws.client_msg_id': msg.clientMsgId },
+          { 'ws.client_id': clientId, 'ws.client_msg_id': msg.clientMsgId ?? '' },
+          () => {
+            interruptChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
           },
           contextFromTraceparent(traceparent),
         );
-        interruptChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
-        span.end();
       } else if (msg.type === 'stop') {
-        const span = tracer.startSpan(
+        withSpan(
           'ws.stop',
-          {
-            attributes: { 'ws.client_id': clientId },
+          { 'ws.client_id': clientId },
+          () => {
+            stopChat(clientId);
           },
           contextFromTraceparent(traceparent),
         );
-        stopChat(clientId);
-        span.end();
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Unknown error';
@@ -758,25 +723,24 @@ function handleChatWs(
     transportMap.delete(ws);
     log.info('chat disconnected', { clientId, code, reason: reason?.toString() });
 
-    const span = tracer.startSpan('ws.disconnect', {
-      attributes: {
+    withSpan(
+      'ws.disconnect',
+      {
         'ws.client_id': clientId,
         'ws.close_code': code,
         'ws.close_reason': reason?.toString() || '',
       },
-    });
-
-    if (isActive(clientId)) {
-      detachChat(clientId);
-      span.setAttribute('ws.disconnect.detached', true);
-      log.info('session detached (surviving)', { clientId });
-    }
-    span.end();
-    connSpan.end();
+      (span) => {
+        if (isActive(clientId)) {
+          detachChat(clientId);
+          span.setAttribute('ws.disconnect.detached', true);
+          log.info('session detached (surviving)', { clientId });
+        }
+      },
+    );
   });
 
   ws.on('error', (err) => {
-    connSpan.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
     log.error('ws error', { clientId, error: err.message });
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,7 +70,7 @@ import {
   dispatchV2Message,
   type V2HandlerContext,
 } from './ws-handler-v2.js';
-import { withSpan } from './tracing.js';
+import { withSpan, withSpanAsync } from './tracing.js';
 import { contextFromTraceparent } from './trace-context.js';
 
 const log = createLogger('server');
@@ -689,11 +689,17 @@ function handleChatWs(
           contextFromTraceparent(traceparent),
         );
       } else if (msg.type === 'interrupt') {
-        withSpan(
+        await withSpanAsync(
           'ws.interrupt',
           { 'ws.client_id': clientId, 'ws.client_msg_id': msg.clientMsgId ?? '' },
-          () => {
-            interruptChat(clientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
+          async () => {
+            await interruptChat(
+              clientId,
+              msg.prompt,
+              msg.images,
+              msg.contextBlocks,
+              msg.clientMsgId,
+            );
           },
           contextFromTraceparent(traceparent),
         );

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -599,7 +599,10 @@ async function _runQueryLoopInner(
               currentSession.currentSnapshot?.blocks.push(snapshotBlock);
 
               // Start tool child span under the current turn span
-              const toolSpan = tracer.startSpan(`tool.${toolName}`, {}, context.active());
+              const toolParent = currentTurnSpan
+                ? trace.setSpan(context.active(), currentTurnSpan)
+                : context.active();
+              const toolSpan = tracer.startSpan(`tool.${toolName}`, {}, toolParent);
               toolSpan.setAttribute('tool.name', toolName);
               toolSpan.setAttribute('tool.id', toolId);
               toolSpans.set(blockId, toolSpan);

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -17,7 +17,7 @@ import { extractSnippet } from './notification-helpers.js';
 import { NOTIFY_SNIPPET_MAX_CHARS } from './constants.js';
 import { createGoal, reportUsage, deriveGoalTitle } from './goal-client.js';
 import { tracer } from './tracing.js';
-import { SpanStatusCode } from '@opentelemetry/api';
+import { context, trace, SpanStatusCode, type Span } from '@opentelemetry/api';
 import { ProgressTracker } from './progress-tracker.js';
 const log = createLogger('query-loop');
 
@@ -126,7 +126,26 @@ export async function runQueryLoop(
 ) {
   const span = tracer.startSpan('session');
   span.setAttribute('session.clientId', clientId);
+  const sessionContext = trace.setSpan(context.active(), span);
 
+  // Run the entire loop body inside the session span's context so that:
+  // - All log.info() calls inject trace_id/span_id via the pino OTel mixin
+  // - Child spans (turn, tool) inherit the session span as parent
+  return context.with(sessionContext, () =>
+    _runQueryLoopInner(q, clientId, registry, abortController, span, store, initialPrompt, options),
+  );
+}
+
+async function _runQueryLoopInner(
+  q: AsyncIterable<Record<string, unknown>>,
+  clientId: string,
+  registry: SessionRegistry,
+  abortController: AbortController,
+  span: Span,
+  store?: EventStore,
+  initialPrompt?: string,
+  options?: QueryLoopOptions,
+) {
   const connRegistry = options?.connRegistry;
   const onSessionResolved = options?.onSessionResolved;
   const onInitialPrompt = options?.onInitialPrompt;
@@ -149,6 +168,11 @@ export async function runQueryLoop(
   let pendingMessageEnd: Record<string, unknown> | null = null;
   let resolvedSessionId: string | undefined;
   let resolvedGoalId: string | undefined;
+
+  // Turn and tool span tracking (Steps 5-6 of OTel overhaul)
+  let currentTurnSpan: Span | null = null;
+  let turnBlockCount = 0;
+  const toolSpans = new Map<string, Span>(); // blockId → tool span
   let goalCreationPromise: Promise<string | null> | undefined;
   let goalTitle: string | undefined;
 
@@ -187,6 +211,13 @@ export async function runQueryLoop(
       pendingMessageEnd = null;
       currentMessageId = null;
       (session as { currentSnapshot: null }).currentSnapshot = null;
+      // End turn span when message is fully flushed
+      if (currentTurnSpan) {
+        currentTurnSpan.setAttribute('turn.block_count', turnBlockCount);
+        currentTurnSpan.setStatus({ code: SpanStatusCode.OK });
+        currentTurnSpan.end();
+        currentTurnSpan = null;
+      }
     }
   }
 
@@ -427,6 +458,10 @@ export async function runQueryLoop(
             });
           }
 
+          span.setAttribute('session.num_turns', usageData.numTurns);
+          span.setAttribute('session.total_tokens', currentSession.cumulativeSessionTokens);
+          span.setAttribute('session.duration_ms', usageData.durationMs);
+          span.setAttribute('session.cost_usd', usageData.totalCostUsd);
           emit(v2('session_end', { sessionId: msg.session_id, usage: usageData }));
           const resultSid = (msg.session_id as string) || currentSession.sessionId;
           if (resultSid && connRegistry?.hasOpenWatchers(resultSid)) {
@@ -452,17 +487,29 @@ export async function runQueryLoop(
           log.debug('stream event', { clientId, evtType: evt?.type });
 
           if (evt?.type === 'message_start') {
+            // End previous turn span if still open (e.g. deferred message_end)
+            if (currentTurnSpan) {
+              currentTurnSpan.setAttribute('turn.block_count', turnBlockCount);
+              currentTurnSpan.setStatus({ code: SpanStatusCode.OK });
+              currentTurnSpan.end();
+              currentTurnSpan = null;
+            }
             forceFlushPendingMessage(currentSession);
             toolInputBuffers.clear();
             blockIdByIndex.clear();
             progressTracker.reset();
             blockCounter = 0;
             openBlockCount = 0;
-            // Use API message ID if available, otherwise generate one.
+            turnBlockCount = 0;
             const apiMsg = evt.message as Record<string, unknown> | undefined;
             currentMessageId = (apiMsg?.id as string | undefined) ?? `msg-${Date.now()}`;
-            // Init snapshot on the session.
             currentSession.currentSnapshot = { messageId: currentMessageId, blocks: [] };
+
+            // Start turn child span under the session span
+            currentTurnSpan = tracer.startSpan('turn', {}, context.active());
+            currentTurnSpan.setAttribute('turn.index', turnIndex);
+            currentTurnSpan.setAttribute('turn.message_id', currentMessageId);
+
             emit(v2('message_start', { messageId: currentMessageId }));
 
             // Extract agent context from message_start usage.
@@ -538,27 +585,31 @@ export async function runQueryLoop(
                 }),
               );
             } else if (blockType === 'tool_use') {
-              toolInputBuffers.set(index, {
-                name: contentBlock!.name as string,
-                id: contentBlock!.id as string,
-                inputBuf: '',
-                blockId,
-              });
+              const toolName = contentBlock!.name as string;
+              const toolId = contentBlock!.id as string;
+              toolInputBuffers.set(index, { name: toolName, id: toolId, inputBuf: '', blockId });
               const snapshotBlock: SnapshotBlock = {
                 blockId,
                 blockType: 'tool_use',
                 content: '',
                 done: false,
-                toolName: contentBlock!.name as string,
-                toolId: contentBlock!.id as string,
+                toolName,
+                toolId,
               };
               currentSession.currentSnapshot?.blocks.push(snapshotBlock);
+
+              // Start tool child span under the current turn span
+              const toolSpan = tracer.startSpan(`tool.${toolName}`, {}, context.active());
+              toolSpan.setAttribute('tool.name', toolName);
+              toolSpan.setAttribute('tool.id', toolId);
+              toolSpans.set(blockId, toolSpan);
+
               emit(
                 v2('block_start', {
                   messageId: currentMessageId,
                   blockId,
                   blockType: 'tool_use',
-                  toolName: contentBlock!.name as string,
+                  toolName,
                 }),
               );
             } else if (blockType === 'text') {
@@ -634,6 +685,14 @@ export async function runQueryLoop(
 
               log.info('tool call', { clientId, tool: toolEntry.name, toolId: toolEntry.id });
 
+              // End tool span
+              const toolSpan = toolSpans.get(blockId);
+              if (toolSpan) {
+                toolSpan.setStatus({ code: SpanStatusCode.OK });
+                toolSpan.end();
+                toolSpans.delete(blockId);
+              }
+
               // Mark snapshot block done with tool metadata.
               const block = currentSession.currentSnapshot?.blocks.find(
                 (b) => b.blockId === blockId,
@@ -685,6 +744,7 @@ export async function runQueryLoop(
               }
             }
             openBlockCount = Math.max(0, openBlockCount - 1);
+            turnBlockCount++;
             tryFlushMessageEnd(currentSession);
           }
         } else if (msg.type === 'system') {
@@ -768,6 +828,20 @@ export async function runQueryLoop(
       if (store && resolvedSessionId) {
         store.markSessionInactive(resolvedSessionId);
       }
+      // Clean up any open tool spans
+      for (const [, ts] of toolSpans) {
+        ts.setStatus({ code: SpanStatusCode.OK });
+        ts.end();
+      }
+      toolSpans.clear();
+      // Clean up open turn span
+      if (currentTurnSpan) {
+        currentTurnSpan.setAttribute('turn.block_count', turnBlockCount);
+        currentTurnSpan.setStatus({ code: SpanStatusCode.OK });
+        currentTurnSpan.end();
+        currentTurnSpan = null;
+      }
+
       span.setStatus({ code: SpanStatusCode.OK });
       log.info('query loop ended', { clientId, doneSent });
     }

--- a/server/tracing.ts
+++ b/server/tracing.ts
@@ -11,7 +11,7 @@ import { NodeTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
-import { trace } from '@opentelemetry/api';
+import { trace, context, type Span, type Context, SpanStatusCode } from '@opentelemetry/api';
 import { createLogger } from './logger.js';
 
 const log = createLogger('tracing');
@@ -42,3 +42,66 @@ if (endpoint) {
  * configured, so instrumentation code can call startSpan unconditionally.
  */
 export const tracer = trace.getTracer('mitzo', '1.0.0');
+
+/**
+ * Run `fn` inside an OTel span with proper context propagation.
+ * The span is set as the active context so:
+ *  - pino's otelMixin injects trace_id/span_id into log lines
+ *  - child spans created inside `fn` inherit this span as parent
+ *
+ * Handles status setting and span.end() automatically.
+ * For async callbacks, use `withSpanAsync`.
+ */
+export function withSpan<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => T,
+  parentContext?: Context,
+): T {
+  const parent = parentContext ?? context.active();
+  const span = tracer.startSpan(name, {}, parent);
+  for (const [k, v] of Object.entries(attrs)) span.setAttribute(k, v);
+  return context.with(trace.setSpan(parent, span), () => {
+    try {
+      const result = fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      span.recordException(err instanceof Error ? err : new Error(message));
+      span.end();
+      throw err;
+    }
+  });
+}
+
+/**
+ * Async variant of `withSpan` — awaits the callback and handles
+ * rejection. Context propagation works across awaits within the callback.
+ */
+export async function withSpanAsync<T>(
+  name: string,
+  attrs: Record<string, string | number | boolean>,
+  fn: (span: Span) => Promise<T>,
+  parentContext?: Context,
+): Promise<T> {
+  const parent = parentContext ?? context.active();
+  const span = tracer.startSpan(name, {}, parent);
+  for (const [k, v] of Object.entries(attrs)) span.setAttribute(k, v);
+  return context.with(trace.setSpan(parent, span), async () => {
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+      return result;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+      span.recordException(err instanceof Error ? err : new Error(message));
+      span.end();
+      throw err;
+    }
+  });
+}

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -33,8 +33,7 @@ type InterruptMsg = z.infer<typeof V2InterruptMessage>;
 type PermissionMsg = z.infer<typeof V2PermissionResponseMessage>;
 type SetModeMsg = z.infer<typeof V2SetModeMessage>;
 import { randomUUID } from 'crypto';
-import { tracer } from './tracing.js';
-import { SpanStatusCode } from '@opentelemetry/api';
+import { withSpan, withSpanAsync } from './tracing.js';
 import { resolvePending, denyPendingBySession } from './permissions.js';
 import {
   startChat,
@@ -116,112 +115,88 @@ export function handleReconnect(
   msg: { type: 'reconnect'; sessions: Array<{ sessionId: string; lastSeq: number }> },
   ctx: V2HandlerContext,
 ): void {
-  const span = tracer.startSpan('ws.reconnect');
-  span.setAttribute('ws.connectionId', connectionId);
-  span.setAttribute('ws.sessionCount', msg.sessions.length);
+  withSpan(
+    'ws.reconnect',
+    { 'ws.connectionId': connectionId, 'ws.sessionCount': msg.sessions.length },
+    () => {
+      const summaries: Array<{ sessionId: string; replayed: number; running: boolean }> = [];
 
-  const summaries: Array<{ sessionId: string; replayed: number; running: boolean }> = [];
+      for (const entry of msg.sessions) {
+        ctx.connRegistry.watch(connectionId, entry.sessionId);
 
-  try {
-    for (const entry of msg.sessions) {
-      ctx.connRegistry.watch(connectionId, entry.sessionId);
-
-      const events = ctx.eventStore.getEventsAfter(entry.sessionId, entry.lastSeq);
-      for (const evt of events) {
-        ctx.connRegistry.get(connectionId)?.transport.send({
-          ...evt.payload,
-          seq: evt.seq,
-        } as Record<string, unknown>);
-      }
-
-      // Check if the session's query loop is truly running. The in-memory
-      // SessionRegistry keeps entries alive during the detach TTL window even
-      // after the query loop has ended (e.g. laptop sleep → wake hours later).
-      // Cross-reference with the durable EventStore: markSessionInactive() is
-      // called in the query loop's finally block, so isActive=false in the
-      // store is ground truth that the loop has ended.
-      const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
-      let running = found ? ctx.sessionRegistry.isActive(found.clientId) : false;
-      if (running) {
-        const storeMeta = ctx.eventStore.getSession(entry.sessionId);
-        if (storeMeta && !storeMeta.isActive) {
-          running = false;
-          log.info('removing stale session from registry', {
-            connectionId,
-            sessionId: entry.sessionId,
-            clientId: found!.clientId,
-          });
-          ctx.sessionRegistry.remove(found!.clientId);
+        const events = ctx.eventStore.getEventsAfter(entry.sessionId, entry.lastSeq);
+        for (const evt of events) {
+          ctx.connRegistry.get(connectionId)?.transport.send({
+            ...evt.payload,
+            seq: evt.seq,
+          } as Record<string, unknown>);
         }
-      }
-      if (found && running && !ctx.sessionRegistry.isAttached(found.clientId)) {
-        // Reattach if the reconnecting client's connectionId matches the
-        // session's original owner, OR the original owner connection is no
-        // longer registered (meaning its WebSocket died — the normal
-        // reconnect path). This prevents a different device from hijacking
-        // a session that is still actively driven elsewhere, while allowing
-        // the same client to reclaim its session after a WS drop.
-        const ownerConnection = getOwnerConnection(found.clientId);
-        const ownerGone = !ctx.connRegistry.get(ownerConnection);
-        const isOwner = ownerConnection === connectionId;
-        if (isOwner || ownerGone) {
-          const conn = ctx.connRegistry.get(connectionId);
-          if (conn) {
-            reattachChat(found.clientId, conn.transport);
-            // Transfer ownership: rekey the session so subsequent sends
-            // from this connection pass the ownership check. Without this,
-            // getOwnerConnection() still returns the dead connection's ID
-            // and handleSendV2 rejects with active_elsewhere.
-            const newClientId = `${connectionId}:${entry.sessionId}`;
-            if (found.clientId !== newClientId) {
-              rekeyChat(found.clientId, newClientId);
-              log.info('rekeyed session to new connection', {
-                connectionId,
-                sessionId: entry.sessionId,
-                oldClientId: found.clientId,
-                newClientId,
-              });
-            }
-            log.info('reattached detached session on reconnect', {
+
+        // Cross-reference with the durable EventStore: markSessionInactive() is
+        // called in the query loop's finally block, so isActive=false in the
+        // store is ground truth that the loop has ended.
+        const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
+        let running = found ? ctx.sessionRegistry.isActive(found.clientId) : false;
+        if (running) {
+          const storeMeta = ctx.eventStore.getSession(entry.sessionId);
+          if (storeMeta && !storeMeta.isActive) {
+            running = false;
+            log.info('removing stale session from registry', {
               connectionId,
               sessionId: entry.sessionId,
-              clientId: newClientId,
-              ownerGone,
+              clientId: found!.clientId,
             });
+            ctx.sessionRegistry.remove(found!.clientId);
           }
         }
+        if (found && running && !ctx.sessionRegistry.isAttached(found.clientId)) {
+          const ownerConnection = getOwnerConnection(found.clientId);
+          const ownerGone = !ctx.connRegistry.get(ownerConnection);
+          const isOwner = ownerConnection === connectionId;
+          if (isOwner || ownerGone) {
+            const conn = ctx.connRegistry.get(connectionId);
+            if (conn) {
+              reattachChat(found.clientId, conn.transport);
+              const newClientId = `${connectionId}:${entry.sessionId}`;
+              if (found.clientId !== newClientId) {
+                rekeyChat(found.clientId, newClientId);
+                log.info('rekeyed session to new connection', {
+                  connectionId,
+                  sessionId: entry.sessionId,
+                  oldClientId: found.clientId,
+                  newClientId,
+                });
+              }
+              log.info('reattached detached session on reconnect', {
+                connectionId,
+                sessionId: entry.sessionId,
+                clientId: newClientId,
+                ownerGone,
+              });
+            }
+          }
+        }
+
+        summaries.push({
+          sessionId: entry.sessionId,
+          replayed: events.length,
+          running,
+        });
+
+        log.info('reconnect replay', {
+          connectionId,
+          sessionId: entry.sessionId,
+          lastSeq: entry.lastSeq,
+          replayed: events.length,
+        });
       }
 
-      summaries.push({
-        sessionId: entry.sessionId,
-        replayed: events.length,
-        running,
+      ctx.connRegistry.get(connectionId)?.transport.send({
+        type: 'reconnected',
+        sessions: summaries,
       });
-
-      log.info('reconnect replay', {
-        connectionId,
-        sessionId: entry.sessionId,
-        lastSeq: entry.lastSeq,
-        replayed: events.length,
-      });
-    }
-
-    ctx.connRegistry.get(connectionId)?.transport.send({
-      type: 'reconnected',
-      sessions: summaries,
-    });
-
-    span.setStatus({ code: SpanStatusCode.OK });
-  } catch (err: unknown) {
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err instanceof Error ? err.message : 'unknown',
-    });
-    span.recordException(err instanceof Error ? err : new Error(String(err)));
-    throw err;
-  } finally {
-    span.end();
-  }
+    },
+  );
 }
 
 export function handleWatch(connectionId: string, msg: WatchMsg, ctx: V2HandlerContext): void {
@@ -247,84 +222,60 @@ export async function handleSwitchSession(
   msg: SwitchSessionMsg,
   ctx: V2HandlerContext,
 ): Promise<void> {
-  const span = tracer.startSpan('ws.switch_session');
-  span.setAttribute('ws.connectionId', connectionId);
-  span.setAttribute('ws.sessionId', msg.sessionId ?? 'null');
+  return withSpanAsync(
+    'ws.switch_session',
+    { 'ws.connectionId': connectionId, 'ws.sessionId': msg.sessionId ?? 'null' },
+    async (span) => {
+      if (msg.sessionId === null) {
+        const prev = ctx.connRegistry.get(connectionId)?.activeSession;
+        if (prev) {
+          ctx.connRegistry.unwatch(connectionId, prev);
+        }
+        ctx.connRegistry.setActive(connectionId, null);
+        ctx.connRegistry.get(connectionId)?.transport.send({ type: 'session_cleared' });
+        return;
+      }
 
-  try {
-    // null sessionId = clear active session and stop watching it so
-    // broadcast events from the old session don't leak into a new chat.
-    // Trade-off: background permission prompts for the old session will
-    // no longer reach this client. Push notifications (ntfy/Pushover)
-    // still fire, so the user is notified externally. The alternative
-    // (keeping the watch) caused session bleed when switching to a new
-    // chat — the old session's events leaked through the client-side
-    // filter during the window when currentSessionId is null.
-    if (msg.sessionId === null) {
+      let sessionMeta = ctx.eventStore.getSession(msg.sessionId);
+
+      if (!sessionMeta) {
+        span.setAttribute('ws.discovery', 'sdk_fallback');
+        sessionMeta = await discoverSession(msg.sessionId);
+      }
+
+      if (!sessionMeta) {
+        ctx.connRegistry.get(connectionId)?.transport.send({
+          type: 'error',
+          error: `Session not found: ${msg.sessionId}`,
+        });
+        return;
+      }
+
       const prev = ctx.connRegistry.get(connectionId)?.activeSession;
-      if (prev) {
+      if (prev && prev !== msg.sessionId) {
         ctx.connRegistry.unwatch(connectionId, prev);
       }
-      ctx.connRegistry.setActive(connectionId, null);
-      ctx.connRegistry.get(connectionId)?.transport.send({ type: 'session_cleared' });
-      span.setStatus({ code: SpanStatusCode.OK });
-      return;
-    }
+      ctx.connRegistry.setActive(connectionId, msg.sessionId);
 
-    let sessionMeta = ctx.eventStore.getSession(msg.sessionId);
-
-    // Fallback: if EventStore doesn't know the session, try discovering it
-    // via the Claude SDK. This handles sessions orphaned by server restarts
-    // or created by external agents.
-    if (!sessionMeta) {
-      span.setAttribute('ws.discovery', 'sdk_fallback');
-      sessionMeta = await discoverSession(msg.sessionId);
-    }
-
-    if (!sessionMeta) {
-      span.setStatus({ code: SpanStatusCode.ERROR, message: 'session not found' });
       ctx.connRegistry.get(connectionId)?.transport.send({
-        type: 'error',
-        error: `Session not found: ${msg.sessionId}`,
+        type: 'session_switched',
+        sessionId: msg.sessionId,
+        mode: sessionMeta.mode,
+        cwd: sessionMeta.cwd,
+        branch: sessionMeta.branch,
+        wtId: sessionMeta.wtId,
+        tokens: {
+          input: sessionMeta.inputTokens,
+          output: sessionMeta.outputTokens,
+          cacheRead: sessionMeta.cacheReadTokens,
+          cacheCreation: sessionMeta.cacheCreationTokens,
+          costUsd: sessionMeta.totalCostUsd,
+        },
       });
-      return;
-    }
 
-    const prev = ctx.connRegistry.get(connectionId)?.activeSession;
-    if (prev && prev !== msg.sessionId) {
-      ctx.connRegistry.unwatch(connectionId, prev);
-    }
-    ctx.connRegistry.setActive(connectionId, msg.sessionId);
-
-    // Synchronous metadata delivery — design doc §2.2 "no zero-flash"
-    ctx.connRegistry.get(connectionId)?.transport.send({
-      type: 'session_switched',
-      sessionId: msg.sessionId,
-      mode: sessionMeta.mode,
-      cwd: sessionMeta.cwd,
-      branch: sessionMeta.branch,
-      wtId: sessionMeta.wtId,
-      tokens: {
-        input: sessionMeta.inputTokens,
-        output: sessionMeta.outputTokens,
-        cacheRead: sessionMeta.cacheReadTokens,
-        cacheCreation: sessionMeta.cacheCreationTokens,
-        costUsd: sessionMeta.totalCostUsd,
-      },
-    });
-
-    span.setStatus({ code: SpanStatusCode.OK });
-    log.info('switch_session', { connectionId, sessionId: msg.sessionId });
-  } catch (err: unknown) {
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err instanceof Error ? err.message : 'unknown',
-    });
-    span.recordException(err instanceof Error ? err : new Error(String(err)));
-    throw err;
-  } finally {
-    span.end();
-  }
+      log.info('switch_session', { connectionId, sessionId: msg.sessionId });
+    },
+  );
 }
 
 export function handleSendV2(
@@ -333,195 +284,172 @@ export function handleSendV2(
   msg: SendMsg,
   ctx: V2HandlerContext,
 ): void {
-  const span = tracer.startSpan('ws.send');
-  span.setAttribute('ws.connectionId', connectionId);
-  span.setAttribute('ws.sessionId', msg.sessionId ?? 'new');
+  withSpan(
+    'ws.send',
+    { 'ws.connectionId': connectionId, 'ws.sessionId': msg.sessionId ?? 'new' },
+    (span) => {
+      try {
+        const rawCwd = msg.cwd || BASE_REPO;
+        const cwd = rawCwd && isAllowedPath(rawCwd) ? rawCwd : BASE_REPO;
+        const skillRegistry = buildSkillRegistry(cwd);
+        const resolution = resolveSlashCommand(msg.prompt, skillRegistry, NATIVE_COMMAND_NAMES);
 
-  try {
-    const rawCwd = msg.cwd || BASE_REPO;
-    const cwd = rawCwd && isAllowedPath(rawCwd) ? rawCwd : BASE_REPO;
-    const skillRegistry = buildSkillRegistry(cwd);
-    const resolution = resolveSlashCommand(msg.prompt, skillRegistry, NATIVE_COMMAND_NAMES);
-
-    if (resolution.type === 'native') {
-      const result = ctx.nativeCommands.execute(
-        resolution.name,
-        resolution.arguments,
-        skillRegistry,
-      );
-      if (result) {
-        transport.send({
-          type: 'native_command_result',
-          v: 2,
-          command: result.command,
-          content: result.content,
-        });
-      }
-      span.setStatus({ code: SpanStatusCode.OK });
-      return;
-    }
-
-    if (resolution.type === 'error') {
-      transport.send({ type: 'error', error: resolution.message });
-      span.setStatus({ code: SpanStatusCode.OK });
-      return;
-    }
-
-    const prompt = resolution.type === 'skill' ? resolution.renderedPrompt : msg.prompt;
-    const skillAllowedTools = resolution.type === 'skill' ? resolution.allowedTools : undefined;
-
-    if (resolution.type === 'skill') {
-      transport.send({
-        type: 'skill_invoked',
-        v: 2,
-        name: resolution.name,
-        source: skillRegistry.get(resolution.name)?.scope || 'bundled',
-        arguments: resolution.arguments,
-        ...(resolution.collisions ? { collisions: resolution.collisions } : {}),
-      });
-    }
-
-    // Helper: apply skill policy to the correct session clientId.
-    // Must be called AFTER startChat registers the session.
-    const applySkillPolicy = (targetClientId: string) => {
-      if (skillAllowedTools) {
-        setSkillPolicy(ctx.sessionRegistry, targetClientId, skillAllowedTools);
-      } else {
-        clearSkillPolicy(ctx.sessionRegistry, targetClientId);
-      }
-    };
-
-    const sessionId = msg.sessionId;
-
-    if (sessionId) {
-      // Resume existing session
-      const found = ctx.sessionRegistry.findBySessionId(sessionId);
-      if (found && isActive(found.clientId)) {
-        // Cross-reference with durable EventStore: the in-memory registry
-        // keeps entries alive during the detach TTL window even after the
-        // query loop has ended. markSessionInactive() in the query loop's
-        // finally block is ground truth.
-        const storeMeta = ctx.eventStore.getSession(sessionId);
-        const staleInMemory = storeMeta && !storeMeta.isActive;
-
-        if (staleInMemory) {
-          log.info('removing stale session from registry (send)', {
-            connectionId,
-            sessionId,
-            clientId: found.clientId,
-          });
-          ctx.sessionRegistry.remove(found.clientId);
-          // Fall through to resume path below — session is not truly active.
-        } else {
-          const ownerConnection = getOwnerConnection(found.clientId);
-          const isOwner = ownerConnection === connectionId;
-          const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
-
-          // Takeover: transfer ownership regardless of whether the session is
-          // detached, the owner is gone, or actively attached elsewhere. Explicit
-          // user action (send) always wins — reconnect stays passive (R1).
-          let activeClientId = found.clientId;
-          if (!isOwner) {
-            const oldTransport = found.session?.transport;
-            if (oldTransport?.isOpen()) {
-              oldTransport.send({ type: 'session_takeover', sessionId });
-            }
-            ctx.connRegistry.unwatch(ownerConnection, sessionId);
-            denyPendingBySession(sessionId);
-
-            reattachChat(found.clientId, transport);
-            const newClientId = `${connectionId}:${sessionId}`;
-            if (found.clientId !== newClientId) {
-              rekeyChat(found.clientId, newClientId);
-              activeClientId = newClientId;
-            }
-            log.info('takeover on send', {
-              connectionId,
-              sessionId,
-              oldOwner: ownerConnection,
-              newClientId: activeClientId,
-            });
-          } else if (isDetached) {
-            reattachChat(found.clientId, transport);
-            log.info('reattached own detached session on send', {
-              connectionId,
-              sessionId,
+        if (resolution.type === 'native') {
+          const result = ctx.nativeCommands.execute(
+            resolution.name,
+            resolution.arguments,
+            skillRegistry,
+          );
+          if (result) {
+            transport.send({
+              type: 'native_command_result',
+              v: 2,
+              command: result.command,
+              content: result.content,
             });
           }
-          applySkillPolicy(activeClientId);
-          sendToChat(activeClientId, prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
-          ctx.connRegistry.watch(connectionId, sessionId);
-          ctx.connRegistry.setActive(connectionId, sessionId);
-          span.setAttribute('routing.decision', isOwner ? 'active' : 'takeover');
-          span.setStatus({ code: SpanStatusCode.OK });
           return;
         }
+
+        if (resolution.type === 'error') {
+          transport.send({ type: 'error', error: resolution.message });
+          return;
+        }
+
+        const prompt = resolution.type === 'skill' ? resolution.renderedPrompt : msg.prompt;
+        const skillAllowedTools = resolution.type === 'skill' ? resolution.allowedTools : undefined;
+
+        if (resolution.type === 'skill') {
+          transport.send({
+            type: 'skill_invoked',
+            v: 2,
+            name: resolution.name,
+            source: skillRegistry.get(resolution.name)?.scope || 'bundled',
+            arguments: resolution.arguments,
+            ...(resolution.collisions ? { collisions: resolution.collisions } : {}),
+          });
+        }
+
+        const applySkillPolicy = (targetClientId: string) => {
+          if (skillAllowedTools) {
+            setSkillPolicy(ctx.sessionRegistry, targetClientId, skillAllowedTools);
+          } else {
+            clearSkillPolicy(ctx.sessionRegistry, targetClientId);
+          }
+        };
+
+        const sessionId = msg.sessionId;
+
+        if (sessionId) {
+          const found = ctx.sessionRegistry.findBySessionId(sessionId);
+          if (found && isActive(found.clientId)) {
+            const storeMeta = ctx.eventStore.getSession(sessionId);
+            const staleInMemory = storeMeta && !storeMeta.isActive;
+
+            if (staleInMemory) {
+              log.info('removing stale session from registry (send)', {
+                connectionId,
+                sessionId,
+                clientId: found.clientId,
+              });
+              ctx.sessionRegistry.remove(found.clientId);
+            } else {
+              const ownerConnection = getOwnerConnection(found.clientId);
+              const isOwner = ownerConnection === connectionId;
+              const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
+
+              let activeClientId = found.clientId;
+              if (!isOwner) {
+                const oldTransport = found.session?.transport;
+                if (oldTransport?.isOpen()) {
+                  oldTransport.send({ type: 'session_takeover', sessionId });
+                }
+                ctx.connRegistry.unwatch(ownerConnection, sessionId);
+                denyPendingBySession(sessionId);
+
+                reattachChat(found.clientId, transport);
+                const newClientId = `${connectionId}:${sessionId}`;
+                if (found.clientId !== newClientId) {
+                  rekeyChat(found.clientId, newClientId);
+                  activeClientId = newClientId;
+                }
+                log.info('takeover on send', {
+                  connectionId,
+                  sessionId,
+                  oldOwner: ownerConnection,
+                  newClientId: activeClientId,
+                });
+              } else if (isDetached) {
+                reattachChat(found.clientId, transport);
+                log.info('reattached own detached session on send', {
+                  connectionId,
+                  sessionId,
+                });
+              }
+              applySkillPolicy(activeClientId);
+              sendToChat(activeClientId, prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
+              ctx.connRegistry.watch(connectionId, sessionId);
+              ctx.connRegistry.setActive(connectionId, sessionId);
+              span.setAttribute('routing.decision', isOwner ? 'active' : 'takeover');
+              return;
+            }
+          }
+
+          const sessionClientId = `${connectionId}:${sessionId}`;
+          ctx.connRegistry.watch(connectionId, sessionId);
+          ctx.connRegistry.setActive(connectionId, sessionId);
+          span.setAttribute('routing.decision', 'resume');
+          startChat(transport, sessionClientId, prompt, {
+            resume: sessionId,
+            cwd: msg.cwd,
+            model: msg.model,
+            extraTools: msg.extraTools,
+            isolation: msg.isolation,
+            mode: msg.mode,
+            images: msg.images,
+            contextBlocks: msg.contextBlocks,
+            clientMsgId: msg.clientMsgId,
+          });
+          applySkillPolicy(sessionClientId);
+        } else {
+          const sessionClientId = `${connectionId}:new-${randomUUID().slice(0, 8)}`;
+          span.setAttribute('routing.decision', 'create');
+          const onSessionResolved = (resolvedId: string) => {
+            ctx.connRegistry.watch(connectionId, resolvedId);
+            ctx.connRegistry.setActive(connectionId, resolvedId);
+          };
+          startChat(transport, sessionClientId, prompt, {
+            cwd: msg.cwd,
+            model: msg.model,
+            extraTools: msg.extraTools,
+            isolation: msg.isolation,
+            mode: msg.mode,
+            images: msg.images,
+            contextBlocks: msg.contextBlocks,
+            clientMsgId: msg.clientMsgId,
+            onSessionResolved,
+          });
+          applySkillPolicy(sessionClientId);
+        }
+      } catch (err: unknown) {
+        span.recordException(err instanceof Error ? err : new Error(String(err)));
+        transport.send({
+          type: 'error',
+          error: err instanceof Error ? err.message : 'Send failed',
+        });
       }
-
-      // Session exists in store but no active driver — start with resume.
-      // Use a per-session clientId so multiple sessions from the same v2
-      // connection each get their own registry entry (prevents overwrites).
-      const sessionClientId = `${connectionId}:${sessionId}`;
-      ctx.connRegistry.watch(connectionId, sessionId);
-      ctx.connRegistry.setActive(connectionId, sessionId);
-      span.setAttribute('routing.decision', 'resume');
-      startChat(transport, sessionClientId, prompt, {
-        resume: sessionId,
-        cwd: msg.cwd,
-        model: msg.model,
-        extraTools: msg.extraTools,
-        isolation: msg.isolation,
-        mode: msg.mode,
-        images: msg.images,
-        contextBlocks: msg.contextBlocks,
-        clientMsgId: msg.clientMsgId,
-      });
-      applySkillPolicy(sessionClientId);
-    } else {
-      // null sessionId — new session. Use a unique clientId so concurrent
-      // new-session starts don't collide in the registry.
-      const sessionClientId = `${connectionId}:new-${randomUUID().slice(0, 8)}`;
-      span.setAttribute('routing.decision', 'create');
-      const onSessionResolved = (resolvedId: string) => {
-        ctx.connRegistry.watch(connectionId, resolvedId);
-        ctx.connRegistry.setActive(connectionId, resolvedId);
-      };
-      startChat(transport, sessionClientId, prompt, {
-        cwd: msg.cwd,
-        model: msg.model,
-        extraTools: msg.extraTools,
-        isolation: msg.isolation,
-        mode: msg.mode,
-        images: msg.images,
-        contextBlocks: msg.contextBlocks,
-        clientMsgId: msg.clientMsgId,
-        onSessionResolved,
-      });
-      applySkillPolicy(sessionClientId);
-    }
-
-    span.setStatus({ code: SpanStatusCode.OK });
-  } catch (err: unknown) {
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err instanceof Error ? err.message : 'unknown',
-    });
-    span.recordException(err instanceof Error ? err : new Error(String(err)));
-    transport.send({
-      type: 'error',
-      error: err instanceof Error ? err.message : 'Send failed',
-    });
-  } finally {
-    span.end();
-  }
+    },
+  );
 }
 
 export function handleStopV2(connectionId: string, msg: StopMsg, ctx: V2HandlerContext): void {
-  const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
-  if (found) {
-    stopChat(found.clientId);
-    log.info('stop', { connectionId, sessionId: msg.sessionId });
-  }
+  withSpan('ws.stop', { 'ws.connectionId': connectionId, 'ws.sessionId': msg.sessionId }, () => {
+    const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
+    if (found) {
+      stopChat(found.clientId);
+      log.info('stop', { connectionId, sessionId: msg.sessionId });
+    }
+  });
 }
 
 export function handleInterruptV2(
@@ -530,74 +458,75 @@ export function handleInterruptV2(
   msg: InterruptMsg,
   ctx: V2HandlerContext,
 ): void {
-  const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
-  if (!found) return;
+  withSpan(
+    'ws.interrupt',
+    { 'ws.connectionId': connectionId, 'ws.sessionId': msg.sessionId },
+    () => {
+      const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
+      if (!found) return;
 
-  let activeClientId = found.clientId;
+      let activeClientId = found.clientId;
 
-  // Ownership guard: reject if another connection actively drives this session
-  if (isActive(found.clientId)) {
-    // Cross-reference with durable EventStore to catch stale in-memory state.
-    const storeMeta = ctx.eventStore.getSession(msg.sessionId);
-    const staleInMemory = storeMeta && !storeMeta.isActive;
+      if (isActive(found.clientId)) {
+        const storeMeta = ctx.eventStore.getSession(msg.sessionId);
+        const staleInMemory = storeMeta && !storeMeta.isActive;
 
-    if (staleInMemory) {
-      log.info('removing stale session from registry (interrupt)', {
-        connectionId,
-        sessionId: msg.sessionId,
-        clientId: found.clientId,
-      });
-      ctx.sessionRegistry.remove(found.clientId);
-      // Session is not truly active — fall through to resume path below.
-    } else {
-      const ownerConnection = getOwnerConnection(found.clientId);
-      const isOwner = ownerConnection === connectionId;
-      const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
+        if (staleInMemory) {
+          log.info('removing stale session from registry (interrupt)', {
+            connectionId,
+            sessionId: msg.sessionId,
+            clientId: found.clientId,
+          });
+          ctx.sessionRegistry.remove(found.clientId);
+        } else {
+          const ownerConnection = getOwnerConnection(found.clientId);
+          const isOwner = ownerConnection === connectionId;
+          const isDetached = !ctx.sessionRegistry.isAttached(found.clientId);
 
-      // Takeover: explicit user action (interrupt) always wins — same as send.
-      if (!isOwner) {
-        const oldTransport = found.session?.transport;
-        if (oldTransport?.isOpen()) {
-          oldTransport.send({ type: 'session_takeover', sessionId: msg.sessionId });
+          if (!isOwner) {
+            const oldTransport = found.session?.transport;
+            if (oldTransport?.isOpen()) {
+              oldTransport.send({ type: 'session_takeover', sessionId: msg.sessionId });
+            }
+            ctx.connRegistry.unwatch(ownerConnection, msg.sessionId);
+            denyPendingBySession(msg.sessionId);
+
+            reattachChat(found.clientId, transport);
+            const newClientId = `${connectionId}:${msg.sessionId}`;
+            if (found.clientId !== newClientId) {
+              rekeyChat(found.clientId, newClientId);
+              activeClientId = newClientId;
+            }
+            log.info('takeover on interrupt', {
+              connectionId,
+              sessionId: msg.sessionId,
+              oldOwner: ownerConnection,
+              newClientId: activeClientId,
+            });
+          } else if (isDetached) {
+            reattachChat(found.clientId, transport);
+          }
+
+          ctx.connRegistry.watch(connectionId, msg.sessionId);
+          ctx.connRegistry.setActive(connectionId, msg.sessionId);
+          interruptChat(activeClientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
+          log.info('interrupt', { connectionId, sessionId: msg.sessionId });
+          return;
         }
-        ctx.connRegistry.unwatch(ownerConnection, msg.sessionId);
-        denyPendingBySession(msg.sessionId);
-
-        reattachChat(found.clientId, transport);
-        const newClientId = `${connectionId}:${msg.sessionId}`;
-        if (found.clientId !== newClientId) {
-          rekeyChat(found.clientId, newClientId);
-          activeClientId = newClientId;
-        }
-        log.info('takeover on interrupt', {
-          connectionId,
-          sessionId: msg.sessionId,
-          oldOwner: ownerConnection,
-          newClientId: activeClientId,
-        });
-      } else if (isDetached) {
-        reattachChat(found.clientId, transport);
       }
 
+      const sessionClientId = `${connectionId}:${msg.sessionId}`;
       ctx.connRegistry.watch(connectionId, msg.sessionId);
       ctx.connRegistry.setActive(connectionId, msg.sessionId);
-      interruptChat(activeClientId, msg.prompt, msg.images, msg.contextBlocks, msg.clientMsgId);
-      log.info('interrupt', { connectionId, sessionId: msg.sessionId });
-      return;
-    }
-  }
-
-  // Session is either idle or stale — resume with a fresh driver.
-  const sessionClientId = `${connectionId}:${msg.sessionId}`;
-  ctx.connRegistry.watch(connectionId, msg.sessionId);
-  ctx.connRegistry.setActive(connectionId, msg.sessionId);
-  startChat(transport, sessionClientId, msg.prompt, {
-    resume: msg.sessionId,
-    images: msg.images,
-    contextBlocks: msg.contextBlocks,
-    clientMsgId: msg.clientMsgId,
-  });
-  log.info('interrupt_resume', { connectionId, sessionId: msg.sessionId });
+      startChat(transport, sessionClientId, msg.prompt, {
+        resume: msg.sessionId,
+        images: msg.images,
+        contextBlocks: msg.contextBlocks,
+        clientMsgId: msg.clientMsgId,
+      });
+      log.info('interrupt_resume', { connectionId, sessionId: msg.sessionId });
+    },
+  );
 }
 
 export function handlePermissionResponseV2(
@@ -605,12 +534,22 @@ export function handlePermissionResponseV2(
   msg: PermissionMsg,
   _ctx: V2HandlerContext,
 ): void {
-  resolvePending(msg.permId, msg.decision ?? 'deny');
-  log.info('permission_response', {
-    connectionId,
-    sessionId: msg.sessionId,
-    permId: msg.permId,
-  });
+  withSpan(
+    'ws.permission_response',
+    {
+      'ws.connectionId': connectionId,
+      'ws.sessionId': msg.sessionId ?? '',
+      'ws.permId': msg.permId,
+    },
+    () => {
+      resolvePending(msg.permId, msg.decision ?? 'deny');
+      log.info('permission_response', {
+        connectionId,
+        sessionId: msg.sessionId,
+        permId: msg.permId,
+      });
+    },
+  );
 }
 
 export function handleSetModeV2(
@@ -618,22 +557,27 @@ export function handleSetModeV2(
   msg: SetModeMsg,
   ctx: V2HandlerContext,
 ): void {
-  const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
-  if (!found) {
-    log.warn('set_mode: session not found', { connectionId, sessionId: msg.sessionId });
-    return;
-  }
+  withSpan(
+    'ws.set_mode',
+    { 'ws.connectionId': connectionId, 'ws.sessionId': msg.sessionId, 'ws.mode': msg.mode },
+    () => {
+      const found = ctx.sessionRegistry.findBySessionId(msg.sessionId);
+      if (!found) {
+        log.warn('set_mode: session not found', { connectionId, sessionId: msg.sessionId });
+        return;
+      }
 
-  ctx.sessionRegistry.setMode(found.clientId, msg.mode);
+      ctx.sessionRegistry.setMode(found.clientId, msg.mode);
 
-  // Broadcast to all watchers of this session
-  ctx.connRegistry.broadcast(msg.sessionId, {
-    type: 'mode_changed',
-    sessionId: msg.sessionId,
-    mode: msg.mode,
-  });
+      ctx.connRegistry.broadcast(msg.sessionId, {
+        type: 'mode_changed',
+        sessionId: msg.sessionId,
+        mode: msg.mode,
+      });
 
-  log.info('set_mode', { connectionId, sessionId: msg.sessionId, mode: msg.mode });
+      log.info('set_mode', { connectionId, sessionId: msg.sessionId, mode: msg.mode });
+    },
+  );
 }
 
 // ─── Dispatcher ──────────────────────────────────────────────────────────────

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -34,6 +34,7 @@ type PermissionMsg = z.infer<typeof V2PermissionResponseMessage>;
 type SetModeMsg = z.infer<typeof V2SetModeMessage>;
 import { randomUUID } from 'crypto';
 import { withSpan, withSpanAsync } from './tracing.js';
+import { SpanStatusCode } from '@opentelemetry/api';
 import { resolvePending, denyPendingBySession } from './permissions.js';
 import {
   startChat,
@@ -432,7 +433,9 @@ export function handleSendV2(
           applySkillPolicy(sessionClientId);
         }
       } catch (err: unknown) {
-        span.recordException(err instanceof Error ? err : new Error(String(err)));
+        const message = err instanceof Error ? err.message : String(err);
+        span.recordException(err instanceof Error ? err : new Error(message));
+        span.setStatus({ code: SpanStatusCode.ERROR, message });
         transport.send({
           type: 'error',
           error: err instanceof Error ? err.message : 'Send failed',


### PR DESCRIPTION
## Summary

- Fix broken OTel context propagation — spans were created but never set as active context, so zero log lines carried `trace_id`. Add `withSpan`/`withSpanAsync` helpers and migrate all span sites across `ws-handler-v2.ts`, `index.ts`, `query-loop.ts`, and `chat.ts`.
- Add per-turn and per-tool child spans in the query loop for Jaeger drill-down: `session` → `turn` → `tool.Bash`.
- Add spans for all chat entry points (`chat.start`, `chat.send`, `chat.interrupt`, `session.detach/reattach/rekey/closeout`) and previously untraced WS handlers (`ws.stop`, `ws.interrupt`, `ws.permission_response`, `ws.set_mode`).
- Add provisioned Grafana dashboard (8 panels: log stream, volume by level/module, errors, WS ops, session lifecycle, traces table, trace-correlated logs).
- Fix Loki config (`delete_request_store` required for retention on newer versions).
- Add `restart: always` to all compose services.

## Test plan

- [x] `withSpan`/`withSpanAsync` unit tests (9 tests): context propagation, error recording, parent inheritance
- [x] All existing `ws-handler-v2.test.ts` tests pass (3378 tests)
- [x] All existing `query-loop.test.ts` tests pass (1942 tests)
- [x] `chat.test.ts`, `send-to-chat.test.ts`, `reattach-isolation.test.ts`, `multi-client-sessions.test.ts` pass
- [x] E2E verified: Jaeger receives `mitzo` traces, Loki logs carry `trace_id` matching Jaeger, Grafana dashboard renders

Made with [Cursor](https://cursor.com)