### PR TITLE
fix(otel): address Centaur review findings from #282

### DIFF
--- a/server/__tests__/with-span.test.ts
+++ b/server/__tests__/with-span.test.ts
@@ -173,3 +173,66 @@ describe('withSpanAsync', () => {
     expect(childTraceId).toBe(parentTraceId);
   });
 });
+
+describe('span hierarchy pattern', () => {
+  /** SDK stores parent as parentSpanContext, not parentSpanId. */
+  function parentId(span: { parentSpanContext?: { spanId?: string } }): string | undefined {
+    return span.parentSpanContext?.spanId;
+  }
+
+  it('tool spans parent to turn spans via explicit setSpan', async () => {
+    const { withSpan } = await import('../tracing.js');
+    exporter.reset();
+
+    // Mirrors query-loop: session span wraps turn, turn wraps tool
+    withSpan('session', { 'session.clientId': 'test' }, () => {
+      const tracer = trace.getTracer('mitzo', '1.0.0');
+
+      // Turn span created with context.active() (session is active)
+      const turnSpan = tracer.startSpan('turn', {}, context.active());
+
+      // Fix pattern: explicitly parent tool to turn via setSpan
+      const toolParent = trace.setSpan(context.active(), turnSpan);
+      const toolSpan = tracer.startSpan('tool.Read', {}, toolParent);
+      toolSpan.end();
+      turnSpan.end();
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const session = spans.find((s) => s.name === 'session')!;
+    const turn = spans.find((s) => s.name === 'turn')!;
+    const tool = spans.find((s) => s.name === 'tool.Read')!;
+
+    expect(session).toBeDefined();
+    expect(turn).toBeDefined();
+    expect(tool).toBeDefined();
+
+    // session → turn → tool
+    expect(parentId(turn)).toBe(session.spanContext().spanId);
+    expect(parentId(tool)).toBe(turn.spanContext().spanId);
+  });
+
+  it('tool spans incorrectly parent to session without setSpan', async () => {
+    const { withSpan } = await import('../tracing.js');
+    exporter.reset();
+
+    withSpan('session', { 'session.clientId': 'test' }, () => {
+      const tracer = trace.getTracer('mitzo', '1.0.0');
+
+      // Turn created but NOT set as active context
+      const turnSpan = tracer.startSpan('turn', {}, context.active());
+      turnSpan.end();
+
+      // Without setSpan fix, context.active() still has session
+      const toolSpan = tracer.startSpan('tool.Read', {}, context.active());
+      toolSpan.end();
+    });
+
+    const spans = exporter.getFinishedSpans();
+    const session = spans.find((s) => s.name === 'session')!;
+    const tool = spans.find((s) => s.name === 'tool.Read')!;
+
+    // Bug case: tool lands under session, not turn
+    expect(parentId(tool)).toBe(session.spanContext().spanId);
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -435,6 +435,9 @@ function tryRouteToActiveSession(
   return found.clientId;
 }
 
+// v1 WS handler — no connection-level span. Per-handler spans (ws.send,
+// ws.interrupt, etc.) provide sufficient tracing. v2 handlers in
+// ws-handler-v2.ts are the primary path; this is legacy.
 function handleChatWs(
   ws: WebSocket,
   initialClientId: string,

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -168,13 +168,13 @@ async function _runQueryLoopInner(
   let pendingMessageEnd: Record<string, unknown> | null = null;
   let resolvedSessionId: string | undefined;
   let resolvedGoalId: string | undefined;
+  let goalCreationPromise: Promise<string | null> | undefined;
+  let goalTitle: string | undefined;
 
-  // Turn and tool span tracking (Steps 5-6 of OTel overhaul)
+  // Turn and tool span tracking
   let currentTurnSpan: Span | null = null;
   let turnBlockCount = 0;
   const toolSpans = new Map<string, Span>(); // blockId → tool span
-  let goalCreationPromise: Promise<string | null> | undefined;
-  let goalTitle: string | undefined;
 
   // Token tracking state for live token_update events
   let agentContextTokens = 0; // full context window size (input + cached) from parent message_start


### PR DESCRIPTION
## Summary

Follow-up to #282 — addresses remaining Centaur review findings:

- **Finding 2 (style)**: Regroup `goalCreationPromise` / `goalTitle` declarations back with their logical group (`resolvedGoalId`) in query-loop.ts, separated by the OTel span tracking variables
- **Finding 4 (regression)**: Add comment documenting intentional v1 `connSpan` removal — per-handler spans provide sufficient tracing, v2 is the primary path
- **Finding 7 (missing_tests)**: Add 2 span hierarchy tests verifying the `trace.setSpan()` pattern that ensures tool spans parent to turn spans (not session spans), plus a negative test showing the bug case

The 3 bug findings (1, 3, 5) were already fixed in the squash merge of #282. The 2 regression findings (4, 6) were triaged as acceptable.

## Test plan

- [x] `with-span.test.ts` — 11 tests pass (9 existing + 2 new hierarchy tests)
- [x] `query-loop.test.ts` — 41 tests pass (variable reorder didn't break anything)
- [x] Full suite: no new failures vs main


Made with [Cursor](https://cursor.com)