### PR TITLE
fix: address Centaur review findings from merged PRs

### DIFF
--- a/docs/design/session-isolation-counter-proposal.md
+++ b/docs/design/session-isolation-counter-proposal.md
@@ -1,6 +1,6 @@
 # Session Isolation Counter Proposal
 
-**Status:** Proposed
+**Status:** Proposed (Phase 1 of the overhaul has since shipped in PR #278, addressing several critiques below — see inline notes)
 **Date:** 2026-04-22
 **Author:** GPT-5.4 + Dimitri
 **Counter to:** `docs/design/session-isolation-overhaul.md`

--- a/docs/design/session-isolation-overhaul.md
+++ b/docs/design/session-isolation-overhaul.md
@@ -1,10 +1,10 @@
 # Session Isolation Overhaul — Design Doc
 
-**Status:** Approved (pending implementation)
+**Status:** Phase 1 implemented (PR #278, merged 2026-04-23). Phase 2 in progress (PR #280).
 **Date:** 2026-04-22
 **Author:** Claude Opus 4.6 + Dimitri
-**Reviewed by:** Cursor agent (see `canvases/session-isolation-overhaul-review.canvas.tsx` and `canvases/session-isolation-counter-proposal.canvas.tsx`)
-**Prior art:** `~/.claude/plans/linear-stirring-hopcroft.md` + its `-review.md`, `~/.cursor/plans/session_resilience_fix_480a9f51.plan.md`, `~/.cursor/plans/session_identity_redesign_173f16be.plan.md`, `~/.cursor/plans/ws_session_architecture_fix_7226b2c5.plan.md`
+**Reviewed by:** Cursor agent (review artifacts were generated as Cursor canvases during the design session, not committed to the repo)
+**Prior art:** Planning documents from earlier design sessions (local-only, not committed)
 
 ---
 
@@ -35,7 +35,7 @@ On the client side, `MitzoConnection.seqBySession` (`packages/client/src/connect
 
 ### P3. Worktree ID Collision
 
-`generateWtId()` in `server/chat.ts` L117-121 uses `randomBytes(3)` (16M values). Concurrent sessions race on the same date prefix. Confirmed in logs: "fatal: path already exists". The `createWorktree` function at `server/worktree.ts` L46-101 handles the "already exists" case by trying without `-b`, but when TWO sessions race for the same repo path, one gets a corrupt state.
+**[Fixed in Phase 1]** `generateWtId()` in `server/chat.ts` originally used `randomBytes(3)` (6 hex chars, 16M values). Concurrent sessions raced on the same date prefix. Fixed: now uses `randomUUID().replace(/-/g, '').slice(0, 12)` (12 hex chars, 4.8T values) with a `.mitzo-session` lockfile.
 
 ### P4. Missing Executables
 
@@ -43,7 +43,7 @@ Gitignored dirs (`.venv`, `node_modules`) don't exist in worktrees. Agents can't
 
 ### P5. Stale Registry Entries
 
-In `server/ws-handler-v2.ts`, `handleReconnect` (L145-154), `handleSendV2` (L398-408), and `handleInterruptV2` (L546-556) all detect when EventStore says `is_active=false` but SessionRegistry has an entry. They correct a local `running` variable but **never call `registry.remove()`**. The stale entry blocks subsequent operations until the 48h detach TTL fires (from `packages/harness/src/constants.ts` L15: `DETACHED_TTL_MS = 172_800_000`).
+**[Fixed in Phase 1]** In `server/ws-handler-v2.ts`, `handleReconnect`, `handleSendV2`, and `handleInterruptV2` originally detected when EventStore said `is_active=false` but SessionRegistry had an entry, correcting a local variable but never calling `registry.remove()`. Fixed: all three sites now call `ctx.sessionRegistry.remove(found.clientId)` to evict stale entries immediately.
 
 ### P6. Resume Breaks
 
@@ -104,10 +104,10 @@ This means executables are found via `PATH` (no shared state), and symlinks are 
 
 1. Send `session_takeover` to old transport
 2. **Unwatch the session from the old connection** in ConnectionRegistry (`connRegistry.unwatch(oldConnectionId, sessionId)`)
-3. Auto-deny pending permissions for the session (add `denyPendingBySession(sessionId)` to `server/permissions.ts` — the `pendingPermissions` Map at L15 already stores the toolName per permId; need to add sessionId tracking)
+3. **[Shipped in Phase 1]** Auto-deny pending permissions for the session via `denyPendingBySession(sessionId)` (already implemented in `packages/harness/src/permissions.ts`)
 4. Reattach transport to new connection
 
-**Impact on implementation**: The `permissions.ts` module needs a new `registerPending` overload or field that associates permissions with a sessionId. The `buildPermissionHandler` at `packages/harness/src/permission-handler.ts` L111 already receives `clientId` — pass the sessionId through.
+**Note**: `denyPendingBySession` and the session-scoped permission tracking are fully implemented in the harness package, not in `server/permissions.ts` (which is a thin re-export).
 
 ### R5. (MEDIUM) Shorter handshake timeout is only partial — accepted
 
@@ -458,9 +458,9 @@ try {
 
 ### 2b. Collision-Proof IDs
 
-**Where**: `server/chat.ts` `generateWtId()` L117-121
+**Where**: `server/chat.ts` `generateWtId()`
 
-Change from `randomBytes(3).toString('hex')` (6 hex chars) to `randomUUID().slice(0, 12)` (12 hex chars). Also add a `.mitzo-session` lockfile inside each worktree containing the wtId and creation timestamp.
+**[Shipped in Phase 1]** Changed from `randomBytes(3).toString('hex')` (6 hex chars) to `randomUUID().replace(/-/g, '').slice(0, 12)` (12 hex chars). Added `.mitzo-session` lockfile inside each worktree containing the wtId and creation timestamp.
 
 ### 2c. Runtime Symlinks (opt-in)
 
@@ -505,7 +505,7 @@ The on-demand path runs inside `canUseTool` which is async. `execFileSync` block
 | F3  | `packages/client/src/store.ts` `wsListener`                  | Add `onReconnected` callback that re-fetches messages                                                 | iOS eviction loses in-memory state                              |
 | F4  | `packages/client/src/store.ts` `_foreground` handler         | Remove `messages.length === 0 && !current` guard                                                      | Always re-fetch, not just when empty                            |
 | F5  | `packages/client/src/protocol-parser.ts`                     | Add `session_takeover` case → `SET_RUNNING: false` + `ERROR` with "Session resumed on another device" | Old device needs clean exit on takeover                         |
-| F6  | `packages/client/src/protocol-parser.ts`                     | Remove `active_elsewhere` case (L328-340)                                                             | Dead code after server-side takeover                            |
+| F6  | `packages/client/src/protocol-parser.ts`                     | ~~Remove `active_elsewhere` case~~ (no-op: case does not exist in current parser)                     | Already absent — no action needed                               |
 | F7  | `packages/client/src/store.ts` event filter (L644-658)       | When `currentSessionId` is null, only allow `session_id`                                              | Prevent foreign `session_end` from assigning wrong session      |
 | F8  | `packages/client/src/protocol-parser.ts` `error` case (L344) | Change "Session expired" from silent wipe to recoverable error message                                | Better UX — show "Start fresh?" button                          |
 | F9  | `packages/client/src/connection.ts`                          | Add `getTrackedSessions(): string[]` method                                                           | Needed by F2                                                    |
@@ -585,6 +585,6 @@ The on-demand path runs inside `canUseTool` which is async. `execFileSync` block
 
 ## Deferred
 
-- **Session identity decoupling** (registry key = sessionId instead of `${connectionId}:${sessionId}`) — correct per `linear-stirring-hopcroft.md` Phase 2, but Phase 1 fixes the user-facing bugs without it
-- **Session state machine** (ACTIVE/SUSPENDED/CLOSED in EventStore) — architectural improvement, not blocking
-- **Frontend session state UI** (dots, explicit close) — separate concern
+- **Session identity decoupling** (registry key = sessionId instead of `${connectionId}:${sessionId}`) — still deferred. Phase 1 auto-takeover with rekey addresses the user-facing bugs without it
+- **Session state machine** (ACTIVE/SUSPENDED/CLOSED in EventStore) — still deferred, architectural improvement
+- **Frontend session state UI** (dots, explicit close) — still deferred, separate concern

--- a/docs/design/session-isolation-phase2-handoff.md
+++ b/docs/design/session-isolation-phase2-handoff.md
@@ -161,8 +161,8 @@ Recommended sequence (dependencies noted):
 ## Key File Locations (post-Phase 1)
 
 | File                                         | Symbol / Function                               |
-| -------------------------------------------- | ----------------------------------------------- | ------------------------------------- |
-| `server/chat.ts`                             | `createSessionWorktrees()`                      | L278-338 (secondary loop at L317-332) |
+| -------------------------------------------- | ----------------------------------------------- |
+| `server/chat.ts`                             | `createSessionWorktrees()` (secondary loop)     |
 | `server/chat.ts`                             | `buildWorktreeSystemPrompt()`                   |
 | `server/chat.ts`                             | `startChat()` finally block                     |
 | `server/chat.ts`                             | `validateResumable()`                           |

--- a/docs/design/session-isolation-phase2-handoff.md
+++ b/docs/design/session-isolation-phase2-handoff.md
@@ -12,7 +12,7 @@
 
 These are done and deployed — don't re-implement:
 
-- **2b (Collision-proof IDs):** `generateWtId()` in `server/chat.ts` now uses `randomUUID().slice(0, 12)`. `.mitzo-session` lockfile written inside primary worktree at creation time.
+- **2b (Collision-proof IDs):** `generateWtId()` in `server/chat.ts` now uses `randomUUID().replace(/-/g, '').slice(0, 12)` (strips dashes first, then slices — result is 12 hex chars). `.mitzo-session` lockfile written inside primary worktree at creation time.
 - **Stale registry cleanup:** `registry.remove()` in all 3 handler stale-detection sites
 - **Session bleed fix:** server unwatches on switch, client clears `seqBySession`, null-session filter tightened (allows `session_id` + `permission_request` only)
 - **Auto-takeover:** send/interrupt from another device does full ownership transfer instead of `active_elsewhere` rejection
@@ -40,7 +40,8 @@ These are done and deployed — don't re-implement:
    - Call async `createWorktreeAsync(session.wtId, repoPath)` (new, see 2f)
    - Add to `session.worktreePaths` Map
    - Broadcast `worktree_opened` event to client
-   - Return deny with redirect message (existing behavior — agent retries with the worktree path)
+   - On success: return deny with redirect message (existing behavior — agent retries with the worktree path)
+   - On failure (disk full, git lock, branch conflict): hard deny with error — do NOT redirect, or the agent enters a retry loop
 
 3. `server/chat.ts` `buildWorktreeSystemPrompt()` (L380-402) — update text to note secondary repos are lazy: "Worktrees for secondary repos are created on first write. Use `$MITZO_REPO_<NAME>` env vars."
 
@@ -74,6 +75,9 @@ These are done and deployed — don't re-implement:
 **Test plan:**
 
 - `server/__tests__/worktree.test.ts`: `symlinkRuntimeDirs` creates symlinks for existing dirs, skips missing
+- `server/__tests__/worktree.test.ts`: `symlinkRuntimeDirs` idempotent on resume (symlink already exists)
+- `server/__tests__/worktree.test.ts`: `symlinkRuntimeDirs` handles dangling symlinks (target deleted)
+- `server/__tests__/chat.test.ts`: system prompt includes shared-mutable-state warning when symlinks active
 
 ### 2d. Resume-Aware Worktree Rebuild
 
@@ -94,7 +98,7 @@ These are done and deployed — don't re-implement:
 
 ### 2e. Cleanup Only on Close
 
-**Problem:** `cleanupSessionWorktrees(session)` in the `finally` block of `startChat()` (L694-697) destroys worktrees after every query loop, breaking resume.
+**Problem:** `cleanupSessionWorktrees(session)` in the `finally` block of `startChat()` destroys secondary worktrees after every query loop. The primary worktree is preserved (`if (repoName === 'primary') continue`), so resume itself is not broken today, but Phase 2 lazy-created secondaries would be lost on each turn boundary.
 
 **Files to modify:**
 
@@ -119,6 +123,8 @@ These are done and deployed — don't re-implement:
     // cleanupSessionWorktrees removed — see design doc 2e.
 }
 ```
+
+**Note:** Today both `catch` (conditionally via `if (failedSession)`) and `finally` call `cleanupSessionWorktrees`, resulting in a double-call. This is harmless (`removeWorktree` is idempotent) but worth knowing when removing only the `finally` call.
 
 **Test plan:**
 
@@ -154,19 +160,19 @@ Recommended sequence (dependencies noted):
 
 ## Key File Locations (post-Phase 1)
 
-| File                                         | What                          | Key lines                             |
-| -------------------------------------------- | ----------------------------- | ------------------------------------- |
-| `server/chat.ts`                             | `createSessionWorktrees()`    | L278-338 (secondary loop at L317-332) |
-| `server/chat.ts`                             | `buildWorktreeSystemPrompt()` | L380-402                              |
-| `server/chat.ts`                             | `startChat()` finally block   | L693-698                              |
-| `server/chat.ts`                             | `validateResumable()`         | L116-157                              |
-| `server/chat.ts`                             | `cleanupSessionWorktrees()`   | L803+                                 |
-| `server/worktree.ts`                         | `createWorktree()` (sync)     | L46-102                               |
-| `server/worktree.ts`                         | `cleanupStaleWorktrees()`     | L271+                                 |
-| `server/constants.ts`                        | `WORKTREE_STALE_HOURS`        | L29 (currently 96)                    |
-| `server/repo-config.ts`                      | `RepoConfig` interface        | L30-36 (`repos` field)                |
-| `packages/harness/src/worktree-guard.ts`     | `checkWorktreePolicy()`       | L80-143 (sync)                        |
-| `packages/harness/src/permission-handler.ts` | `buildPermissionHandler()`    | L44-146 (async `canUseTool`)          |
+| File                                         | What                          | Key lines                                                 |
+| -------------------------------------------- | ----------------------------- | --------------------------------------------------------- |
+| `server/chat.ts`                             | `createSessionWorktrees()`    | L278-338 (secondary loop at L317-332)                     |
+| `server/chat.ts`                             | `buildWorktreeSystemPrompt()` | search for function name (line numbers shift between PRs) |
+| `server/chat.ts`                             | `startChat()` finally block   | search for `} finally {`                                  |
+| `server/chat.ts`                             | `validateResumable()`         | search for function name                                  |
+| `server/chat.ts`                             | `cleanupSessionWorktrees()`   | search for function name                                  |
+| `server/worktree.ts`                         | `createWorktree()` (sync)     | search for function name                                  |
+| `server/worktree.ts`                         | `cleanupStaleWorktrees()`     | search for function name                                  |
+| `server/constants.ts`                        | `WORKTREE_STALE_HOURS`        | search for constant name (currently 96)                   |
+| `server/repo-config.ts`                      | `RepoConfig` interface        | search for interface name (`repos` field)                 |
+| `packages/harness/src/worktree-guard.ts`     | `checkWorktreePolicy()`       | search for function name (sync)                           |
+| `packages/harness/src/permission-handler.ts` | `buildPermissionHandler()`    | search for function name (async `canUseTool`)             |
 
 ---
 
@@ -215,6 +221,6 @@ Recommended sequence (dependencies noted):
 
 3. **`.mitzo-session` lockfile** was added in Phase 1 for primary worktrees. Extend it to secondary worktrees when they're created on-demand.
 
-4. **Review findings pattern:** Centaur + Codex caught a real bug in Phase 1 (missing sessionId passthrough). Add the `openai` label to the PR for Codex review. If the centaur webhook fails (ngrok tunnel at `beamily-operable-shenita.ngrok-free.dev`), push an empty commit to retrigger, or redeliver via `gh api repos/dimakis/mitzo/hooks/604995403/deliveries/<id>/attempts -X POST`.
+4. **Review findings pattern:** Centaur + Codex caught a real bug in Phase 1 (missing sessionId passthrough). Add the `openai` label to the PR for Codex review. If the centaur webhook fails, push an empty commit to retrigger, or redeliver via `gh api repos/{owner}/{repo}/hooks` to find the webhook ID, then `gh api repos/{owner}/{repo}/hooks/<id>/deliveries` to inspect and retry.
 
 5. **Never push to main.** Branch + PR + CI + merge. See CLAUDE.md.

--- a/docs/design/session-isolation-phase2-handoff.md
+++ b/docs/design/session-isolation-phase2-handoff.md
@@ -160,19 +160,19 @@ Recommended sequence (dependencies noted):
 
 ## Key File Locations (post-Phase 1)
 
-| File                                         | What                          | Key lines                                                 |
-| -------------------------------------------- | ----------------------------- | --------------------------------------------------------- |
-| `server/chat.ts`                             | `createSessionWorktrees()`    | L278-338 (secondary loop at L317-332)                     |
-| `server/chat.ts`                             | `buildWorktreeSystemPrompt()` | search for function name (line numbers shift between PRs) |
-| `server/chat.ts`                             | `startChat()` finally block   | search for `} finally {`                                  |
-| `server/chat.ts`                             | `validateResumable()`         | search for function name                                  |
-| `server/chat.ts`                             | `cleanupSessionWorktrees()`   | search for function name                                  |
-| `server/worktree.ts`                         | `createWorktree()` (sync)     | search for function name                                  |
-| `server/worktree.ts`                         | `cleanupStaleWorktrees()`     | search for function name                                  |
-| `server/constants.ts`                        | `WORKTREE_STALE_HOURS`        | search for constant name (currently 96)                   |
-| `server/repo-config.ts`                      | `RepoConfig` interface        | search for interface name (`repos` field)                 |
-| `packages/harness/src/worktree-guard.ts`     | `checkWorktreePolicy()`       | search for function name (sync)                           |
-| `packages/harness/src/permission-handler.ts` | `buildPermissionHandler()`    | search for function name (async `canUseTool`)             |
+| File                                         | Symbol / Function                               |
+| -------------------------------------------- | ----------------------------------------------- | ------------------------------------- |
+| `server/chat.ts`                             | `createSessionWorktrees()`                      | L278-338 (secondary loop at L317-332) |
+| `server/chat.ts`                             | `buildWorktreeSystemPrompt()`                   |
+| `server/chat.ts`                             | `startChat()` finally block                     |
+| `server/chat.ts`                             | `validateResumable()`                           |
+| `server/chat.ts`                             | `cleanupSessionWorktrees()`                     |
+| `server/worktree.ts`                         | `createWorktree()` (sync)                       |
+| `server/worktree.ts`                         | `cleanupStaleWorktrees()`                       |
+| `server/constants.ts`                        | `WORKTREE_STALE_HOURS` (currently 96)           |
+| `server/repo-config.ts`                      | `RepoConfig` interface (`repos` field)          |
+| `packages/harness/src/worktree-guard.ts`     | `checkWorktreePolicy()` (sync)                  |
+| `packages/harness/src/permission-handler.ts` | `buildPermissionHandler()` (async `canUseTool`) |
 
 ---
 

--- a/frontend/src/components/SessionSearchBar.tsx
+++ b/frontend/src/components/SessionSearchBar.tsx
@@ -23,6 +23,12 @@ export function SessionSearchBar({
 }: SessionSearchBarProps) {
   const [open, setOpen] = useState(active);
   const inputRef = useRef<HTMLInputElement>(null);
+  const prevActiveRef = useRef(active);
+
+  useEffect(() => {
+    if (active && !prevActiveRef.current) setOpen(true);
+    prevActiveRef.current = active;
+  }, [active]);
 
   useEffect(() => {
     if (open && inputRef.current) {
@@ -61,6 +67,9 @@ export function SessionSearchBar({
         placeholder="Search sessions..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') handleClose();
+        }}
       />
       <button className="session-search-close" onClick={handleClose} title="Close search">
         ✕
@@ -71,21 +80,24 @@ export function SessionSearchBar({
           {!searching && results.length === 0 && (
             <div className="session-search-status">No matches</div>
           )}
-          {results.map((r) => (
-            <button
-              key={r.sessionId}
-              className="session-search-result"
-              onClick={() => handleSelect(r.sessionId)}
-            >
-              <div className="session-search-result-summary">{r.summary || 'Untitled session'}</div>
-              <div className="session-search-result-snippet">{r.snippet}</div>
-              <div className="session-search-result-meta">
-                <span className="session-search-result-time">
-                  {formatRelativeTime(r.updatedAt)}
-                </span>
-              </div>
-            </button>
-          ))}
+          {!searching &&
+            results.map((r) => (
+              <button
+                key={r.sessionId}
+                className="session-search-result"
+                onClick={() => handleSelect(r.sessionId)}
+              >
+                <div className="session-search-result-summary">
+                  {r.summary || 'Untitled session'}
+                </div>
+                <div className="session-search-result-snippet">{r.snippet}</div>
+                <div className="session-search-result-meta">
+                  <span className="session-search-result-time">
+                    {formatRelativeTime(r.updatedAt)}
+                  </span>
+                </div>
+              </button>
+            ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/__tests__/SessionSearchBar.test.ts
+++ b/frontend/src/components/__tests__/SessionSearchBar.test.ts
@@ -84,6 +84,8 @@ describe('SessionSearchBar', () => {
     await user.click(screen.getByText('Fix auth bug'));
     expect(onSelectSession).toHaveBeenCalledWith('abc123');
     expect(clear).toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText('Search sessions...')).toBeNull();
+    expect(screen.getByTitle('Search sessions')).toBeTruthy();
   });
 
   it('shows searching indicator', () => {
@@ -96,12 +98,14 @@ describe('SessionSearchBar', () => {
     expect(screen.getByText('No matches')).toBeTruthy();
   });
 
-  it('calls clear on close', async () => {
+  it('calls clear on close and reverts to toggle', async () => {
     const clear = vi.fn();
     const user = userEvent.setup();
     renderBar({ active: true, query: 'auth', results: mockResults, clear });
     await user.click(screen.getByTitle('Close search'));
     expect(clear).toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText('Search sessions...')).toBeNull();
+    expect(screen.getByTitle('Search sessions')).toBeTruthy();
   });
 
   it('reverts to toggle button when closed with no active query', async () => {
@@ -110,9 +114,58 @@ describe('SessionSearchBar', () => {
     // Open
     await user.click(screen.getByTitle('Search sessions'));
     expect(screen.getByPlaceholderText('Search sessions...')).toBeTruthy();
-    // Close (active=false, so visible becomes false)
+    // Close
     await user.click(screen.getByTitle('Close search'));
     expect(screen.queryByPlaceholderText('Search sessions...')).toBeNull();
     expect(screen.getByTitle('Search sessions')).toBeTruthy();
+  });
+
+  it('hides stale results while searching', () => {
+    renderBar({ active: true, query: 'auth', results: mockResults, searching: true });
+    expect(screen.getByText('Searching...')).toBeTruthy();
+    expect(screen.queryByText('Fix auth bug')).toBeNull();
+  });
+
+  it('dismisses on Escape key', async () => {
+    const clear = vi.fn();
+    const user = userEvent.setup();
+    renderBar({ active: true, query: 'auth', results: mockResults, clear });
+    const input = screen.getByPlaceholderText('Search sessions...');
+    await user.click(input);
+    await user.keyboard('{Escape}');
+    expect(clear).toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText('Search sessions...')).toBeNull();
+    expect(screen.getByTitle('Search sessions')).toBeTruthy();
+  });
+
+  it('syncs open state when active prop transitions to true', async () => {
+    const { rerender } = render(
+      createElement(SessionSearchBar, {
+        query: '',
+        setQuery: vi.fn(),
+        results: [],
+        searching: false,
+        active: false,
+        clear: vi.fn(),
+        onSelectSession: vi.fn(),
+      }),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByTitle('Search sessions'));
+    await user.click(screen.getByTitle('Close search'));
+    expect(screen.getByTitle('Search sessions')).toBeTruthy();
+
+    rerender(
+      createElement(SessionSearchBar, {
+        query: 'test',
+        setQuery: vi.fn(),
+        results: mockResults,
+        searching: false,
+        active: true,
+        clear: vi.fn(),
+        onSelectSession: vi.fn(),
+      }),
+    );
+    expect(screen.getByPlaceholderText('Search sessions...')).toBeTruthy();
   });
 });

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -536,7 +536,7 @@ textarea:focus {
   position: absolute;
   top: 100%;
   right: 0;
-  left: -60px;
+  left: max(-60px, calc(-1 * (100vw - 100% - var(--space-4))));
   margin-top: var(--space-2);
   background: var(--surface);
   border: 1px solid var(--border);

--- a/infra/com.mitzo.podman-machine.plist
+++ b/infra/com.mitzo.podman-machine.plist
@@ -6,16 +6,14 @@
     <string>com.mitzo.podman-machine</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/opt/homebrew/bin/podman</string>
-        <string>machine</string>
-        <string>start</string>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>PODMAN=$(command -v podman || echo /opt/homebrew/bin/podman); "$PODMAN" machine init 2>/dev/null; exec "$PODMAN" machine start</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <false/>
-    <key>LaunchOnlyOnce</key>
-    <true/>
     <key>StandardOutPath</key>
     <string>__MITZO_HOME__/logs/podman-machine-stdout.log</string>
     <key>StandardErrorPath</key>

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -183,6 +183,22 @@ describe('switchSession', () => {
     });
   });
 
+  it('resets progress state on session switch', async () => {
+    const store = createReadyStore();
+    store.setState({
+      progress: {
+        blocks: { 'tool-1': { done: 3, total: 5, label: 'Build' } },
+        toolIndex: { 'call-1': 'tool-1' },
+      },
+    });
+    expect(Object.keys(store.getState().progress.blocks)).toHaveLength(1);
+
+    await store.getState().switchSession('session-abc');
+
+    expect(store.getState().progress.blocks).toEqual({});
+    expect(store.getState().progress.toolIndex).toEqual({});
+  });
+
   it('filters events from non-active sessions after switch', async () => {
     const store = createReadyStore();
     await store.getState().switchSession('session-b');
@@ -220,6 +236,22 @@ describe('newSession', () => {
       type: 'switch_session',
       sessionId: null,
     });
+  });
+
+  it('resets progress state on new session', () => {
+    const store = createReadyStore();
+    store.setState({
+      progress: {
+        blocks: { 'tool-1': { done: 2, total: 4, label: 'Test' } },
+        toolIndex: { 'call-1': 'tool-1' },
+      },
+    });
+    expect(Object.keys(store.getState().progress.blocks)).toHaveLength(1);
+
+    store.getState().newSession();
+
+    expect(store.getState().progress.blocks).toEqual({});
+    expect(store.getState().progress.toolIndex).toEqual({});
   });
 
   it('isolates new session from old session messages via sessionId filter', async () => {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,9 @@ sed "s|__MITZO_HOME__|${MITZO_HOME}|g" infra/com.mitzo.podman-machine.plist > "$
 launchctl bootout "gui/$(id -u)/com.mitzo.podman-machine" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PODMAN_PLIST_DEST"
 
-# Ensure podman machine exists and is running before bringing up containers
+# Ensure podman machine exists and is running before bringing up containers.
+# The launchd plist also handles init+start at boot — podman uses lock files
+# so concurrent attempts are safe, just redundant.
 if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q Running; then
   if ! podman machine inspect 2>/dev/null >/dev/null; then
     echo "Initializing podman machine..."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,8 +21,12 @@ sed "s|__MITZO_HOME__|${MITZO_HOME}|g" infra/com.mitzo.podman-machine.plist > "$
 launchctl bootout "gui/$(id -u)/com.mitzo.podman-machine" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PODMAN_PLIST_DEST"
 
-# Ensure podman machine is running before bringing up containers
+# Ensure podman machine exists and is running before bringing up containers
 if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q Running; then
+  if ! podman machine inspect 2>/dev/null >/dev/null; then
+    echo "Initializing podman machine..."
+    podman machine init
+  fi
   echo "Starting podman machine..."
   podman machine start
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,9 +21,7 @@ sed "s|__MITZO_HOME__|${MITZO_HOME}|g" infra/com.mitzo.podman-machine.plist > "$
 launchctl bootout "gui/$(id -u)/com.mitzo.podman-machine" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PODMAN_PLIST_DEST"
 
-# Ensure podman machine exists and is running before bringing up containers.
-# The launchd plist also handles init+start at boot — podman uses lock files
-# so concurrent attempts are safe, just redundant.
+# Ensure podman machine exists and is running (safe to race with launchd plist — podman uses lock files).
 if ! podman machine inspect --format '{{.State}}' 2>/dev/null | grep -q Running; then
   if ! podman machine inspect 2>/dev/null >/dev/null; then
     echo "Initializing podman machine..."

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import { resolve } from 'path';
 
 export default defineConfig({
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
   test: {
-    exclude: ['**/node_modules/**', '**/.claude/worktrees/**', '**/.cursor/worktrees/**'],
+    exclude: [...configDefaults.exclude, '**/.claude/worktrees/**', '**/.cursor/worktrees/**'],
     env: {
       NODE_ENV: 'test',
       AUTH_PASSPHRASE: 'test-passphrase-for-vitest',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     },
   },
   test: {
+    exclude: ['**/node_modules/**', '**/.claude/worktrees/**', '**/.cursor/worktrees/**'],
     env: {
       NODE_ENV: 'test',
       AUTH_PASSPHRASE: 'test-passphrase-for-vitest',


### PR DESCRIPTION
## Summary

Addresses Centaur review comments that were not resolved before merging PRs #273, #277, #279, #281, #283, #284. PR #277 was clean (LGTM).

### SessionSearchBar (#273) — 2 bugs + 3 improvements
- **Bug**: stale results from prior query shown while new search is in progress — gate `results.map()` on `!searching`
- **Bug**: `useState(active)` never syncs after mount — add `useEffect` with `prevActiveRef` to open bar on `false→true` transition
- Add Escape key to dismiss search bar
- Use viewport-safe `max()` calc for results dropdown instead of magic `-60px`
- 4 new tests: stale results hidden, Escape dismisses, active prop sync, close reverts UI

### Store progress reset (#281) — 1 missing test
- Add `progress` reset assertions to both `switchSession` and `newSession` describe blocks

### Design docs (#283) — 9 findings
- Update status: Phase 1 shipped (PR #278), not "pending implementation"
- Mark P3 (generateWtId) and P5 (registry.remove) as fixed in Phase 1
- Remove dead canvas path refs and ephemeral local-machine paths
- Mark `denyPendingBySession` as already implemented in harness
- Mark `active_elsewhere` F6 as no-op (case doesn't exist in parser)
- Annotate deferred items with current relevance

### Phase 2 handoff (#279) — 7 findings
- Fix `generateWtId` description: `randomUUID().replace(/-/g, '').slice(0, 12)`
- Correct 2e resume claim: primary is preserved, secondaries are the problem
- Add failure path for on-demand creation (hard deny, no redirect loop)
- Add double-cleanup note (catch + finally both call cleanup)
- Add missing symlink edge case tests to plan
- Replace stale line references with search instructions
- Remove hardcoded ngrok URL and webhook ID

### Infrastructure (#284) — 4 findings
- Make podman path portable (`command -v` fallback)
- Add `podman machine init` fallback in plist and deploy script
- Remove undocumented `LaunchOnlyOnce` launchd key

### Testing infrastructure
- Exclude `.claude/worktrees/` and `.cursor/worktrees/` from vitest to prevent stale test copies from running

## Test plan

- [x] SessionSearchBar: 13 tests pass (4 new)
- [x] Store: 57 tests pass (2 new)
- [x] Pre-commit hooks pass (lint, format, gitleaks)
- [x] Pre-existing test failures unchanged (TabBar, TaskNode, worktree, token-update, prompt-compare — all unrelated)


Made with [Cursor](https://cursor.com)