### PR TITLE
fix(tests): update stale test expectations

### DIFF
--- a/frontend/src/components/__tests__/TabBar.test.tsx
+++ b/frontend/src/components/__tests__/TabBar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -18,6 +18,22 @@ vi.mock('react-router-dom', async () => {
 });
 
 import { TabBar } from '../TabBar';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 afterEach(() => {
   cleanup();
@@ -42,7 +58,7 @@ describe('TabBar', () => {
   it('shows tab labels', () => {
     renderAt('/');
     expect(screen.getByText('Chat')).toBeTruthy();
-    expect(screen.getByText('Tasks')).toBeTruthy();
+    expect(screen.getByText('Calendar')).toBeTruthy();
     expect(screen.getByText('Inbox')).toBeTruthy();
     expect(screen.getByText('Todos')).toBeTruthy();
     expect(screen.getByText('More')).toBeTruthy();
@@ -54,10 +70,10 @@ describe('TabBar', () => {
     expect(chatTab?.className).toContain('tab-bar-item--active');
   });
 
-  it('highlights Tasks tab on /tasks route', () => {
+  it('highlights More tab on /tasks route', () => {
     renderAt('/tasks');
-    const tasksTab = screen.getByText('Tasks').closest('button');
-    expect(tasksTab?.className).toContain('tab-bar-item--active');
+    const moreTab = screen.getByText('More').closest('button');
+    expect(moreTab?.className).toContain('tab-bar-item--active');
   });
 
   it('shows badge on Inbox tab when count > 0', () => {
@@ -74,8 +90,8 @@ describe('TabBar', () => {
 
   it('navigates when tab is clicked', () => {
     renderAt('/');
-    fireEvent.click(screen.getByText('Tasks'));
-    expect(mockNavigate).toHaveBeenCalledWith('/tasks');
+    fireEvent.click(screen.getByText('Calendar'));
+    expect(mockNavigate).toHaveBeenCalledWith('/calendar');
   });
 
   it('uses the tab-bar CSS class', () => {

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -54,14 +54,14 @@ describe('TaskNode', () => {
   });
 
   it.each([
-    ['pending', 'Pending'],
-    ['active', 'Active'],
-    ['done', 'Done'],
-    ['pending_review', 'Review'],
-    ['blocked', 'Blocked'],
-    ['skipped', 'Skipped'],
-    ['failed', 'Failed'],
-  ] as const)('renders correct label for status %s', (status, expectedLabel) => {
+    ['pending', '\u25CB'],
+    ['active', '\u25C9'],
+    ['done', '\u2713'],
+    ['pending_review', '\u25D4'],
+    ['blocked', '\u2298'],
+    ['skipped', '\u2014'],
+    ['failed', '\u2717'],
+  ] as const)('renders correct label for status %s', (status, expectedIcon) => {
     const { container } = render(
       <TaskNode
         task={makeTask({ status })}
@@ -71,8 +71,8 @@ describe('TaskNode', () => {
         onAddChild={vi.fn()}
       />,
     );
-    const statusBtn = container.querySelector('.task-card-chip');
-    expect(statusBtn?.textContent).toBe(expectedLabel);
+    const statusBtn = container.querySelector('.task-node-status');
+    expect(statusBtn?.textContent).toBe(expectedIcon);
   });
 
   it('toggles expand/collapse for tasks with children', () => {
@@ -93,7 +93,7 @@ describe('TaskNode', () => {
     expect(screen.getByText('Child task')).toBeTruthy();
 
     // Click collapse
-    const chevron = screen.getByText('\u25BE');
+    const chevron = screen.getByText('\u25BC');
     fireEvent.click(chevron);
 
     // Children should be hidden
@@ -156,7 +156,7 @@ describe('TaskNode', () => {
       />,
     );
 
-    const statusBtn = container.querySelector('.task-card-chip')!;
+    const statusBtn = container.querySelector('.task-node-status')!;
     fireEvent.click(statusBtn);
     expect(onStatusChange).toHaveBeenCalledWith('sc-1', expect.any(String));
   });
@@ -173,7 +173,7 @@ describe('TaskNode', () => {
       />,
     );
 
-    const deleteBtn = container.querySelector('.task-card-action--reject')!;
+    const deleteBtn = container.querySelector('.task-node-action--danger')!;
     fireEvent.click(deleteBtn);
     expect(onDelete).toHaveBeenCalledWith('del-1');
   });

--- a/frontend/src/lib/__tests__/biometric.test.ts
+++ b/frontend/src/lib/__tests__/biometric.test.ts
@@ -105,6 +105,9 @@ describe('biometricLogin', () => {
       password: 'stored-jwt',
     });
 
+    // Mock fetch for server validation
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+
     const token = await biometricLogin();
     expect(token).toBe('stored-jwt');
     expect(localStorage.getItem('mitzo_auth_token')).toBe('stored-jwt');

--- a/frontend/src/lib/__tests__/biometric.test.ts
+++ b/frontend/src/lib/__tests__/biometric.test.ts
@@ -105,8 +105,8 @@ describe('biometricLogin', () => {
       password: 'stored-jwt',
     });
 
-    // Mock fetch for server validation
-    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+    // Mock fetch for server validation (vi.spyOn auto-restores on clearAllMocks)
+    vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true } as Response);
 
     const token = await biometricLogin();
     expect(token).toBe('stored-jwt');

--- a/frontend/src/pages/__tests__/CalendarView.test.tsx
+++ b/frontend/src/pages/__tests__/CalendarView.test.tsx
@@ -88,7 +88,7 @@ describe('CalendarView', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    const header = container.querySelector('.cal-header');
+    const header = container.querySelector('.page-header');
     expect(header).not.toBeNull();
 
     const prevBtn = container.querySelector('.cal-nav-prev');
@@ -160,17 +160,6 @@ describe('CalendarView', () => {
 
     // Should have fetched again with a later date
     expect(fetch).toHaveBeenCalledTimes(2);
-  });
-
-  it('renders back button for navigation', async () => {
-    renderCalendar();
-
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 10));
-    });
-
-    const back = container.querySelector('.cal-back');
-    expect(back).not.toBeNull();
   });
 
   it('switches to day view on Day toggle click', async () => {

--- a/frontend/src/pages/__tests__/TodoDetailView.test.tsx
+++ b/frontend/src/pages/__tests__/TodoDetailView.test.tsx
@@ -149,16 +149,6 @@ describe('TodoDetailView', () => {
     ).toBeTruthy();
   });
 
-  it('navigates back to /todos on back button click', () => {
-    const { container } = render(
-      <MemoryRouter>
-        <TodoDetailView />
-      </MemoryRouter>,
-    );
-    fireEvent.click(container.querySelector('.todo-detail-back')!);
-    expect(mockNavigate).toHaveBeenCalledWith('/todos');
-  });
-
   it('navigates to chat with prompt on "Open in Chat" click', () => {
     const { container } = render(
       <MemoryRouter>

--- a/packages/harness/__tests__/permission-handler.test.ts
+++ b/packages/harness/__tests__/permission-handler.test.ts
@@ -112,7 +112,6 @@ describe('buildPermissionHandler', () => {
   });
 
   it('sends permission_request for unknown tools and resolves on response', async () => {
-    vi.useFakeTimers();
     const transport = fakeTransport();
     registry.register('client-1', {
       transport,
@@ -131,6 +130,9 @@ describe('buildPermissionHandler', () => {
       },
     );
 
+    // Flush microtasks to allow async checkWorktreePolicy to complete
+    await Promise.resolve();
+
     // Should have sent a permission_request
     expect(transport.sent.length).toBe(1);
     expect(transport.sent[0].type).toBe('permission_request');
@@ -141,8 +143,6 @@ describe('buildPermissionHandler', () => {
     const result = await promise;
     expect(result.behavior).toBe('allow');
     expect(result.decisionClassification).toBe('user_temporary');
-
-    vi.useRealTimers();
   });
 
   it('denies when aborted', async () => {

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -791,6 +791,7 @@ describe('skills routes', () => {
     it('returns 204 and calls registry.suspend for valid request', async () => {
       const res = await request(app)
         .post('/api/sessions/suspend')
+        .set('Cookie', authCookie)
         .send({ connectionId: 'conn-abc', sessions: [{ sessionId: 's1', lastSeq: 5 }] });
       expect(res.status).toBe(204);
 
@@ -803,6 +804,7 @@ describe('skills routes', () => {
     it('returns 400 when connectionId is missing', async () => {
       const res = await request(app)
         .post('/api/sessions/suspend')
+        .set('Cookie', authCookie)
         .send({ sessions: [{ sessionId: 's1', lastSeq: 0 }] });
       expect(res.status).toBe(400);
     });
@@ -810,6 +812,7 @@ describe('skills routes', () => {
     it('returns 400 when sessions array is empty', async () => {
       const res = await request(app)
         .post('/api/sessions/suspend')
+        .set('Cookie', authCookie)
         .send({ connectionId: 'conn-abc', sessions: [] });
       expect(res.status).toBe(400);
     });
@@ -822,14 +825,16 @@ describe('skills routes', () => {
 
       const res = await request(app)
         .post('/api/sessions/suspend')
+        .set('Cookie', authCookie)
         .send({ connectionId: 'conn-other', sessions: [{ sessionId: 's1', lastSeq: 0 }] });
       expect(res.status).toBe(204);
       expect(registry.suspend).not.toHaveBeenCalled();
     });
 
-    it('does not require auth cookie (sendBeacon cannot set headers)', async () => {
+    it('authenticates via cookie (sendBeacon sends cookies automatically)', async () => {
       const res = await request(app)
         .post('/api/sessions/suspend')
+        .set('Cookie', authCookie)
         .send({ connectionId: 'conn-abc', sessions: [{ sessionId: 's1', lastSeq: 0 }] });
       expect(res.status).toBe(204);
     });

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -557,7 +557,6 @@ async function _runQueryLoopInner(
                   type: 'token_update',
                   agentContext: agentContextTokens,
                   contextCeiling: CONTEXT_CEILING_TOKENS,
-                  sessionTotal: liveSessionTokens,
                   turnIndex,
                   ...compactionFields(),
                 });


### PR DESCRIPTION
## Summary
- Fixes 31 test failures across 8 test files where tests had drifted from implementation
- Server: auth cookies for suspend endpoint, sessionTotal removed from message_start, async microtask flush
- Frontend: TabBar tabs reshuffled (Calendar added, Tasks→More), TaskNode CSS selectors + icons, PageHeader adoption, fetch mock for biometric

## Test plan
- [x] All 8 previously-failing test files now pass (147/147 tests)
- [x] No implementation changes except removing `sessionTotal` from message_start token_update (test-driven correction — result updates should be the only source)
- [ ] Full `npm test` suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)