### PR TITLE
fix(client): prevent UI freeze from foreground state wipe + 3 related bugs

### DIFF
--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -635,9 +635,7 @@ describe('reconnected', () => {
       makeCallbacks(),
       POOL_KEY,
     );
-    expect(r.messagesActions).not.toContainEqual(
-      expect.objectContaining({ type: 'SET_RUNNING' }),
-    );
+    expect(r.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
   });
 
   it('no-ops when no currentSessionId', () => {
@@ -648,22 +646,13 @@ describe('reconnected', () => {
       makeCallbacks(),
       POOL_KEY,
     );
-    expect(r.messagesActions).not.toContainEqual(
-      expect.objectContaining({ type: 'SET_RUNNING' }),
-    );
+    expect(r.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
   });
 
   it('no-ops when sessions field is undefined (backward compat)', () => {
     const state = makeState({ currentSessionId: 'sid-1' });
-    const r = parseServerMessage(
-      { type: 'reconnected' },
-      state,
-      makeCallbacks(),
-      POOL_KEY,
-    );
-    expect(r.messagesActions).not.toContainEqual(
-      expect.objectContaining({ type: 'SET_RUNNING' }),
-    );
+    const r = parseServerMessage({ type: 'reconnected' }, state, makeCallbacks(), POOL_KEY);
+    expect(r.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
   });
 });
 

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -615,6 +615,56 @@ describe('reconnected', () => {
     parseServerMessage({ type: 'reconnected', sessions: [] }, makeState(), cb, POOL_KEY);
     expect(onReconnected).toHaveBeenCalled();
   });
+
+  it('dispatches SET_RUNNING false when active session reports not running', () => {
+    const state = makeState({ currentSessionId: 'sid-1' });
+    const r = parseServerMessage(
+      { type: 'reconnected', sessions: [{ sessionId: 'sid-1', replayed: 0, running: false }] },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).toContainEqual({ type: 'SET_RUNNING', running: false });
+  });
+
+  it('does not dispatch SET_RUNNING when active session is still running', () => {
+    const state = makeState({ currentSessionId: 'sid-1' });
+    const r = parseServerMessage(
+      { type: 'reconnected', sessions: [{ sessionId: 'sid-1', replayed: 0, running: true }] },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).not.toContainEqual(
+      expect.objectContaining({ type: 'SET_RUNNING' }),
+    );
+  });
+
+  it('no-ops when no currentSessionId', () => {
+    const state = makeState({ currentSessionId: undefined });
+    const r = parseServerMessage(
+      { type: 'reconnected', sessions: [{ sessionId: 'sid-1', replayed: 0, running: false }] },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).not.toContainEqual(
+      expect.objectContaining({ type: 'SET_RUNNING' }),
+    );
+  });
+
+  it('no-ops when sessions field is undefined (backward compat)', () => {
+    const state = makeState({ currentSessionId: 'sid-1' });
+    const r = parseServerMessage(
+      { type: 'reconnected' },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions).not.toContainEqual(
+      expect.objectContaining({ type: 'SET_RUNNING' }),
+    );
+  });
 });
 
 // ─── error handling (session expired) ────────────────────────────────────────

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -5,7 +5,7 @@ import type { ProtocolCallbacks, ProtocolParserState } from '../src/protocol-par
 function makeState(overrides?: Partial<ProtocolParserState>): ProtocolParserState {
   return {
     currentSessionId: undefined,
-    pendingSend: null,
+    pendingSend: [],
     ...overrides,
   };
 }
@@ -155,14 +155,20 @@ describe('session lifecycle', () => {
     ]);
   });
 
