### PR TITLE
fix(server): persist user messages for resumed sessions

### DIFF
--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -304,12 +304,31 @@ describe('startChat stores user message for resumed sessions', () => {
   });
 
   it('echoes user_message to transport and broadcasts to observers', () => {
-    const nearAppend = chatSource.indexOf("eventStore.append(options.resume, 'user_message'");
-    expect(nearAppend).toBeGreaterThan(-1);
-    const region = chatSource.slice(nearAppend, nearAppend + 500);
+    // Region between the resume guard and runQueryLoop — bounds the block
+    // without fragile brace-matching or magic byte offsets.
+    const start = chatSource.indexOf(
+      'if (options.resume) {',
+      chatSource.indexOf('session.queryInstance = q'),
+    );
+    const end = chatSource.indexOf('await runQueryLoop(', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const region = chatSource.slice(start, end);
+    expect(region).toContain("eventStore.append(options.resume, 'user_message'");
     expect(region).toContain('send(transport');
     expect(region).toContain("type: 'user_message'");
     expect(region).toContain('broadcastToObservers(session.observers');
+  });
+
+  it('uses clientMsgId with resume fallback for messageId', () => {
+    const start = chatSource.indexOf(
+      'if (options.resume) {',
+      chatSource.indexOf('session.queryInstance = q'),
+    );
+    const end = chatSource.indexOf('await runQueryLoop(', start);
+    const region = chatSource.slice(start, end);
+    expect(region).toContain('options.clientMsgId');
+    expect(region).toMatch(/umsg-.*-resume/);
   });
 });
 

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -282,6 +282,42 @@ describe('startChat finally block does NOT clean up worktrees', () => {
   });
 });
 
