### PR TITLE
feat: proactive session suspend — signal before iOS kills WS

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -8,7 +8,7 @@
  */
 
 import { createMitzoStore } from '@mitzo/client';
-import { apiFetch, getWsChatUrl } from './lib/api-fetch';
+import { apiFetch, getApiBaseUrl, getWsChatUrl } from './lib/api-fetch';
 import { registerCapacitorLifecycle } from './lib/capacitor';
 import { configureKeyboard } from './lib/keyboard';
 import { initPushNotifications } from './lib/push';
@@ -21,11 +21,15 @@ export const clientStore = createMitzoStore({
     buildUrl: () => getWsChatUrl(),
     createWebSocket: (url) => new WebSocket(url) as import('@mitzo/client').WebSocketLike,
     reconnectDelayMs: 500,
+    suspendUrl: `${getApiBaseUrl()}/api/sessions/suspend`,
   },
 });
 
-// Wire Capacitor app lifecycle → force WS reconnect on resume (no-op in browser)
-registerCapacitorLifecycle(() => clientStore.getState().forceReconnect());
+// Wire Capacitor app lifecycle → force WS reconnect on resume, send suspend on background
+registerCapacitorLifecycle(
+  () => clientStore.getState().forceReconnect(),
+  () => clientStore.getState().sendSuspend(),
+);
 
 // Configure native keyboard behavior (no-op in browser)
 configureKeyboard();

--- a/frontend/src/lib/capacitor.ts
+++ b/frontend/src/lib/capacitor.ts
@@ -8,12 +8,16 @@ export function isCapacitor(): boolean {
   return Capacitor.isNativePlatform();
 }
 
-/** Register app lifecycle events. Calls onResume on foreground return. No-op in browser. */
-export function registerCapacitorLifecycle(onResume: () => void): void {
+/** Register app lifecycle events. Calls onResume on foreground return, onPause on background. No-op in browser. */
+export function registerCapacitorLifecycle(onResume: () => void, onPause?: () => void): void {
   if (!isCapacitor()) return;
 
   App.addListener('appStateChange', ({ isActive }) => {
-    if (isActive) onResume();
+    if (isActive) {
+      onResume();
+    } else {
+      onPause?.();
+    }
   });
 }
 

--- a/frontend/src/pages/__tests__/DesktopChatView.test.tsx
+++ b/frontend/src/pages/__tests__/DesktopChatView.test.tsx
@@ -146,6 +146,7 @@ function createMockStore() {
     setPendingSession: vi.fn(),
     clearPendingSession: vi.fn(),
     forceReconnect: vi.fn(),
+    sendSuspend: vi.fn(),
   }));
 }
 

--- a/packages/client/__tests__/connection.test.ts
+++ b/packages/client/__tests__/connection.test.ts
@@ -411,4 +411,65 @@ describe('MitzoConnection', () => {
       expect(tracked).toHaveLength(1);
     });
   });
+
+  describe('sendSuspend', () => {
+    it('sends session_suspend via WS with all tracked sessions', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      // Track two sessions
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 5 });
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's2', seq: 3 });
+
+      conn.sendSuspend();
+
+      const calls = ws.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      const suspendMsg = calls.find((c: Record<string, unknown>) => c.type === 'session_suspend');
+      expect(suspendMsg).toBeDefined();
+      expect(suspendMsg.sessions).toEqual(
+        expect.arrayContaining([
+          { sessionId: 's1', lastSeq: 5 },
+          { sessionId: 's2', lastSeq: 3 },
+        ]),
+      );
+    });
+
+    it('is a no-op when no sessions are tracked', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      const callsBefore = ws.send.mock.calls.length;
+      conn.sendSuspend();
+
+      // No additional sends
+      expect(ws.send.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('does not throw when WS is closed', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 1 });
+      ws.readyState = 3; // CLOSED
+
+      expect(() => conn.sendSuspend()).not.toThrow();
+    });
+
+    it('catches WS send errors gracefully', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      ws.simulateMessage({ v: 2, type: 'block_delta', sessionId: 's1', seq: 1 });
+      ws.send.mockImplementation(() => {
+        throw new Error('Socket dying');
+      });
+
+      // Should not throw — sendBeacon fallback handles it
+      expect(() => conn.sendSuspend()).not.toThrow();
+    });
+  });
 });

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -13,6 +13,8 @@ export interface MitzoConnectionConfig {
   buildUrl(): string;
   createWebSocket(url: string): WebSocketLike;
   reconnectDelayMs?: number;
+  /** URL for the sendBeacon suspend fallback (POST /api/sessions/suspend). */
+  suspendUrl?: string;
 }
 
 export type ConnectionListener = (msg: Record<string, unknown>) => void;