-  it('session_end clears pending send and queues it', () => {
-    const state = makeState({ pendingSend: { type: 'send', prompt: 'follow-up' } });
+  it('session_end dequeues first pending send and queues it', () => {
+    const state = makeState({
+      pendingSend: [
+        { type: 'send', prompt: 'follow-up' },
+        { type: 'send', prompt: 'second' },
+      ],
+    });
     const cb = makeCallbacks();
     const r = parseServerMessage({ type: 'session_end', sessionId: 'sid' }, state, cb, POOL_KEY);
     expect(r.messagesActions).toContainEqual({ type: 'SESSION_END', sessionId: 'sid' });
     expect(r.messagesActions).toContainEqual({ type: 'SET_RUNNING', running: true });
     expect(cb.sendQueued).toHaveBeenCalledWith(POOL_KEY, { type: 'send', prompt: 'follow-up' });
-    expect(state.pendingSend).toBeNull();
+    // Second message stays queued
+    expect(state.pendingSend).toEqual([{ type: 'send', prompt: 'second' }]);
   });
 });
 
@@ -369,10 +375,10 @@ describe('error handling', () => {
     expect(r.messagesActions).toEqual([{ type: 'ERROR', error: 'Something broke' }]);
   });
 
-  it('error clears pendingSend', () => {
-    const state = makeState({ pendingSend: { type: 'send', prompt: 'test' } });
+  it('error clears pendingSend queue', () => {
+    const state = makeState({ pendingSend: [{ type: 'send', prompt: 'test' }] });
     parseServerMessage({ type: 'error', error: 'fail' }, state, makeCallbacks(), POOL_KEY);
-    expect(state.pendingSend).toBeNull();
+    expect(state.pendingSend).toEqual([]);
   });
 });
 

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -1142,4 +1142,69 @@ describe('foreground recovery', () => {
     // The original 1 live message persists since RESTORE merges.
     expect(store.getState().messages.messages).toHaveLength(1);
   });
+
+  it('preserves streaming state when REST returns empty array', async () => {
+    const transport = mockTransport();
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/messages')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+          text: () => Promise.resolve(''),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(''),
+      });
+    });
+    const store = createReadyStore(transport);
+
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+    }));
+
+    // Simulate an in-progress streaming message
+    const streamingCurrent = {
+      messageId: 'msg-streaming',
+      blocks: new Map([
+        [
+          'b0',
+          {
+            blockId: 'b0',
+            blockType: 'text' as const,
+            content: 'Let me check the memory vault.',
+            done: false,
+          },
+        ],
+      ]),
+      blockOrder: ['b0'],
+    };
+    store.setState((s) => ({
+      messages: {
+        ...s.messages,
+        messages: [
+          {
+            messageId: 'user-1',
+            role: 'user' as const,
+            timestamp: Date.now(),
+            blocks: [{ blockId: 'u0', blockType: 'text' as const, content: 'hello' }],
+          },
+        ],
+        current: streamingCurrent,
+      },
+    }));
+
+    // Foreground fires — REST returns empty (timing gap)
+    lastWs.simulateMessage({ type: '_foreground' });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Streaming state must survive — not wiped
+    const state = store.getState().messages;
+    expect(state.current).not.toBeNull();
+    expect(state.current?.messageId).toBe('msg-streaming');
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0].messageId).toBe('user-1');
+  });
 });

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -63,8 +63,8 @@ export interface ProtocolParserState {
   /** Currently tracked session ID (used for expiry detection). */
   currentSessionId: string | undefined;
 
-  /** Queued message to send after current session ends. */
-  pendingSend: Record<string, unknown> | null;
+  /** Queued messages to send after current session ends (FIFO). */
+  pendingSend: Record<string, unknown>[];
 }
 
 // ─── Parser result ───────────────────────────────────────────────────────────
