### PR TITLE
feat(watch): MitzoShared Swift package for watchOS companion

### DIFF
--- a/frontend/ios/MitzoShared/.gitignore
+++ b/frontend/ios/MitzoShared/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/frontend/ios/MitzoShared/Package.swift
+++ b/frontend/ios/MitzoShared/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MitzoShared",
+    platforms: [
+        .iOS(.v15),
+        .watchOS(.v10),
+        .macOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "MitzoShared",
+            targets: ["MitzoShared"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "MitzoShared"
+        ),
+        .testTarget(
+            name: "MitzoSharedTests",
+            dependencies: ["MitzoShared"]
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Auth/AuthManager.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Auth/AuthManager.swift
@@ -8,11 +8,13 @@ public actor AuthManager {
         case noToken
         case keychainError(OSStatus)
         case invalidResponse
+        case encodingError
     }
 
     private let keychainService = "com.mitzo.app"
     private let keychainAccount = "jwt"
-    private let accessGroup = "$(TeamIdentifierPrefix)com.mitzo.app"
+    // Team ID prefix for shared Keychain access group (iOS + watchOS)
+    private let accessGroup = "Y4QGXHYSY3.com.mitzo.app"
 
     private var cachedToken: String?
 
@@ -40,6 +42,9 @@ public actor AuthManager {
         guard status == errSecSuccess,
               let data = result as? Data,
               let token = String(data: data, encoding: .utf8) else {
+            if status == errSecItemNotFound {
+                throw AuthError.noToken
+            }
             throw AuthError.keychainError(status)
         }
 
@@ -50,7 +55,9 @@ public actor AuthManager {
     public func saveToken(_ token: String) throws {
         cachedToken = token
 
-        let data = token.data(using: .utf8)!
+        guard let data = token.data(using: .utf8) else {
+            throw AuthError.encodingError
+        }
 
         // Try to update first
         let query: [String: Any] = [
@@ -67,7 +74,6 @@ public actor AuthManager {
         var status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
 
         if status == errSecItemNotFound {
-            // Item doesn't exist, add it
             var addQuery = query
             addQuery[kSecValueData as String] = data
             addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
@@ -104,7 +110,10 @@ public actor AuthManager {
     // MARK: - Login
 
     public func login(passphrase: String, serverURL: URL) async throws -> String {
-        var request = URLRequest(url: serverURL.appendingPathComponent("/api/auth/login"))
+        var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
+        components.path = "/api/auth/login"
+
+        var request = URLRequest(url: components.url!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -126,5 +135,6 @@ public actor AuthManager {
 }
 
 private struct LoginResponse: Decodable {
+    let ok: Bool
     let token: String
 }

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Auth/AuthManager.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Auth/AuthManager.swift
@@ -1,0 +1,130 @@
+// Auth manager with shared Keychain storage
+
+import Foundation
+import Security
+
+public actor AuthManager {
+    public enum AuthError: Error {
+        case noToken
+        case keychainError(OSStatus)
+        case invalidResponse
+    }
+
+    private let keychainService = "com.mitzo.app"
+    private let keychainAccount = "jwt"
+    private let accessGroup = "$(TeamIdentifierPrefix)com.mitzo.app"
+
+    private var cachedToken: String?
+
+    public init() {}
+
+    // MARK: - Token Management
+
+    public func getToken() throws -> String {
+        if let cached = cachedToken {
+            return cached
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            throw AuthError.keychainError(status)
+        }
+
+        cachedToken = token
+        return token
+    }
+
+    public func saveToken(_ token: String) throws {
+        cachedToken = token
+
+        let data = token.data(using: .utf8)!
+
+        // Try to update first
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        var status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+
+        if status == errSecItemNotFound {
+            // Item doesn't exist, add it
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+
+        guard status == errSecSuccess else {
+            throw AuthError.keychainError(status)
+        }
+    }
+
+    public func clearToken() throws {
+        cachedToken = nil
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: keychainService,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccessGroup as String: accessGroup
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw AuthError.keychainError(status)
+        }
+    }
+
+    public func isAuthenticated() -> Bool {
+        (try? getToken()) != nil
+    }
+
+    // MARK: - Login
+
+    public func login(passphrase: String, serverURL: URL) async throws -> String {
+        var request = URLRequest(url: serverURL.appendingPathComponent("/api/auth/login"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body = ["passphrase": passphrase]
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw AuthError.invalidResponse
+        }
+
+        let loginResponse = try JSONDecoder().decode(LoginResponse.self, from: data)
+        try saveToken(loginResponse.token)
+
+        return loginResponse.token
+    }
+}
+
+private struct LoginResponse: Decodable {
+    let token: String
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoAPIClient.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoAPIClient.swift
@@ -1,0 +1,62 @@
+// REST API client for sessions and messages
+
+import Foundation
+
+public actor MitzoAPIClient {
+    public enum APIError: Error {
+        case invalidResponse
+        case unauthorized
+        case networkError(Error)
+    }
+
+    private let baseURL: URL
+    private let authManager: AuthManager
+
+    public init(baseURL: URL, authManager: AuthManager) {
+        self.baseURL = baseURL
+        self.authManager = authManager
+    }
+
+    // MARK: - Sessions
+
+    public func getSessions() async throws -> [Session] {
+        try await get(path: "/api/sessions")
+    }
+
+    public func getSession(id: String) async throws -> Session {
+        try await get(path: "/api/sessions/\(id)")
+    }
+
+    public func getMessages(sessionId: String) async throws -> [FinishedMessage] {
+        try await get(path: "/api/sessions/\(sessionId)/messages")
+    }
+
+    // MARK: - Generic Request
+
+    private func get<T: Decodable>(path: String) async throws -> T {
+        let url = baseURL.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        // Add auth token
+        if let token = try? await authManager.getToken() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.invalidResponse
+        }
+
+        if httpResponse.statusCode == 401 {
+            throw APIError.unauthorized
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw APIError.invalidResponse
+        }
+
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoAPIClient.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoAPIClient.swift
@@ -6,6 +6,7 @@ public actor MitzoAPIClient {
     public enum APIError: Error {
         case invalidResponse
         case unauthorized
+        case notFound
         case networkError(Error)
     }
 
@@ -19,12 +20,15 @@ public actor MitzoAPIClient {
 
     // MARK: - Sessions
 
-    public func getSessions() async throws -> [Session] {
-        try await get(path: "/api/sessions")
+    public func getSessions(offset: Int = 0, limit: Int = 20) async throws -> SessionsResponse {
+        try await get(path: "/api/sessions", query: [
+            URLQueryItem(name: "offset", value: "\(offset)"),
+            URLQueryItem(name: "limit", value: "\(limit)")
+        ])
     }
 
-    public func getSession(id: String) async throws -> Session {
-        try await get(path: "/api/sessions/\(id)")
+    public func getSessionMeta(id: String) async throws -> SessionMeta {
+        try await get(path: "/api/sessions/\(id)/meta")
     }
 
     public func getMessages(sessionId: String) async throws -> [FinishedMessage] {
@@ -33,15 +37,19 @@ public actor MitzoAPIClient {
 
     // MARK: - Generic Request
 
-    private func get<T: Decodable>(path: String) async throws -> T {
-        let url = baseURL.appendingPathComponent(path)
+    private func get<T: Decodable>(path: String, query: [URLQueryItem]? = nil) async throws -> T {
+        var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false)!
+        components.queryItems = query
+
+        guard let url = components.url else {
+            throw APIError.invalidResponse
+        }
+
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
 
-        // Add auth token
-        if let token = try? await authManager.getToken() {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
+        let token = try await authManager.getToken()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -49,14 +57,15 @@ public actor MitzoAPIClient {
             throw APIError.invalidResponse
         }
 
-        if httpResponse.statusCode == 401 {
+        switch httpResponse.statusCode {
+        case 200...299:
+            return try JSONDecoder().decode(T.self, from: data)
+        case 401:
             throw APIError.unauthorized
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
+        case 404:
+            throw APIError.notFound
+        default:
             throw APIError.invalidResponse
         }
-
-        return try JSONDecoder().decode(T.self, from: data)
     }
 }

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoWSClient.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/MitzoWSClient.swift
@@ -1,0 +1,242 @@
+// WebSocket v2 Client
+// Swift equivalent of packages/client/src/connection.ts
+
+import Foundation
+
+public actor MitzoWSClient {
+    public enum State: Sendable, Equatable {
+        case disconnected
+        case connecting
+        case connected(connectionId: String)
+        case reconnecting
+
+        public static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.disconnected, .disconnected),
+                 (.connecting, .connecting),
+                 (.reconnecting, .reconnecting):
+                return true
+            case (.connected(let lhsId), .connected(let rhsId)):
+                return lhsId == rhsId
+            default:
+                return false
+            }
+        }
+    }
+
+    public enum Event: Sendable {
+        case stateChanged(State)
+        case message(ServerMessage)
+        case error(Error)
+    }
+
+    private let url: URL
+    private var wsTask: URLSessionWebSocketTask?
+    private var state: State = .disconnected
+    private var seqBySession: [String: Int] = [:]
+    private var pendingSends: [ClientMessage] = []
+    private var reconnectTimer: Task<Void, Never>?
+    private var heartbeatTimer: Task<Void, Never>?
+    private var eventHandler: ((Event) -> Void)?
+
+    private let maxPendingSends = 100
+    private let heartbeatInterval: TimeInterval = 5.0
+    private let reconnectDelay: TimeInterval = 0.5
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    // MARK: - Public API
+
+    public func connect(onEvent: @escaping (Event) -> Void) {
+        eventHandler = onEvent
+        Task {
+            await _connect()
+        }
+    }
+
+    public func disconnect() async {
+        heartbeatTimer?.cancel()
+        heartbeatTimer = nil
+        reconnectTimer?.cancel()
+        reconnectTimer = nil
+        wsTask?.cancel(with: .goingAway, reason: nil)
+        wsTask = nil
+        state = .disconnected
+        eventHandler?(.stateChanged(.disconnected))
+    }
+
+    public func send(_ message: ClientMessage) async throws {
+        // If not connected, queue it
+        guard case .connected = state else {
+            if pendingSends.count < maxPendingSends {
+                pendingSends.append(message)
+            }
+            return
+        }
+
+        let data = try JSONEncoder().encode(message)
+        try await wsTask?.send(.data(data))
+    }
+
+    public func reconnect(sessions: [ReconnectSession]) async throws {
+        try await send(.reconnect(sessions: sessions))
+    }
+
+    public func suspend(sessions: [SuspendSession]) async throws {
+        try await send(.sessionSuspend(sessions: sessions))
+    }
+
+    public func updateSeq(sessionId: String, seq: Int) {
+        seqBySession[sessionId] = max(seqBySession[sessionId] ?? 0, seq)
+    }
+
+    public func getSeq(sessionId: String) -> Int {
+        seqBySession[sessionId] ?? 0
+    }
+
+    public func getSuspendSessions() -> [SuspendSession] {
+        seqBySession.map { SuspendSession(sessionId: $0.key, lastSeq: $0.value) }
+    }
+
+    // MARK: - Internal Connection Logic
+
+    private func _connect() async {
+        guard state == .disconnected || state == .reconnecting else { return }
+
+        state = .connecting
+        eventHandler?(.stateChanged(.connecting))
+
+        let session = URLSession(configuration: .default)
+        wsTask = session.webSocketTask(with: url)
+        wsTask?.resume()
+
+        // Send hello
+        do {
+            try await send(.hello())
+            startReceiving()
+            startHeartbeat()
+        } catch {
+            eventHandler?(.error(error))
+            scheduleReconnect()
+        }
+    }
+
+    private func startReceiving() {
+        Task {
+            while let wsTask = wsTask {
+                do {
+                    let message = try await wsTask.receive()
+                    await handleMessage(message)
+                } catch {
+                    // Connection closed or error
+                    await handleDisconnect()
+                    break
+                }
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) async {
+        switch message {
+        case .data(let data):
+            do {
+                let serverMsg = try JSONDecoder().decode(ServerMessage.self, from: data)
+                await processServerMessage(serverMsg)
+            } catch {
+                eventHandler?(.error(error))
+            }
+
+        case .string(let text):
+            // Try to decode as JSON
+            guard let data = text.data(using: .utf8) else { return }
+            do {
+                let serverMsg = try JSONDecoder().decode(ServerMessage.self, from: data)
+                await processServerMessage(serverMsg)
+            } catch {
+                eventHandler?(.error(error))
+            }
+
+        @unknown default:
+            break
+        }
+    }
+
+    private func processServerMessage(_ message: ServerMessage) async {
+        // Update seq if present
+        switch message {
+        case .sessionId(let sessionId, let seq, _):
+            if let seq = seq {
+                updateSeq(sessionId: sessionId, seq: seq)
+            }
+
+        case .messageStart(let params):
+            updateSeq(sessionId: params.sessionId, seq: params.seq)
+
+        case .blockStart(let params):
+            updateSeq(sessionId: params.sessionId, seq: params.seq)
+
+        case .blockDelta(let params):
+            updateSeq(sessionId: params.sessionId, seq: params.seq)
+
+        case .blockEnd(let params):
+            updateSeq(sessionId: params.sessionId, seq: params.seq)
+
+        case .messageEnd(let params):
+            updateSeq(sessionId: params.sessionId, seq: params.seq)
+
+        case .welcome(_, let connectionId):
+            state = .connected(connectionId: connectionId)
+            eventHandler?(.stateChanged(.connected(connectionId: connectionId)))
+
+            // Flush pending sends
+            let pending = pendingSends
+            pendingSends = []
+            for msg in pending {
+                try? await send(msg)
+            }
+
+        default:
+            break
+        }
+
+        // Forward to handler
+        eventHandler?(.message(message))
+    }
+
+    private func handleDisconnect() async {
+        heartbeatTimer?.cancel()
+        heartbeatTimer = nil
+        wsTask = nil
+
+        guard state != .disconnected else { return }
+
+        state = .reconnecting
+        eventHandler?(.stateChanged(.reconnecting))
+        scheduleReconnect()
+    }
+
+    private func scheduleReconnect() {
+        reconnectTimer?.cancel()
+        reconnectTimer = Task {
+            try? await Task.sleep(nanoseconds: UInt64(reconnectDelay * 1_000_000_000))
+            await _connect()
+        }
+    }
+
+    private func startHeartbeat() {
+        heartbeatTimer?.cancel()
+        heartbeatTimer = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(heartbeatInterval * 1_000_000_000))
+
+                // Check if connection is dead
+                if wsTask?.state != .running {
+                    await handleDisconnect()
+                    break
+                }
+            }
+        }
+    }
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/YapperClient.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/YapperClient.swift
@@ -1,0 +1,139 @@
+// Yapper STT client
+// Streaming WebSocket transcription
+
+import Foundation
+
+public actor YapperClient {
+    public enum TranscriptEvent: Sendable {
+        case partial(String)
+        case final(String)
+        case error(Error)
+    }
+
+    public enum YapperError: Error {
+        case notConnected
+        case connectionFailed
+    }
+
+    private let baseURL: URL
+    private var wsTask: URLSessionWebSocketTask?
+    private var eventHandler: ((TranscriptEvent) -> Void)?
+
+    public init(baseURL: URL) {
+        self.baseURL = baseURL
+    }
+
+    // MARK: - Health Check
+
+    public func checkHealth() async throws -> Bool {
+        let healthURL = baseURL.appendingPathComponent("/health")
+        let (data, _) = try await URLSession.shared.data(from: healthURL)
+
+        struct HealthResponse: Decodable {
+            let status: String
+            let models: Models?
+
+            struct Models: Decodable {
+                let stt: Bool?
+                let tts: Bool?
+            }
+        }
+
+        let health = try JSONDecoder().decode(HealthResponse.self, from: data)
+        return health.status == "ready" && (health.models?.stt == true)
+    }
+
+    // MARK: - Streaming STT
+
+    public func startStreaming(onEvent: @escaping (TranscriptEvent) -> Void) async throws {
+        eventHandler = onEvent
+
+        // Build WS URL
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.scheme = components.scheme == "https" ? "wss" : "ws"
+        components.path = "/v1/transcribe/stream"
+
+        guard let wsURL = components.url else {
+            throw YapperError.connectionFailed
+        }
+
+        let session = URLSession(configuration: .default)
+        wsTask = session.webSocketTask(with: wsURL)
+        wsTask?.resume()
+
+        // Send format frame
+        try await wsTask?.send(.string("{\"format\":\"pcm\"}"))
+
+        // Start receiving
+        startReceiving()
+    }
+
+    public func sendAudio(_ data: Data) async throws {
+        guard let wsTask = wsTask else {
+            throw YapperError.notConnected
+        }
+
+        try await wsTask.send(.data(data))
+    }
+
+    public func endStreaming() async throws {
+        guard let wsTask = wsTask else {
+            throw YapperError.notConnected
+        }
+
+        try await wsTask.send(.string("END"))
+    }
+
+    public func close() async {
+        wsTask?.cancel(with: .goingAway, reason: nil)
+        wsTask = nil
+    }
+
+    // MARK: - Receiving
+
+    private func startReceiving() {
+        Task {
+            while let wsTask = wsTask {
+                do {
+                    let message = try await wsTask.receive()
+                    await handleMessage(message)
+                } catch {
+                    eventHandler?(.error(error))
+                    break
+                }
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) async {
+        switch message {
+        case .string(let text):
+            // Parse JSON transcript event
+            guard let data = text.data(using: .utf8) else { return }
+
+            struct TranscriptResponse: Decodable {
+                let type: String
+                let text: String
+            }
+
+            do {
+                let response = try JSONDecoder().decode(TranscriptResponse.self, from: data)
+
+                if response.type == "partial" {
+                    eventHandler?(.partial(response.text))
+                } else if response.type == "final" {
+                    eventHandler?(.final(response.text))
+                }
+            } catch {
+                eventHandler?(.error(error))
+            }
+
+        case .data:
+            // Unexpected binary frame
+            break
+
+        @unknown default:
+            break
+        }
+    }
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
@@ -1,0 +1,194 @@
+// Core protocol types mirroring @mitzo/protocol
+// Swift translation of packages/protocol/src/types.ts
+
+import Foundation
+
+// MARK: - Modes & Enums
+
+public enum MitzoMode: String, Codable, Sendable {
+    case ask
+    case agent
+    case auto
+}
+
+public enum BlockType: String, Codable, Sendable {
+    case text
+    case thinking
+    case redactedThinking = "redacted_thinking"
+    case toolUse = "tool_use"
+}
+
+public enum ToolTier: String, Codable, Sendable {
+    case safe
+    case standard
+    case elevated
+    case unknown
+}
+
+// MARK: - Tool Input
+
+public enum RawToolInputType: String, Codable, Sendable {
+    case write
+    case diff
+    case command
+}
+
+public struct RawToolInput: Codable, Sendable {
+    public let type: RawToolInputType
+    public let path: String?
+    public let contents: String?
+    public let oldString: String?
+    public let newString: String?
+    public let command: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type, path, contents
+        case oldString = "old_string"
+        case newString = "new_string"
+        case command
+    }
+}
+
+// MARK: - Snapshot
+
+public struct SnapshotBlock: Codable, Sendable {
+    public let blockId: String
+    public let blockType: BlockType
+    public let content: String
+    public let done: Bool
+    public let toolName: String?
+    public let toolId: String?
+    public let toolInput: String?
+    public let rawInput: RawToolInput?
+}
+
+public struct MessageSnapshot: Codable, Sendable {
+    public let messageId: String
+    public let blocks: [SnapshotBlock]
+}
+
+// MARK: - Streaming Message
+
+public struct StreamingBlock: Sendable {
+    public var blockId: String
+    public var blockType: BlockType
+    public var content: String
+    public var done: Bool
+    public var toolName: String?
+    public var toolId: String?
+    public var toolInput: String?
+    public var rawInput: RawToolInput?
+    public var toolResult: String?
+    public var toolError: Bool?
+
+    public init(
+        blockId: String,
+        blockType: BlockType,
+        content: String = "",
+        done: Bool = false,
+        toolName: String? = nil,
+        toolId: String? = nil,
+        toolInput: String? = nil,
+        rawInput: RawToolInput? = nil,
+        toolResult: String? = nil,
+        toolError: Bool? = nil
+    ) {
+        self.blockId = blockId
+        self.blockType = blockType
+        self.content = content
+        self.done = done
+        self.toolName = toolName
+        self.toolId = toolId
+        self.toolInput = toolInput
+        self.rawInput = rawInput
+        self.toolResult = toolResult
+        self.toolError = toolError
+    }
+}
+
+public struct StreamingMessage: Sendable {
+    public var messageId: String
+    public var blocks: [String: StreamingBlock]
+    public var blockOrder: [String]
+
+    public init(messageId: String) {
+        self.messageId = messageId
+        self.blocks = [:]
+        self.blockOrder = []
+    }
+}
+
+// MARK: - Finished Message
+
+public struct FinishedBlock: Codable, Sendable {
+    public let blockId: String
+    public let blockType: BlockType
+    public let content: String
+    public let toolName: String?
+    public let toolId: String?
+    public let toolInput: String?
+    public let rawInput: RawToolInput?
+    public let toolResult: String?
+    public let toolError: Bool?
+}
+
+public enum MessageRole: String, Codable, Sendable {
+    case user
+    case assistant
+}
+
+public struct FinishedMessage: Codable, Sendable {
+    public let messageId: String
+    public let role: MessageRole
+    public let blocks: [FinishedBlock]
+    public let images: [String]?
+    public let contextBlocks: [String]?
+    public let timestamp: Int?
+}
+
+// MARK: - Permission
+
+public struct PermissionRequest: Codable, Sendable {
+    public let permId: String
+    public let toolName: String
+    public let toolInput: String
+    public let title: String?
+    public let description: String?
+    public let displayName: String?
+    public let tier: ToolTier?
+}
+
+// MARK: - Image Attachment
+
+public struct ImageAttachment: Codable, Sendable {
+    public let data: String
+    public let mediaType: String
+}
+
+// MARK: - Session
+
+public struct Session: Codable, Sendable {
+    public let id: String
+    public let mode: MitzoMode
+    public let cwd: String?
+    public let branch: String?
+    public let wtId: String?
+    public let tokens: TokenUsage?
+    public let createdAt: Int?
+    public let updatedAt: Int?
+}
+
+public struct TokenUsage: Codable, Sendable {
+    public let input: Int
+    public let output: Int
+    public let cacheRead: Int
+    public let cacheCreation: Int
+    public let costUsd: Double
+
+    enum CodingKeys: String, CodingKey {
+        case input, output
+        case cacheRead = "cache_read"
+        case cacheCreation = "cache_creation"
+        case costUsd = "cost_usd"
+    }
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
@@ -163,6 +163,7 @@ public struct PermissionRequest: Codable, Sendable {
 public struct ImageAttachment: Codable, Sendable {
     public let data: String
     public let mediaType: String
+    public let preview: String?
 }
 
 // MARK: - Session (matches GET /api/sessions response)

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/CoreTypes.swift
@@ -165,17 +165,37 @@ public struct ImageAttachment: Codable, Sendable {
     public let mediaType: String
 }
 
-// MARK: - Session
+// MARK: - Session (matches GET /api/sessions response)
 
-public struct Session: Codable, Sendable {
+public struct Session: Codable, Sendable, Identifiable {
     public let id: String
-    public let mode: MitzoMode
+    public let summary: String
+    public let lastModified: Int
+    public let branch: String?
     public let cwd: String?
+    public let isActive: Bool?
+    public let isAttached: Bool?
+    public let totalTokens: Int?
+    public let numTurns: Int?
+}
+
+public struct SessionsResponse: Codable, Sendable {
+    public let sessions: [Session]
+    public let hasMore: Bool
+}
+
+// MARK: - Session Metadata (matches GET /api/sessions/:id/meta)
+
+public struct SessionMeta: Codable, Sendable {
+    public let sessionId: String
     public let branch: String?
     public let wtId: String?
-    public let tokens: TokenUsage?
-    public let createdAt: Int?
-    public let updatedAt: Int?
+    public let cwd: String?
+    public let mode: MitzoMode
+    public let isActive: Bool
+    public let totalTokens: Int?
+    public let totalCostUsd: Double?
+    public let numTurns: Int?
 }
 
 public struct TokenUsage: Codable, Sendable {
@@ -184,11 +204,4 @@ public struct TokenUsage: Codable, Sendable {
     public let cacheRead: Int
     public let cacheCreation: Int
     public let costUsd: Double
-
-    enum CodingKeys: String, CodingKey {
-        case input, output
-        case cacheRead = "cache_read"
-        case cacheCreation = "cache_creation"
-        case costUsd = "cost_usd"
-    }
 }

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
@@ -1,0 +1,407 @@
+// WebSocket v2 Protocol Messages
+// Swift translation of packages/protocol/src/ws-schemas-v2.ts
+
+import Foundation
+
+// MARK: - Client → Server Messages
+
+public enum ClientMessage: Encodable, Sendable {
+    case hello(protocolVersion: Int = 2)
+    case reconnect(sessions: [ReconnectSession])
+    case watch(sessionId: String)
+    case unwatch(sessionId: String)
+    case switchSession(sessionId: String?)
+    case sessionSuspend(sessions: [SuspendSession])
+    case send(SendParams)
+    case interrupt(InterruptParams)
+    case stop(sessionId: String)
+    case permissionResponse(PermissionResponseParams)
+    case setMode(sessionId: String, mode: MitzoMode)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        switch self {
+        case .hello(let version):
+            try container.encode("hello", forKey: .type)
+            try container.encode(version, forKey: CodingKeys(stringValue: "protocolVersion")!)
+
+        case .reconnect(let sessions):
+            try container.encode("reconnect", forKey: .type)
+            try container.encode(sessions, forKey: CodingKeys(stringValue: "sessions")!)
+
+        case .watch(let sessionId):
+            try container.encode("watch", forKey: .type)
+            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+
+        case .unwatch(let sessionId):
+            try container.encode("unwatch", forKey: .type)
+            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+
+        case .switchSession(let sessionId):
+            try container.encode("switch_session", forKey: .type)
+            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+
+        case .sessionSuspend(let sessions):
+            try container.encode("session_suspend", forKey: .type)
+            try container.encode(sessions, forKey: CodingKeys(stringValue: "sessions")!)
+
+        case .send(let params):
+            try container.encode("send", forKey: .type)
+            try params.encode(to: encoder)
+
+        case .interrupt(let params):
+            try container.encode("interrupt", forKey: .type)
+            try params.encode(to: encoder)
+
+        case .stop(let sessionId):
+            try container.encode("stop", forKey: .type)
+            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+
+        case .permissionResponse(let params):
+            try container.encode("permission_response", forKey: .type)
+            try params.encode(to: encoder)
+
+        case .setMode(let sessionId, let mode):
+            try container.encode("set_mode", forKey: .type)
+            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+            try container.encode(mode, forKey: CodingKeys(stringValue: "mode")!)
+        }
+    }
+}
+
+public struct ReconnectSession: Codable, Sendable {
+    public let sessionId: String
+    public let lastSeq: Int
+
+    public init(sessionId: String, lastSeq: Int) {
+        self.sessionId = sessionId
+        self.lastSeq = lastSeq
+    }
+}
+
+public struct SuspendSession: Codable, Sendable {
+    public let sessionId: String
+    public let lastSeq: Int
+
+    public init(sessionId: String, lastSeq: Int) {
+        self.sessionId = sessionId
+        self.lastSeq = lastSeq
+    }
+}
+
+public struct SendParams: Encodable, Sendable {
+    public let sessionId: String?
+    public let prompt: String
+    public let clientMsgId: String
+    public let model: String?
+    public let mode: MitzoMode?
+    public let cwd: String?
+    public let extraTools: String?
+    public let isolation: Bool?
+    public let images: [ImageAttachment]?
+    public let contextBlocks: [String]?
+
+    public init(
+        sessionId: String?,
+        prompt: String,
+        clientMsgId: String = UUID().uuidString,
+        model: String? = nil,
+        mode: MitzoMode? = nil,
+        cwd: String? = nil,
+        extraTools: String? = nil,
+        isolation: Bool? = nil,
+        images: [ImageAttachment]? = nil,
+        contextBlocks: [String]? = nil
+    ) {
+        self.sessionId = sessionId
+        self.prompt = prompt
+        self.clientMsgId = clientMsgId
+        self.model = model
+        self.mode = mode
+        self.cwd = cwd
+        self.extraTools = extraTools
+        self.isolation = isolation
+        self.images = images
+        self.contextBlocks = contextBlocks
+    }
+}
+
+public struct InterruptParams: Encodable, Sendable {
+    public let sessionId: String
+    public let prompt: String
+    public let clientMsgId: String
+    public let images: [ImageAttachment]?
+    public let contextBlocks: [String]?
+
+    public init(
+        sessionId: String,
+        prompt: String,
+        clientMsgId: String = UUID().uuidString,
+        images: [ImageAttachment]? = nil,
+        contextBlocks: [String]? = nil
+    ) {
+        self.sessionId = sessionId
+        self.prompt = prompt
+        self.clientMsgId = clientMsgId
+        self.images = images
+        self.contextBlocks = contextBlocks
+    }
+}
+
+public struct PermissionResponseParams: Encodable, Sendable {
+    public let sessionId: String?
+    public let permId: String
+    public let decision: PermissionDecision?
+
+    public init(sessionId: String? = nil, permId: String, decision: PermissionDecision? = nil) {
+        self.sessionId = sessionId
+        self.permId = permId
+        self.decision = decision
+    }
+}
+
+public enum PermissionDecision: String, Codable, Sendable {
+    case once
+    case always
+    case deny
+}
+
+// MARK: - Server → Client Messages
+
+public enum ServerMessage: Decodable, Sendable {
+    case welcome(protocolVersion: Int, connectionId: String)
+    case reconnected(sessions: [ReconnectedSession])
+    case watched(sessionId: String)
+    case unwatched(sessionId: String)
+    case sessionSwitched(SessionSwitchedParams)
+    case sessionCleared
+    case sessionId(sessionId: String, seq: Int?, ts: Int?)
+    case sessionResumed(sessionId: String, replayed: Int)
+    case sessionTakeover(sessionId: String)
+    case sessionEnd(SessionEndParams)
+    case messageStart(MessageStartParams)
+    case blockStart(BlockStartParams)
+    case blockDelta(BlockDeltaParams)
+    case blockEnd(BlockEndParams)
+    case messageEnd(MessageEndParams)
+    case tokenUpdate(TokenUpdateParams)
+    case error(error: String)
+    case modeChanged(sessionId: String, mode: MitzoMode)
+    case unknown(type: String)
+
+    enum CodingKeys: String, CodingKey {
+        case type, v
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "welcome":
+            let protocolVersion = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(Int.self, forKey: AnyCodingKey(stringValue: "protocolVersion")!)
+            let connectionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "connectionId")!)
+            self = .welcome(protocolVersion: protocolVersion, connectionId: connectionId)
+
+        case "reconnected":
+            let sessions = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode([ReconnectedSession].self, forKey: AnyCodingKey(stringValue: "sessions")!)
+            self = .reconnected(sessions: sessions)
+
+        case "watched":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            self = .watched(sessionId: sessionId)
+
+        case "unwatched":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            self = .unwatched(sessionId: sessionId)
+
+        case "session_switched":
+            let params = try SessionSwitchedParams(from: decoder)
+            self = .sessionSwitched(params)
+
+        case "session_cleared":
+            self = .sessionCleared
+
+        case "session_id":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let seq = try? decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(Int.self, forKey: AnyCodingKey(stringValue: "seq")!)
+            let ts = try? decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(Int.self, forKey: AnyCodingKey(stringValue: "ts")!)
+            self = .sessionId(sessionId: sessionId, seq: seq, ts: ts)
+
+        case "session_resumed":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let replayed = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(Int.self, forKey: AnyCodingKey(stringValue: "replayed")!)
+            self = .sessionResumed(sessionId: sessionId, replayed: replayed)
+
+        case "session_takeover":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            self = .sessionTakeover(sessionId: sessionId)
+
+        case "session_end":
+            let params = try SessionEndParams(from: decoder)
+            self = .sessionEnd(params)
+
+        case "message_start":
+            let params = try MessageStartParams(from: decoder)
+            self = .messageStart(params)
+
+        case "block_start":
+            let params = try BlockStartParams(from: decoder)
+            self = .blockStart(params)
+
+        case "block_delta":
+            let params = try BlockDeltaParams(from: decoder)
+            self = .blockDelta(params)
+
+        case "block_end":
+            let params = try BlockEndParams(from: decoder)
+            self = .blockEnd(params)
+
+        case "message_end":
+            let params = try MessageEndParams(from: decoder)
+            self = .messageEnd(params)
+
+        case "token_update":
+            let params = try TokenUpdateParams(from: decoder)
+            self = .tokenUpdate(params)
+
+        case "error":
+            let error = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "error")!)
+            self = .error(error: error)
+
+        case "mode_changed":
+            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let mode = try decoder.container(keyedBy: AnyCodingKey.self)
+                .decode(MitzoMode.self, forKey: AnyCodingKey(stringValue: "mode")!)
+            self = .modeChanged(sessionId: sessionId, mode: mode)
+
+        default:
+            self = .unknown(type: type)
+        }
+    }
+}
+
+// MARK: - Server Message Params
+
+public struct ReconnectedSession: Decodable, Sendable {
+    public let sessionId: String
+    public let replayed: Int
+    public let running: Bool
+}
+
+public struct SessionSwitchedParams: Decodable, Sendable {
+    public let sessionId: String
+    public let mode: MitzoMode
+    public let cwd: String
+    public let branch: String
+    public let wtId: String?
+    public let tokens: TokenUsage
+}
+
+public struct SessionEndParams: Decodable, Sendable {
+    public let sessionId: String
+    public let usage: UsageStats
+}
+
+public struct UsageStats: Decodable, Sendable {
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let cacheCreationTokens: Int
+    public let totalCostUsd: Double
+    public let numTurns: Int
+    public let durationMs: Int
+    public let durationApiMs: Int
+}
+
+public struct MessageStartParams: Decodable, Sendable {
+    public let messageId: String
+    public let sessionId: String
+    public let seq: Int
+    public let ts: Int
+}
+
+public struct BlockStartParams: Decodable, Sendable {
+    public let messageId: String
+    public let blockId: String
+    public let blockType: BlockType
+    public let sessionId: String
+    public let seq: Int
+    public let ts: Int
+    public let toolName: String?
+}
+
+public struct BlockDeltaParams: Decodable, Sendable {
+    public let messageId: String
+    public let blockId: String
+    public let blockType: BlockType
+    public let delta: String
+    public let sessionId: String
+    public let seq: Int
+    public let ts: Int
+}
+
+public struct BlockEndParams: Decodable, Sendable {
+    public let messageId: String
+    public let blockId: String
+    public let blockType: BlockType
+    public let sessionId: String
+    public let seq: Int
+    public let ts: Int
+    public let toolName: String?
+    public let toolId: String?
+    public let input: String?
+}
+
+public struct MessageEndParams: Decodable, Sendable {
+    public let messageId: String
+    public let sessionId: String
+    public let seq: Int
+    public let ts: Int
+}
+
+public struct TokenUpdateParams: Decodable, Sendable {
+    public let agentContext: Int
+    public let contextCeiling: Int
+    public let sessionTotal: Int
+    public let turnIndex: Int
+    public let numCompactions: Int?
+    public let sessionId: String?
+    public let seq: Int?
+    public let ts: Int?
+}
+
+// MARK: - Helper
+
+private struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
@@ -3,6 +3,28 @@
 
 import Foundation
 
+// MARK: - Flexible Coding Key
+
+struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init(_ key: String) {
+        self.stringValue = key
+        self.intValue = nil
+    }
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+}
+
 // MARK: - Client → Server Messages
 
 public enum ClientMessage: Encodable, Sendable {
@@ -18,58 +40,54 @@ public enum ClientMessage: Encodable, Sendable {
     case permissionResponse(PermissionResponseParams)
     case setMode(sessionId: String, mode: MitzoMode)
 
-    private enum CodingKeys: String, CodingKey {
-        case type
-    }
-
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
 
         switch self {
         case .hello(let version):
-            try container.encode("hello", forKey: .type)
-            try container.encode(version, forKey: CodingKeys(stringValue: "protocolVersion")!)
+            try container.encode("hello", forKey: AnyCodingKey("type"))
+            try container.encode(version, forKey: AnyCodingKey("protocolVersion"))
 
         case .reconnect(let sessions):
-            try container.encode("reconnect", forKey: .type)
-            try container.encode(sessions, forKey: CodingKeys(stringValue: "sessions")!)
+            try container.encode("reconnect", forKey: AnyCodingKey("type"))
+            try container.encode(sessions, forKey: AnyCodingKey("sessions"))
 
         case .watch(let sessionId):
-            try container.encode("watch", forKey: .type)
-            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+            try container.encode("watch", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
 
         case .unwatch(let sessionId):
-            try container.encode("unwatch", forKey: .type)
-            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+            try container.encode("unwatch", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
 
         case .switchSession(let sessionId):
-            try container.encode("switch_session", forKey: .type)
-            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+            try container.encode("switch_session", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
 
         case .sessionSuspend(let sessions):
-            try container.encode("session_suspend", forKey: .type)
-            try container.encode(sessions, forKey: CodingKeys(stringValue: "sessions")!)
+            try container.encode("session_suspend", forKey: AnyCodingKey("type"))
+            try container.encode(sessions, forKey: AnyCodingKey("sessions"))
 
         case .send(let params):
-            try container.encode("send", forKey: .type)
-            try params.encode(to: encoder)
+            try container.encode("send", forKey: AnyCodingKey("type"))
+            try params.encodeFields(to: &container)
 
         case .interrupt(let params):
-            try container.encode("interrupt", forKey: .type)
-            try params.encode(to: encoder)
+            try container.encode("interrupt", forKey: AnyCodingKey("type"))
+            try params.encodeFields(to: &container)
 
         case .stop(let sessionId):
-            try container.encode("stop", forKey: .type)
-            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
+            try container.encode("stop", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
 
         case .permissionResponse(let params):
-            try container.encode("permission_response", forKey: .type)
-            try params.encode(to: encoder)
+            try container.encode("permission_response", forKey: AnyCodingKey("type"))
+            try params.encodeFields(to: &container)
 
         case .setMode(let sessionId, let mode):
-            try container.encode("set_mode", forKey: .type)
-            try container.encode(sessionId, forKey: CodingKeys(stringValue: "sessionId")!)
-            try container.encode(mode, forKey: CodingKeys(stringValue: "mode")!)
+            try container.encode("set_mode", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(mode, forKey: AnyCodingKey("mode"))
         }
     }
 }
@@ -94,7 +112,7 @@ public struct SuspendSession: Codable, Sendable {
     }
 }
 
-public struct SendParams: Encodable, Sendable {
+public struct SendParams: Sendable {
     public let sessionId: String?
     public let prompt: String
     public let clientMsgId: String
@@ -129,9 +147,22 @@ public struct SendParams: Encodable, Sendable {
         self.images = images
         self.contextBlocks = contextBlocks
     }
+
+    func encodeFields(to container: inout KeyedEncodingContainer<AnyCodingKey>) throws {
+        try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+        try container.encode(prompt, forKey: AnyCodingKey("prompt"))
+        try container.encode(clientMsgId, forKey: AnyCodingKey("clientMsgId"))
+        try container.encodeIfPresent(model, forKey: AnyCodingKey("model"))
+        try container.encodeIfPresent(mode, forKey: AnyCodingKey("mode"))
+        try container.encodeIfPresent(cwd, forKey: AnyCodingKey("cwd"))
+        try container.encodeIfPresent(extraTools, forKey: AnyCodingKey("extraTools"))
+        try container.encodeIfPresent(isolation, forKey: AnyCodingKey("isolation"))
+        try container.encodeIfPresent(images, forKey: AnyCodingKey("images"))
+        try container.encodeIfPresent(contextBlocks, forKey: AnyCodingKey("contextBlocks"))
+    }
 }
 
-public struct InterruptParams: Encodable, Sendable {
+public struct InterruptParams: Sendable {
     public let sessionId: String
     public let prompt: String
     public let clientMsgId: String
@@ -151,9 +182,17 @@ public struct InterruptParams: Encodable, Sendable {
         self.images = images
         self.contextBlocks = contextBlocks
     }
+
+    func encodeFields(to container: inout KeyedEncodingContainer<AnyCodingKey>) throws {
+        try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+        try container.encode(prompt, forKey: AnyCodingKey("prompt"))
+        try container.encode(clientMsgId, forKey: AnyCodingKey("clientMsgId"))
+        try container.encodeIfPresent(images, forKey: AnyCodingKey("images"))
+        try container.encodeIfPresent(contextBlocks, forKey: AnyCodingKey("contextBlocks"))
+    }
 }
 
-public struct PermissionResponseParams: Encodable, Sendable {
+public struct PermissionResponseParams: Sendable {
     public let sessionId: String?
     public let permId: String
     public let decision: PermissionDecision?
@@ -162,6 +201,12 @@ public struct PermissionResponseParams: Encodable, Sendable {
         self.sessionId = sessionId
         self.permId = permId
         self.decision = decision
+    }
+
+    func encodeFields(to container: inout KeyedEncodingContainer<AnyCodingKey>) throws {
+        try container.encodeIfPresent(sessionId, forKey: AnyCodingKey("sessionId"))
+        try container.encode(permId, forKey: AnyCodingKey("permId"))
+        try container.encodeIfPresent(decision, forKey: AnyCodingKey("decision"))
     }
 }
 
@@ -190,39 +235,32 @@ public enum ServerMessage: Decodable, Sendable {
     case blockEnd(BlockEndParams)
     case messageEnd(MessageEndParams)
     case tokenUpdate(TokenUpdateParams)
+    case permissionRequest(PermissionRequestParams)
+    case toolResult(ToolResultParams)
     case error(error: String)
     case modeChanged(sessionId: String, mode: MitzoMode)
     case unknown(type: String)
 
-    enum CodingKeys: String, CodingKey {
-        case type, v
-    }
-
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        let type = try container.decode(String.self, forKey: AnyCodingKey("type"))
 
         switch type {
         case "welcome":
-            let protocolVersion = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(Int.self, forKey: AnyCodingKey(stringValue: "protocolVersion")!)
-            let connectionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "connectionId")!)
+            let protocolVersion = try container.decode(Int.self, forKey: AnyCodingKey("protocolVersion"))
+            let connectionId = try container.decode(String.self, forKey: AnyCodingKey("connectionId"))
             self = .welcome(protocolVersion: protocolVersion, connectionId: connectionId)
 
         case "reconnected":
-            let sessions = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode([ReconnectedSession].self, forKey: AnyCodingKey(stringValue: "sessions")!)
+            let sessions = try container.decode([ReconnectedSession].self, forKey: AnyCodingKey("sessions"))
             self = .reconnected(sessions: sessions)
 
         case "watched":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
             self = .watched(sessionId: sessionId)
 
         case "unwatched":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
             self = .unwatched(sessionId: sessionId)
 
         case "session_switched":
@@ -233,24 +271,18 @@ public enum ServerMessage: Decodable, Sendable {
             self = .sessionCleared
 
         case "session_id":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
-            let seq = try? decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(Int.self, forKey: AnyCodingKey(stringValue: "seq")!)
-            let ts = try? decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(Int.self, forKey: AnyCodingKey(stringValue: "ts")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
+            let seq = try container.decodeIfPresent(Int.self, forKey: AnyCodingKey("seq"))
+            let ts = try container.decodeIfPresent(Int.self, forKey: AnyCodingKey("ts"))
             self = .sessionId(sessionId: sessionId, seq: seq, ts: ts)
 
         case "session_resumed":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
-            let replayed = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(Int.self, forKey: AnyCodingKey(stringValue: "replayed")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
+            let replayed = try container.decode(Int.self, forKey: AnyCodingKey("replayed"))
             self = .sessionResumed(sessionId: sessionId, replayed: replayed)
 
         case "session_takeover":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
             self = .sessionTakeover(sessionId: sessionId)
 
         case "session_end":
@@ -281,16 +313,21 @@ public enum ServerMessage: Decodable, Sendable {
             let params = try TokenUpdateParams(from: decoder)
             self = .tokenUpdate(params)
 
+        case "permission_request":
+            let params = try PermissionRequestParams(from: decoder)
+            self = .permissionRequest(params)
+
+        case "tool_result":
+            let params = try ToolResultParams(from: decoder)
+            self = .toolResult(params)
+
         case "error":
-            let error = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "error")!)
+            let error = try container.decode(String.self, forKey: AnyCodingKey("error"))
             self = .error(error: error)
 
         case "mode_changed":
-            let sessionId = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(String.self, forKey: AnyCodingKey(stringValue: "sessionId")!)
-            let mode = try decoder.container(keyedBy: AnyCodingKey.self)
-                .decode(MitzoMode.self, forKey: AnyCodingKey(stringValue: "mode")!)
+            let sessionId = try container.decode(String.self, forKey: AnyCodingKey("sessionId"))
+            let mode = try container.decode(MitzoMode.self, forKey: AnyCodingKey("mode"))
             self = .modeChanged(sessionId: sessionId, mode: mode)
 
         default:
@@ -389,19 +426,20 @@ public struct TokenUpdateParams: Decodable, Sendable {
     public let ts: Int?
 }
 
-// MARK: - Helper
+public struct PermissionRequestParams: Decodable, Sendable {
+    public let permId: String
+    public let toolName: String
+    public let toolInput: String
+    public let title: String?
+    public let description: String?
+    public let displayName: String?
+    public let decisionReason: String?
+    public let tier: ToolTier?
+}
 
-private struct AnyCodingKey: CodingKey {
-    var stringValue: String
-    var intValue: Int?
-
-    init?(stringValue: String) {
-        self.stringValue = stringValue
-        self.intValue = nil
-    }
-
-    init?(intValue: Int) {
-        self.stringValue = "\(intValue)"
-        self.intValue = intValue
-    }
+public struct ToolResultParams: Decodable, Sendable {
+    public let messageId: String
+    public let toolId: String
+    public let result: String
+    public let isError: Bool
 }

--- a/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
+++ b/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
@@ -1,8 +1,250 @@
 import Testing
+import Foundation
 @testable import MitzoShared
 
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-    // Swift Testing Documentation
-    // https://developer.apple.com/documentation/testing
+// MARK: - ClientMessage Encoding
+
+@Test func testHelloEncoding() throws {
+    let msg = ClientMessage.hello()
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "hello")
+    #expect(dict["protocolVersion"] as? Int == 2)
+}
+
+@Test func testWatchEncoding() throws {
+    let msg = ClientMessage.watch(sessionId: "sess-123")
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "watch")
+    #expect(dict["sessionId"] as? String == "sess-123")
+}
+
+@Test func testSendEncoding() throws {
+    let params = SendParams(sessionId: "sess-abc", prompt: "hello world", clientMsgId: "msg-1")
+    let msg = ClientMessage.send(params)
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "send")
+    #expect(dict["sessionId"] as? String == "sess-abc")
+    #expect(dict["prompt"] as? String == "hello world")
+    #expect(dict["clientMsgId"] as? String == "msg-1")
+}
+
+@Test func testSendWithNullSessionEncoding() throws {
+    let params = SendParams(sessionId: nil, prompt: "new session", clientMsgId: "msg-2")
+    let msg = ClientMessage.send(params)
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "send")
+    #expect(dict["sessionId"] is NSNull)
+}
+
+@Test func testStopEncoding() throws {
+    let msg = ClientMessage.stop(sessionId: "sess-xyz")
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "stop")
+    #expect(dict["sessionId"] as? String == "sess-xyz")
+}
+
+@Test func testPermissionResponseEncoding() throws {
+    let params = PermissionResponseParams(sessionId: "sess-1", permId: "perm-abc", decision: .once)
+    let msg = ClientMessage.permissionResponse(params)
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "permission_response")
+    #expect(dict["permId"] as? String == "perm-abc")
+    #expect(dict["decision"] as? String == "once")
+}
+
+@Test func testSessionSuspendEncoding() throws {
+    let sessions = [SuspendSession(sessionId: "s1", lastSeq: 42)]
+    let msg = ClientMessage.sessionSuspend(sessions: sessions)
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "session_suspend")
+    let sessArr = dict["sessions"] as? [[String: Any]]
+    #expect(sessArr?.count == 1)
+    #expect(sessArr?[0]["sessionId"] as? String == "s1")
+    #expect(sessArr?[0]["lastSeq"] as? Int == 42)
+}
+
+@Test func testSetModeEncoding() throws {
+    let msg = ClientMessage.setMode(sessionId: "sess-1", mode: .agent)
+    let data = try JSONEncoder().encode(msg)
+    let dict = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+    #expect(dict["type"] as? String == "set_mode")
+    #expect(dict["mode"] as? String == "agent")
+}
+
+// MARK: - ServerMessage Decoding
+
+@Test func testWelcomeDecoding() throws {
+    let json = """
+    {"type":"welcome","protocolVersion":2,"connectionId":"conn-123-abc"}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .welcome(let version, let connId) = msg else {
+        Issue.record("Expected welcome")
+        return
+    }
+    #expect(version == 2)
+    #expect(connId == "conn-123-abc")
+}
+
+@Test func testBlockDeltaDecoding() throws {
+    let json = """
+    {"v":2,"type":"block_delta","messageId":"m1","blockId":"b1","blockType":"text","delta":"hello ","sessionId":"s1","seq":5,"ts":1234567890}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .blockDelta(let params) = msg else {
+        Issue.record("Expected block_delta")
+        return
+    }
+    #expect(params.delta == "hello ")
+    #expect(params.blockType == .text)
+    #expect(params.seq == 5)
+    #expect(params.sessionId == "s1")
+}
+
+@Test func testBlockStartToolUseDecoding() throws {
+    let json = """
+    {"v":2,"type":"block_start","messageId":"m1","blockId":"b2","blockType":"tool_use","sessionId":"s1","seq":3,"ts":100,"toolName":"Read"}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .blockStart(let params) = msg else {
+        Issue.record("Expected block_start")
+        return
+    }
+    #expect(params.blockType == .toolUse)
+    #expect(params.toolName == "Read")
+}
+
+@Test func testPermissionRequestDecoding() throws {
+    let json = """
+    {"type":"permission_request","permId":"perm-abc","toolName":"Bash","toolInput":"npm test","displayName":"Run command","tier":"standard"}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .permissionRequest(let params) = msg else {
+        Issue.record("Expected permission_request")
+        return
+    }
+    #expect(params.permId == "perm-abc")
+    #expect(params.toolName == "Bash")
+    #expect(params.tier == .standard)
+}
+
+@Test func testToolResultDecoding() throws {
+    let json = """
+    {"type":"tool_result","messageId":"m1","toolId":"t1","result":"file contents here","isError":false}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .toolResult(let params) = msg else {
+        Issue.record("Expected tool_result")
+        return
+    }
+    #expect(params.toolId == "t1")
+    #expect(params.isError == false)
+}
+
+@Test func testErrorDecoding() throws {
+    let json = """
+    {"type":"error","error":"something went wrong"}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .error(let err) = msg else {
+        Issue.record("Expected error")
+        return
+    }
+    #expect(err == "something went wrong")
+}
+
+@Test func testUnknownTypeDecoding() throws {
+    let json = """
+    {"type":"future_message_type","data":"whatever"}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(ServerMessage.self, from: json)
+    guard case .unknown(let type) = msg else {
+        Issue.record("Expected unknown")
+        return
+    }
+    #expect(type == "future_message_type")
+}
+
+// MARK: - CoreTypes Decoding
+
+@Test func testSessionDecoding() throws {
+    let json = """
+    {"id":"sess-1","summary":"Fix the login bug","lastModified":1714070400000,"branch":"fix/login","cwd":"/home/user","isActive":true,"isAttached":false,"totalTokens":5000,"numTurns":3}
+    """.data(using: .utf8)!
+
+    let session = try JSONDecoder().decode(Session.self, from: json)
+    #expect(session.id == "sess-1")
+    #expect(session.summary == "Fix the login bug")
+    #expect(session.branch == "fix/login")
+    #expect(session.isActive == true)
+    #expect(session.totalTokens == 5000)
+}
+
+@Test func testSessionMinimalDecoding() throws {
+    let json = """
+    {"id":"sess-2","summary":"Quick question","lastModified":1714070400000}
+    """.data(using: .utf8)!
+
+    let session = try JSONDecoder().decode(Session.self, from: json)
+    #expect(session.id == "sess-2")
+    #expect(session.branch == nil)
+    #expect(session.isActive == nil)
+}
+
+@Test func testSessionsResponseDecoding() throws {
+    let json = """
+    {"sessions":[{"id":"s1","summary":"Test","lastModified":100}],"hasMore":true}
+    """.data(using: .utf8)!
+
+    let response = try JSONDecoder().decode(SessionsResponse.self, from: json)
+    #expect(response.sessions.count == 1)
+    #expect(response.hasMore == true)
+}
+
+@Test func testFinishedMessageDecoding() throws {
+    let json = """
+    {"messageId":"m1","role":"assistant","blocks":[{"blockId":"b1","blockType":"text","content":"Hello!"}]}
+    """.data(using: .utf8)!
+
+    let msg = try JSONDecoder().decode(FinishedMessage.self, from: json)
+    #expect(msg.role == .assistant)
+    #expect(msg.blocks.count == 1)
+    #expect(msg.blocks[0].content == "Hello!")
+}
+
+@Test func testBlockTypeDecoding() throws {
+    let cases: [(String, BlockType)] = [
+        ("\"text\"", .text),
+        ("\"thinking\"", .thinking),
+        ("\"redacted_thinking\"", .redactedThinking),
+        ("\"tool_use\"", .toolUse),
+    ]
+
+    for (jsonStr, expected) in cases {
+        let data = jsonStr.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(BlockType.self, from: data)
+        #expect(decoded == expected)
+    }
 }

--- a/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
+++ b/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import MitzoShared
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+}

--- a/frontend/ios/MitzoWatch/Info.plist
+++ b/frontend/ios/MitzoWatch/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Mitzo</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Mitzo uses the microphone for voice input to send messages.</string>
+	<key>WKApplication</key>
+	<true/>
+</dict>
+</plist>

--- a/frontend/ios/MitzoWatch/MitzoWatch.entitlements
+++ b/frontend/ios/MitzoWatch/MitzoWatch.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.mitzo.app</string>
+	</array>
+</dict>
+</plist>

--- a/frontend/ios/MitzoWatch/MitzoWatchApp.swift
+++ b/frontend/ios/MitzoWatch/MitzoWatchApp.swift
@@ -1,0 +1,21 @@
+// Mitzo Watch — Apple Watch companion app
+
+import SwiftUI
+import MitzoShared
+
+@main
+struct MitzoWatchApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            if appState.isAuthenticated {
+                SessionListView()
+                    .environmentObject(appState)
+            } else {
+                LoginView()
+                    .environmentObject(appState)
+            }
+        }
+    }
+}

--- a/frontend/ios/MitzoWatch/SETUP.md
+++ b/frontend/ios/MitzoWatch/SETUP.md
@@ -1,0 +1,40 @@
+# MitzoWatch — Xcode Setup
+
+## Add watchOS Target
+
+1. Open `frontend/ios/App/App.xcworkspace` in Xcode
+2. File → New → Target → **watchOS App**
+3. Settings:
+   - Product Name: `MitzoWatch`
+   - Bundle ID: `com.mitzo.app.watchkitapp`
+   - Team: Y4QGXHYSY3
+   - Interface: SwiftUI
+   - Language: Swift
+   - Minimum Deployment: watchOS 10.0
+   - Include Notification Scene: No
+4. Delete the generated template files (ContentView.swift, Assets, etc.)
+5. Drag the `MitzoWatch/` source files into the new target group
+
+## Add MitzoShared Dependency
+
+1. File → Add Package Dependencies → Add Local
+2. Navigate to `frontend/ios/MitzoShared/`
+3. Add to both `App` and `MitzoWatch` targets
+
+## Configure Shared Keychain
+
+1. Select `App` target → Signing & Capabilities → + Capability → Keychain Sharing
+2. Add group: `com.mitzo.app`
+3. Select `MitzoWatch` target → same steps
+4. Both targets must use the same access group for JWT sharing
+
+## Build & Run
+
+1. Select `MitzoWatch` scheme
+2. Choose Apple Watch simulator or device
+3. Build & Run (⌘R)
+
+## Server URL
+
+Edit `AppState.swift` and `VoiceService.swift` to set the correct server/Yapper URLs
+for your Tailscale network.

--- a/frontend/ios/MitzoWatch/Services/AppState.swift
+++ b/frontend/ios/MitzoWatch/Services/AppState.swift
@@ -1,0 +1,132 @@
+// Central app state — owns auth, WS connection, and session state
+
+import SwiftUI
+import MitzoShared
+
+@MainActor
+final class AppState: ObservableObject {
+    @Published var isAuthenticated = false
+    @Published var connectionState: MitzoWSClient.State = .disconnected
+    @Published var sessions: [SessionSummary] = []
+    @Published var error: String?
+
+    private let authManager = AuthManager()
+    private var wsClient: MitzoWSClient?
+    private var apiClient: MitzoAPIClient?
+
+    // Server URL — configure per environment
+    var serverURL: URL {
+        // Default to Tailscale hostname; override via environment or settings
+        URL(string: "https://mitzo.tail:3100")!
+    }
+
+    init() {
+        Task {
+            await checkAuth()
+        }
+    }
+
+    // MARK: - Auth
+
+    func checkAuth() async {
+        isAuthenticated = await authManager.isAuthenticated()
+        if isAuthenticated {
+            await connect()
+        }
+    }
+
+    func login(passphrase: String) async {
+        do {
+            _ = try await authManager.login(passphrase: passphrase, serverURL: serverURL)
+            isAuthenticated = true
+            await connect()
+        } catch {
+            self.error = "Login failed"
+        }
+    }
+
+    // MARK: - Connection
+
+    func connect() async {
+        guard let token = try? await authManager.getToken() else { return }
+
+        var components = URLComponents(url: serverURL.appendingPathComponent("/ws"), resolvingAgainstBaseURL: false)!
+        components.scheme = components.scheme == "https" ? "wss" : "ws"
+        components.queryItems = [URLQueryItem(name: "token", value: token)]
+
+        guard let wsURL = components.url else { return }
+
+        let client = MitzoWSClient(url: wsURL)
+        wsClient = client
+
+        apiClient = MitzoAPIClient(baseURL: serverURL, authManager: authManager)
+
+        await client.connect { [weak self] event in
+            Task { @MainActor in
+                self?.handleWSEvent(event)
+            }
+        }
+
+        await loadSessions()
+    }
+
+    func suspend() async {
+        guard let client = wsClient else { return }
+        let sessions = await client.getSuspendSessions()
+        if !sessions.isEmpty {
+            try? await client.suspend(sessions: sessions)
+        }
+    }
+
+    func reconnect() async {
+        // Handled automatically by MitzoWSClient
+    }
+
+    // MARK: - Sessions
+
+    func loadSessions() async {
+        do {
+            let fetched: [Session] = try await apiClient?.getSessions() ?? []
+            sessions = fetched.map { SessionSummary(from: $0) }
+        } catch {
+            self.error = "Failed to load sessions"
+        }
+    }
+
+    // MARK: - Event Handling
+
+    private func handleWSEvent(_ event: MitzoWSClient.Event) {
+        switch event {
+        case .stateChanged(let state):
+            connectionState = state
+
+        case .message:
+            // Forwarded to active ChatViewModel
+            break
+
+        case .error(let err):
+            error = err.localizedDescription
+        }
+    }
+
+    // MARK: - Accessors
+
+    func getWSClient() -> MitzoWSClient? { wsClient }
+    func getAPIClient() -> MitzoAPIClient? { apiClient }
+}
+
+// MARK: - Session Summary
+
+struct SessionSummary: Identifiable {
+    let id: String
+    let mode: MitzoMode
+    let branch: String?
+    let updatedAt: Int?
+
+    init(from session: Session) {
+        self.id = session.id
+        self.mode = session.mode
+        self.branch = session.branch
+        self.updatedAt = session.updatedAt
+    }
+}

--- a/frontend/ios/MitzoWatch/Services/AppState.swift
+++ b/frontend/ios/MitzoWatch/Services/AppState.swift
@@ -7,17 +7,18 @@ import MitzoShared
 final class AppState: ObservableObject {
     @Published var isAuthenticated = false
     @Published var connectionState: MitzoWSClient.State = .disconnected
-    @Published var sessions: [SessionSummary] = []
+    @Published var sessions: [Session] = []
     @Published var error: String?
 
     private let authManager = AuthManager()
     private var wsClient: MitzoWSClient?
     private var apiClient: MitzoAPIClient?
+    private var activeChatVM: ChatViewModel?
 
-    // Server URL — configure per environment
+    // Configurable via UserDefaults; defaults to Tailscale hostname
     var serverURL: URL {
-        // Default to Tailscale hostname; override via environment or settings
-        URL(string: "https://mitzo.tail:3100")!
+        let stored = UserDefaults.standard.string(forKey: "mitzo_server_url")
+        return URL(string: stored ?? "https://mitzo.tail:3100")!
     }
 
     init() {
@@ -50,8 +51,10 @@ final class AppState: ObservableObject {
     func connect() async {
         guard let token = try? await authManager.getToken() else { return }
 
-        var components = URLComponents(url: serverURL.appendingPathComponent("/ws"), resolvingAgainstBaseURL: false)!
+        // WS path is /ws/chat, not /ws
+        var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
         components.scheme = components.scheme == "https" ? "wss" : "ws"
+        components.path = "/ws/chat"
         components.queryItems = [URLQueryItem(name: "token", value: token)]
 
         guard let wsURL = components.url else { return }
@@ -78,19 +81,21 @@ final class AppState: ObservableObject {
         }
     }
 
-    func reconnect() async {
-        // Handled automatically by MitzoWSClient
-    }
-
     // MARK: - Sessions
 
     func loadSessions() async {
         do {
-            let fetched: [Session] = try await apiClient?.getSessions() ?? []
-            sessions = fetched.map { SessionSummary(from: $0) }
+            let response: SessionsResponse = try await apiClient?.getSessions() ?? SessionsResponse(sessions: [], hasMore: false)
+            sessions = response.sessions
         } catch {
             self.error = "Failed to load sessions"
         }
+    }
+
+    // MARK: - Active Chat
+
+    func setActiveChatVM(_ vm: ChatViewModel?) {
+        activeChatVM = vm
     }
 
     // MARK: - Event Handling
@@ -100,9 +105,9 @@ final class AppState: ObservableObject {
         case .stateChanged(let state):
             connectionState = state
 
-        case .message:
-            // Forwarded to active ChatViewModel
-            break
+        case .message(let msg):
+            // Forward to active ChatViewModel
+            activeChatVM?.handleMessage(msg)
 
         case .error(let err):
             error = err.localizedDescription
@@ -113,20 +118,4 @@ final class AppState: ObservableObject {
 
     func getWSClient() -> MitzoWSClient? { wsClient }
     func getAPIClient() -> MitzoAPIClient? { apiClient }
-}
-
-// MARK: - Session Summary
-
-struct SessionSummary: Identifiable {
-    let id: String
-    let mode: MitzoMode
-    let branch: String?
-    let updatedAt: Int?
-
-    init(from session: Session) {
-        self.id = session.id
-        self.mode = session.mode
-        self.branch = session.branch
-        self.updatedAt = session.updatedAt
-    }
 }

--- a/frontend/ios/MitzoWatch/Services/ChatViewModel.swift
+++ b/frontend/ios/MitzoWatch/Services/ChatViewModel.swift
@@ -1,0 +1,250 @@
+// Chat view model — manages a single session's message stream
+
+import SwiftUI
+import MitzoShared
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    @Published var messages: [ChatMessage] = []
+    @Published var currentStream: StreamingMessage?
+    @Published var isStreaming = false
+    @Published var permissionRequest: PermissionRequest?
+    @Published var toolStatus: String?
+
+    let sessionId: String?
+    private var resolvedSessionId: String?
+    private(set) weak var appState: AppState?
+    private var wsClient: MitzoWSClient?
+
+    init(sessionId: String?, appState: AppState? = nil) {
+        self.sessionId = sessionId
+        self.resolvedSessionId = sessionId
+        self.appState = appState
+        self.wsClient = appState?.getWSClient()
+    }
+
+    func configure(appState: AppState) {
+        self.appState = appState
+        self.wsClient = appState.getWSClient()
+    }
+
+    // MARK: - Load History
+
+    func loadHistory() async {
+        guard let sessionId = resolvedSessionId,
+              let apiClient = appState?.getAPIClient() else { return }
+
+        do {
+            let finished: [FinishedMessage] = try await apiClient.getMessages(sessionId: sessionId)
+            messages = finished.map { ChatMessage(from: $0) }
+        } catch {
+            // History load failure is non-fatal
+        }
+
+        // Watch this session
+        if let client = wsClient {
+            try? await client.send(.watch(sessionId: sessionId))
+        }
+    }
+
+    // MARK: - Send Message
+
+    func send(text: String) async {
+        guard let client = wsClient else { return }
+
+        // Add user message to display
+        let userMsg = ChatMessage(role: .user, text: text)
+        messages.append(userMsg)
+
+        // Send via WS
+        let params = SendParams(
+            sessionId: resolvedSessionId,
+            prompt: text
+        )
+
+        do {
+            try await client.send(.send(params))
+            isStreaming = true
+        } catch {
+            // Handle send failure
+        }
+    }
+
+    // MARK: - Permission
+
+    func respondToPermission(decision: PermissionDecision) async {
+        guard let perm = permissionRequest,
+              let client = wsClient else { return }
+
+        let params = PermissionResponseParams(
+            sessionId: resolvedSessionId,
+            permId: perm.permId,
+            decision: decision
+        )
+
+        try? await client.send(.permissionResponse(params))
+        permissionRequest = nil
+    }
+
+    // MARK: - Stop
+
+    func stop() async {
+        guard let sessionId = resolvedSessionId,
+              let client = wsClient else { return }
+
+        try? await client.send(.stop(sessionId: sessionId))
+    }
+
+    // MARK: - Process Server Messages
+
+    func handleMessage(_ message: ServerMessage) {
+        switch message {
+        case .sessionId(let sid, _, _):
+            resolvedSessionId = sid
+
+        case .messageStart(let params):
+            guard params.sessionId == resolvedSessionId else { return }
+            currentStream = StreamingMessage(messageId: params.messageId)
+            isStreaming = true
+            toolStatus = nil
+
+        case .blockStart(let params):
+            guard params.sessionId == resolvedSessionId,
+                  var stream = currentStream else { return }
+
+            var block = StreamingBlock(
+                blockId: params.blockId,
+                blockType: params.blockType,
+                toolName: params.toolName
+            )
+            stream.blocks[params.blockId] = block
+            stream.blockOrder.append(params.blockId)
+            currentStream = stream
+
+            // Update tool status
+            if params.blockType == .toolUse, let name = params.toolName {
+                toolStatus = formatToolStatus(name)
+            } else if params.blockType == .thinking {
+                toolStatus = "Thinking..."
+            }
+
+        case .blockDelta(let params):
+            guard params.sessionId == resolvedSessionId,
+                  var stream = currentStream,
+                  var block = stream.blocks[params.blockId] else { return }
+
+            block.content += params.delta
+            stream.blocks[params.blockId] = block
+            currentStream = stream
+
+        case .blockEnd(let params):
+            guard params.sessionId == resolvedSessionId,
+                  var stream = currentStream,
+                  var block = stream.blocks[params.blockId] else { return }
+
+            block.done = true
+            if let toolName = params.toolName { block.toolName = toolName }
+            if let toolId = params.toolId { block.toolId = toolId }
+            if let input = params.input { block.toolInput = input }
+            stream.blocks[params.blockId] = block
+            currentStream = stream
+
+        case .messageEnd(let params):
+            guard params.sessionId == resolvedSessionId else { return }
+
+            // Finalize streaming message into messages array
+            if let stream = currentStream {
+                let chatMsg = ChatMessage(from: stream)
+                messages.append(chatMsg)
+            }
+            currentStream = nil
+            isStreaming = false
+            toolStatus = nil
+
+        case .sessionEnd:
+            isStreaming = false
+            toolStatus = nil
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatToolStatus(_ toolName: String) -> String {
+        switch toolName {
+        case "Read": return "Reading file..."
+        case "Write": return "Writing file..."
+        case "Edit": return "Editing..."
+        case "Bash": return "Running command..."
+        case "Grep": return "Searching..."
+        case "Glob": return "Finding files..."
+        case "Agent": return "Delegating..."
+        default: return toolName
+        }
+    }
+}
+
+// MARK: - Chat Message Model
+
+struct ChatMessage: Identifiable {
+    let id = UUID()
+    let role: MessageRole
+    let text: String
+    let blocks: [ChatBlock]
+    let timestamp: Date
+
+    init(role: MessageRole, text: String) {
+        self.role = role
+        self.text = text
+        self.blocks = [ChatBlock(type: .text, content: text)]
+        self.timestamp = Date()
+    }
+
+    init(from finished: FinishedMessage) {
+        self.role = finished.role
+        self.blocks = finished.blocks.map { ChatBlock(from: $0) }
+        self.text = blocks.first(where: { $0.type == .text })?.content ?? ""
+        if let ts = finished.timestamp {
+            self.timestamp = Date(timeIntervalSince1970: TimeInterval(ts) / 1000)
+        } else {
+            self.timestamp = Date()
+        }
+    }
+
+    init(from streaming: StreamingMessage) {
+        self.role = .assistant
+        self.blocks = streaming.blockOrder.compactMap { id in
+            guard let block = streaming.blocks[id] else { return nil }
+            return ChatBlock(from: block)
+        }
+        self.text = blocks.first(where: { $0.type == .text })?.content ?? ""
+        self.timestamp = Date()
+    }
+}
+
+struct ChatBlock: Identifiable {
+    let id = UUID()
+    let type: BlockType
+    let content: String
+    let toolName: String?
+
+    init(type: BlockType, content: String, toolName: String? = nil) {
+        self.type = type
+        self.content = content
+        self.toolName = toolName
+    }
+
+    init(from finished: FinishedBlock) {
+        self.type = finished.blockType
+        self.content = finished.content
+        self.toolName = finished.toolName
+    }
+
+    init(from streaming: StreamingBlock) {
+        self.type = streaming.blockType
+        self.content = streaming.content
+        self.toolName = streaming.toolName
+    }
+}

--- a/frontend/ios/MitzoWatch/Services/ChatViewModel.swift
+++ b/frontend/ios/MitzoWatch/Services/ChatViewModel.swift
@@ -8,7 +8,7 @@ final class ChatViewModel: ObservableObject {
     @Published var messages: [ChatMessage] = []
     @Published var currentStream: StreamingMessage?
     @Published var isStreaming = false
-    @Published var permissionRequest: PermissionRequest?
+    @Published var permissionRequest: PermissionRequestParams?
     @Published var toolStatus: String?
 
     let sessionId: String?
@@ -26,6 +26,12 @@ final class ChatViewModel: ObservableObject {
     func configure(appState: AppState) {
         self.appState = appState
         self.wsClient = appState.getWSClient()
+        appState.setActiveChatVM(self)
+    }
+
+    deinit {
+        // Can't call appState methods from deinit in actor context,
+        // but weak reference means AppState won't retain us
     }
 
     // MARK: - Load History
@@ -164,6 +170,19 @@ final class ChatViewModel: ObservableObject {
         case .sessionEnd:
             isStreaming = false
             toolStatus = nil
+
+        case .permissionRequest(let params):
+            permissionRequest = params
+
+        case .toolResult(let params):
+            // Update the block with tool result if we're tracking it
+            if var stream = currentStream,
+               var block = stream.blocks.values.first(where: { $0.toolId == params.toolId }) {
+                block.toolResult = params.result
+                block.toolError = params.isError
+                stream.blocks[block.blockId] = block
+                currentStream = stream
+            }
 
         default:
             break

--- a/frontend/ios/MitzoWatch/Services/VoiceService.swift
+++ b/frontend/ios/MitzoWatch/Services/VoiceService.swift
@@ -1,0 +1,173 @@
+// Voice capture service — AVAudioEngine → Yapper STT
+
+import AVFoundation
+import MitzoShared
+
+@MainActor
+final class VoiceService: ObservableObject {
+    @Published var isRecording = false
+    @Published var partialTranscript = ""
+    @Published var isYapperAvailable = false
+
+    private var audioEngine: AVAudioEngine?
+    private var yapperClient: YapperClient?
+    private var finalTranscript = ""
+    private var completionHandler: ((String) -> Void)?
+
+    // Yapper URL — same Tailscale network
+    var yapperURL: URL {
+        URL(string: "http://mitzo.tail:8700")!
+    }
+
+    init() {
+        yapperClient = YapperClient(baseURL: yapperURL)
+        Task { await checkYapper() }
+    }
+
+    // MARK: - Health
+
+    func checkYapper() async {
+        do {
+            isYapperAvailable = try await yapperClient?.checkHealth() ?? false
+        } catch {
+            isYapperAvailable = false
+        }
+    }
+
+    // MARK: - Recording
+
+    func startRecording() {
+        guard !isRecording else { return }
+
+        partialTranscript = ""
+        finalTranscript = ""
+
+        Task {
+            do {
+                // Request mic permission
+                let session = AVAudioSession.sharedInstance()
+                try session.setCategory(.record, mode: .measurement)
+                try session.setActive(true)
+
+                // Start Yapper streaming
+                try await yapperClient?.startStreaming { [weak self] event in
+                    Task { @MainActor in
+                        self?.handleTranscriptEvent(event)
+                    }
+                }
+
+                // Start audio engine
+                let engine = AVAudioEngine()
+                let inputNode = engine.inputNode
+                let format = AVAudioFormat(
+                    commonFormat: .pcmFormatInt16,
+                    sampleRate: 16000,
+                    channels: 1,
+                    interleaved: true
+                )!
+
+                // Install tap
+                let busFormat = inputNode.outputFormat(forBus: 0)
+                let converter = AVAudioConverter(from: busFormat, to: format)!
+
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: busFormat) { [weak self] buffer, _ in
+                    // Convert to PCM int16 16kHz mono
+                    let frameCount = AVAudioFrameCount(
+                        Double(buffer.frameLength) * 16000.0 / busFormat.sampleRate
+                    )
+                    guard let convertedBuffer = AVAudioPCMBuffer(
+                        pcmFormat: format,
+                        frameCapacity: frameCount
+                    ) else { return }
+
+                    var error: NSError?
+                    converter.convert(to: convertedBuffer, error: &error) { _, outStatus in
+                        outStatus.pointee = .haveData
+                        return buffer
+                    }
+
+                    if let channelData = convertedBuffer.int16ChannelData {
+                        let data = Data(
+                            bytes: channelData[0],
+                            count: Int(convertedBuffer.frameLength) * 2
+                        )
+
+                        Task {
+                            try? await self?.yapperClient?.sendAudio(data)
+                        }
+                    }
+                }
+
+                try engine.start()
+                audioEngine = engine
+                isRecording = true
+
+            } catch {
+                isRecording = false
+            }
+        }
+    }
+
+    func stopRecording(completion: @escaping (String) -> Void) {
+        guard isRecording else {
+            completion("")
+            return
+        }
+
+        completionHandler = completion
+        isRecording = false
+
+        // Stop audio engine
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+
+        // Signal end to Yapper
+        Task {
+            try? await yapperClient?.endStreaming()
+
+            // Wait a moment for final transcript, then deliver
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+
+            let transcript = finalTranscript.isEmpty ? partialTranscript : finalTranscript
+            completionHandler?(transcript)
+            completionHandler = nil
+            partialTranscript = ""
+        }
+    }
+
+    func cancelRecording() {
+        isRecording = false
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        partialTranscript = ""
+        finalTranscript = ""
+
+        Task {
+            await yapperClient?.close()
+        }
+    }
+
+    // MARK: - Transcript Events
+
+    private func handleTranscriptEvent(_ event: YapperClient.TranscriptEvent) {
+        switch event {
+        case .partial(let text):
+            partialTranscript = text
+
+        case .final(let text):
+            finalTranscript = text
+            partialTranscript = text
+
+            // If completion handler is waiting, deliver immediately
+            if let handler = completionHandler {
+                handler(text)
+                completionHandler = nil
+            }
+
+        case .error:
+            break
+        }
+    }
+}

--- a/frontend/ios/MitzoWatch/Services/VoiceService.swift
+++ b/frontend/ios/MitzoWatch/Services/VoiceService.swift
@@ -14,9 +14,10 @@ final class VoiceService: ObservableObject {
     private var finalTranscript = ""
     private var completionHandler: ((String) -> Void)?
 
-    // Yapper URL — same Tailscale network
+    // Configurable via UserDefaults; defaults to Tailscale hostname
     var yapperURL: URL {
-        URL(string: "http://mitzo.tail:8700")!
+        let stored = UserDefaults.standard.string(forKey: "mitzo_yapper_url")
+        return URL(string: stored ?? "http://mitzo.tail:8700")!
     }
 
     init() {
@@ -122,17 +123,21 @@ final class VoiceService: ObservableObject {
         audioEngine?.stop()
         audioEngine = nil
 
-        // Signal end to Yapper
+        // Signal end to Yapper — final transcript arrives via handleTranscriptEvent
         Task {
             try? await yapperClient?.endStreaming()
 
-            // Wait a moment for final transcript, then deliver
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            // Short timeout fallback: if final transcript doesn't arrive within 3s,
+            // use whatever partial we have
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
 
-            let transcript = finalTranscript.isEmpty ? partialTranscript : finalTranscript
-            completionHandler?(transcript)
-            completionHandler = nil
-            partialTranscript = ""
+            if let handler = completionHandler {
+                // Final never arrived — use best-effort partial
+                let transcript = finalTranscript.isEmpty ? partialTranscript : finalTranscript
+                handler(transcript)
+                completionHandler = nil
+                partialTranscript = ""
+            }
         }
     }
 

--- a/frontend/ios/MitzoWatch/Views/ChatView.swift
+++ b/frontend/ios/MitzoWatch/Views/ChatView.swift
@@ -1,0 +1,205 @@
+// Chat view — streaming messages + voice input
+
+import SwiftUI
+import MitzoShared
+
+struct ChatView: View {
+    @EnvironmentObject var appState: AppState
+    @StateObject private var viewModel: ChatViewModel
+    @StateObject private var voiceService = VoiceService()
+    @State private var scrollProxy: ScrollViewProxy?
+
+    init(sessionId: String?) {
+        _viewModel = StateObject(wrappedValue: ChatViewModel(sessionId: sessionId))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Message stream
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(viewModel.messages) { message in
+                            MessageBubble(message: message)
+                                .id(message.id)
+                        }
+
+                        // Live streaming content
+                        if let stream = viewModel.currentStream {
+                            StreamingBubble(stream: stream)
+                                .id("streaming")
+                        }
+
+                        // Tool status pill
+                        if let status = viewModel.toolStatus {
+                            ToolPill(status: status)
+                                .id("tool")
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                    .padding(.bottom, 8)
+                }
+                .onChange(of: viewModel.messages.count) { _, _ in
+                    withAnimation {
+                        proxy.scrollTo("streaming", anchor: .bottom)
+                    }
+                }
+                .onAppear { scrollProxy = proxy }
+            }
+
+            // Permission banner
+            if let perm = viewModel.permissionRequest {
+                PermissionBanner(
+                    request: perm,
+                    onAllow: {
+                        Task { await viewModel.respondToPermission(decision: .once) }
+                    },
+                    onDeny: {
+                        Task { await viewModel.respondToPermission(decision: .deny) }
+                    }
+                )
+            }
+
+            Divider()
+
+            // Voice input bar
+            VoiceInputBar(voiceService: voiceService) { transcript in
+                Task { await viewModel.send(text: transcript) }
+            }
+        }
+        .navigationTitle(viewModel.sessionId?.prefix(6).description ?? "New")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if viewModel.isStreaming {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task { await viewModel.stop() }
+                    } label: {
+                        Image(systemName: "stop.fill")
+                            .foregroundStyle(.red)
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .task {
+            viewModel.configure(appState: appState)
+            await viewModel.loadHistory()
+        }
+    }
+}
+
+// MARK: - Message Bubble
+
+struct MessageBubble: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 20) }
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(message.blocks) { block in
+                    switch block.type {
+                    case .text:
+                        Text(block.content)
+                            .font(.caption)
+
+                    case .thinking:
+                        Text("Thinking...")
+                            .font(.caption2)
+                            .italic()
+                            .foregroundStyle(.secondary)
+
+                    case .toolUse:
+                        Label(
+                            block.toolName ?? "Tool",
+                            systemImage: "gearshape"
+                        )
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+
+                    case .redactedThinking:
+                        EmptyView()
+                    }
+                }
+            }
+            .padding(8)
+            .background(message.role == .user ? Color.blue.opacity(0.3) : Color.gray.opacity(0.2))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            if message.role == .assistant { Spacer(minLength: 20) }
+        }
+    }
+}
+
+// MARK: - Streaming Bubble
+
+struct StreamingBubble: View {
+    let stream: StreamingMessage
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(stream.blockOrder, id: \.self) { blockId in
+                    if let block = stream.blocks[blockId] {
+                        switch block.blockType {
+                        case .text:
+                            Text(block.content)
+                                .font(.caption)
+                            + Text(block.done ? "" : " ▊")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+
+                        case .thinking:
+                            HStack(spacing: 4) {
+                                ProgressView()
+                                    .scaleEffect(0.4)
+                                Text("Thinking...")
+                                    .font(.caption2)
+                                    .italic()
+                                    .foregroundStyle(.secondary)
+                            }
+
+                        case .toolUse:
+                            Label(
+                                block.toolName ?? "Tool",
+                                systemImage: "gearshape"
+                            )
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+
+                        case .redactedThinking:
+                            EmptyView()
+                        }
+                    }
+                }
+            }
+            .padding(8)
+            .background(Color.gray.opacity(0.2))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Spacer(minLength: 20)
+        }
+    }
+}
+
+// MARK: - Tool Pill
+
+struct ToolPill: View {
+    let status: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ProgressView()
+                .scaleEffect(0.4)
+            Text(status)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.quaternary)
+        .clipShape(Capsule())
+    }
+}

--- a/frontend/ios/MitzoWatch/Views/LoginView.swift
+++ b/frontend/ios/MitzoWatch/Views/LoginView.swift
@@ -1,0 +1,45 @@
+// Login view — one-time passphrase entry
+
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject var appState: AppState
+    @State private var passphrase = ""
+    @State private var isLoading = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 36))
+                .foregroundStyle(.blue)
+
+            Text("Mitzo")
+                .font(.headline)
+
+            SecureField("Passphrase", text: $passphrase)
+                .textContentType(.password)
+
+            Button {
+                isLoading = true
+                Task {
+                    await appState.login(passphrase: passphrase)
+                    isLoading = false
+                }
+            } label: {
+                if isLoading {
+                    ProgressView()
+                } else {
+                    Text("Connect")
+                }
+            }
+            .disabled(passphrase.isEmpty || isLoading)
+
+            if let error = appState.error {
+                Text(error)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+            }
+        }
+        .padding()
+    }
+}

--- a/frontend/ios/MitzoWatch/Views/PermissionBanner.swift
+++ b/frontend/ios/MitzoWatch/Views/PermissionBanner.swift
@@ -1,0 +1,67 @@
+// Permission approval banner
+
+import SwiftUI
+import MitzoShared
+
+struct PermissionBanner: View {
+    let request: PermissionRequest
+    let onAllow: () -> Void
+    let onDeny: () -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 4) {
+                Image(systemName: tierIcon)
+                    .foregroundStyle(tierColor)
+                    .font(.caption2)
+                Text(request.displayName ?? request.toolName)
+                    .font(.caption2)
+                    .bold()
+                    .lineLimit(1)
+            }
+
+            if let desc = request.description {
+                Text(desc)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            HStack(spacing: 12) {
+                Button(role: .destructive, action: onDeny) {
+                    Text("Deny")
+                        .font(.caption2)
+                }
+
+                Button(action: onAllow) {
+                    Text("Allow")
+                        .font(.caption2)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.blue)
+            }
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .padding(.horizontal, 4)
+    }
+
+    private var tierIcon: String {
+        switch request.tier {
+        case .safe: return "checkmark.shield"
+        case .standard: return "shield"
+        case .elevated: return "exclamationmark.shield"
+        case .unknown, .none: return "questionmark.shield"
+        }
+    }
+
+    private var tierColor: Color {
+        switch request.tier {
+        case .safe: return .green
+        case .standard: return .blue
+        case .elevated: return .orange
+        case .unknown, .none: return .gray
+        }
+    }
+}

--- a/frontend/ios/MitzoWatch/Views/PermissionBanner.swift
+++ b/frontend/ios/MitzoWatch/Views/PermissionBanner.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import MitzoShared
 
 struct PermissionBanner: View {
-    let request: PermissionRequest
+    let request: PermissionRequestParams
     let onAllow: () -> Void
     let onDeny: () -> Void
 

--- a/frontend/ios/MitzoWatch/Views/SessionListView.swift
+++ b/frontend/ios/MitzoWatch/Views/SessionListView.swift
@@ -61,28 +61,37 @@ struct SessionListView: View {
 // MARK: - Session Row
 
 struct SessionRow: View {
-    let session: SessionSummary
+    let session: Session
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text(session.branch ?? session.id.prefix(8).description)
+            Text(session.summary)
                 .font(.caption)
                 .lineLimit(1)
 
             HStack {
-                Text(session.mode.rawValue)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 1)
-                    .background(.quaternary)
-                    .clipShape(Capsule())
+                if session.isActive == true {
+                    Text("active")
+                        .font(.caption2)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(.green)
+                        .clipShape(Capsule())
+                }
 
-                if let ts = session.updatedAt {
-                    Text(timeAgo(ts))
+                if let branch = session.branch {
+                    Text(branch)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
+
+                Spacer()
+
+                Text(timeAgo(session.lastModified))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/frontend/ios/MitzoWatch/Views/SessionListView.swift
+++ b/frontend/ios/MitzoWatch/Views/SessionListView.swift
@@ -1,0 +1,99 @@
+// Session list — recent sessions + new session button
+
+import SwiftUI
+import MitzoShared
+
+struct SessionListView: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        NavigationStack {
+            List {
+                // New session
+                NavigationLink {
+                    ChatView(sessionId: nil)
+                        .environmentObject(appState)
+                } label: {
+                    Label("New Session", systemImage: "plus.bubble")
+                        .foregroundStyle(.blue)
+                }
+
+                // Existing sessions
+                ForEach(appState.sessions) { session in
+                    NavigationLink {
+                        ChatView(sessionId: session.id)
+                            .environmentObject(appState)
+                    } label: {
+                        SessionRow(session: session)
+                    }
+                }
+            }
+            .navigationTitle("Mitzo")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    connectionIndicator
+                }
+            }
+        }
+        .task {
+            await appState.loadSessions()
+        }
+    }
+
+    @ViewBuilder
+    private var connectionIndicator: some View {
+        switch appState.connectionState {
+        case .connected:
+            Circle()
+                .fill(.green)
+                .frame(width: 8, height: 8)
+        case .connecting, .reconnecting:
+            ProgressView()
+                .scaleEffect(0.5)
+        case .disconnected:
+            Circle()
+                .fill(.red)
+                .frame(width: 8, height: 8)
+        }
+    }
+}
+
+// MARK: - Session Row
+
+struct SessionRow: View {
+    let session: SessionSummary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(session.branch ?? session.id.prefix(8).description)
+                .font(.caption)
+                .lineLimit(1)
+
+            HStack {
+                Text(session.mode.rawValue)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(.quaternary)
+                    .clipShape(Capsule())
+
+                if let ts = session.updatedAt {
+                    Text(timeAgo(ts))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func timeAgo(_ timestamp: Int) -> String {
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000)
+        let interval = Date().timeIntervalSince(date)
+
+        if interval < 60 { return "now" }
+        if interval < 3600 { return "\(Int(interval / 60))m ago" }
+        if interval < 86400 { return "\(Int(interval / 3600))h ago" }
+        return "\(Int(interval / 86400))d ago"
+    }
+}

--- a/frontend/ios/MitzoWatch/Views/VoiceInputBar.swift
+++ b/frontend/ios/MitzoWatch/Views/VoiceInputBar.swift
@@ -1,0 +1,71 @@
+// Voice input bar — push-to-talk with live transcript
+
+import SwiftUI
+
+struct VoiceInputBar: View {
+    @ObservedObject var voiceService: VoiceService
+    let onSend: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 4) {
+            // Partial transcript
+            if !voiceService.partialTranscript.isEmpty {
+                Text(voiceService.partialTranscript)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+            }
+
+            HStack(spacing: 12) {
+                // Cancel (visible while recording)
+                if voiceService.isRecording {
+                    Button {
+                        voiceService.cancelRecording()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // Mic button — hold to talk
+                Button {
+                    // Toggle behavior for watch (long press is awkward)
+                    if voiceService.isRecording {
+                        voiceService.stopRecording { transcript in
+                            if !transcript.isEmpty {
+                                onSend(transcript)
+                            }
+                        }
+                    } else {
+                        voiceService.startRecording()
+                    }
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(voiceService.isRecording ? Color.red : Color.blue)
+                            .frame(width: 44, height: 44)
+
+                        Image(systemName: voiceService.isRecording ? "stop.fill" : "mic.fill")
+                            .font(.body)
+                            .foregroundStyle(.white)
+                    }
+                }
+                .buttonStyle(.plain)
+
+                // Recording indicator
+                if voiceService.isRecording {
+                    Circle()
+                        .fill(.red)
+                        .frame(width: 8, height: 8)
+                        .opacity(voiceService.isRecording ? 1 : 0)
+                        .animation(.easeInOut(duration: 0.5).repeatForever(), value: voiceService.isRecording)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MitzoShared` Swift package (`frontend/ios/MitzoShared/`) — the foundation for an Apple Watch companion app
- Implements the full v2 WebSocket protocol as Swift Codable types, plus WS client with seq tracking, reconnect, and suspend support
- Includes Yapper streaming STT client, REST API client for sessions/messages, and shared Keychain auth manager
- Targets iOS 15+ / watchOS 10+ / macOS 12+, compiles cleanly with Swift 6

### What's here

| Module | Purpose |
|--------|---------|
| `Protocol/CoreTypes` | `BlockType`, `StreamingBlock`, `FinishedMessage`, `PermissionRequest`, etc. |
| `Protocol/WSMessages` | `ClientMessage` (hello, send, watch, suspend...) and `ServerMessage` (welcome, block_delta, session_end...) |
| `Networking/MitzoWSClient` | URLSessionWebSocketTask-based v2 client — mirrors `connection.ts` |
| `Networking/MitzoAPIClient` | REST client for session list and message history |
| `Networking/YapperClient` | Streaming STT via Yapper WebSocket (PCM int16 16kHz) |
| `Auth/AuthManager` | JWT in shared Keychain access group for iOS↔watchOS |

### What's next

1. Add watchOS app target to `App.xcodeproj` (needs Xcode UI)
2. SwiftUI views: LoginView, SessionListView, ChatView, VoiceInputBar
3. AVAudioEngine voice capture → Yapper streaming STT
4. Permission handling UI
5. Unit tests for Codable round-trips and WS state machine

## Test plan

- [x] `swift build` passes on macOS
- [ ] Add to Xcode project, build for watchOS simulator
- [ ] Unit tests for protocol Codable round-trips
- [ ] Integration test: connect to running Mitzo server
- [ ] Voice capture → Yapper transcription on watch hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)