### PR TITLE
fix(worktree): raise stale TTL to 96h and skip active sessions during cleanup

### DIFF
--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -457,6 +457,49 @@ describe('cleanupStaleWorktrees', () => {
     expect(remaining).not.toContain(sessionId);
   });
 
+  it('skips worktrees whose names appear in activeSessionIds', () => {
+    const wtDir = join(baseRepo, '.claude', 'worktrees');
+    mkdirSync(wtDir, { recursive: true });
+    const sessionId = 'test-active-session';
+    const wtPath = join(wtDir, sessionId);
+    execFileSync('git', ['-C', baseRepo, 'worktree', 'add', '-b', `session/${sessionId}`, wtPath], {
+      stdio: 'pipe',
+    });
+
+    // Age the worktree past the cutoff
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    utimesSync(wtPath, fiveDaysAgo, fiveDaysAgo);
+
+    // Pass the session as active — should be protected from cleanup
+    cleanupStaleWorktrees(baseRepo, inboxDir, new Set([sessionId]));
+
+    const remaining = readdirSync(wtDir);
+    expect(remaining).toContain(sessionId);
+  });
+
+  it('still removes stale worktrees not in activeSessionIds', () => {
+    const wtDir = join(baseRepo, '.claude', 'worktrees');
+    mkdirSync(wtDir, { recursive: true });
+
+    const activeId = 'test-active';
+    const staleId = 'test-stale';
+
+    for (const id of [activeId, staleId]) {
+      const wtPath = join(wtDir, id);
+      execFileSync('git', ['-C', baseRepo, 'worktree', 'add', '-b', `session/${id}`, wtPath], {
+        stdio: 'pipe',
+      });
+      const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+      utimesSync(wtPath, fiveDaysAgo, fiveDaysAgo);
+    }
+
+    cleanupStaleWorktrees(baseRepo, inboxDir, new Set([activeId]));
+
+    const remaining = readdirSync(wtDir);
+    expect(remaining).toContain(activeId);
+    expect(remaining).not.toContain(staleId);
+  });
+
   it('creates unique filenames for multiple dirty worktrees', () => {
     const wtDir = join(baseRepo, '.claude', 'worktrees');
     mkdirSync(wtDir, { recursive: true });

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -500,6 +500,25 @@ describe('cleanupStaleWorktrees', () => {
     expect(remaining).not.toContain(staleId);
   });
 
+  it('active-session guard takes priority over name-based age detection', () => {
+    const wtDir = join(baseRepo, '.claude', 'worktrees');
+    mkdirSync(wtDir, { recursive: true });
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    const oldDate = fiveDaysAgo.toISOString().slice(0, 10);
+    const sessionId = `${oldDate}-a1b2c3`;
+    const wtPath = join(wtDir, sessionId);
+    execFileSync('git', ['-C', baseRepo, 'worktree', 'add', '-b', `session/${sessionId}`, wtPath], {
+      stdio: 'pipe',
+    });
+    // Both name-age and mtime are stale — would normally be cleaned up
+    utimesSync(wtPath, fiveDaysAgo, fiveDaysAgo);
+
+    cleanupStaleWorktrees(baseRepo, inboxDir, new Set([sessionId]));
+
+    const remaining = readdirSync(wtDir);
+    expect(remaining).toContain(sessionId);
+  });
+
   it('creates unique filenames for multiple dirty worktrees', () => {
     const wtDir = join(baseRepo, '.claude', 'worktrees');
     mkdirSync(wtDir, { recursive: true });

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -26,7 +26,7 @@ export {
 
 // --- Worktree ---
 export const WORKTREE_BRANCH_PREFIX = 'session/';
-export const WORKTREE_STALE_HOURS = 24; // 1 day
+export const WORKTREE_STALE_HOURS = 96; // 4 days
 export const WORKTREE_GIT_TIMEOUT_MS = 30_000;
 export const WORKTREE_REMOVE_TIMEOUT_MS = 15_000;
 export const WORKTREE_PRUNE_TIMEOUT_MS = 5_000;

--- a/server/index.ts
+++ b/server/index.ts
@@ -795,9 +795,17 @@ checkPort(PORT).then((inUse) => {
         error: err instanceof Error ? err.message : 'unknown',
       });
     }
+    function collectActiveWtIds(): Set<string> {
+      const ids = new Set<string>();
+      for (const [, session] of registry.entries()) {
+        if (session.wtId) ids.add(session.wtId);
+      }
+      return ids;
+    }
+
     for (const [label, repoPath] of repoEntries) {
       try {
-        cleanupStaleWorktrees(repoPath, inboxDir);
+        cleanupStaleWorktrees(repoPath, inboxDir, collectActiveWtIds());
       } catch (err: unknown) {
         log.warn(`stale worktree cleanup failed for ${label}`, {
           error: err instanceof Error ? err.message : 'unknown',
@@ -827,9 +835,10 @@ checkPort(PORT).then((inUse) => {
     }, GUARD_STATS_INTERVAL_MS);
 
     setInterval(() => {
+      const activeWtIds = collectActiveWtIds();
       for (const [label, repoPath] of repoEntries) {
         try {
-          cleanupStaleWorktrees(repoPath, inboxDir);
+          cleanupStaleWorktrees(repoPath, inboxDir, activeWtIds);
         } catch (err: unknown) {
           log.warn(`periodic worktree cleanup failed for ${label}`, {
             error: err instanceof Error ? err.message : 'unknown',

--- a/server/index.ts
+++ b/server/index.ts
@@ -803,9 +803,10 @@ checkPort(PORT).then((inUse) => {
       return ids;
     }
 
+    const startupActiveWtIds = collectActiveWtIds();
     for (const [label, repoPath] of repoEntries) {
       try {
-        cleanupStaleWorktrees(repoPath, inboxDir, collectActiveWtIds());
+        cleanupStaleWorktrees(repoPath, inboxDir, startupActiveWtIds);
       } catch (err: unknown) {
         log.warn(`stale worktree cleanup failed for ${label}`, {
           error: err instanceof Error ? err.message : 'unknown',

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -421,6 +421,11 @@ export function cleanupStaleWorktrees(
   let skipped = 0;
 
   for (const entry of readdirSync(dir)) {
+    if (activeSessionIds?.has(entry)) {
+      log.info('skipped worktree owned by active session', { repo: baseRepo, session: entry });
+      continue;
+    }
+
     const fullPath = join(dir, entry);
     try {
       // Prefer name-based age (immune to mtime being refreshed by git operations),
@@ -429,11 +434,6 @@ export function cleanupStaleWorktrees(
       const nameAge = parseWorktreeAge(entry);
       const mtimeAge = now - statSync(fullPath).mtimeMs;
       const isStale = nameAge !== null ? nameAge > cutoff && mtimeAge > cutoff : mtimeAge > cutoff;
-
-      if (activeSessionIds?.has(entry)) {
-        log.info('skipped worktree owned by active session', { repo: baseRepo, session: entry });
-        continue;
-      }
 
       if (isStale) {
         const dirty = hasUncommittedWork(fullPath);

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -419,10 +419,11 @@ export function cleanupStaleWorktrees(
   const cutoff = WORKTREE_STALE_HOURS * 60 * 60 * 1000;
   let cleaned = 0;
   let skipped = 0;
+  let protected_ = 0;
 
   for (const entry of readdirSync(dir)) {
     if (activeSessionIds?.has(entry)) {
-      log.info('skipped worktree owned by active session', { repo: baseRepo, session: entry });
+      protected_++;
       continue;
     }
 
@@ -475,10 +476,11 @@ export function cleanupStaleWorktrees(
     // Non-fatal
   }
 
-  if (cleaned > 0 || skipped > 0) {
-    log.info(`worktree cleanup: ${cleaned} removed, ${skipped} skipped (dirty)`, {
-      repo: baseRepo,
-    });
+  if (cleaned > 0 || skipped > 0 || protected_ > 0) {
+    log.info(
+      `worktree cleanup: ${cleaned} removed, ${skipped} skipped (dirty), ${protected_} active`,
+      { repo: baseRepo },
+    );
   }
 }
 

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -403,9 +403,15 @@ ${dirtyFiles}
 /**
  * Clean up stale worktrees in the given repo's .claude/worktrees/ directory.
  * Worktrees with uncommitted work are skipped and flagged in the mgmt inbox.
+ * Worktrees belonging to active sessions are never cleaned up.
  * @param inboxDir — path to the mgmt inbox directory for dirty worktree proposals.
+ * @param activeSessionIds — wtIds of sessions currently in the registry (always skipped).
  */
-export function cleanupStaleWorktrees(baseRepo: string, inboxDir?: string): void {
+export function cleanupStaleWorktrees(
+  baseRepo: string,
+  inboxDir?: string,
+  activeSessionIds?: ReadonlySet<string>,
+): void {
   const dir = worktreesDir(baseRepo);
   if (!existsSync(dir)) return;
 
@@ -423,6 +429,11 @@ export function cleanupStaleWorktrees(baseRepo: string, inboxDir?: string): void
       const nameAge = parseWorktreeAge(entry);
       const mtimeAge = now - statSync(fullPath).mtimeMs;
       const isStale = nameAge !== null ? nameAge > cutoff && mtimeAge > cutoff : mtimeAge > cutoff;
+
+      if (activeSessionIds?.has(entry)) {
+        log.info('skipped worktree owned by active session', { repo: baseRepo, session: entry });
+        continue;
+      }
 
       if (isStale) {
         const dirty = hasUncommittedWork(fullPath);


### PR DESCRIPTION
## Summary

- **Bumps `WORKTREE_STALE_HOURS` from 24h to 96h** — the old 1-day TTL was deleting worktrees from under active Cursor/Claude Code sessions that went idle for even a workday. The 96h value matches what CLAUDE.md already documented.
- **Adds active-session guard** — `cleanupStaleWorktrees` now accepts an optional `activeSessionIds` set (wtIds from the `SessionRegistry`). Worktrees belonging to live sessions are never cleaned up, regardless of age.
- Both startup and periodic cleanup in `index.ts` now collect active wtIds from the registry before each sweep.

## Test plan

- [x] Two new tests: `skips worktrees whose names appear in activeSessionIds` and `still removes stale worktrees not in activeSessionIds`
- [x] All 31 worktree tests pass
- [x] All 94 dependent tests (routes, todos, yapper-proxy) pass
- [x] No linter errors
- [ ] CI green


Made with [Cursor](https://cursor.com)