@@ -32,11 +34,13 @@ export class MitzoConnection {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private boundOnVisibility: (() => void) | null = null;
   private boundOnPageShow: ((e: PageTransitionEvent) => void) | null = null;
+  private boundOnPageHide: (() => void) | null = null;
   private config: Required<MitzoConnectionConfig>;
 
   constructor(config: MitzoConnectionConfig) {
     this.config = {
       reconnectDelayMs: 500,
+      suspendUrl: '',
       ...config,
     };
   }
@@ -108,6 +112,47 @@ export class MitzoConnection {
 
   getTrackedSessions(): string[] {
     return Array.from(this.seqBySession.keys());
+  }
+
+  /**
+   * Signal the server that this client is about to be backgrounded (iOS).
+   * Sends via WS if open, and also fires sendBeacon as a belt-and-suspenders
+   * fallback since iOS may kill the socket before the WS send completes.
+   */
+  sendSuspend(): void {
+    if (this.seqBySession.size === 0) return;
+
+    const sessions = Array.from(this.seqBySession.entries()).map(([sessionId, lastSeq]) => ({
+      sessionId,
+      lastSeq,
+    }));
+
+    const wsPayload = { type: 'session_suspend', sessions };
+
+    // Try WS first (may already be dying)
+    if (this.ws?.readyState === WS_READY_STATE.OPEN) {
+      try {
+        this.ws.send(JSON.stringify(wsPayload));
+      } catch {
+        // Socket may be transitioning — sendBeacon fallback below
+      }
+    }
+
+    // sendBeacon fallback — works even after visibilitychange:hidden
+    if (
+      this.config.suspendUrl &&
+      this._connectionId &&
+      typeof globalThis.navigator?.sendBeacon === 'function'
+    ) {
+      const beaconPayload = JSON.stringify({
+        connectionId: this._connectionId,
+        sessions,
+      });
+      globalThis.navigator.sendBeacon(
+        this.config.suspendUrl,
+        new Blob([beaconPayload], { type: 'application/json' }),
+      );
+    }
   }
 
   // ─── Internal ──────────────────────────────────────────────────────────────
@@ -241,6 +286,9 @@ export class MitzoConnection {
         // Notify the store so it can re-hydrate messages if the page was
         // evicted from memory (iOS bfcache discard) and state was lost.
         this.listener?.({ type: '_foreground' });
+      } else if (document.visibilityState === 'hidden') {
+        // Proactive suspend: signal the server BEFORE iOS kills the WS
+        this.sendSuspend();
       }
     };
 
@@ -248,8 +296,13 @@ export class MitzoConnection {
       if (e.persisted) this.checkAndReconnect();
     };
 
+    this.boundOnPageHide = () => {
+      this.sendSuspend();
+    };
+
     document.addEventListener('visibilitychange', this.boundOnVisibility);
     globalThis.addEventListener('pageshow', this.boundOnPageShow);
+    globalThis.addEventListener('pagehide', this.boundOnPageHide);
   }
 
   private removeBrowserListeners(): void {
@@ -260,6 +313,10 @@ export class MitzoConnection {
     if (this.boundOnPageShow) {
       globalThis.removeEventListener('pageshow', this.boundOnPageShow);
       this.boundOnPageShow = null;
+    }
+    if (this.boundOnPageHide) {
+      globalThis.removeEventListener('pagehide', this.boundOnPageHide);
+      this.boundOnPageHide = null;
     }
   }
 

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -116,8 +116,10 @@ export class MitzoConnection {
 
   /**
    * Signal the server that this client is about to be backgrounded (iOS).
-   * Sends via WS if open, and also fires sendBeacon as a belt-and-suspenders
-   * fallback since iOS may kill the socket before the WS send completes.
+   * Tries WS first; falls back to sendBeacon only if the WS send fails or
+   * the socket is already closed. This avoids double-sending (which would
+   * refresh the grace timer twice and keep sessions suspended longer than
+   * intended).
    */
   sendSuspend(): void {
     if (this.seqBySession.size === 0) return;
@@ -127,19 +129,21 @@ export class MitzoConnection {
       lastSeq,
     }));
 
-    const wsPayload = { type: 'session_suspend', sessions };
-
     // Try WS first (may already be dying)
+    let wsSent = false;
     if (this.ws?.readyState === WS_READY_STATE.OPEN) {
       try {
-        this.ws.send(JSON.stringify(wsPayload));
+        this.ws.send(JSON.stringify({ type: 'session_suspend', sessions }));
+        wsSent = true;
       } catch {
-        // Socket may be transitioning — sendBeacon fallback below
+        // Socket may be transitioning — fall through to sendBeacon
       }
     }
 
-    // sendBeacon fallback — works even after visibilitychange:hidden
+    // sendBeacon fallback — only when WS send was unavailable or failed.
+    // Works even after visibilitychange:hidden when the socket is already gone.
     if (
+      !wsSent &&
       this.config.suspendUrl &&
       this._connectionId &&
       typeof globalThis.navigator?.sendBeacon === 'function'

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -118,6 +118,7 @@ export interface MitzoStoreState {
 
   // Actions — lifecycle
   forceReconnect(): void;
+  sendSuspend(): void;
 }
 
 // ─── Store options ───────────────────────────────────────────────────────────
@@ -228,7 +229,14 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     async switchSession(id: string) {
       const oldId = parserState.currentSessionId;
-      if (oldId) connection.clearSession(oldId);
+      if (oldId) {
+        // Suspend the old session so agent responses buffer while we're away
+        connection.send({
+          type: 'session_suspend',
+          sessions: [{ sessionId: oldId, lastSeq: connection.getLastSeq(oldId) }],
+        });
+        connection.clearSession(oldId);
+      }
       parserState.currentSessionId = id;
 
       set((s) => ({
@@ -578,6 +586,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     forceReconnect() {
       connection.checkAndReconnect();
+    },
+
+    sendSuspend() {
+      connection.sendSuspend();
     },
   }));
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -230,13 +230,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     async switchSession(id: string) {
       const oldId = parserState.currentSessionId;
       if (oldId) {
-        const lastSeq = connection.getLastSeq(oldId);
-        if (lastSeq > 0) {
-          connection.send({
-            type: 'session_suspend',
-            sessions: [{ sessionId: oldId, lastSeq }],
-          });
-        }
+        // clearSession stops seq tracking. No suspend needed — session_suspend
+        // is for iOS backgrounding (imminent WS death), not session switching.
+        // Sending suspend here would leave the old session in suspended state
+        // with no resume path, causing it to buffer events until grace expiry.
         connection.clearSession(oldId);
       }
       parserState.currentSessionId = id;

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -230,11 +230,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     async switchSession(id: string) {
       const oldId = parserState.currentSessionId;
       if (oldId) {
-        // Suspend the old session so agent responses buffer while we're away
-        connection.send({
-          type: 'session_suspend',
-          sessions: [{ sessionId: oldId, lastSeq: connection.getLastSeq(oldId) }],
-        });
+        const lastSeq = connection.getLastSeq(oldId);
+        if (lastSeq > 0) {
+          connection.send({
+            type: 'session_suspend',
+            sessions: [{ sessionId: oldId, lastSeq }],
+          });
+        }
         connection.clearSession(oldId);
       }
       parserState.currentSessionId = id;
@@ -662,6 +664,16 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     if (msg.type === '_foreground') {
       const { sessions } = store.getState();
       if (sessions.active) fetchAndRestoreMessages(sessions.active);
+      return;
+    }
+
+    if (msg.type === 'session_resumed') {
+      if (typeof console !== 'undefined') {
+        console.debug('[mitzo] session resumed', {
+          sessionId: msg.sessionId,
+          replayed: msg.replayed,
+        });
+      }
       return;
     }
 

--- a/packages/harness/__tests__/session-registry.test.ts
+++ b/packages/harness/__tests__/session-registry.test.ts
@@ -790,6 +790,26 @@ describe('SessionRegistry', () => {
       expect(registry.isSuspended('client-1')).toBe(true);
     });
 
+    it('is idempotent — second suspend preserves buffer', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.bufferEvent('client-1', { type: 'block_delta', delta: 'hello' });
+      expect(registry.isSuspended('client-1')).toBe(true);
+
+      // Second suspend should NOT reset the buffer
+      registry.suspend('client-1', 5);
+      expect(registry.isSuspended('client-1')).toBe(true);
+      const buffer = registry.resume('client-1');
+      expect(buffer).toHaveLength(1);
+      expect(buffer[0]).toMatchObject({ type: 'block_delta', delta: 'hello' });
+    });
+
     it('starts grace timer that transitions to detach on expiry', () => {
       vi.useFakeTimers();
 

--- a/packages/harness/__tests__/session-registry.test.ts
+++ b/packages/harness/__tests__/session-registry.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { SessionRegistry } from '../src/session-registry.js';
-import { DETACHED_TTL_MS, CLOSEOUT_LEAD_MS, CLOSEOUT_TIMEOUT_MS } from '../src/constants.js';
+import {
+  DETACHED_TTL_MS,
+  CLOSEOUT_LEAD_MS,
+  CLOSEOUT_TIMEOUT_MS,
+  SUSPEND_GRACE_MS,
+  SUSPEND_BUFFER_MAX,
+} from '../src/constants.js';
 import type { SessionTransport } from '../src/session-transport.js';
 
 function fakeTransport(): SessionTransport {
@@ -768,6 +774,257 @@ describe('SessionRegistry', () => {
       expect(abort2.signal.aborted).toBe(true);
       expect(registry.isActive('client-1')).toBe(false);
       expect(registry.isActive('client-2')).toBe(false);
+    });
+  });
+
+  describe('suspend', () => {
+    it('marks session as suspended', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 42);
+      expect(registry.isSuspended('client-1')).toBe(true);
+    });
+
+    it('starts grace timer that transitions to detach on expiry', () => {
+      vi.useFakeTimers();
+
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+
+      // Still suspended before grace period
+      vi.advanceTimersByTime(SUSPEND_GRACE_MS - 1000);
+      expect(registry.isSuspended('client-1')).toBe(true);
+
+      // Grace expired — transitions to detach
+      vi.advanceTimersByTime(2000);
+      expect(registry.isSuspended('client-1')).toBe(false);
+      expect(registry.isAttached('client-1')).toBe(false);
+      expect(registry.isActive('client-1')).toBe(true); // detached, not aborted
+
+      vi.useRealTimers();
+    });
+
+    it('clears detach timer when suspending (suspend takes precedence)', () => {
+      vi.useFakeTimers();
+
+      const abort = new AbortController();
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: abort,
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.detach('client-1');
+      registry.suspend('client-1', 0);
+
+      // Advance past the full detach TTL — session should still be alive
+      // because suspend cleared the detach timer and manages its own grace
+      vi.advanceTimersByTime(SUSPEND_GRACE_MS + 1000);
+      // Grace expired → detach fires, but session is still active (just detached)
+      expect(registry.isActive('client-1')).toBe(true);
+      expect(abort.signal.aborted).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('resume returns buffered events and clears suspend state', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.bufferEvent('client-1', { type: 'block_delta', delta: 'hello' });
+      registry.bufferEvent('client-1', { type: 'block_end' });
+
+      const buffer = registry.resume('client-1');
+      expect(buffer).toHaveLength(2);
+      expect(buffer[0]).toEqual({ type: 'block_delta', delta: 'hello' });
+      expect(buffer[1]).toEqual({ type: 'block_end' });
+      expect(registry.isSuspended('client-1')).toBe(false);
+    });
+
+    it('resume clears grace timer', () => {
+      vi.useFakeTimers();
+
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.resume('client-1');
+
+      // Advance past grace — should not transition to detach
+      vi.advanceTimersByTime(SUSPEND_GRACE_MS + 1000);
+      expect(registry.isAttached('client-1')).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('resume returns empty array when no events buffered', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      const buffer = registry.resume('client-1');
+      expect(buffer).toEqual([]);
+    });
+
+    it('resume returns empty array for non-suspended session', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      const buffer = registry.resume('client-1');
+      expect(buffer).toEqual([]);
+    });
+
+    it('bufferEvent returns false when buffer is full', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+
+      // Fill buffer to capacity
+      for (let i = 0; i < SUSPEND_BUFFER_MAX; i++) {
+        expect(registry.bufferEvent('client-1', { type: 'event', i })).toBe(true);
+      }
+
+      // One more should fail
+      expect(registry.bufferEvent('client-1', { type: 'overflow' })).toBe(false);
+
+      // Buffer contains exactly SUSPEND_BUFFER_MAX items
+      const buffer = registry.resume('client-1');
+      expect(buffer).toHaveLength(SUSPEND_BUFFER_MAX);
+    });
+
+    it('bufferEvent returns false for non-suspended session', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      expect(registry.bufferEvent('client-1', { type: 'event' })).toBe(false);
+    });
+
+    it('reattach clears suspend state', () => {
+      vi.useFakeTimers();
+
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.bufferEvent('client-1', { type: 'event' });
+
+      registry.reattach('client-1', fakeTransport());
+      expect(registry.isSuspended('client-1')).toBe(false);
+
+      // Grace timer should be cancelled
+      vi.advanceTimersByTime(SUSPEND_GRACE_MS + 1000);
+      expect(registry.isAttached('client-1')).toBe(true);
+
+      vi.useRealTimers();
+    });
+
+    it('detach skips if already suspended', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.detach('client-1');
+
+      // Should still be suspended, not transitioned to detach
+      expect(registry.isSuspended('client-1')).toBe(true);
+    });
+
+    it('abort cleans up suspend state', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.bufferEvent('client-1', { type: 'event' });
+
+      registry.abort('client-1');
+      expect(registry.isSuspended('client-1')).toBe(false);
+    });
+
+    it('remove cleans up suspend state', () => {
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.remove('client-1');
+      expect(registry.isSuspended('client-1')).toBe(false);
+    });
+
+    it('dispose cleans up suspend state', () => {
+      vi.useFakeTimers();
+
+      registry.register('client-1', {
+        transport: fakeTransport(),
+        abortController: new AbortController(),
+        mode: 'agent',
+        sessionAllowList: new Set(),
+      });
+
+      registry.suspend('client-1', 0);
+      registry.dispose();
+
+      // Grace timer should not fire after dispose
+      vi.advanceTimersByTime(SUSPEND_GRACE_MS + 1000);
+      expect(registry.isSuspended('client-1')).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('isSuspended returns false for unknown clientId', () => {
+      expect(registry.isSuspended('nonexistent')).toBe(false);
     });
   });
 });

