### PR TITLE
fix(worktree): deduplicate dirty worktree inbox notifications

### DIFF
--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -378,6 +378,31 @@ describe('cleanupStaleWorktrees', () => {
     expect(inboxFiles[0]).toContain(sessionId);
   });
 
+  it('does not re-post inbox proposal for already-notified dirty worktree', () => {
+    const wtDir = join(baseRepo, '.claude', 'worktrees');
+    mkdirSync(wtDir, { recursive: true });
+    const sessionId = 'test-dedup-session';
+    const wtPath = join(wtDir, sessionId);
+    execFileSync('git', ['-C', baseRepo, 'worktree', 'add', '-b', `session/${sessionId}`, wtPath], {
+      stdio: 'pipe',
+    });
+    writeFileSync(join(wtPath, 'dirty-file.txt'), 'uncommitted work');
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    utimesSync(wtPath, fiveDaysAgo, fiveDaysAgo);
+
+    // First run — should create one inbox item
+    cleanupStaleWorktrees(baseRepo, inboxDir);
+    expect(readdirSync(inboxDir).length).toBe(1);
+
+    // Second run — should NOT create a duplicate
+    cleanupStaleWorktrees(baseRepo, inboxDir);
+    expect(readdirSync(inboxDir).length).toBe(1);
+
+    // Third run — still just one
+    cleanupStaleWorktrees(baseRepo, inboxDir);
+    expect(readdirSync(inboxDir).length).toBe(1);
+  });
+
   it('does not touch worktrees younger than cutoff', () => {
     const wtDir = join(baseRepo, '.claude', 'worktrees');
     mkdirSync(wtDir, { recursive: true });

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -427,9 +427,15 @@ export function cleanupStaleWorktrees(baseRepo: string, inboxDir?: string): void
       if (isStale) {
         const dirty = hasUncommittedWork(fullPath);
         if (dirty && inboxDir) {
-          const branch = `${WORKTREE_BRANCH_PREFIX}${entry}`;
-          const repoName = basename(baseRepo);
-          postDirtyWorktreeToInbox(entry, repoName, fullPath, branch, dirty, inboxDir);
+          // Only post once per session — check if an inbox item already exists
+          const alreadyNotified =
+            existsSync(inboxDir) &&
+            readdirSync(inboxDir).some((f) => f.endsWith(`_worktree_gc_${entry}.md`));
+          if (!alreadyNotified) {
+            const branch = `${WORKTREE_BRANCH_PREFIX}${entry}`;
+            const repoName = basename(baseRepo);
+            postDirtyWorktreeToInbox(entry, repoName, fullPath, branch, dirty, inboxDir);
+          }
           skipped++;
           log.info('skipped stale worktree with uncommitted work', {
             repo: baseRepo,


### PR DESCRIPTION
## Summary
- Worktree GC was posting a new inbox item for every dirty worktree on every run (startup + every 6h), with no dedup check
- 21 dirty worktrees × ~130 GC runs = **1,403 duplicate notifications** flooding the inbox
- Added `existsSync` + `readdirSync` check before posting — if an inbox item for that session already exists, skip it

## Test plan
- [x] New test: 3 consecutive GC runs produce exactly 1 inbox item
- [x] All 29 existing worktree tests pass
- [ ] Verify no new inbox spam after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)