### PR TITLE
chore(infra): always-on observability stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@
 services:
   jaeger:
     image: jaegertracing/jaeger:latest
+    restart: always
     ports:
       - '4318:4318' # OTLP HTTP receiver (server + browser)
       - '16686:16686' # Jaeger UI
@@ -15,6 +16,7 @@ services:
 
   loki:
     image: grafana/loki:3.4.2
+    restart: always
     ports:
       - '3200:3100' # 3200 externally — 3100 conflicts with Mitzo server
     volumes:
@@ -23,6 +25,7 @@ services:
 
   grafana:
     image: grafana/grafana:12.4.1
+    restart: always
     ports:
       - '3001:3000'
     environment:

--- a/infra/com.mitzo.podman-machine.plist
+++ b/infra/com.mitzo.podman-machine.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.mitzo.podman-machine</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/podman</string>
+        <string>machine</string>
+        <string>start</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__MITZO_HOME__/logs/podman-machine-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__MITZO_HOME__/logs/podman-machine-stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/infra/loki-config.yaml
+++ b/infra/loki-config.yaml
@@ -2,6 +2,7 @@ auth_enabled: false
 
 server:
   http_listen_port: 3100
+  log_level: warn
 
 common:
   ring:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,21 @@ npm run build
 echo "Installing launchd plist..."
 sed "s|__MITZO_HOME__|${MITZO_HOME}|g" com.mitzo.server.plist > "$PLIST_DEST"
 
+# Install podman machine launchd agent
+PODMAN_PLIST_DEST="$HOME/Library/LaunchAgents/com.mitzo.podman-machine.plist"
+sed "s|__MITZO_HOME__|${MITZO_HOME}|g" infra/com.mitzo.podman-machine.plist > "$PODMAN_PLIST_DEST"
+launchctl bootout "gui/$(id -u)/com.mitzo.podman-machine" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PODMAN_PLIST_DEST"
+
+# Ensure podman machine is running before bringing up containers
+if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q Running; then
+  echo "Starting podman machine..."
+  podman machine start
+fi
+
+echo "Ensuring observability stack is running..."
+docker compose up -d
+
 echo "Restarting service..."
 # kickstart -k sends SIGTERM and waits for termination before restarting.
 launchctl kickstart -k "gui/$(id -u)/com.mitzo.server"


### PR DESCRIPTION
## Summary

- Add `restart: always` to Jaeger, Loki, and Grafana containers so they survive podman restarts
- Add a launchd agent (`com.mitzo.podman-machine`) to auto-start the podman machine on login
- `deploy.sh` now ensures podman machine + containers are up before restarting the Mitzo server
- Set Loki `log_level: warn` to suppress noisy query metric and gRPC scheduler logs

## Test plan

- [ ] Reboot Mac, verify podman machine starts automatically
- [ ] Verify Jaeger, Loki, Grafana containers come up with the machine
- [ ] Run `npm run deploy`, confirm observability stack is healthy before server starts
- [ ] Check `podman logs mitzo_loki_1` is quiet (no info-level query spam)

Made with [Cursor](https://cursor.com)