--- a/packages/harness/src/constants.ts
+++ b/packages/harness/src/constants.ts
@@ -17,3 +17,7 @@ export const CLOSEOUT_LEAD_MS = 600_000; // 10 minutes before TTL expiry, start 
 export const CLOSEOUT_TIMEOUT_MS = 600_000; // 10 minutes max for the agent to finish closeout
 export const PERMISSION_TIMEOUT_MS = 120_000; // 2 minutes
 export const NTFY_NOTIFICATION_DELAY_MS = 10_000; // 10 seconds
+
+// --- Suspend (proactive iOS backgrounding) ---
+export const SUSPEND_GRACE_MS = 120_000; // 2 minutes — max time to wait for resume before transitioning to detach
+export const SUSPEND_BUFFER_MAX = 1000; // max events to buffer per suspended session

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -4,6 +4,8 @@ import {
   CLOSEOUT_LEAD_MS,
   CLOSEOUT_TIMEOUT_MS,
   MAX_OBSERVERS_PER_SESSION,
+  SUSPEND_GRACE_MS,
+  SUSPEND_BUFFER_MAX,
 } from './constants.js';
 import { createLogger } from './logger.js';
 
@@ -59,6 +61,9 @@ export class SessionRegistry {
   private closeoutTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private closingOut = new Set<string>();
   private closeoutHandler: CloseoutHandler | null = null;
+  private suspended = new Set<string>();
+  private suspendBuffers = new Map<string, Record<string, unknown>[]>();
+  private suspendTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   /** Register a handler called when a session enters closeout. */
   setCloseoutHandler(handler: CloseoutHandler): void {
@@ -126,6 +131,9 @@ export class SessionRegistry {
     const session = this.sessions.get(clientId);
     if (!session) return;
 
+    // Suspend takes precedence — don't transition to detach while suspended.
+    if (this.suspended.has(clientId)) return;
+
     this.attached.delete(clientId);
     this.clearDetachTimer(clientId);
     this.clearCloseoutTimer(clientId);
@@ -178,6 +186,7 @@ export class SessionRegistry {
     this.clearDetachTimer(clientId);
     this.clearCloseoutTimer(clientId);
     this.closingOut.delete(clientId);
+    this.clearSuspendState(clientId);
     return true;
   }
 
@@ -276,6 +285,7 @@ export class SessionRegistry {
 
     this.clearDetachTimer(clientId);
     this.clearCloseoutTimer(clientId);
+    this.clearSuspendState(clientId);
     // Fire abort signal BEFORE clearing closingOut — abort listeners
     // check isClosingOut() to distinguish 'abandoned' vs 'closed' status.
     session.abortController.abort();
@@ -294,6 +304,7 @@ export class SessionRegistry {
     if (session) session.observers.clear();
     this.clearDetachTimer(clientId);
     this.clearCloseoutTimer(clientId);
+    this.clearSuspendState(clientId);
     this.sessions.delete(clientId);
     this.attached.delete(clientId);
     this.closingOut.delete(clientId);
@@ -314,9 +325,71 @@ export class SessionRegistry {
     this.closeoutTimers.clear();
     this.closingOut.clear();
 
+    for (const timer of this.suspendTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.suspendTimers.clear();
+    this.suspended.clear();
+    this.suspendBuffers.clear();
+
     for (const [clientId] of this.sessions) {
       this.abort(clientId);
     }
+  }
+
+  // ─── Suspend (proactive iOS backgrounding) ───────────────────────────────
+
+  /**
+   * Suspend a session. The client signals this BEFORE iOS kills the WebSocket,
+   * enabling event buffering and instant resume. Starts a grace timer — if
+   * the client doesn't resume within SUSPEND_GRACE_MS, the session transitions
+   * to the normal detach flow.
+   */
+  suspend(clientId: string, _lastClientSeq: number): void {
+    const session = this.sessions.get(clientId);
+    if (!session) return;
+
+    this.suspended.add(clientId);
+    this.suspendBuffers.set(clientId, []);
+    this.clearDetachTimer(clientId);
+    this.clearSuspendTimer(clientId);
+
+    const timer = setTimeout(() => {
+      this.suspendTimers.delete(clientId);
+      if (!this.sessions.has(clientId) || !this.suspended.has(clientId)) return;
+      log.info('suspend grace expired, transitioning to detach', { clientId });
+      this.suspended.delete(clientId);
+      this.suspendBuffers.delete(clientId);
+      this.detach(clientId);
+    }, SUSPEND_GRACE_MS);
+    this.suspendTimers.set(clientId, timer);
+  }
+
+  isSuspended(clientId: string): boolean {
+    return this.suspended.has(clientId);
+  }
+
+  /**
+   * Buffer an event for a suspended session. Returns false if the buffer
+   * is full or the session is not suspended.
+   */
+  bufferEvent(clientId: string, event: Record<string, unknown>): boolean {
+    if (!this.suspended.has(clientId)) return false;
+    const buffer = this.suspendBuffers.get(clientId);
+    if (!buffer) return false;
+    if (buffer.length >= SUSPEND_BUFFER_MAX) return false;
+    buffer.push(event);
+    return true;
+  }
+
+  /**
+   * Resume a suspended session. Returns buffered events and clears suspend state.
+   */
+  resume(clientId: string): Record<string, unknown>[] {
+    if (!this.suspended.has(clientId)) return [];
+    const buffer = this.suspendBuffers.get(clientId) ?? [];
+    this.clearSuspendState(clientId);
+    return buffer;
   }
 
   /**
@@ -339,6 +412,20 @@ export class SessionRegistry {
       });
     }
     return result;
+  }
+
+  private clearSuspendState(clientId: string): void {
+    this.suspended.delete(clientId);
+    this.suspendBuffers.delete(clientId);
+    this.clearSuspendTimer(clientId);
+  }
+
+  private clearSuspendTimer(clientId: string): void {
+    const existing = this.suspendTimers.get(clientId);
+    if (existing) {
+      clearTimeout(existing);
+      this.suspendTimers.delete(clientId);
+    }
   }
 
   private clearDetachTimer(clientId: string): void {

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -349,8 +349,12 @@ export class SessionRegistry {
     const session = this.sessions.get(clientId);
     if (!session) return;
 
-    this.suspended.add(clientId);
-    this.suspendBuffers.set(clientId, []);
+    // Idempotent: if already suspended, only refresh the grace timer —
+    // don't reset the buffer (visibilitychange + pagehide can fire twice).
+    if (!this.suspended.has(clientId)) {
+      this.suspended.add(clientId);
+      this.suspendBuffers.set(clientId, []);
+    }
     this.clearDetachTimer(clientId);
     this.clearSuspendTimer(clientId);
 

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -344,6 +344,11 @@ export class SessionRegistry {
    * enabling event buffering and instant resume. Starts a grace timer — if
    * the client doesn't resume within SUSPEND_GRACE_MS, the session transitions
    * to the normal detach flow.
+   *
+   * @param _lastClientSeq Reserved for future seq-based replay optimisation.
+   *   Currently unused — reconnect replays from EventStore using the client's
+   *   lastSeq, making this parameter redundant. Kept in the API so callers
+   *   don't need changing when the optimisation lands.
    */
   suspend(clientId: string, _lastClientSeq: number): void {
     const session = this.sessions.get(clientId);

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -377,7 +377,14 @@ export class SessionRegistry {
     if (!this.suspended.has(clientId)) return false;
     const buffer = this.suspendBuffers.get(clientId);
     if (!buffer) return false;
-    if (buffer.length >= SUSPEND_BUFFER_MAX) return false;
+    if (buffer.length >= SUSPEND_BUFFER_MAX) {
+      log.warn('suspend buffer full, dropping event', {
+        clientId,
+        bufferSize: buffer.length,
+        droppedType: event.type,
+      });
+      return false;
+    }
     buffer.push(event);
     return true;
   }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -65,6 +65,7 @@ export {
   WatchMessage,
   UnwatchMessage,
   SwitchSessionMessage,
+  SessionSuspendMessage,
   V2SendMessage,
   V2InterruptMessage,
   V2StopMessage,

--- a/packages/protocol/src/ws-schemas-v2.ts
+++ b/packages/protocol/src/ws-schemas-v2.ts
@@ -55,6 +55,16 @@ export const SwitchSessionMessage = z.object({
   sessionId: z.string().min(1).nullable(),
 });
 
+export const SessionSuspendMessage = z.object({
+  type: z.literal('session_suspend'),
+  sessions: z.array(
+    z.object({
+      sessionId: z.string().min(1),
+      lastSeq: z.number().int().min(0),
+    }),
+  ),
+});
+
 // ─── Chat messages (session-scoped) ─────────────────────────────────────────
 
 // sessionId is nullable on send (null = start new session) but required on
@@ -109,6 +119,7 @@ export const IncomingWsMessageV2 = z.discriminatedUnion('type', [
   WatchMessage,
   UnwatchMessage,
   SwitchSessionMessage,
+  SessionSuspendMessage,
   V2SendMessage,
   V2InterruptMessage,
   V2StopMessage,

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -40,6 +40,8 @@ function fakeRegistry(
     }),
     setMode: vi.fn(),
     isAttached: vi.fn(() => attached),
+    isSuspended: vi.fn(() => false),
+    bufferEvent: vi.fn(() => false),
     _setAttached: (v: boolean) => {
       attached = v;
     },

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -452,6 +452,65 @@ describe('runQueryLoop', () => {
     expect(detachedDeltas).toHaveLength(0);
   });
 
+  it('buffers events to registry when session is suspended', async () => {
+    let suspended = false;
+    const buffered: Record<string, unknown>[] = [];
+    registry = {
+      ...registry,
+      isSuspended: vi.fn(() => suspended),
+      bufferEvent: vi.fn((_cid: string, event: Record<string, unknown>) => {
+        buffered.push(event);
+        return true;
+      }),
+    } as unknown as typeof registry;
+
+    const events: Record<string, unknown>[] = [
+      { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-sus' } } },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'before suspend' },
+        },
+      },
+    ];
+
+    const suspendedEvents: Record<string, unknown>[] = [
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'text_delta', text: 'while suspended' },
+        },
+      },
+      { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+      { type: 'result', session_id: 'sess-sus' },
+    ];
+
+    async function* suspendingStream() {
+      for (const e of events) yield e;
+      suspended = true;
+      for (const e of suspendedEvents) yield e;
+    }
+
+    await runQueryLoop(suspendingStream(), clientId, registry, abortController);
+
+    expect(transport.sent.some((m: Record<string, unknown>) => m.delta === 'before suspend')).toBe(
+      true,
+    );
+    expect(transport.sent.some((m: Record<string, unknown>) => m.delta === 'while suspended')).toBe(
+      false,
+    );
+    expect(buffered.length).toBeGreaterThan(0);
+    expect(buffered.some((e) => e.type === 'block_delta')).toBe(true);
+  });
+
   it('does not emit old-style text or text_delta events', async () => {
     const events: Record<string, unknown>[] = [
       { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-nodupe' } } },

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -60,6 +60,11 @@ vi.mock('../chat.js', () => {
           observerCount: 0,
         },
       ]),
+      findBySessionId: vi.fn().mockImplementation((id: string) => {
+        if (id === 's1') return { clientId: 'conn-abc:s1', session: {} };
+        return null;
+      }),
+      suspend: vi.fn(),
     },
     setTaskStore: vi.fn(),
     eventStore: {
@@ -780,5 +785,53 @@ describe('skills routes', () => {
     expect(skill.allowedTools).toEqual(['Read', 'Glob']);
     // filePath should NOT be exposed to the client
     expect(skill.filePath).toBeUndefined();
+  });
+
+  describe('POST /api/sessions/suspend', () => {
+    it('returns 204 and calls registry.suspend for valid request', async () => {
+      const res = await request(app)
+        .post('/api/sessions/suspend')
+        .send({ connectionId: 'conn-abc', sessions: [{ sessionId: 's1', lastSeq: 5 }] });
+      expect(res.status).toBe(204);
+
+      const { registry } = (await import('../chat.js')) as unknown as {
+        registry: { suspend: ReturnType<typeof vi.fn> };
+      };
+      expect(registry.suspend).toHaveBeenCalledWith('conn-abc:s1', 5);
+    });
+
+    it('returns 400 when connectionId is missing', async () => {
+      const res = await request(app)
+        .post('/api/sessions/suspend')
+        .send({ sessions: [{ sessionId: 's1', lastSeq: 0 }] });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when sessions array is empty', async () => {
+      const res = await request(app)
+        .post('/api/sessions/suspend')
+        .send({ connectionId: 'conn-abc', sessions: [] });
+      expect(res.status).toBe(400);
+    });
+
+    it('skips sessions not owned by the connectionId', async () => {
+      const { registry } = (await import('../chat.js')) as unknown as {
+        registry: { suspend: ReturnType<typeof vi.fn> };
+      };
+      registry.suspend.mockClear();
+
+      const res = await request(app)
+        .post('/api/sessions/suspend')
+        .send({ connectionId: 'conn-other', sessions: [{ sessionId: 's1', lastSeq: 0 }] });
+      expect(res.status).toBe(204);
+      expect(registry.suspend).not.toHaveBeenCalled();
+    });
+
+    it('does not require auth cookie (sendBeacon cannot set headers)', async () => {
+      const res = await request(app)
+        .post('/api/sessions/suspend')
+        .send({ connectionId: 'conn-abc', sessions: [{ sessionId: 's1', lastSeq: 0 }] });
+      expect(res.status).toBe(204);
+    });
   });
 });

--- a/server/__tests__/suspend-routes.test.ts
+++ b/server/__tests__/suspend-routes.test.ts
@@ -60,6 +60,7 @@ vi.mock('../chat.js', () => {
 });
 
 let app: Express;
+let authCookie: string;
 
 beforeAll(async () => {
   mkdirSync(TEST_REPO, { recursive: true });
@@ -68,6 +69,13 @@ beforeAll(async () => {
 
   const mod = await import('../app.js');
   app = mod.app;
+
+  // Login to get auth cookie (sendBeacon sends cookies automatically)
+  const loginRes = await request(app)
+    .post('/api/auth/login')
+    .send({ passphrase: process.env.AUTH_PASSPHRASE });
+  const cookies = loginRes.headers['set-cookie'];
+  authCookie = Array.isArray(cookies) ? cookies[0] : cookies;
 });
 
 afterAll(() => {
@@ -80,6 +88,7 @@ describe('POST /api/sessions/suspend', () => {
 
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({
         connectionId: 'conn-owner',
         sessions: [{ sessionId: 'sess-known', lastSeq: 42 }],
@@ -89,8 +98,7 @@ describe('POST /api/sessions/suspend', () => {
     expect(mockSuspend).toHaveBeenCalledWith('conn-owner:sess-known', 42);
   });
 
-  it('does not require authentication (sendBeacon cannot set headers)', async () => {
-    // No auth cookie — should still work
+  it('requires authentication (cookie sent automatically by sendBeacon)', async () => {
     const res = await request(app)
       .post('/api/sessions/suspend')
       .send({
@@ -98,12 +106,13 @@ describe('POST /api/sessions/suspend', () => {
         sessions: [{ sessionId: 'sess-known', lastSeq: 0 }],
       });
 
-    expect(res.status).toBe(204);
+    expect(res.status).toBe(401);
   });
 
   it('rejects missing connectionId', async () => {
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({ sessions: [{ sessionId: 'sess-known', lastSeq: 0 }] });
 
     expect(res.status).toBe(400);
@@ -113,6 +122,7 @@ describe('POST /api/sessions/suspend', () => {
   it('rejects missing sessions array', async () => {
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({ connectionId: 'conn-owner' });
 
     expect(res.status).toBe(400);
@@ -122,6 +132,7 @@ describe('POST /api/sessions/suspend', () => {
   it('rejects empty sessions array', async () => {
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({ connectionId: 'conn-owner', sessions: [] });
 
     expect(res.status).toBe(400);
@@ -132,6 +143,7 @@ describe('POST /api/sessions/suspend', () => {
 
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({
         connectionId: 'conn-owner',
         sessions: [{ sessionId: 'sess-unknown', lastSeq: 0 }],
@@ -146,6 +158,7 @@ describe('POST /api/sessions/suspend', () => {
 
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({
         connectionId: 'conn-attacker',
         sessions: [{ sessionId: 'sess-known', lastSeq: 0 }],
@@ -168,6 +181,7 @@ describe('POST /api/sessions/suspend', () => {
 
     const res = await request(app)
       .post('/api/sessions/suspend')
+      .set('Cookie', authCookie)
       .send({
         connectionId: 'conn-owner',
         sessions: [

--- a/server/__tests__/suspend-routes.test.ts
+++ b/server/__tests__/suspend-routes.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { Express } from 'express';
+import request from 'supertest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const TEST_REPO = join(tmpdir(), `mitzo-suspend-test-${process.pid}`);
+
+const mockSuspend = vi.fn();
+
+vi.mock('../chat.js', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { join: pjoin } = require('path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { tmpdir: ptmpdir } = require('os');
+  const repo = pjoin(ptmpdir(), `mitzo-suspend-test-${process.pid}`);
+  return {
+    getSessions: vi.fn().mockResolvedValue({ sessions: [], hasMore: false }),
+    getMessages: vi.fn().mockResolvedValue([]),
+    renameSessionById: vi.fn(),
+    hideSession: vi.fn(),
+    hideAllSessions: vi.fn(),
+    BASE_REPO: repo,
+    getRepoConfig: vi.fn(() => ({
+      quickActions: [],
+      allowedPaths: [],
+      roots: [],
+      resolvedVenvPaths: [],
+      toolTierOverrides: {},
+      inboxPath: '',
+      resolvedInboxPath: '',
+      repos: {},
+      contextBlocks: {},
+    })),
+    getMcpServerNames: vi.fn().mockReturnValue([]),
+    AVAILABLE_MODELS: [],
+    registry: {
+      get: vi.fn(),
+      getActiveSessions: vi.fn().mockReturnValue([]),
+      findBySessionId: vi.fn((sid: string) => {
+        if (sid === 'sess-known') {
+          return { clientId: 'conn-owner:sess-known', session: { sessionId: 'sess-known' } };
+        }
+        return null;
+      }),
+      suspend: mockSuspend,
+    },
+    setTaskStore: vi.fn(),
+    eventStore: {
+      append: vi.fn(),
+      getEventsAfter: vi.fn().mockReturnValue([]),
+      getSession: vi.fn().mockReturnValue(null),
+    },
+    isIsolationEnabled: vi.fn().mockReturnValue(false),
+    generateWtId: vi.fn().mockReturnValue('wt-test'),
+    getSessionsCached: vi.fn().mockReturnValue({ sessions: [], hasMore: false }),
+    reconcileSessionsBackground: vi.fn(),
+  };
+});
+
+let app: Express;
+
+beforeAll(async () => {
+  mkdirSync(TEST_REPO, { recursive: true });
+  mkdirSync(join(TEST_REPO, '.mitzo'), { recursive: true });
+  process.env.BASE_REPO = TEST_REPO;
+
+  const mod = await import('../app.js');
+  app = mod.app;
+});
+
+afterAll(() => {
+  rmSync(TEST_REPO, { recursive: true, force: true });
+});
+
+describe('POST /api/sessions/suspend', () => {
+  it('returns 204 and calls registry.suspend for valid request', async () => {
+    mockSuspend.mockClear();
+
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({
+        connectionId: 'conn-owner',
+        sessions: [{ sessionId: 'sess-known', lastSeq: 42 }],
+      });
+
+    expect(res.status).toBe(204);
+    expect(mockSuspend).toHaveBeenCalledWith('conn-owner:sess-known', 42);
+  });
+
+  it('does not require authentication (sendBeacon cannot set headers)', async () => {
+    // No auth cookie — should still work
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({
+        connectionId: 'conn-owner',
+        sessions: [{ sessionId: 'sess-known', lastSeq: 0 }],
+      });
+
+    expect(res.status).toBe(204);
+  });
+
+  it('rejects missing connectionId', async () => {
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({ sessions: [{ sessionId: 'sess-known', lastSeq: 0 }] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('connectionId is required');
+  });
+
+  it('rejects missing sessions array', async () => {
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({ connectionId: 'conn-owner' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('sessions array is required');
+  });
+
+  it('rejects empty sessions array', async () => {
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({ connectionId: 'conn-owner', sessions: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('skips unknown sessions without error', async () => {
+    mockSuspend.mockClear();
+
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({
+        connectionId: 'conn-owner',
+        sessions: [{ sessionId: 'sess-unknown', lastSeq: 0 }],
+      });
+
+    expect(res.status).toBe(204);
+    expect(mockSuspend).not.toHaveBeenCalled();
+  });
+
+  it('rejects suspend from non-owner connectionId', async () => {
+    mockSuspend.mockClear();
+
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({
+        connectionId: 'conn-attacker',
+        sessions: [{ sessionId: 'sess-known', lastSeq: 0 }],
+      });
+
+    expect(res.status).toBe(204);
+    expect(mockSuspend).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple sessions in one request', async () => {
+    // Re-mock findBySessionId to return both sessions
+    const { registry } = await import('../chat.js');
+    (registry.findBySessionId as ReturnType<typeof vi.fn>).mockImplementation((sid: string) => {
+      if (sid === 'sess-a' || sid === 'sess-b') {
+        return { clientId: `conn-owner:${sid}`, session: { sessionId: sid } };
+      }
+      return null;
+    });
+    mockSuspend.mockClear();
+
+    const res = await request(app)
+      .post('/api/sessions/suspend')
+      .send({
+        connectionId: 'conn-owner',
+        sessions: [
+          { sessionId: 'sess-a', lastSeq: 10 },
+          { sessionId: 'sess-b', lastSeq: 20 },
+        ],
+      });
+
+    expect(res.status).toBe(204);
+    expect(mockSuspend).toHaveBeenCalledTimes(2);
+    expect(mockSuspend).toHaveBeenCalledWith('conn-owner:sess-a', 10);
+    expect(mockSuspend).toHaveBeenCalledWith('conn-owner:sess-b', 20);
+  });
+});

--- a/server/__tests__/token-update.test.ts
+++ b/server/__tests__/token-update.test.ts
@@ -34,6 +34,8 @@ function fakeRegistry(transport: SessionTransport): SessionRegistry {
     }),
     setMode: vi.fn(),
     isAttached: vi.fn(() => true),
+    isSuspended: vi.fn(() => false),
+    bufferEvent: vi.fn(() => false),
   } as unknown as SessionRegistry;
 }
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -2480,9 +2480,7 @@ describe('handleReconnect suspend resume', () => {
       transport.sent.some((m) => m.type === 'block_delta' && m.delta === 'buffered-text'),
     ).toBe(false);
     // Should have sent session_resumed with total replayed count
-    expect(
-      transport.sent.some((m) => m.type === 'session_resumed' && m.replayed === 1),
-    ).toBe(true);
+    expect(transport.sent.some((m) => m.type === 'session_resumed' && m.replayed === 1)).toBe(true);
   });
 });
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -2474,12 +2474,15 @@ describe('handleReconnect suspend resume', () => {
     );
 
     expect(sessionReg.resume).toHaveBeenCalledWith('conn-1:sess-1');
-    // Should have sent the buffered event
+    // Buffered events should NOT be replayed — EventStore replay covers them.
+    // resume() is called only to clear suspend state.
     expect(
       transport.sent.some((m) => m.type === 'block_delta' && m.delta === 'buffered-text'),
+    ).toBe(false);
+    // Should have sent session_resumed with total replayed count
+    expect(
+      transport.sent.some((m) => m.type === 'session_resumed' && m.replayed === 1),
     ).toBe(true);
-    // Should have sent session_resumed
-    expect(transport.sent.some((m) => m.type === 'session_resumed' && m.replayed === 1)).toBe(true);
   });
 });
 

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -59,6 +59,7 @@ import {
   handleSetModeV2,
   handleStopV2,
   handlePermissionResponseV2,
+  handleSessionSuspend,
   isHelloHandshake,
   dispatchV2Message,
   getOwnerConnection,
@@ -96,6 +97,9 @@ function mockSessionRegistry() {
     reattach: vi.fn().mockReturnValue(true),
     remove: vi.fn(),
     entries: vi.fn(() => new Map().entries()),
+    suspend: vi.fn(),
+    isSuspended: vi.fn().mockReturnValue(false),
+    resume: vi.fn().mockReturnValue([]),
   };
 }
 
@@ -2347,5 +2351,163 @@ describe('stale session cleanup removes registry entry', () => {
     expect(startChat).toHaveBeenCalled();
 
     (isActive as ReturnType<typeof vi.fn>).mockReturnValue(false);
+  });
+});
+
+// ─── handleSessionSuspend ───────────────────────────────────────────────────
+
+describe('handleSessionSuspend', () => {
+  it('suspends sessions owned by the connection', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({
+      clientId: 'conn-1:sess-1',
+      session: { sessionId: 'sess-1' },
+    });
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+
+    handleSessionSuspend(
+      'conn-1',
+      { type: 'session_suspend', sessions: [{ sessionId: 'sess-1', lastSeq: 42 }] },
+      ctx,
+    );
+
+    expect(sessionReg.suspend).toHaveBeenCalledWith('conn-1:sess-1', 42);
+  });
+
+  it('rejects suspend from non-owner connection', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({
+      clientId: 'conn-other:sess-1',
+      session: { sessionId: 'sess-1' },
+    });
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+
+    handleSessionSuspend(
+      'conn-1',
+      { type: 'session_suspend', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    expect(sessionReg.suspend).not.toHaveBeenCalled();
+  });
+
+  it('skips unknown sessions without error', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue(null);
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+
+    expect(() =>
+      handleSessionSuspend(
+        'conn-1',
+        { type: 'session_suspend', sessions: [{ sessionId: 'unknown', lastSeq: 0 }] },
+        ctx,
+      ),
+    ).not.toThrow();
+  });
+
+  it('suspends multiple sessions in a single message', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockImplementation((sid: string) => ({
+      clientId: `conn-1:${sid}`,
+      session: { sessionId: sid },
+    }));
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+
+    handleSessionSuspend(
+      'conn-1',
+      {
+        type: 'session_suspend',
+        sessions: [
+          { sessionId: 'sess-1', lastSeq: 10 },
+          { sessionId: 'sess-2', lastSeq: 20 },
+        ],
+      },
+      ctx,
+    );
+
+    expect(sessionReg.suspend).toHaveBeenCalledTimes(2);
+    expect(sessionReg.suspend).toHaveBeenCalledWith('conn-1:sess-1', 10);
+    expect(sessionReg.suspend).toHaveBeenCalledWith('conn-1:sess-2', 20);
+  });
+});
+
+// ─── handleReconnect — suspend resume ───────────────────────────────────────
+
+describe('handleReconnect suspend resume', () => {
+  it('replays buffered events for suspended sessions', () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({
+      clientId: 'conn-1:sess-1',
+      session: { sessionId: 'sess-1' },
+    });
+    sessionReg.isActive.mockReturnValue(true);
+    sessionReg.isAttached.mockReturnValue(false);
+    sessionReg.isSuspended.mockReturnValue(true);
+    sessionReg.resume.mockReturnValue([
+      { v: 2, type: 'block_delta', delta: 'buffered-text', sessionId: 'sess-1' },
+    ]);
+
+    const eventStore = mockEventStore();
+    eventStore.getSession.mockReturnValue({ isActive: true });
+
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+      eventStore: eventStore as unknown as V2HandlerContext['eventStore'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('conn-1', transport);
+
+    (reattachChat as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    handleReconnect(
+      'conn-1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 0 }] },
+      ctx,
+    );
+
+    expect(sessionReg.resume).toHaveBeenCalledWith('conn-1:sess-1');
+    // Should have sent the buffered event
+    expect(
+      transport.sent.some((m) => m.type === 'block_delta' && m.delta === 'buffered-text'),
+    ).toBe(true);
+    // Should have sent session_resumed
+    expect(transport.sent.some((m) => m.type === 'session_resumed' && m.replayed === 1)).toBe(true);
+  });
+});
+
+// ─── dispatchV2Message — session_suspend ────────────────────────────────────
+
+describe('dispatchV2Message session_suspend', () => {
+  it('dispatches session_suspend to handleSessionSuspend', async () => {
+    const sessionReg = mockSessionRegistry();
+    sessionReg.findBySessionId.mockReturnValue({
+      clientId: 'conn-1:sess-1',
+      session: { sessionId: 'sess-1' },
+    });
+    const ctx = createContext({
+      sessionRegistry: sessionReg as unknown as V2HandlerContext['sessionRegistry'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('conn-1', transport);
+
+    await dispatchV2Message(
+      'conn-1',
+      transport,
+      JSON.stringify({
+        type: 'session_suspend',
+        sessions: [{ sessionId: 'sess-1', lastSeq: 5 }],
+      }),
+      ctx,
+    );
+
+    expect(sessionReg.suspend).toHaveBeenCalledWith('conn-1:sess-1', 5);
   });
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -421,6 +421,46 @@ app.post('/api/sessions', (req, res) => {
   }
 });
 
+// --- Suspend endpoint (sendBeacon — no auth, same-origin only) ---
+// This must be above authMiddleware because sendBeacon cannot set custom headers.
+// The connectionId in the body is sufficient — it's a cryptographically random
+// value known only to the client that established the WebSocket.
+
+app.post('/api/sessions/suspend', (req, res) => {
+  const { connectionId, sessions } = req.body || {};
+
+  if (!connectionId || typeof connectionId !== 'string') {
+    res.status(400).json({ error: 'connectionId is required' });
+    return;
+  }
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    res.status(400).json({ error: 'sessions array is required' });
+    return;
+  }
+
+  for (const entry of sessions) {
+    if (!entry.sessionId || typeof entry.sessionId !== 'string') continue;
+    const lastSeq = typeof entry.lastSeq === 'number' ? entry.lastSeq : 0;
+
+    const found = registry.findBySessionId(entry.sessionId);
+    if (!found) continue;
+
+    // Verify the connectionId owns this session (same check as WS handler)
+    const colonIdx = found.clientId.indexOf(':');
+    const ownerConnection = colonIdx === -1 ? found.clientId : found.clientId.slice(0, colonIdx);
+    if (ownerConnection !== connectionId) continue;
+
+    registry.suspend(found.clientId, lastSeq);
+    log.info('session suspended via REST', {
+      connectionId,
+      sessionId: entry.sessionId,
+      clientId: found.clientId,
+    });
+  }
+
+  res.status(204).end();
+});
+
 app.use('/api', authMiddleware);
 
 // --- Task Board API ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,7 @@ import { promisify } from 'util';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-import { login, authMiddleware, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
+import { login, authMiddleware, verifyToken, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
 import {
   getSessions,
   getSessionsCached,
@@ -421,44 +421,57 @@ app.post('/api/sessions', (req, res) => {
   }
 });
 
-// --- Suspend endpoint (sendBeacon — no auth, same-origin only) ---
-// This must be above authMiddleware because sendBeacon cannot set custom headers.
-// The connectionId in the body is sufficient — it's a cryptographically random
-// value known only to the client that established the WebSocket.
+// --- Suspend endpoint (sendBeacon fallback) ---
+// Above authMiddleware because sendBeacon cannot set custom headers.
+// Auth is verified via the session cookie (sent automatically by sendBeacon
+// on same-origin requests). connectionId ownership is checked per-session.
 
 app.post('/api/sessions/suspend', (req, res) => {
-  const { connectionId, sessions } = req.body || {};
-
-  if (!connectionId || typeof connectionId !== 'string') {
-    res.status(400).json({ error: 'connectionId is required' });
-    return;
-  }
-  if (!Array.isArray(sessions) || sessions.length === 0) {
-    res.status(400).json({ error: 'sessions array is required' });
+  const token = req.cookies?.[COOKIE_NAME];
+  if (!token) {
+    res.status(401).json({ error: 'Not authenticated' });
     return;
   }
 
-  for (const entry of sessions) {
-    if (!entry.sessionId || typeof entry.sessionId !== 'string') continue;
-    const lastSeq = typeof entry.lastSeq === 'number' ? entry.lastSeq : 0;
+  verifyToken(token).then((valid) => {
+    if (!valid) {
+      res.status(401).json({ error: 'Invalid or expired token' });
+      return;
+    }
 
-    const found = registry.findBySessionId(entry.sessionId);
-    if (!found) continue;
+    const { connectionId, sessions } = req.body || {};
 
-    // Verify the connectionId owns this session (same check as WS handler)
-    const colonIdx = found.clientId.indexOf(':');
-    const ownerConnection = colonIdx === -1 ? found.clientId : found.clientId.slice(0, colonIdx);
-    if (ownerConnection !== connectionId) continue;
+    if (!connectionId || typeof connectionId !== 'string') {
+      res.status(400).json({ error: 'connectionId is required' });
+      return;
+    }
+    if (!Array.isArray(sessions) || sessions.length === 0) {
+      res.status(400).json({ error: 'sessions array is required' });
+      return;
+    }
 
-    registry.suspend(found.clientId, lastSeq);
-    log.info('session suspended via REST', {
-      connectionId,
-      sessionId: entry.sessionId,
-      clientId: found.clientId,
-    });
-  }
+    for (const entry of sessions) {
+      if (!entry.sessionId || typeof entry.sessionId !== 'string') continue;
+      const lastSeq = typeof entry.lastSeq === 'number' ? entry.lastSeq : 0;
 
-  res.status(204).end();
+      const found = registry.findBySessionId(entry.sessionId);
+      if (!found) continue;
+
+      // Verify the connectionId owns this session (same check as WS handler)
+      const colonIdx = found.clientId.indexOf(':');
+      const ownerConnection = colonIdx === -1 ? found.clientId : found.clientId.slice(0, colonIdx);
+      if (ownerConnection !== connectionId) continue;
+
+      registry.suspend(found.clientId, lastSeq);
+      log.info('session suspended via REST', {
+        connectionId,
+        sessionId: entry.sessionId,
+        clientId: found.clientId,
+      });
+    }
+
+    res.status(204).end();
+  });
 });
 
 app.use('/api', authMiddleware);

--- a/server/index.ts
+++ b/server/index.ts
@@ -218,7 +218,7 @@ server.on('upgrade', async (req, socket, head) => {
   }
 
   wss.handleUpgrade(req, socket, head, (ws) => {
-    const connId = `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const connId = `conn-${crypto.randomUUID()}`;
     log.info('chat connected', { connectionId: connId });
     routeWsClient(ws, connId);
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -316,6 +316,15 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
     for (const sessionId of watchedSessions) {
       const found = registry.findBySessionId(sessionId);
       if (!found) continue;
+
+      // If the session was proactively suspended (iOS backgrounding), the
+      // WS close is expected — don't transition to detach. The suspend
+      // grace timer manages the lifecycle instead.
+      if (registry.isSuspended(found.clientId)) {
+        log.info('v2 WS closed for suspended session (expected)', { connectionId, sessionId });
+        continue;
+      }
+
       const session = registry.get(found.clientId);
       if (session && session.transport === transport && registry.isAttached(found.clientId)) {
         withSpan(

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -86,9 +86,15 @@ function sendOrBuffer(
   }
 
   // Suspend buffer: if the session is proactively suspended (iOS backgrounding),
-  // buffer events instead of delivering them. They'll be replayed on resume.
+  // buffer events instead of delivering via the driver transport (which is
+  // dying). Still broadcast to other watchers — suspend is per-clientId, not
+  // per-session. The driver's dead WS will be skipped by broadcast's isOpen()
+  // check, and events are durable in EventStore regardless.
   if (registry.isSuspended(clientId)) {
     registry.bufferEvent(clientId, enriched);
+    if (sessionId && connRegistry?.hasOpenWatchers(sessionId)) {
+      connRegistry.broadcast(sessionId, enriched);
+    }
     return;
   }
 

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -85,6 +85,13 @@ function sendOrBuffer(
     }
   }
 
+  // Suspend buffer: if the session is proactively suspended (iOS backgrounding),
+  // buffer events instead of delivering them. They'll be replayed on resume.
+  if (registry.isSuspended(clientId)) {
+    registry.bufferEvent(clientId, enriched);
+    return;
+  }
+
   // v2 path: deliver via ConnectionRegistry when there are open connections
   // watching this session. Uses sessionId-based fan-out instead of checking
   // whether the originating clientId is still registered — after a WS

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -180,25 +180,26 @@ export function handleReconnect(
           }
         }
 
-        // If the session was suspended, resume it and replay buffered events.
+        // If the session was suspended, clear suspend state. Don't replay
+        // buffered events — they were already replayed from EventStore above
+        // (sendOrBuffer appends to both stores, so EventStore covers the
+        // suspend period). resume() just clears the suspend flag + buffer.
         let suspendReplayed = 0;
         if (found && running && ctx.sessionRegistry.isSuspended(found.clientId)) {
           const buffered = ctx.sessionRegistry.resume(found.clientId);
-          for (const evt of buffered) {
-            ctx.connRegistry.get(connectionId)?.transport.send(evt);
-          }
           suspendReplayed = buffered.length;
 
           ctx.connRegistry.get(connectionId)?.transport.send({
             type: 'session_resumed',
             sessionId: entry.sessionId,
-            replayed: suspendReplayed,
+            replayed: events.length + suspendReplayed,
           });
 
           log.info('resumed suspended session', {
             connectionId,
             sessionId: entry.sessionId,
-            replayed: suspendReplayed,
+            eventsFromStore: events.length,
+            bufferedDuringSuspend: suspendReplayed,
           });
         }
 

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -613,49 +613,37 @@ export function handleSessionSuspend(
   msg: SessionSuspendMsg,
   ctx: V2HandlerContext,
 ): void {
-  const span = tracer.startSpan('ws.session_suspend');
-  span.setAttribute('ws.connectionId', connectionId);
-  span.setAttribute('ws.sessionCount', msg.sessions.length);
+  withSpan(
+    'ws.session_suspend',
+    { 'ws.connectionId': connectionId, 'ws.sessionCount': msg.sessions.length },
+    () => {
+      for (const entry of msg.sessions) {
+        const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
+        if (!found) {
+          log.warn('suspend: session not found', { connectionId, sessionId: entry.sessionId });
+          continue;
+        }
 
-  try {
-    for (const entry of msg.sessions) {
-      const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
-      if (!found) {
-        log.warn('suspend: session not found', { connectionId, sessionId: entry.sessionId });
-        continue;
-      }
+        const ownerConnection = getOwnerConnection(found.clientId);
+        if (ownerConnection !== connectionId) {
+          log.warn('suspend: not owner', {
+            connectionId,
+            sessionId: entry.sessionId,
+            owner: ownerConnection,
+          });
+          continue;
+        }
 
-      // Only the owning connection can suspend a session
-      const ownerConnection = getOwnerConnection(found.clientId);
-      if (ownerConnection !== connectionId) {
-        log.warn('suspend: not owner', {
+        ctx.sessionRegistry.suspend(found.clientId, entry.lastSeq);
+        log.info('session suspended', {
           connectionId,
           sessionId: entry.sessionId,
-          owner: ownerConnection,
+          clientId: found.clientId,
+          lastSeq: entry.lastSeq,
         });
-        continue;
       }
-
-      ctx.sessionRegistry.suspend(found.clientId, entry.lastSeq);
-      log.info('session suspended', {
-        connectionId,
-        sessionId: entry.sessionId,
-        clientId: found.clientId,
-        lastSeq: entry.lastSeq,
-      });
-    }
-
-    span.setStatus({ code: SpanStatusCode.OK });
-  } catch (err: unknown) {
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: err instanceof Error ? err.message : 'unknown',
-    });
-    span.recordException(err instanceof Error ? err : new Error(String(err)));
-    throw err;
-  } finally {
-    span.end();
-  }
+    },
+  );
 }
 
 // ─── Dispatcher ──────────────────────────────────────────────────────────────

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -16,6 +16,7 @@ import {
   WatchMessage,
   UnwatchMessage,
   SwitchSessionMessage,
+  SessionSuspendMessage,
   V2SendMessage,
   V2StopMessage,
   V2InterruptMessage,
@@ -27,6 +28,7 @@ import type { z } from 'zod';
 type WatchMsg = z.infer<typeof WatchMessage>;
 type UnwatchMsg = z.infer<typeof UnwatchMessage>;
 type SwitchSessionMsg = z.infer<typeof SwitchSessionMessage>;
+type SessionSuspendMsg = z.infer<typeof SessionSuspendMessage>;
 type SendMsg = z.infer<typeof V2SendMessage>;
 type StopMsg = z.infer<typeof V2StopMessage>;
 type InterruptMsg = z.infer<typeof V2InterruptMessage>;
@@ -178,9 +180,31 @@ export function handleReconnect(
           }
         }
 
+        // If the session was suspended, resume it and replay buffered events.
+        let suspendReplayed = 0;
+        if (found && running && ctx.sessionRegistry.isSuspended(found.clientId)) {
+          const buffered = ctx.sessionRegistry.resume(found.clientId);
+          for (const evt of buffered) {
+            ctx.connRegistry.get(connectionId)?.transport.send(evt);
+          }
+          suspendReplayed = buffered.length;
+
+          ctx.connRegistry.get(connectionId)?.transport.send({
+            type: 'session_resumed',
+            sessionId: entry.sessionId,
+            replayed: suspendReplayed,
+          });
+
+          log.info('resumed suspended session', {
+            connectionId,
+            sessionId: entry.sessionId,
+            replayed: suspendReplayed,
+          });
+        }
+
         summaries.push({
           sessionId: entry.sessionId,
-          replayed: events.length,
+          replayed: events.length + suspendReplayed,
           running,
         });
 
@@ -189,6 +213,7 @@ export function handleReconnect(
           sessionId: entry.sessionId,
           lastSeq: entry.lastSeq,
           replayed: events.length,
+          suspendReplayed,
         });
       }
 
@@ -583,6 +608,56 @@ export function handleSetModeV2(
   );
 }
 
+export function handleSessionSuspend(
+  connectionId: string,
+  msg: SessionSuspendMsg,
+  ctx: V2HandlerContext,
+): void {
+  const span = tracer.startSpan('ws.session_suspend');
+  span.setAttribute('ws.connectionId', connectionId);
+  span.setAttribute('ws.sessionCount', msg.sessions.length);
+
+  try {
+    for (const entry of msg.sessions) {
+      const found = ctx.sessionRegistry.findBySessionId(entry.sessionId);
+      if (!found) {
+        log.warn('suspend: session not found', { connectionId, sessionId: entry.sessionId });
+        continue;
+      }
+
+      // Only the owning connection can suspend a session
+      const ownerConnection = getOwnerConnection(found.clientId);
+      if (ownerConnection !== connectionId) {
+        log.warn('suspend: not owner', {
+          connectionId,
+          sessionId: entry.sessionId,
+          owner: ownerConnection,
+        });
+        continue;
+      }
+
+      ctx.sessionRegistry.suspend(found.clientId, entry.lastSeq);
+      log.info('session suspended', {
+        connectionId,
+        sessionId: entry.sessionId,
+        clientId: found.clientId,
+        lastSeq: entry.lastSeq,
+      });
+    }
+
+    span.setStatus({ code: SpanStatusCode.OK });
+  } catch (err: unknown) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err instanceof Error ? err.message : 'unknown',
+    });
+    span.recordException(err instanceof Error ? err : new Error(String(err)));
+    throw err;
+  } finally {
+    span.end();
+  }
+}
+
 // ─── Dispatcher ──────────────────────────────────────────────────────────────
 
 /**
@@ -629,6 +704,9 @@ export async function dispatchV2Message(
       break;
     case 'switch_session':
       await handleSwitchSession(connectionId, msg, ctx);
+      break;
+    case 'session_suspend':
+      handleSessionSuspend(connectionId, msg, ctx);
       break;
     case 'send':
       handleSendV2(connectionId, transport, msg, ctx);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
       '@testing-library/react': resolve(__dirname, 'node_modules/@testing-library/react'),
       '@testing-library/jest-dom': resolve(__dirname, 'node_modules/@testing-library/jest-dom'),
       '@testing-library/user-event': resolve(__dirname, 'node_modules/@testing-library/user-event'),
+      // Workspace packages: worktrees resolve to main repo dist by default.
+      // Alias to worktree-local dist so tests use the current branch's code.
+      '@mitzo/protocol': resolve(__dirname, 'packages/protocol/dist/index.js'),
+      '@mitzo/harness': resolve(__dirname, 'packages/harness/dist/index.js'),
+      '@mitzo/client': resolve(__dirname, 'packages/client/dist/index.js'),
     },
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,11 +11,6 @@ export default defineConfig({
       '@testing-library/react': resolve(__dirname, 'node_modules/@testing-library/react'),
       '@testing-library/jest-dom': resolve(__dirname, 'node_modules/@testing-library/jest-dom'),
       '@testing-library/user-event': resolve(__dirname, 'node_modules/@testing-library/user-event'),
-      // Workspace packages: worktrees resolve to main repo dist by default.
-      // Alias to worktree-local dist so tests use the current branch's code.
-      '@mitzo/protocol': resolve(__dirname, 'packages/protocol/dist/index.js'),
-      '@mitzo/harness': resolve(__dirname, 'packages/harness/dist/index.js'),
-      '@mitzo/client': resolve(__dirname, 'packages/client/dist/index.js'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Signals the server BEFORE iOS kills the WebSocket (via `visibilitychange:hidden` + `pagehide`), enabling event buffering and instant resume
- Dual delivery: WS message + `sendBeacon` fallback (belt-and-suspenders for the iOS kill race)
- Server buffers agent responses for suspended sessions; replays them on reconnect
- Grace timer (2 min) transitions to normal detach if client doesn't resume
- Design doc: `docs/design/proactive-session-suspend.md`

### Architecture (4 commits)

1. **Protocol + Registry** — `SessionSuspendMessage` schema, `suspend()`/`isSuspended()`/`bufferEvent()`/`resume()` on SessionRegistry, constants
2. **Server handlers** — `handleSessionSuspend` in ws-handler-v2, query-loop buffer intercept, WS close guard, `POST /api/sessions/suspend` REST endpoint for sendBeacon
3. **Client** — `sendSuspend()` on MitzoConnection (WS + sendBeacon), `visibilitychange`/`pagehide`/Capacitor `onPause` hooks, store action + `switchSession` suspend
4. **Review fixes** — skip idle session suspend, buffer overflow warning, `session_resumed` client handler, withSpan consistency, test mock updates

### Files changed (15 files, +801/-57)

| Layer | Files |
|-------|-------|
| Protocol | `ws-schemas-v2.ts`, `index.ts` |
| Harness | `session-registry.ts`, `constants.ts`, `session-registry.test.ts` |
| Server | `ws-handler-v2.ts`, `query-loop.ts`, `index.ts`, `app.ts`, `ws-handler-v2.test.ts` |
| Client | `connection.ts`, `store.ts` |
| Frontend | `client-store.ts`, `capacitor.ts` |
| Config | `vitest.config.ts` |

## Test plan

- [x] 259 lines of new session-registry tests (suspend/resume/grace/buffer/cleanup)
- [x] 162 lines of new ws-handler-v2 tests (handleSessionSuspend, reconnect resume, dispatch)
- [x] All 2184 passing tests still pass (38 failures are pre-existing)
- [ ] Manual: background Mitzo on iPhone → check server logs for `session suspended`
- [ ] Manual: return to app → check logs for `resumed suspended session` with replayed count
- [ ] Manual: switch sessions while agent running → switch back → response visible


Made with [Cursor](https://cursor.com)