+describe('startChat stores user message for resumed sessions', () => {
+  it('appends user_message to eventStore when options.resume is set', async () => {
+    // Structural test: verify that startChat stores the user message before
+    // starting the query loop when resuming. Without this, user messages are
+    // invisible after WS reconnect because sendOrBuffer only persists v2
+    // events emitted by the query loop — the user's prompt is never one of those.
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const chatSource = readFileSync(join(import.meta.dirname, '..', 'chat.ts'), 'utf-8');
+
+    // The pattern: eventStore.append(options.resume, 'user_message', ...)
+    // must appear BEFORE runQueryLoop in startChat
+    const appendIdx = chatSource.indexOf("eventStore.append(options.resume, 'user_message'");
+    const queryLoopIdx = chatSource.indexOf('await runQueryLoop(');
+    expect(appendIdx).toBeGreaterThan(-1);
+    expect(queryLoopIdx).toBeGreaterThan(-1);
+    expect(appendIdx).toBeLessThan(queryLoopIdx);
+  });
+
+  it('echoes user_message to transport on resume', async () => {
+    const { readFileSync } = await import('fs');
+    const { join } = await import('path');
+    const chatSource = readFileSync(join(import.meta.dirname, '..', 'chat.ts'), 'utf-8');
+
+    // Find the resume block near the eventStore.append call (not the earlier
+    // resumability validation block). Look for the block that contains both
+    // the append and the send.
+    const nearAppend = chatSource.indexOf("eventStore.append(options.resume, 'user_message'");
+    expect(nearAppend).toBeGreaterThan(-1);
+    // The send(transport, ...) echo must be in the same code region
+    const regionAfterAppend = chatSource.slice(nearAppend, nearAppend + 500);
+    expect(regionAfterAppend).toContain('send(transport');
+    expect(regionAfterAppend).toContain("type: 'user_message'");
+  });
+});
+
 describe('isIsolationEnabled', () => {
   let originalEnv: string | undefined;
 

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
 import type { ManagedSession } from '@mitzo/harness';
 
 vi.mock('../worktree.js', async (importOriginal) => {
@@ -282,18 +282,20 @@ describe('startChat finally block does NOT clean up worktrees', () => {
   });
 });
 
+// Structural tests: startChat requires the full Agent SDK query() pipeline,
+// making behavioral mocking impractical. Source-code assertions lock in the
+// key invariant (store + echo + broadcast before runQueryLoop) with minimal
+// coupling to the SDK internals.
 describe('startChat stores user message for resumed sessions', () => {
-  it('appends user_message to eventStore when options.resume is set', async () => {
-    // Structural test: verify that startChat stores the user message before
-    // starting the query loop when resuming. Without this, user messages are
-    // invisible after WS reconnect because sendOrBuffer only persists v2
-    // events emitted by the query loop — the user's prompt is never one of those.
+  let chatSource: string;
+
+  beforeAll(async () => {
     const { readFileSync } = await import('fs');
     const { join } = await import('path');
-    const chatSource = readFileSync(join(import.meta.dirname, '..', 'chat.ts'), 'utf-8');
+    chatSource = readFileSync(join(import.meta.dirname, '..', 'chat.ts'), 'utf-8');
+  });
 
-    // The pattern: eventStore.append(options.resume, 'user_message', ...)
-    // must appear BEFORE runQueryLoop in startChat
+  it('appends user_message to eventStore before runQueryLoop', () => {
     const appendIdx = chatSource.indexOf("eventStore.append(options.resume, 'user_message'");
     const queryLoopIdx = chatSource.indexOf('await runQueryLoop(');
     expect(appendIdx).toBeGreaterThan(-1);
@@ -301,20 +303,13 @@ describe('startChat stores user message for resumed sessions', () => {
     expect(appendIdx).toBeLessThan(queryLoopIdx);
   });
 
-  it('echoes user_message to transport on resume', async () => {
-    const { readFileSync } = await import('fs');
-    const { join } = await import('path');
-    const chatSource = readFileSync(join(import.meta.dirname, '..', 'chat.ts'), 'utf-8');
-
-    // Find the resume block near the eventStore.append call (not the earlier
-    // resumability validation block). Look for the block that contains both
-    // the append and the send.
+  it('echoes user_message to transport and broadcasts to observers', () => {
     const nearAppend = chatSource.indexOf("eventStore.append(options.resume, 'user_message'");
     expect(nearAppend).toBeGreaterThan(-1);
-    // The send(transport, ...) echo must be in the same code region
-    const regionAfterAppend = chatSource.slice(nearAppend, nearAppend + 500);
-    expect(regionAfterAppend).toContain('send(transport');
-    expect(regionAfterAppend).toContain("type: 'user_message'");
+    const region = chatSource.slice(nearAppend, nearAppend + 500);
+    expect(region).toContain('send(transport');
+    expect(region).toContain("type: 'user_message'");
+    expect(region).toContain('broadcastToObservers(session.observers');
   });
 });
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -759,7 +759,9 @@ async function _startChatInner(
         messageId,
         text: fullPrompt,
       });
-      send(transport, { type: 'user_message', messageId, text: fullPrompt });
+      const echo = { type: 'user_message', messageId, text: fullPrompt };
+      send(transport, echo);
+      broadcastToObservers(session.observers, echo);
     }
 
     await runQueryLoop(

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -747,6 +747,21 @@ async function _startChatInner(
 
     session.queryInstance = q;
 
+    // For resumed sessions the prompt is sent to the SDK but was never stored
+    // in the event store — making user messages invisible after WS reconnect.
+    // Store and echo it here so the frontend can replay it.
+    if (options.resume) {
+      const messageId = options.clientMsgId || `umsg-${Date.now()}-resume`;
+      eventStore.append(options.resume, 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId,
+        text: fullPrompt,
+      });
+      send(transport, { type: 'user_message', messageId, text: fullPrompt });
+    }
+
     await runQueryLoop(
       q as unknown as AsyncIterable<Record<string, unknown>>,
       clientId,


### PR DESCRIPTION
## Summary

- User messages sent through the resume path (`startChat({ resume })`) were never stored in the event store — only assistant responses were persisted
- After any WS reconnect (frequent on iOS), the frontend replays from the event store and user messages vanished
- **Every** message in a typical session hits the resume path (confirmed via Jaeger traces — all `routing.decision=resume`)
- Fix: store the `user_message` event and echo it to the transport before starting the query loop, mirroring `sendToChat()` behavior

## Root cause

`startChat` line 756 passes `undefined` as `initialPrompt` when `options.resume` is set:
```typescript
options.resume ? undefined : fullPrompt,
```
The query loop only stores user messages when `initialPrompt` is truthy. Result: resumed sessions silently drop all user messages from the event store.

## Test plan

- [x] Structural tests verify `eventStore.append(options.resume, 'user_message')` appears before `runQueryLoop` and includes transport echo
- [x] All 29 chat tests pass
- [ ] Manual: send messages on iOS, background app, return — user messages should persist across WS reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)