@@ -113,10 +113,19 @@ export function parseServerMessage(
 
     // ── v2 handshake events ────────────────────────────────────────────────
 
-    case 'reconnected':
+    case 'reconnected': {
       result.connectionUpdate = { status: 'connected' };
+      // Apply authoritative running state from the server for the active session
+      const sessions = msg.sessions as Array<{ sessionId: string; running: boolean }> | undefined;
+      if (sessions && state.currentSessionId) {
+        const active = sessions.find((s) => s.sessionId === state.currentSessionId);
+        if (active && !active.running) {
+          result.messagesActions.push({ type: 'SET_RUNNING', running: false });
+        }
+      }
       callbacks.onReconnected?.();
       break;
+    }
 
     case 'session_takeover':
       result.messagesActions.push({ type: 'SET_RUNNING', running: false });
@@ -267,9 +276,8 @@ export function parseServerMessage(
       if (msg.sessionId && !state.currentSessionId) {
         callbacks.onSessionAssigned(msg.sessionId as string);
       }
-      const pending = state.pendingSend;
+      const pending = state.pendingSend.shift();
       if (pending) {
-        state.pendingSend = null;
         result.messagesActions.push({ type: 'SET_RUNNING', running: true });
         // v2 path: use onSendQueued callback (no pool key needed)
         if (callbacks.onSendQueued) {
@@ -335,7 +343,7 @@ export function parseServerMessage(
       const errorMsg = msg.error as string;
 
       callbacks.setWsRunning?.(poolKey, false);
-      state.pendingSend = null;
+      state.pendingSend = [];
       result.messagesActions.push({
         type: 'ERROR',
         error: errorMsg || 'Unknown error',

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -183,7 +183,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
             messages:
               msgs.length > 0
                 ? messagesReducer(s.messages, { type: 'RESTORE', messages: msgs })
-                : { ...s.messages, messages: [], current: null },
+                : s.messages, // preserve state — empty REST response doesn't mean state is invalid
           }));
         }
       })

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -167,7 +167,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     pendingSendTimer?: ReturnType<typeof setTimeout>;
   } = {
     currentSessionId: undefined,
-    pendingSend: null,
+    pendingSend: [],
   };
 
   let recoveryInFlight = false;
@@ -266,7 +266,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         connection.clearSession(sid);
       }
       parserState.currentSessionId = undefined;
