### PR TITLE
docs: add session isolation design docs

### DIFF
--- a/docs/design/session-isolation-counter-proposal.md
+++ b/docs/design/session-isolation-counter-proposal.md
@@ -1,0 +1,523 @@
+# Session Isolation Counter Proposal
+
+**Status:** Proposed
+**Date:** 2026-04-22
+**Author:** GPT-5.4 + Dimitri
+**Counter to:** `docs/design/session-isolation-overhaul.md`
+
+## Goal
+
+Build a session system that can sustain 5+ parallel Mitzo sessions across 11 configured repos with:
+
+- Zero session bleed
+- Deterministic session ownership across phone, laptop, and browser tabs
+- Real workspace isolation for both tracked files and runtime state
+- Reliable resume after disconnect, iOS background, or server restart
+- Predictable cleanup and recovery semantics
+- Full observability of the session control plane and workspace lifecycle
+
+This proposal assumes correctness, determinism, and debuggability matter more than startup time, disk usage, implementation effort, or operational cost.
+
+## Thesis
+
+The current overhaul proposal improves several real bugs, but it still optimizes around the existing shape of the system:
+
+- session identity is still entangled with connection identity
+- git worktrees remain the primary isolation primitive
+- secondary repo provisioning becomes lazy and policy-driven
+- reconnect is allowed to become a takeover path
+- missing runtime state is patched with symlinks
+
+That keeps a lot of hidden coupling in place.
+
+My counter-proposal is to optimize for the simplest system to reason about, not the cheapest system to run:
+
+1. Make session identity durable and independent from WebSocket connections.
+2. Make connection attachment explicit instead of inferred from reconnect behavior.
+3. Give every session a fully provisioned workspace bundle up front.
+4. Stop relying on git worktree tricks for runtime availability.
+5. Make resume depend on a durable session record plus a durable workspace manifest.
+
+The core idea is:
+
+> A Mitzo session should be a durable object with a stable ID, a stable workspace bundle, and explicit attachment semantics. Connections come and go. Workspaces do not.
+
+## Why This Is A Counter Proposal
+
+The existing design doc treats the main job as "fix the current worktree-based system so it behaves." This proposal treats the main job as "pick the most deterministic architecture for the goal, even if it is heavier."
+
+That leads to two major changes:
+
+1. **Do the deferred identity work now.**
+   The current doc defers decoupling session identity from connection identity. I think that is foundational, not optional.
+
+2. **Replace worktree-centric isolation with session sandboxes.**
+   If cost and effort are not constraints, a fully provisioned per-session workspace is easier to reason about than a dynamic mesh of worktrees, lazy creation, redirects, and symlinked runtime state.
+
+## Design Principles
+
+### 1. Session identity is durable
+
+A session is not a WebSocket, not a transport, and not a composite `connectionId:sessionId` key.
+
+It is a durable record with:
+
+- a stable `session_id`
+- a durable `sdk_session_id` when the SDK assigns one
+- a durable lifecycle state
+- a durable workspace bundle manifest
+- a current driver attachment, if any
+
+### 2. Connections are ephemeral
+
+Connections may disconnect, reconnect, or multiply. That should not rewrite ownership semantics by accident.
+
+### 3. Ownership changes are explicit
+
+Reconnect should reattach a connection that already owns the session. It should not silently steal the session from another active device. Takeover should be a deliberate state transition.
+
+### 4. Provisioning should be deterministic
+
+If the system knows a session may work across 11 repos, provision the full session workspace once and keep it stable for the life of the session. Do not hide repo creation behind a write denial path.
+
+### 5. Runtime state must be isolated too
+
+If `.venv` or `node_modules` are needed, each session gets its own copy or clone of them. Do not reintroduce shared mutable state through symlinks just to make executables visible.
+
+### 6. Resume should be honest
+
+If the session can be resumed, resume it against the real workspace. If it cannot, say so clearly and preserve the transcript. Never fake resume by pointing the SDK at a different CWD.
+
+### 7. Observability should trace state transitions, not just request entry points
+
+The important events are session attach, detach, takeover, provision, recovery, permission routing, cleanup, and query-loop transitions.
+
+## Proposed System
+
+## 1. Stable Session Control Plane
+
+Introduce a durable `SessionRecord` that is the canonical session object.
+
+Suggested fields:
+
+- `session_id`
+- `sdk_session_id`
+- `state`
+- `mode`
+- `summary`
+- `workspace_bundle_id`
+- `driver_attachment_id`
+- `current_snapshot`
+- `tokens`
+- `cost_usd`
+- `created_at`
+- `updated_at`
+
+Session states should be explicit. A simple model is enough:
+
+- `provisioning`
+- `active`
+- `detached`
+- `recovering`
+- `closing`
+- `closed`
+- `recovery_failed`
+
+The in-memory registry becomes a cache of live session handles, not the source of truth.
+
+### Why this matters
+
+Today the system still uses composite client IDs and transport-driven ownership rules. That is why reconnect, detach, and send paths keep needing special-case logic. If `session_id` is the stable key, those branches get much simpler.
+
+## 2. Explicit Attachment Model
+
+Introduce a separate `AttachmentRecord` for each browser tab or device attachment.
+
+Suggested fields:
+
+- `attachment_id`
+- `session_id`
+- `connection_id`
+- `role` (`driver` or `observer`)
+- `client_instance_id`
+- `last_seq`
+- `attached_at`
+- `detached_at`
+
+Rules:
+
+1. A session has at most one `driver` attachment.
+2. A reconnect from the same logical client instance may reattach as driver.
+3. A different client instance may attach as observer by default.
+4. A takeover is an explicit transition:
+   - old driver downgraded to observer or detached
+   - pending permissions for the old driver cancelled
+   - new driver assigned
+   - user-visible event emitted
+
+### Consequence
+
+`handleReconnect()` becomes passive. It restores the same attachment. It does not decide ownership policy for a different device.
+
+That is a much safer model than "latest connection always wins," especially on mobile where reconnects are automatic and frequent.
+
+## 3. Session Workspace Bundles, Not Git Worktrees
+
+Every session gets a **workspace bundle** at creation time containing all configured repos.
+
+Suggested layout:
+
+```text
+<state-root>/sessions/<session-id>/
+  manifest.json
+  repos/
+    primary/
+    repo-a/
+    repo-b/
+    ...
+```
+
+Each repo entry is a **standalone sandbox repo**, not a git worktree. The safest implementation is:
+
+1. create a clean standalone local clone from the source repo
+2. create or checkout branch `session/<session-id>`
+3. copy or clone allowed runtime directories into that repo
+4. record the resulting paths in the workspace manifest
+
+On macOS, runtime directories can use APFS copy-on-write cloning for speed and space efficiency. On other systems, a real copy is acceptable because cost is not a constraint.
+
+### Why not git worktrees?
+
+Because the current problem set is not only about branch isolation. It is about the total session environment:
+
+- tracked files
+- ignored runtime directories
+- repo-local executables
+- predictable paths
+- durable recovery
+- no collisions
+
+Standalone sandboxes give cleaner guarantees:
+
+- no shared git index
+- no shared working tree metadata
+- no worktree path collisions
+- no need for lazy secondary creation
+- no need for symlinked `.venv` or `node_modules`
+
+### Runtime policy
+
+Runtime directories should be **copied**, not symlinked.
+
+Examples:
+
+- `.venv`
+- `node_modules`
+- `.tox`
+- `.bundle`
+- `vendor`
+
+This is intentionally expensive. The benefit is that agents can mutate their environment without affecting other sessions.
+
+### Source of truth
+
+The bundle manifest should store, per repo:
+
+- source repo path
+- sandbox path
+- branch
+- runtime overlays copied
+- creation time
+- last validation time
+
+## 4. Eager Provisioning Of All Configured Repos
+
+Provision all configured repos at session start.
+
+Do not make secondary repo creation lazy.
+
+Do not trigger repo creation inside the worktree guard.
+
+Do not depend on a deny-and-retry loop to materialize the session workspace.
+
+### Why
+
+Lazy provisioning is attractive when startup cost matters. In this proposal, startup cost does not matter. Determinism does.
+
+Eager provisioning gives you:
+
+- one stable path table for the whole session
+- one stable system prompt for the whole session
+- one stable set of env vars for the whole session
+- no policy gap between "repo is configured" and "repo exists"
+- no need to teach the guard to create infrastructure during tool evaluation
+
+It also removes an entire class of bugs where the session's idea of its workspace changes halfway through a turn.
+
+## 5. Guard Rails Become Simpler
+
+With workspace bundles, mutating tool policy becomes much simpler:
+
+- writes must target one of the sandbox repo roots
+- shell commands must execute with `working_directory` inside a sandbox root
+- absolute and relative paths are resolved against known sandbox roots
+
+This is easier than trying to map "base repo path" to "worktree path that might not exist yet."
+
+The system prompt can also be stricter:
+
+- do your work inside the session bundle
+- use the provided repo path table
+- do not write to base repos
+
+Read-only access to base repos can still be allowed if needed for reference, but it is no longer required for normal operation because every configured repo already exists in the bundle.
+
+## 6. Resume And Recovery
+
+Resume should be driven by the durable session record plus the workspace manifest.
+
+Recovery flow:
+
+1. Load `SessionRecord`
+2. Load workspace manifest
+3. Validate each sandbox path exists and is still a git repo
+4. Validate the primary repo path still matches the session record
+5. Rebuild the in-memory session handle
+6. Reattach the correct driver attachment if the same client returns
+7. Replay events and snapshot state from the event store
+
+If validation fails:
+
+- do **not** point the SDK at `BASE_REPO`
+- do **not** pass `resume` with a fake CWD
+- mark the session `recovery_failed`
+- keep transcript and metadata intact
+- surface a clear user-facing recovery message
+
+If the workspace is missing but the system is allowed to rebuild it, it may rebuild the bundle from the manifest and then attempt resume. That rebuild must happen before calling the SDK.
+
+## 7. Query Lifetime And Workspace Lifetime Are Separate
+
+The query loop may end many times during the life of a session. The workspace bundle should not.
+
+That means:
+
+- no cleanup in the `startChat()` `finally` path
+- no deleting secondary repos between turns
+- detached sessions keep their workspace
+- explicit close or GC owns cleanup
+
+This is a major simplification compared to the current behavior where query-loop boundaries and workspace lifetime are still partially coupled.
+
+## 8. Permission Routing
+
+Permissions belong to the current driver attachment, not to whichever connection happens to be watching the session.
+
+Rules:
+
+1. Only the driver attachment receives live permission prompts.
+2. On explicit takeover:
+   - cancel outstanding permissions for the old driver
+   - emit timeout/cancel events to that client
+   - transfer future prompts to the new driver
+3. Observers never become permission owners implicitly.
+
+This avoids another hidden coupling in the current design, where watches, active session selection, and permission delivery still partially overlap.
+
+## 9. Observability
+
+Instrument the actual state transitions.
+
+Recommended spans:
+
+- `session.create`
+- `session.attach`
+- `session.detach`
+- `session.takeover`
+- `session.recover`
+- `session.recover.validate`
+- `workspace.bundle.create`
+- `workspace.bundle.validate`
+- `workspace.bundle.cleanup`
+- `permission.request`
+- `permission.cancel`
+- `query.run`
+- `query.resume`
+- `query.finish`
+
+Recommended log fields on every relevant event:
+
+- `session_id`
+- `sdk_session_id`
+- `workspace_bundle_id`
+- `attachment_id`
+- `connection_id`
+- `role`
+- `repo_name`
+- `sandbox_path`
+- `state`
+
+This makes Grafana and Jaeger useful for forensic debugging instead of just showing entry-point spans.
+
+## 10. Cleanup And Retention
+
+Cleanup should be state-driven.
+
+Rules:
+
+- `closed` sessions enter a retention window
+- `detached` sessions do not lose their workspace until detach TTL expires
+- dirty session bundles are never deleted silently
+- dirty bundles are surfaced for rescue or explicit approval
+
+Suggested separation:
+
+- **detach TTL**: when to stop trying to preserve an idle live session
+- **bundle retention TTL**: when to clean up a closed session's sandbox
+
+Those are different concepts and should not share the same cleanup path.
+
+## Pros
+
+### 1. Stronger isolation
+
+This model isolates:
+
+- session identity
+- transport ownership
+- repo contents
+- runtime state
+
+That is much closer to the actual goal than branch-only isolation.
+
+### 2. Simpler mental model
+
+Each session has:
+
+- one durable session record
+- one durable workspace bundle
+- one explicit driver
+- zero or more observers
+
+That is much easier to explain and debug than composite IDs plus watch sets plus lazy worktree creation plus runtime symlinks.
+
+### 3. Executables work without cheating
+
+You do not need to pretend isolation exists while all sessions share the same `.venv` or `node_modules`.
+
+### 4. Resume is more honest and more reliable
+
+Recovery either finds the real workspace bundle or it does not. There is no fake fallback CWD.
+
+### 5. Guard logic is less heuristic
+
+Because the full session workspace exists from the start, the guard no longer has to create infrastructure while deciding whether to allow a tool call.
+
+### 6. Better observability
+
+State transitions become first-class events instead of side effects buried in reconnect and send handlers.
+
+## Cons
+
+### 1. Much heavier provisioning
+
+Creating full sandbox repos for all configured repos is far more expensive than worktrees.
+
+### 2. Higher disk usage
+
+If runtime directories are copied, the storage footprint can be substantial, especially with 11 repos and multiple concurrent sessions.
+
+### 3. More up-front engineering
+
+This is not a patch-on-top-of-current-state change. It is a control-plane redesign plus a workspace model change.
+
+### 4. More lifecycle bookkeeping
+
+Bundle manifests, attachment records, and explicit state transitions require new persistence and cleanup code.
+
+### 5. Runtime overlay policy must be curated
+
+If the system copies too much, it drags along junk. If it copies too little, tools still fail. The allowlist needs to be deliberate.
+
+## Why I Prefer This System
+
+Because it optimizes for the exact thing you said matters: accomplishing the goal, regardless of cost.
+
+The current overhaul still carries too much of the old architecture forward:
+
+- transport-shaped ownership
+- worktree-centered isolation
+- lazy materialization of secondary repos
+- symlink-based runtime sharing
+- reconnect as a policy decision point
+
+Those choices are reasonable if the top priority is minimizing startup time, disk, and implementation delta.
+
+They are not the choices I would make if the top priority is:
+
+- zero bleed
+- deterministic ownership
+- honest resume
+- clean debugging
+- true isolation
+
+This counter-proposal is heavier, but it is cleaner. It replaces multiple interacting heuristics with a more explicit model:
+
+- stable session objects
+- stable workspace bundles
+- explicit attachments
+- explicit takeovers
+- explicit recovery states
+
+That is why I would choose it.
+
+## Direct Comparison With The Current Overhaul Proposal
+
+### Current overhaul proposal
+
+**Strengths**
+
+- smaller delta from current code
+- preserves git worktree UX
+- cheaper startup and lower disk cost
+- fixes several real bugs directly
+
+**Weaknesses**
+
+- still postpones the identity problem
+- adds more behavior into the guard path
+- reconnect policy remains overloaded
+- runtime symlinks weaken isolation
+- session workspace can still change shape mid-flight
+
+### This counter-proposal
+
+**Strengths**
+
+- clearer control-plane model
+- stronger workspace isolation
+- no lazy repo materialization
+- no worktree collisions
+- better recovery semantics
+
+**Weaknesses**
+
+- much more expensive
+- larger refactor
+- requires new persistence structures
+
+## Recommendation
+
+If you want the most reliable architecture for the stated goal, I would do this instead of trying to perfect the current worktree-centered design.
+
+If you want a lower-risk incremental path, then the best subset to steal from this proposal is:
+
+1. decouple session identity from connection identity first
+2. make reconnect passive
+3. separate query lifetime from workspace lifetime
+4. keep provisioning eager, not lazy
+5. never share mutable runtime directories across sessions
+
+But if the constraint is truly "whatever best accomplishes the goal is on the table," then my actual recommendation is:
+
+**Build stable session records plus eager per-session sandbox bundles, and treat transport as an attachment layer on top.**

--- a/docs/design/session-isolation-overhaul.md
+++ b/docs/design/session-isolation-overhaul.md
@@ -1,0 +1,590 @@
+# Session Isolation Overhaul — Design Doc
+
+**Status:** Approved (pending implementation)
+**Date:** 2026-04-22
+**Author:** Claude Opus 4.6 + Dimitri
+**Reviewed by:** Cursor agent (see `canvases/session-isolation-overhaul-review.canvas.tsx` and `canvases/session-isolation-counter-proposal.canvas.tsx`)
+**Prior art:** `~/.claude/plans/linear-stirring-hopcroft.md` + its `-review.md`, `~/.cursor/plans/session_resilience_fix_480a9f51.plan.md`, `~/.cursor/plans/session_identity_redesign_173f16be.plan.md`, `~/.cursor/plans/ws_session_architecture_fix_7226b2c5.plan.md`
+
+---
+
+## Goal
+
+5+ parallel Mitzo sessions working across 11 configured repos with zero conflicts:
+
+- Zero session bleed (events from session A never appear in session B)
+- Zero worktree collisions (concurrent sessions don't race on creation)
+- Working executables in worktrees (`.venv`, `node_modules` discoverable)
+- Reliable resume after disconnect, iOS background, or server restart
+- Deterministic ownership (reconnect is passive; takeover is explicit)
+- Full observability via Grafana (logs) + Jaeger (traces)
+
+---
+
+## Problems (confirmed from log forensics 2026-04-22)
+
+### P1. Watch Accumulation → Session Bleed
+
+`handleSwitchSession` in `server/ws-handler-v2.ts` L244-323 calls `connRegistry.setActive(connectionId, msg.sessionId)` at L292, which implicitly adds a watch. But it **never unwatches the previous session**. Unwatching only happens on `switch_session(null)` (L262-270). Over a browsing session, the connection accumulates watches for every session visited (confirmed: last connection in logs watched 5 sessions). All watched sessions broadcast events to the single WebSocket. The client-side filter (`store.ts` L644-658) has race windows that let foreign events through — especially during the null-`currentSessionId` gap between `newSession()` and receiving `session_id`.
+
+On the client side, `MitzoConnection.seqBySession` (`packages/client/src/connection.ts` L29) tracks sequence numbers per session for reconnect replay. `clearSession()` exists at L105 but is **never called** from the store. So on every reconnect, the client sends a `reconnect` message listing every session it's ever seen, causing the server to re-watch all of them.
+
+### P2. Reconnect Storm
+
+388 total WS connections in one server lifecycle, only 6 completed v2 handshake. 382 fell to v1 after 5s `HANDSHAKE_TIMEOUT_MS` (`server/index.ts` L235). Two bursts: 191 in 197ms (pre-restart stale), 188 in 241ms (post-restart reconnect). These consume heartbeat timers and memory.
+
+### P3. Worktree ID Collision
+
+`generateWtId()` in `server/chat.ts` L117-121 uses `randomBytes(3)` (16M values). Concurrent sessions race on the same date prefix. Confirmed in logs: "fatal: path already exists". The `createWorktree` function at `server/worktree.ts` L46-101 handles the "already exists" case by trying without `-b`, but when TWO sessions race for the same repo path, one gets a corrupt state.
+
+### P4. Missing Executables
+
+Gitignored dirs (`.venv`, `node_modules`) don't exist in worktrees. Agents can't find Python, Node, etc. The `sdkEnv()` function in `server/chat.ts` L169-193 already prepends venv paths to `PATH`, but tools that resolve executables relative to CWD (e.g. `./node_modules/.bin/vitest`) still fail.
+
+### P5. Stale Registry Entries
+
+In `server/ws-handler-v2.ts`, `handleReconnect` (L145-154), `handleSendV2` (L398-408), and `handleInterruptV2` (L546-556) all detect when EventStore says `is_active=false` but SessionRegistry has an entry. They correct a local `running` variable but **never call `registry.remove()`**. The stale entry blocks subsequent operations until the 48h detach TTL fires (from `packages/harness/src/constants.ts` L15: `DETACHED_TTL_MS = 172_800_000`).
+
+### P6. Resume Breaks
+
+`resolveResumeCwd()` in `server/chat.ts` L87-114 falls back to `BASE_REPO` when the original worktree CWD is gone, but keeps `resume: sessionId`. The Claude SDK encodes session paths by CWD — when CWD doesn't match, it throws "No conversation found". The client parser (`packages/client/src/protocol-parser.ts` L344) matches this string and calls `onSessionExpired()`, which wipes messages and navigates away — jarring UX.
+
+### P7. Eager Worktree Creation
+
+`createSessionWorktrees()` in `server/chat.ts` L235-293 creates worktrees for ALL configured repos at session start. With 11 repos and 5 sessions = 55 worktree dirs, most never used. 449 accumulated dirs found on disk.
+
+### P8. Observability Gap
+
+`LOKI_HOST` is commented out in `.env` — Grafana has no log data. OTel tracing (`server/tracing.ts`) is configured but only 3 spans exist: `ws.send`, `ws.reconnect`, `ws.switch_session` in `server/ws-handler-v2.ts`. Zero coverage of query-loop, detach/reattach, resume, stale correction. The deep instrumentation roadmap at `docs/design/otel-deep-instrumentation.md` has not been implemented.
+
+---
+
+## Review Responses
+
+The design was reviewed against the codebase (see `canvases/session-isolation-overhaul-review.canvas.tsx`). Five findings were raised. Each is addressed below.
+
+### R1. (HIGH) Reconnect should stay passive — accepted
+
+**Finding**: The original proposal forced takeover in `handleReconnect`, but reconnects are automatic (iOS foreground, network recovery). A stale background device could steal an actively-used session without user intent.
+
+**Resolution**: Agreed. `handleReconnect` stays **passive**: reattach only if the owner connection is gone (current behavior). Auto-takeover only on **explicit user actions**: `handleSendV2` and `handleInterruptV2`. This means: reconnect → observe; send/interrupt → take ownership. The user on the old device sees a `session_takeover` event and gets a clean "Session resumed on another device" message.
+
+**Impact on implementation**: Phase 1.2 is split. The `handleReconnect` code at L156-192 keeps its existing ownership check (`isOwner || ownerGone`). Only `handleSendV2` (L419-429) and `handleInterruptV2` (L563-571) get the takeover logic.
+
+### R2. (HIGH) Lazy guard cannot reliably drive on-demand creation — partially accepted
+
+**Finding**: `checkWorktreePolicy()` (`packages/harness/src/worktree-guard.ts` L80-143) only sees `file_path` fields and absolute paths parsed from shell commands. It misses `working_directory`, relative paths, and `cd`-based navigation.
+
+**Resolution**: The guard IS reliable for write-path tools (Write, Edit, StrReplace) which have explicit `file_path` fields — these are the tools that actually modify files. For Bash/Shell, the heuristic parser (`extractAbsolutePaths` at L25-38) is incomplete but catches the common case. To cover the gap:
+
+1. Primary worktree: **always** created eagerly at session start
+2. Secondary worktrees for write tools: created on-demand via the guard (reliable for file-path tools)
+3. For Bash/Shell targeting new repos: the agent can use `$MITZO_REPO_<NAME>` env vars (already injected by `sdkEnv()` at L548-549 of `chat.ts`) which point to worktree paths once created
+4. Explicit escape hatch: the system prompt tells the agent it can request worktree creation via a system message if the guard misses it
+
+The counter-proposal's "eager all repos" approach re-introduces Problem 7 (55 worktrees). The hybrid approach — eager primary, lazy secondary via guard + explicit request — is the right tradeoff.
+
+### R3. (MEDIUM) Symlinks reintroduce shared mutable state — accepted with caveats
+
+**Finding**: Symlinking `.venv` means `pip install` in one session affects all others.
+
+**Resolution**: Runtime symlinks are an **opt-in escape hatch**, not part of the core isolation guarantee. The design doc must explicitly document the shared-state tradeoff. Implementation:
+
+1. **Primary mechanism**: `PATH` injection (already exists in `sdkEnv()` at L185-187 of `chat.ts`)
+2. **Secondary mechanism**: Configurable symlink allowlist in `.mitzo.json` (`runtimeSymlinks` field). Default empty — user opts in per repo.
+3. **Documentation**: System prompt includes warning: "Symlinked runtime dirs are shared across sessions. Don't install/upgrade packages in a worktree session."
+
+This means executables are found via `PATH` (no shared state), and symlinks are only for repos where `PATH` isn't enough (e.g., tools that resolve via CWD-relative paths).
+
+### R4. (MEDIUM) Reattach alone is not enough for takeover — accepted
+
+**Finding**: After takeover, the old connection still watches the session in ConnectionRegistry. Pending permissions are keyed by `permId` only.
+
+**Resolution**: Takeover becomes a full state transition:
+
+1. Send `session_takeover` to old transport
+2. **Unwatch the session from the old connection** in ConnectionRegistry (`connRegistry.unwatch(oldConnectionId, sessionId)`)
+3. Auto-deny pending permissions for the session (add `denyPendingBySession(sessionId)` to `server/permissions.ts` — the `pendingPermissions` Map at L15 already stores the toolName per permId; need to add sessionId tracking)
+4. Reattach transport to new connection
+
+**Impact on implementation**: The `permissions.ts` module needs a new `registerPending` overload or field that associates permissions with a sessionId. The `buildPermissionHandler` at `packages/harness/src/permission-handler.ts` L111 already receives `clientId` — pass the sessionId through.
+
+### R5. (MEDIUM) Shorter handshake timeout is only partial — accepted
+
+**Finding**: 1s timeout still falls unknown sockets into v1 path. Weak protocol boundary.
+
+**Resolution**: Change `routeWsClient` at `server/index.ts` L234-263:
+
+1. If first message is valid JSON and a hello → v2 path (current behavior)
+2. If first message is valid JSON but NOT hello → v1 path (current behavior, for legacy)
+3. If first message is invalid JSON → **close immediately** (new)
+4. If **no message within 1s** → **close immediately** (new — don't fall through to v1)
+
+v1 clients that still need support must send their first message within 1s. In practice, all current clients are v2. The v1 path is kept only for backward compat during transition, not as a catch-all for dead sockets.
+
+---
+
+## Architecture Decision: Git Worktrees
+
+Alternatives evaluated: pre-warmed pool (divergence problem), shallow clones (too heavy — 2-5s per repo), OverlayFS (macOS doesn't have it), APFS clones (awkward git workflow), file guard only (no parallelism). See full comparison table in prior version.
+
+**Decision**: Git worktrees remain the isolation substrate. They give each session its own branch, working directory, and git index. Creation cost ~200ms. The implementation needs to be bulletproof — which is what this doc addresses.
+
+**Enforcement**: Every tool call goes through `canUseTool()` → `buildPermissionHandler()` (`packages/harness/src/permission-handler.ts` L44-146) → `checkWorktreePolicy()` (`packages/harness/src/worktree-guard.ts` L80-143). Write tools check `file_path`; shell tools parse absolute paths. Reads are unrestricted.
+
+---
+
+## Phase 1: Fix the WS Plumbing (one PR, one branch)
+
+> Prerequisite: read CLAUDE.md for TDD workflow, git workflow (never push to main), and ESM import conventions.
+
+### 1.0 Enable Observability
+
+**What**: Uncomment `LOKI_HOST=http://localhost:3200` in `.env`. Add OTel spans to critical session lifecycle paths.
+
+**Where**: `.env` (one line), `server/query-loop.ts`, `server/chat.ts`, `server/ws-handler-v2.ts`, `server/index.ts`
+
+**OTel spans to add** (use existing `tracer` from `server/tracing.ts` L44):
+
+| Span name                 | File                                  | Wraps                                | Key attributes                                                  |
+| ------------------------- | ------------------------------------- | ------------------------------------ | --------------------------------------------------------------- |
+| `session`                 | `query-loop.ts` L115                  | Entire `runQueryLoop()`              | `session.id`, `session.clientId`, `session.cwd`, `session.mode` |
+| `session.turn`            | `query-loop.ts` (on `message_start`)  | message_start → message_end          | `turn.index`, `turn.messageId`                                  |
+| `session.resume.validate` | `chat.ts` (new `validateResumable()`) | CWD validation + worktree recreation | `resume.sessionId`, `resume.cwdExists`, `resume.recreated`      |
+| `session.detach`          | `index.ts` L314-323                   | v2 WS close detach loop              | `session.sessionId`, `ws.connectionId`                          |
+
+Span events (not separate spans): `session.stale_correction` when EventStore disagrees with registry, `session.takeover` when ownership transfers.
+
+**Why first**: Without observability, debugging the remaining fixes is blind. Loki gives searchable logs (`{app="mitzo", module="ws-v2"}`), Jaeger gives trace correlation.
+
+### 1.1 Clean Up Stale Registry Entries
+
+**What**: When detecting stale sessions, actually remove them from the registry instead of just correcting a local variable.
+
+**Where**: `server/ws-handler-v2.ts` — three locations:
+
+- `handleReconnect` L145-154 (the `if (staleInMemory)` block)
+- `handleSendV2` L398-408 (same pattern)
+- `handleInterruptV2` L546-556 (same pattern)
+
+**Current code** (all three sites are identical in structure):
+
+```typescript
+if (staleInMemory) {
+  log.info('corrected stale running state from EventStore', { ... });
+  // Fall through to resume path
+}
+```
+
+**New code**:
+
+```typescript
+if (staleInMemory) {
+  log.info('removing stale session from registry', {
+    connectionId,
+    sessionId,
+    clientId: found.clientId,
+  });
+  ctx.sessionRegistry.remove(found.clientId);
+  // Fall through to resume path — session will be re-created by startChat()
+}
+```
+
+**Test contract**: Given a session in SessionRegistry with `isActive=true` but EventStore `is_active=false`, when `handleReconnect` processes that session, then `registry.get(found.clientId)` returns `undefined` after the call.
+
+### 1.2 Auto-Takeover on Send/Interrupt (NOT on reconnect)
+
+**What**: Replace `active_elsewhere` rejection with forced ownership transfer, but ONLY on explicit user actions (send, interrupt). Reconnect stays passive per review finding R1.
+
+**Where**:
+
+- `server/ws-handler-v2.ts` `handleSendV2` L415-463 — replace the `if (!isOwner && !isDetached && !ownerGone)` rejection block
+- `server/ws-handler-v2.ts` `handleInterruptV2` L558-594 — same pattern
+- `server/ws-handler-v2.ts` `handleReconnect` L156-192 — **NO CHANGE** (stays passive)
+- `server/permissions.ts` — add `denyPendingBySession(sessionId)` function
+- `packages/client/src/protocol-parser.ts` L328-340 — remove `active_elsewhere` handler, add `session_takeover` handler
+- `packages/client/src/slices/messages.ts` — no new action type needed; `session_takeover` uses existing `ERROR` action with a friendly message + `SET_RUNNING` false
+
+**Takeover sequence** (in handleSendV2):
+
+1. Get old transport from session: `const oldTransport = found.session.transport`
+2. Get old connection ID: `const oldConnectionId = getOwnerConnection(found.clientId)`
+3. Send `session_takeover` to old transport (if open)
+4. Unwatch session from old connection: `ctx.connRegistry.unwatch(oldConnectionId, sessionId)` — **R4 fix**
+5. Auto-deny pending permissions: `denyPendingBySession(sessionId)` — **R4 fix**
+6. Reattach: `reattachChat(found.clientId, transport)`
+7. Rekey: `rekeyChat(found.clientId, newClientId)`
+8. Continue to `sendToChat()`
+
+**Test contracts**:
+
+- Given session owned by conn-A, when conn-B sends to that session, then: conn-A receives `session_takeover`, session transport is now conn-B, pending permissions are denied, conn-A no longer watches the session.
+- Given session owned by conn-A, when conn-B reconnects listing that session, then: session stays with conn-A (passive reconnect), conn-B reports `running: true` but does NOT take over.
+
+**Existing tests to update** (~8 in `server/__tests__/ws-handler-v2.test.ts`):
+
+- L1468-1498: "rejects send when session is active on another connection" → "takeover on send"
+- L1600-1629: "still rejects when EventStore confirms session IS active" → "takeover when active"
+- L1873-1898: "rejects interrupt when active on another connection" → "takeover on interrupt"
+- L1954-2005, L2007-2048, L2050-2087: rekey tests → update for takeover flow
+- L1852-1868: `getOwnerConnection` tests → keep (still used)
+
+### 1.3 Client Reconnect Message Recovery
+
+**What**: After any WS reconnect, always re-fetch messages for the active session from the REST API.
+
+**Where**: `packages/client/src/protocol-parser.ts` — `reconnected` case (L113-115), and `store.ts` — `_foreground` handler (L611-634)
+
+**Current behavior**: `reconnected` just sets `connectionUpdate: { status: 'connected' }`. The `_foreground` handler only re-fetches if `messages.length === 0 && !current`.
+
+**New behavior**:
+
+1. In `protocol-parser.ts`, `reconnected` case: add callback `callbacks.onReconnected?.()`
+2. In `store.ts` `wsListener`, handle the callback:
+   ```typescript
+   onReconnected() {
+     const activeId = parserState.currentSessionId;
+     if (activeId) {
+       api.getSessionMessages(activeId).then(msgs => {
+         if (Array.isArray(msgs) && msgs.length > 0) {
+           store.setState(s => ({
+             messages: messagesReducer(s.messages, { type: 'RESTORE', messages: msgs })
+           }));
+         }
+       }).catch(() => {});
+     }
+   }
+   ```
+3. In `_foreground` handler (L614): remove the `messages.length === 0 && !current` guard.
+
+**Test contract**: Given a store with `sessions.active = 'sess-1'` and `messages.messages = [staleMsg]`, when `reconnected` event arrives, then `api.getSessionMessages('sess-1')` is called regardless of existing message count.
+
+### 1.4 Eliminate Session Bleed
+
+**What**: Two-layer fix. Server stops accumulating watches. Client stops accumulating `seqBySession` entries.
+
+**Server** — `server/ws-handler-v2.ts` `handleSwitchSession` L292:
+
+```typescript
+// NEW: unwatch previous session before setting new active
+const prev = ctx.connRegistry.get(connectionId)?.activeSession;
+if (prev && prev !== msg.sessionId) {
+  ctx.connRegistry.unwatch(connectionId, prev);
+}
+ctx.connRegistry.setActive(connectionId, msg.sessionId);
+```
+
+**Client** — `packages/client/src/store.ts`:
+
+In `switchSession()` (L202):
+
+```typescript
+async switchSession(id: string) {
+  const oldId = parserState.currentSessionId;
+  if (oldId) connection.clearSession(oldId);  // NEW
+  parserState.currentSessionId = id;
+  // ... rest unchanged
+}
+```
+
+In `newSession()` (L227):
+
+```typescript
+newSession() {
+  // NEW: clear all session tracking to prevent reconnect from re-watching
+  for (const sid of connection.getTrackedSessions()) {
+    connection.clearSession(sid);
+  }
+  parserState.currentSessionId = undefined;
+  // ... rest unchanged
+}
+```
+
+Need to add `getTrackedSessions(): string[]` to `MitzoConnection` (returns `Array.from(this.seqBySession.keys())`).
+
+**Client** — `packages/client/src/store.ts` L644-658 (event filter):
+
+Current filter allows `session_id`, `session_end`, and `permission_request` when `currentSessionId` is null. Tighten to only `session_id`:
+
+```typescript
+if (!parserState.currentSessionId) {
+  const isAssignment = msg.type === 'session_id';
+  if (!isAssignment) return; // drop everything else
+}
+```
+
+**Test contracts**:
+
+- Server: Given connection watching sessions A and B, when `switch_session(C)` arrives, then connection watches only C (A and B unwatched).
+- Client: Given `seqBySession` has entries for sessions A and B, when `switchSession('C')` is called, then `seqBySession` has only C. When `newSession()` is called, `seqBySession` is empty.
+- Client filter: Given `currentSessionId = null`, when `session_end` event with `sessionId = 'foreign'` arrives, then it is dropped (not dispatched to store).
+
+### 1.5 Fix Reconnect Storm
+
+**What**: Close dead sockets immediately instead of falling through to v1.
+
+**Where**: `server/index.ts` `routeWsClient` L234-263
+
+**Current**: 5s timeout → fall through to `handleChatWs` (v1 handler).
+
+**New**:
+
+```typescript
+const HANDSHAKE_TIMEOUT_MS = 1_000;
+
+const timer = setTimeout(() => {
+  ws.removeListener('message', onFirstMessage);
+  // NEW: close dead sockets instead of routing to v1
+  log.info('no hello received, closing dead connection', { connectionId: assignedId });
+  ws.close(4000, 'No hello received');
+}, HANDSHAKE_TIMEOUT_MS);
+
+const onFirstMessage = (raw) => {
+  clearTimeout(timer);
+  ws.removeListener('message', onFirstMessage);
+  let parsed;
+  try {
+    parsed = JSON.parse(raw.toString());
+  } catch {
+    // NEW: invalid JSON → close immediately (was: fall to v1)
+    ws.close(4001, 'Invalid handshake');
+    return;
+  }
+  if (isHelloHandshake(parsed)) {
+    handleChatWsV2(ws, assignedId);
+  } else {
+    handleChatWs(ws, assignedId, raw); // genuine v1 client
+  }
+};
+```
+
+Also add 30s idle timeout to `handleChatWs` (after L455): if no message arrives within 30s after the first message, close the connection.
+
+**Test contract**: Given a WS that connects but sends nothing, after 1s it receives close code 4000. Given a WS that sends invalid JSON, it receives close code 4001 immediately.
+
+### 1.6 Validate Session Resumability
+
+**What**: Before calling SDK `query()` with `resume`, validate the CWD is a real git directory.
+
+**Where**: `server/chat.ts` — new function `validateResumable()`, called from `startChat()` before the `query()` call at L573.
+
+```typescript
+export function validateResumable(
+  cwd: string,
+  resumeId: string,
+): { valid: boolean; recreated?: boolean } {
+  // Check if CWD is a valid git worktree or repo
+  try {
+    execFileSync('git', ['-C', cwd, 'rev-parse', '--git-dir'], { stdio: 'pipe', timeout: 5000 });
+    return { valid: true };
+  } catch {
+    // CWD is not a git directory — try to recreate the worktree
+    const wtMatch = cwd.match(/\/(\.claude|\.cursor)\/worktrees\/([^/]+)$/);
+    if (wtMatch) {
+      const [, prefix, wtId] = wtMatch;
+      const repoRoot = cwd.slice(0, cwd.indexOf(`/${prefix}/worktrees/`));
+      try {
+        createWorktree(wtId, repoRoot, { prefix: prefix as '.claude' | '.cursor' });
+        return { valid: true, recreated: true };
+      } catch {
+        return { valid: false };
+      }
+    }
+    return { valid: false };
+  }
+}
+```
+
+In `startChat()`, after `resolveResumeCwd()` and before `query()`:
+
+```typescript
+if (options.resume) {
+  const validation = validateResumable(cwd, options.resume);
+  if (!validation.valid) {
+    log.warn('session not resumable, starting fresh', { sessionId: options.resume, cwd });
+    send(transport, {
+      type: 'error',
+      error: 'Session workspace was cleaned up. Starting a new conversation.',
+    });
+    // Remove resume option — start fresh
+    delete options.resume;
+  }
+}
+```
+
+Also wrap the `query()` call at L573 in a try/catch:
+
+```typescript
+try {
+  const q = query({ ... });
+} catch (err) {
+  if (err.message?.includes('No conversation found') && options.resume) {
+    log.warn('SDK rejected resume, retrying without resume', { sessionId: options.resume });
+    send(transport, { type: 'error', error: 'Session expired. Starting fresh.' });
+    // Retry without resume (recursive call or inline retry)
+  }
+  throw err;
+}
+```
+
+**Test contracts**:
+
+- Given a CWD that is a valid git worktree, `validateResumable` returns `{ valid: true }`.
+- Given a CWD that was cleaned up but the repo root exists, `validateResumable` recreates the worktree and returns `{ valid: true, recreated: true }`.
+- Given a CWD that cannot be recreated, `validateResumable` returns `{ valid: false }` and `startChat` sends an error and starts without resume.
+
+---
+
+## Phase 2: Bulletproof Worktree Isolation (separate PR, separate branch)
+
+### 2a. Lazy Worktree Creation
+
+**Where**: `server/chat.ts` `createSessionWorktrees()` L235-293, `packages/harness/src/worktree-guard.ts` `checkWorktreePolicy()` L80-143
+
+**Change to `createSessionWorktrees()`**: Only create primary worktree. Remove the loop over `config.repos` at L271-285.
+
+**Change to `checkWorktreePolicy()`**: When a write tool targets a configured repo that has no worktree:
+
+1. Identify the repo from the path (check against `config.repos` values)
+2. Call `createWorktreeAsync(session.wtId, repoPath)` — new async function in `worktree.ts`
+3. Call `symlinkRuntimeDirs(repoPath, worktreePath)` — if opt-in
+4. Add to `session.worktreePaths`
+5. Broadcast `worktree_opened` event to client
+6. Return deny with redirect (same as current behavior — agent retries with worktree path)
+
+**Important**: The guard's `canUseTool` callback is async (`buildPermissionHandler` returns `Promise<PermissionResult>`), so calling an async `createWorktreeAsync` is safe. But `checkWorktreePolicy` is currently sync — it needs to become async or the creation needs to happen in the permission handler wrapper.
+
+**System prompt change** in `buildWorktreeSystemPrompt()` (`chat.ts` L330-352): List secondary repos as available with a note like "Worktrees for secondary repos are created on first write. Use `$MITZO_REPO_<NAME>` env vars."
+
+### 2b. Collision-Proof IDs
+
+**Where**: `server/chat.ts` `generateWtId()` L117-121
+
+Change from `randomBytes(3).toString('hex')` (6 hex chars) to `randomUUID().slice(0, 12)` (12 hex chars). Also add a `.mitzo-session` lockfile inside each worktree containing the wtId and creation timestamp.
+
+### 2c. Runtime Symlinks (opt-in)
+
+**Where**: `server/worktree.ts` — new `symlinkRuntimeDirs()`, `server/repo-config.ts` — parse `runtimeSymlinks` from `.mitzo.json`
+
+Default: **empty** (no symlinks). User opts in per repo:
+
+```json
+{ "runtimeSymlinks": [".venv", "node_modules"] }
+```
+
+Primary mechanism remains `PATH` injection via `sdkEnv()`. Symlinks are the escape hatch for CWD-relative tool resolution. The design doc and system prompt must warn: "Symlinked runtime dirs are shared mutable state across sessions."
+
+### 2d. Resume-Aware Worktree Rebuild
+
+**Where**: `server/worktree.ts` — new `discoverSessionWorktrees()`, `server/chat.ts` — integrated into resume path
+
+On resume: scan disk for existing worktrees matching `<repo>/.claude/worktrees/<wtId>` across all configured repos. Rebuild `session.worktreePaths`. Recreate primary if gone. Don't recreate secondaries (lazy creation handles it).
+
+### 2e. Cleanup Only on Close
+
+**Where**: `server/chat.ts` L623-628 — remove `cleanupSessionWorktrees(session)` from the `finally` block.
+
+Worktrees survive until explicit close or stale GC. Reduce `WORKTREE_STALE_HOURS` from 96 to 24 (configurable in `.mitzo.json`).
+
+### 2f. Async Worktree Creation
+
+**Where**: `server/worktree.ts` — convert `createWorktree` from `execFileSync` to async.
+
+The on-demand path runs inside `canUseTool` which is async. `execFileSync` blocks the Node event loop, freezing ALL sessions during git operations.
+
+---
+
+## Frontend Changes
+
+### Phase 1 Frontend
+
+| #   | File                                                         | Change                                                                                                | Why                                                             |
+| --- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| F1  | `packages/client/src/store.ts` `switchSession()`             | Call `connection.clearSession(oldId)` before switching                                                | Prevents `seqBySession` accumulation → reconnect re-watch       |
+| F2  | `packages/client/src/store.ts` `newSession()`                | Clear all `seqBySession` entries                                                                      | Same reason; `getTrackedSessions()` method needed on connection |
+| F3  | `packages/client/src/store.ts` `wsListener`                  | Add `onReconnected` callback that re-fetches messages                                                 | iOS eviction loses in-memory state                              |
+| F4  | `packages/client/src/store.ts` `_foreground` handler         | Remove `messages.length === 0 && !current` guard                                                      | Always re-fetch, not just when empty                            |
+| F5  | `packages/client/src/protocol-parser.ts`                     | Add `session_takeover` case → `SET_RUNNING: false` + `ERROR` with "Session resumed on another device" | Old device needs clean exit on takeover                         |
+| F6  | `packages/client/src/protocol-parser.ts`                     | Remove `active_elsewhere` case (L328-340)                                                             | Dead code after server-side takeover                            |
+| F7  | `packages/client/src/store.ts` event filter (L644-658)       | When `currentSessionId` is null, only allow `session_id`                                              | Prevent foreign `session_end` from assigning wrong session      |
+| F8  | `packages/client/src/protocol-parser.ts` `error` case (L344) | Change "Session expired" from silent wipe to recoverable error message                                | Better UX — show "Start fresh?" button                          |
+| F9  | `packages/client/src/connection.ts`                          | Add `getTrackedSessions(): string[]` method                                                           | Needed by F2                                                    |
+| F10 | `frontend/src/types/ws-messages.ts`                          | Add `session_takeover` to `ServerMessage` union                                                       | Type safety                                                     |
+
+### Phase 2 Frontend
+
+| #   | File                                    | Change                                                             | Why                                                                   |
+| --- | --------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| F11 | `frontend/src/pages/ChatView.tsx`       | Dedicated `WorktreeError` component for worktree creation failures | Raw error string → recoverable "Retry" / "Continue without isolation" |
+| F12 | `frontend/src/components/ChatInput.tsx` | Show dynamic worktree count from `activeWorktrees[]`               | Visibility into lazy worktree creation                                |
+| F13 | `frontend/src/pages/SessionList.tsx`    | Worktree count indicator per session                               | Which sessions are multi-repo                                         |
+
+---
+
+## Test Plan (TDD per CLAUDE.md)
+
+### Phase 1
+
+| Test file                                           | Test description                                                                                         |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `server/__tests__/ws-handler-v2.test.ts`            | Stale session removed from registry on reconnect (not just local var corrected)                          |
+| `server/__tests__/ws-handler-v2.test.ts`            | Send to foreign-owned session → takeover (update ~8 existing `active_elsewhere` tests)                   |
+| `server/__tests__/ws-handler-v2.test.ts`            | Reconnect to foreign-owned session → passive (no takeover)                                               |
+| `server/__tests__/ws-handler-v2.test.ts`            | `session_takeover` sent to old transport on send-takeover                                                |
+| `server/__tests__/ws-handler-v2.test.ts`            | Old connection unwatched on takeover                                                                     |
+| `server/__tests__/ws-handler-v2.test.ts`            | Pending permissions denied on takeover                                                                   |
+| `server/__tests__/ws-handler-v2.test.ts`            | `switch_session(B)` unwatches previous session A                                                         |
+| `server/__tests__/ws-handler-v2.test.ts`            | Dead socket (no hello) closed after 1s (not routed to v1)                                                |
+| `packages/client/__tests__/store.test.ts`           | `switchSession()` calls `clearSession(oldId)`                                                            |
+| `packages/client/__tests__/store.test.ts`           | `newSession()` clears all tracked sessions                                                               |
+| `packages/client/__tests__/store.test.ts`           | `reconnected` event triggers message re-fetch for active session                                         |
+| `packages/client/__tests__/protocol-parser.test.ts` | `session_takeover` produces SET_RUNNING false + ERROR message                                            |
+| `packages/client/__tests__/protocol-parser.test.ts` | null-session filter drops foreign `session_end`                                                          |
+| `server/__tests__/chat.test.ts`                     | `validateResumable` returns valid for good CWD, recreates missing worktree, returns invalid for dead CWD |
+
+### Phase 2
+
+| Test file                                           | Test description                                                                     |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `server/__tests__/chat.test.ts`                     | Session start creates only primary worktree                                          |
+| `packages/harness/__tests__/worktree-guard.test.ts` | Write to uncovered configured repo triggers on-demand worktree creation              |
+| `server/__tests__/worktree.test.ts`                 | `symlinkRuntimeDirs` creates symlinks for existing dirs, skips missing               |
+| `server/__tests__/worktree.test.ts`                 | `discoverSessionWorktrees` finds worktrees across repos                              |
+| `server/__tests__/worktree.test.ts`                 | `createWorktreeAsync` does not block event loop                                      |
+| `server/__tests__/chat.test.ts`                     | Resume rebuilds `worktreePaths` from disk                                            |
+| `server/__tests__/chat.test.ts`                     | Collision-proof IDs: 100 concurrent `generateWtId()` calls produce 100 unique values |
+| `server/__tests__/chat.test.ts`                     | `finally` block does NOT call `cleanupSessionWorktrees`                              |
+
+---
+
+## Verification Checklist
+
+### Phase 1
+
+- [ ] Start session on phone, send message from laptop → seamless takeover, phone shows "resumed on another device"
+- [ ] Phone reconnects in background → passive (no takeover), laptop session uninterrupted
+- [ ] Background iOS app 5 min, return → messages visible (re-fetched)
+- [ ] Switch between 3 sessions rapidly → no bleed, connection watches only current session
+- [ ] Resume session with cleaned-up worktree → worktree recreated or clean "starting fresh" error
+- [ ] Grafana: `{app="mitzo"}` returns log data
+- [ ] Jaeger: `session`, `session.turn`, `session.detach` spans visible
+- [ ] Server restart → no 382-connection burst (dead sockets closed at 1s)
+
+### Phase 2
+
+- [ ] Start session → only primary worktree created
+- [ ] Agent writes to secondary repo → worktree created on-demand, retry succeeds
+- [ ] Agent runs `python` in worktree → found via PATH (or symlink if opted in)
+- [ ] 3 concurrent session starts → no wtId collision
+- [ ] Resume after stale GC → worktrees rebuilt from disk
+- [ ] Work in 3 repos, disconnect, resume → all 3 worktrees survive
+- [ ] Close session → all worktrees cleaned up, branches preserved
+- [ ] 5 parallel sessions → zero conflicts, zero bleed
+
+---
+
+## Deferred
+
+- **Session identity decoupling** (registry key = sessionId instead of `${connectionId}:${sessionId}`) — correct per `linear-stirring-hopcroft.md` Phase 2, but Phase 1 fixes the user-facing bugs without it
+- **Session state machine** (ACTIVE/SUSPENDED/CLOSED in EventStore) — architectural improvement, not blocking
+- **Frontend session state UI** (dots, explicit close) — separate concern


### PR DESCRIPTION
## Summary

Commits the two design documents that drove the session isolation overhaul:

- `session-isolation-overhaul.md` — the approved design (Phase 1 shipped in PR #278)
- `session-isolation-counter-proposal.md` — alternative approach from the review

These have been untracked since creation. Committing for posterity and so the Phase 2 handoff doc (#279) can reference them.

Made with [Cursor](https://cursor.com)