-      parserState.pendingSend = null;
+      parserState.pendingSend = [];
       clearPendingSendTimer();
       connection.send({ type: 'switch_session', sessionId: null });
       set({
@@ -316,14 +316,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       const msg = buildPayload();
 
       if (wasRunning) {
-        parserState.pendingSend = msg;
+        parserState.pendingSend.push(msg);
         // Safety net: if no session_end arrives within 5s (e.g. stale running
-        // state after reconnect), flush the pending message as a new session.
+        // state after reconnect), flush the first pending message as a new session.
         if (parserState.pendingSendTimer) clearTimeout(parserState.pendingSendTimer);
         parserState.pendingSendTimer = setTimeout(() => {
-          const pending = parserState.pendingSend;
+          const pending = parserState.pendingSend.shift();
           if (!pending) return;
-          parserState.pendingSend = null;
           parserState.pendingSendTimer = undefined;
           set((s) => ({
             messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: true }),
@@ -696,9 +695,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
 
-    // If the parser consumed the pending send (session_end handler), cancel the
+    // If the parser consumed all pending sends (session_end handler), cancel the
     // safety-net timer — the normal flush path handled it.
-    if (!parserState.pendingSend && parserState.pendingSendTimer) {
+    if (parserState.pendingSend.length === 0 && parserState.pendingSendTimer) {
       clearPendingSendTimer();
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -320,14 +320,22 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         // Safety net: if no session_end arrives within 5s (e.g. stale running
         // state after reconnect), flush the first pending message as a new session.
         if (parserState.pendingSendTimer) clearTimeout(parserState.pendingSendTimer);
-        parserState.pendingSendTimer = setTimeout(() => {
+        parserState.pendingSendTimer = setTimeout(function drainOne() {
           const pending = parserState.pendingSend.shift();
-          if (!pending) return;
-          parserState.pendingSendTimer = undefined;
+          if (!pending) {
+            parserState.pendingSendTimer = undefined;
+            return;
+          }
           set((s) => ({
             messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: true }),
           }));
           connection.send(pending);
+          // Reschedule for remaining queued messages
+          if (parserState.pendingSend.length > 0) {
+            parserState.pendingSendTimer = setTimeout(drainOne, PENDING_SEND_TIMEOUT_MS);
+          } else {
+            parserState.pendingSendTimer = undefined;
+          }
         }, PENDING_SEND_TIMEOUT_MS);
       } else {
         const sent = connection.send(msg);
@@ -695,8 +703,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
 
-    // If the parser consumed all pending sends (session_end handler), cancel the
-    // safety-net timer — the normal flush path handled it.
+    // If the queue is now empty, cancel the safety-net timer — the normal
+    // session_end flush path handled it.
     if (parserState.pendingSend.length === 0 && parserState.pendingSendTimer) {
       clearPendingSendTimer();
     }

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -1405,6 +1405,34 @@ describe('runQueryLoop', () => {
       expect(v2Transport.sent.some((m) => m.type === 'session_end')).toBe(true);
     });
 
+    it('persists error-path session_end to EventStore via sendOrBuffer', async () => {
+      const store = new EventStore(':memory:');
+      const connRegistry = new ConnectionRegistry();
+      const v2Transport = fakeTransport();
+      connRegistry.register(clientId, v2Transport);
+      connRegistry.watch(clientId, 'sess-err');
+      connRegistry.setActive(clientId, 'sess-err');
+
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-err';
+
+      async function* errorStream() {
+        yield {
+          type: 'stream_event',
+          event: { type: 'message_start', message: { id: 'msg-err' } },
+        };
+        throw new Error('simulated failure');
+      }
+
+      await runQueryLoop(errorStream(), clientId, registry, abortController, store, 'sess-err', {
+        connRegistry,
+      });
+
+      // session_end must be persisted to EventStore for reconnect replay
+      const events = store.getEventsAfter('sess-err', 0);
+      expect(events.some((e) => e.type === 'session_end')).toBe(true);
+    });
+
     it('delivers events to a NEW connection after WS reconnect (old connection gone)', async () => {
       const connRegistry = new ConnectionRegistry();
       const oldTransport = fakeTransport();

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -820,14 +820,11 @@ async function _runQueryLoopInner(
       if (finalSession) {
         finalSession.currentSnapshot = null;
         if (!doneSent) {
-          const endMsg = v2('session_end', { sessionId: finalSession.sessionId });
-          const sid = finalSession.sessionId;
-          if (sid && connRegistry?.hasOpenWatchers(sid)) {
-            connRegistry.broadcast(sid, endMsg);
-          } else {
-            send(finalSession.transport, endMsg);
-            broadcastToObservers(finalSession.observers, endMsg);
-          }
+          // Use sendOrBuffer to persist to EventStore (not just send) so that
+          // reconnect replay includes session_end and clears stale running state.
+          const sid = finalSession.sessionId ?? resolvedSessionId;
+          const endMsg = v2('session_end', { sessionId: sid });
+          sendOrBuffer(endMsg, clientId, registry, store, sid, connRegistry);
           if (sid && connRegistry?.hasOpenWatchers(sid)) {
             // Clear active session only on connections whose active is this session
             for (const { connectionId: cid } of connRegistry.getConnectionsWatching(sid, true)) {


### PR DESCRIPTION
## Summary

- **Foreground state wipe** — when iOS briefly backgrounds/foregrounds the app, `_foreground` fires and `fetchAndRestoreMessages` queries REST. If it returns `[]` (timing gap), all messages + streaming state were wiped (`current: null`). Subsequent `block_delta` events silently dropped → UI frozen. Fix: preserve existing state when REST returns empty.
- **`pendingSend` single-slot** — rapid messages while a turn was running overwrote each other. Only the last survived. Fix: changed to FIFO array, `session_end` dequeues one at a time.
- **Error-path `session_end` not persisted** — when the query loop exited via `finally` (errors/aborts), `session_end` was sent directly bypassing EventStore. On reconnect it wasn't replayed → `running` stuck at true. Fix: use `sendOrBuffer()`.
- **`reconnected` ignored server `running` state** — the server sends authoritative `running: false` in the `reconnected` response but the client ignored it. Fix: apply it for the active session.

## Test plan

- [x] Existing 100 tests pass (protocol-parser + store)
- [x] New regression test: `preserves streaming state when REST returns empty array`
- [x] Updated test: `session_end dequeues first pending send` (verifies FIFO)
- [x] Updated test: `error clears pendingSend queue` (verifies array clear)
- [x] 8 pre-existing failures on main, zero new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)