### PR TITLE
feat(watch): Xcode wiring + WatchConnectivity relay

### DIFF
--- a/frontend/ios/App/App.xcodeproj/project.pbxproj
+++ b/frontend/ios/App/App.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2C807BBEF27900A4B4C713F3 /* VoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438A1E5CA844963819792C4 /* VoiceService.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
+		30271F81931105049A8D0BCA /* MitzoShared in Frameworks */ = {isa = PBXBuildFile; productRef = 2994CBB574BE2544F671F9BF /* MitzoShared */; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
@@ -15,10 +17,22 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		51C82AC7CC9D0CD9BB2B8A2D /* MitzoWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729F6EAA7E6281CC8E027E58 /* MitzoWatchApp.swift */; };
+		87D5F3E4B2B79830BDC6F3CA /* VoiceInputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9D046593F17D7DF6E6056B /* VoiceInputBar.swift */; };
+		91D36789BA83D98F79CA5EA1 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85EF8992F04F5159962BE4 /* ChatViewModel.swift */; };
+		943DEFDDFE001627EFF7273F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B96DE140138DEF5859CB897 /* Foundation.framework */; };
+		9A8EE45055EB9BF5AB711065 /* PermissionBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB84607485C9AAA4D695F477 /* PermissionBanner.swift */; };
+		B87D83BB43FD8D7A331D5C16 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A60979EA195F633EE664E716 /* LoginView.swift */; };
+		BDF94F63DBEDEAABE3DBA4B8 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6B3AF931A2A562E89BCCA0 /* ChatView.swift */; };
+		E7C8020332FACEAD32C32377 /* MitzoShared in Frameworks */ = {isa = PBXBuildFile; productRef = A997DA8238CC43203EE0AD73 /* MitzoShared */; };
+		EB52F01B4D4DE944429DFFB7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3543D568BAEA16F3464C2D /* SessionListView.swift */; };
+		EBDB8718D00B3CAC47EFD6EC /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2544C9BF33F98A575F8F9F /* AppState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		264FB5577C8B9098BE816A36 /* MitzoWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MitzoWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
+		4B96DE140138DEF5859CB897 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS11.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -27,28 +41,59 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		729F6EAA7E6281CC8E027E58 /* MitzoWatchApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MitzoWatchApp.swift; sourceTree = "<group>"; };
+		8B1680960E912FBEABF52962 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		9A3543D568BAEA16F3464C2D /* SessionListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		A1B2C3D40000000000000001 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		A60979EA195F633EE664E716 /* LoginView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		AB84607485C9AAA4D695F477 /* PermissionBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionBanner.swift; sourceTree = "<group>"; };
+		CE85EF8992F04F5159962BE4 /* ChatViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		CF9D046593F17D7DF6E6056B /* VoiceInputBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceInputBar.swift; sourceTree = "<group>"; };
+		E438A1E5CA844963819792C4 /* VoiceService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceService.swift; sourceTree = "<group>"; };
+		FA1E96663E02190E82402696 /* MitzoWatch.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MitzoWatch.entitlements; sourceTree = "<group>"; };
+		FB2544C9BF33F98A575F8F9F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		FF6B3AF931A2A562E89BCCA0 /* ChatView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		46CE6721E210798D5CF8813F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				943DEFDDFE001627EFF7273F /* Foundation.framework in Frameworks */,
+				E7C8020332FACEAD32C32377 /* MitzoShared in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		504EC3011FED79650016851F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */,
+				30271F81931105049A8D0BCA /* MitzoShared in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		02582DED974ED772A6DA674B /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				4B96DE140138DEF5859CB897 /* Foundation.framework */,
+			);
+			name = watchOS;
+			sourceTree = "<group>";
+		};
 		504EC2FB1FED79650016851F = {
 			isa = PBXGroup;
 			children = (
 				958DCC722DB07C7200EA8C5F /* debug.xcconfig */,
 				504EC3061FED79650016851F /* App */,
 				504EC3051FED79650016851F /* Products */,
+				F95D97920EBBC9B6E68A1EC4 /* Frameworks */,
+				CB66E8D7AD779656E2F7F467 /* MitzoWatch */,
 			);
 			sourceTree = "<group>";
 		};
@@ -56,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				504EC3041FED79650016851F /* App.app */,
+				264FB5577C8B9098BE816A36 /* MitzoWatch.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -76,6 +122,51 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		AEA8C8B84D080C413486CD27 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				FB2544C9BF33F98A575F8F9F /* AppState.swift */,
+				CE85EF8992F04F5159962BE4 /* ChatViewModel.swift */,
+				E438A1E5CA844963819792C4 /* VoiceService.swift */,
+			);
+			name = Services;
+			path = Services;
+			sourceTree = "<group>";
+		};
+		CB66E8D7AD779656E2F7F467 /* MitzoWatch */ = {
+			isa = PBXGroup;
+			children = (
+				AEA8C8B84D080C413486CD27 /* Services */,
+				D71D2BBA9260C2CCD68E11B9 /* Views */,
+				729F6EAA7E6281CC8E027E58 /* MitzoWatchApp.swift */,
+				8B1680960E912FBEABF52962 /* Info.plist */,
+				FA1E96663E02190E82402696 /* MitzoWatch.entitlements */,
+			);
+			name = MitzoWatch;
+			path = ../MitzoWatch;
+			sourceTree = "<group>";
+		};
+		D71D2BBA9260C2CCD68E11B9 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A60979EA195F633EE664E716 /* LoginView.swift */,
+				AB84607485C9AAA4D695F477 /* PermissionBanner.swift */,
+				CF9D046593F17D7DF6E6056B /* VoiceInputBar.swift */,
+				FF6B3AF931A2A562E89BCCA0 /* ChatView.swift */,
+				9A3543D568BAEA16F3464C2D /* SessionListView.swift */,
+			);
+			name = Views;
+			path = Views;
+			sourceTree = "<group>";
+		};
+		F95D97920EBBC9B6E68A1EC4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				02582DED974ED772A6DA674B /* watchOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -94,10 +185,31 @@
 			name = App;
 			packageProductDependencies = (
 				4D22ABE82AF431CB00220026 /* CapApp-SPM */,
+				2994CBB574BE2544F671F9BF /* MitzoShared */,
 			);
 			productName = App;
 			productReference = 504EC3041FED79650016851F /* App.app */;
 			productType = "com.apple.product-type.application";
+		};
+		E33326562D8A9AEAE27478C4 /* MitzoWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 17799A0A07B59E02522C0708 /* Build configuration list for PBXNativeTarget "MitzoWatch" */;
+			buildPhases = (
+				5725474A2406FEEDAAE5DA62 /* Sources */,
+				46CE6721E210798D5CF8813F /* Frameworks */,
+				6BDF7BC07BBCE13962BEA325 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MitzoWatch;
+			packageProductDependencies = (
+				A997DA8238CC43203EE0AD73 /* MitzoShared */,
+			);
+			productName = MitzoWatch;
+			productReference = 264FB5577C8B9098BE816A36 /* MitzoWatch.app */;
+			productType = "com.apple.product-type.application.watchapp2";
 		};
 /* End PBXNativeTarget section */
 
@@ -113,6 +225,10 @@
 						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
+					E33326562D8A9AEAE27478C4 = {
+						CreatedOnToolsVersion = 16.0;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */;
@@ -126,12 +242,14 @@
 			mainGroup = 504EC2FB1FED79650016851F;
 			packageReferences = (
 				D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */,
+				F0C38DA10F17B4BECD2F4E09 /* XCLocalSwiftPackageReference "MitzoShared" */,
 			);
 			productRefGroup = 504EC3051FED79650016851F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				504EC3031FED79650016851F /* App */,
+				E33326562D8A9AEAE27478C4 /* MitzoWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -150,6 +268,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6BDF7BC07BBCE13962BEA325 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -158,6 +283,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5725474A2406FEEDAAE5DA62 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				51C82AC7CC9D0CD9BB2B8A2D /* MitzoWatchApp.swift in Sources */,
+				EBDB8718D00B3CAC47EFD6EC /* AppState.swift in Sources */,
+				91D36789BA83D98F79CA5EA1 /* ChatViewModel.swift in Sources */,
+				2C807BBEF27900A4B4C713F3 /* VoiceService.swift in Sources */,
+				B87D83BB43FD8D7A331D5C16 /* LoginView.swift in Sources */,
+				9A8EE45055EB9BF5AB711065 /* PermissionBanner.swift in Sources */,
+				87D5F3E4B2B79830BDC6F3CA /* VoiceInputBar.swift in Sources */,
+				BDF94F63DBEDEAABE3DBA4B8 /* ChatView.swift in Sources */,
+				EB52F01B4D4DE944429DFFB7 /* SessionListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -183,6 +324,32 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		16EF91AC41A8DC5F7DE4223C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/../MitzoWatch/MitzoWatch.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = Y4QGXHYSY3;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "$(SRCROOT)/../MitzoWatch/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mitzo.app.watchkitapp;
+				SDKROOT = watchos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
 		504EC3141FED79650016851F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
@@ -340,9 +507,45 @@
 			};
 			name = Release;
 		};
+		95C9662613A48A0B722F099A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/../MitzoWatch/MitzoWatch.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = Y4QGXHYSY3;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "$(SRCROOT)/../MitzoWatch/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mitzo.app.watchkitapp;
+				SDKROOT = watchos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		17799A0A07B59E02522C0708 /* Build configuration list for PBXNativeTarget "MitzoWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95C9662613A48A0B722F099A /* Release */,
+				16EF91AC41A8DC5F7DE4223C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		504EC2FF1FED79650016851F /* Build configuration list for PBXProject "App" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -368,13 +571,27 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "CapApp-SPM";
 		};
+		F0C38DA10F17B4BECD2F4E09 /* XCLocalSwiftPackageReference "MitzoShared" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../MitzoShared;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2994CBB574BE2544F671F9BF /* MitzoShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F0C38DA10F17B4BECD2F4E09 /* XCLocalSwiftPackageReference "MitzoShared" */;
+			productName = MitzoShared;
+		};
 		4D22ABE82AF431CB00220026 /* CapApp-SPM */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D4C12C0A2AAA248700AAC8A2 /* XCLocalSwiftPackageReference "CapApp-SPM" */;
 			productName = "CapApp-SPM";
+		};
+		A997DA8238CC43203EE0AD73 /* MitzoShared */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F0C38DA10F17B4BECD2F4E09 /* XCLocalSwiftPackageReference "MitzoShared" */;
+			productName = MitzoShared;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/WatchRelay.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/WatchRelay.swift
@@ -1,0 +1,305 @@
+// WatchConnectivity relay — bridges WS messages between watch and iPhone
+//
+// iPhone side: receives relay messages from watch, forwards to/from WS
+// Watch side: sends messages via WCSession when direct WS is unavailable
+
+#if os(iOS)
+import WatchConnectivity
+import Foundation
+
+/// iPhone-side relay: bridges watch messages to the Mitzo WS connection.
+/// Add to AppDelegate or a long-lived coordinator.
+public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Sendable {
+    private var wsClient: MitzoWSClient?
+    private let authManager: AuthManager
+
+    public init(authManager: AuthManager) {
+        self.authManager = authManager
+        super.init()
+    }
+
+    public func activate(wsClient: MitzoWSClient) {
+        self.wsClient = wsClient
+
+        guard WCSession.isSupported() else { return }
+        WCSession.default.delegate = self
+        WCSession.default.activate()
+    }
+
+    // MARK: - WCSessionDelegate
+
+    public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        // Ready to relay
+    }
+
+    public func sessionDidBecomeInactive(_ session: WCSession) {}
+    public func sessionDidDeactivate(_ session: WCSession) {
+        WCSession.default.activate()
+    }
+
+    /// Watch sends a message dict, we forward it as a ClientMessage to the WS
+    public func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        guard let type = message["_relay"] as? String else {
+            replyHandler(["error": "missing _relay type"])
+            return
+        }
+
+        Task {
+            do {
+                switch type {
+                case "send":
+                    let clientMsg = try decodeClientMessage(from: message)
+                    try await wsClient?.send(clientMsg)
+                    replyHandler(["ok": true])
+
+                case "auth_token":
+                    // Watch requests auth token from phone's keychain
+                    if let token = try? await authManager.getToken() {
+                        replyHandler(["token": token])
+                    } else {
+                        replyHandler(["error": "no_token"])
+                    }
+
+                default:
+                    replyHandler(["error": "unknown relay type: \(type)"])
+                }
+            } catch {
+                replyHandler(["error": error.localizedDescription])
+            }
+        }
+    }
+
+    /// Forward server messages to the watch
+    public func forwardToWatch(_ message: ServerMessage) {
+        guard WCSession.default.isReachable else { return }
+
+        // Encode server message to JSON dict for WCSession
+        do {
+            let data = try JSONEncoder().encode(ServerMessageWrapper(message: message))
+            if let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                WCSession.default.sendMessage(["_relay": "server_event", "_payload": dict], replyHandler: nil)
+            }
+        } catch {
+            // Encoding failure — drop the message
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func decodeClientMessage(from dict: [String: Any]) throws -> ClientMessage {
+        guard let action = dict["action"] as? String else {
+            throw RelayError.missingAction
+        }
+
+        switch action {
+        case "hello":
+            return .hello()
+
+        case "send":
+            let params = SendParams(
+                sessionId: dict["sessionId"] as? String,
+                prompt: dict["prompt"] as? String ?? "",
+                clientMsgId: dict["clientMsgId"] as? String ?? UUID().uuidString
+            )
+            return .send(params)
+
+        case "watch":
+            guard let sessionId = dict["sessionId"] as? String else {
+                throw RelayError.missingSessionId
+            }
+            return .watch(sessionId: sessionId)
+
+        case "stop":
+            guard let sessionId = dict["sessionId"] as? String else {
+                throw RelayError.missingSessionId
+            }
+            return .stop(sessionId: sessionId)
+
+        case "permission_response":
+            let params = PermissionResponseParams(
+                sessionId: dict["sessionId"] as? String,
+                permId: dict["permId"] as? String ?? "",
+                decision: PermissionDecision(rawValue: dict["decision"] as? String ?? "deny")
+            )
+            return .permissionResponse(params)
+
+        case "session_suspend":
+            // Relay suspend from watch
+            if let sessions = dict["sessions"] as? [[String: Any]] {
+                let suspendSessions = sessions.compactMap { s -> SuspendSession? in
+                    guard let sid = s["sessionId"] as? String,
+                          let seq = s["lastSeq"] as? Int else { return nil }
+                    return SuspendSession(sessionId: sid, lastSeq: seq)
+                }
+                return .sessionSuspend(sessions: suspendSessions)
+            }
+            return .sessionSuspend(sessions: [])
+
+        default:
+            throw RelayError.unknownAction(action)
+        }
+    }
+}
+
+enum RelayError: Error {
+    case missingAction
+    case missingSessionId
+    case unknownAction(String)
+}
+
+/// Wrapper to make ServerMessage Encodable for relay
+struct ServerMessageWrapper: Encodable {
+    let message: ServerMessage
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+
+        switch message {
+        case .welcome(let version, let connId):
+            try container.encode("welcome", forKey: AnyCodingKey("type"))
+            try container.encode(version, forKey: AnyCodingKey("protocolVersion"))
+            try container.encode(connId, forKey: AnyCodingKey("connectionId"))
+
+        case .blockDelta(let params):
+            try container.encode("block_delta", forKey: AnyCodingKey("type"))
+            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
+            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
+            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
+            try container.encode(params.delta, forKey: AnyCodingKey("delta"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
+
+        case .messageStart(let params):
+            try container.encode("message_start", forKey: AnyCodingKey("type"))
+            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
+
+        case .blockStart(let params):
+            try container.encode("block_start", forKey: AnyCodingKey("type"))
+            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
+            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
+            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
+            try container.encodeIfPresent(params.toolName, forKey: AnyCodingKey("toolName"))
+
+        case .blockEnd(let params):
+            try container.encode("block_end", forKey: AnyCodingKey("type"))
+            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
+            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
+            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
+            try container.encodeIfPresent(params.toolName, forKey: AnyCodingKey("toolName"))
+            try container.encodeIfPresent(params.toolId, forKey: AnyCodingKey("toolId"))
+
+        case .messageEnd(let params):
+            try container.encode("message_end", forKey: AnyCodingKey("type"))
+            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
+
+        case .permissionRequest(let params):
+            try container.encode("permission_request", forKey: AnyCodingKey("type"))
+            try container.encode(params.permId, forKey: AnyCodingKey("permId"))
+            try container.encode(params.toolName, forKey: AnyCodingKey("toolName"))
+            try container.encode(params.toolInput, forKey: AnyCodingKey("toolInput"))
+            try container.encodeIfPresent(params.displayName, forKey: AnyCodingKey("displayName"))
+            try container.encodeIfPresent(params.tier, forKey: AnyCodingKey("tier"))
+
+        case .sessionEnd(let params):
+            try container.encode("session_end", forKey: AnyCodingKey("type"))
+            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
+
+        case .error(let err):
+            try container.encode("error", forKey: AnyCodingKey("type"))
+            try container.encode(err, forKey: AnyCodingKey("error"))
+
+        default:
+            // For other message types, encode just the type
+            try container.encode("unknown", forKey: AnyCodingKey("type"))
+        }
+    }
+}
+
+#endif
+
+// MARK: - Watch-side relay client
+
+#if os(watchOS)
+import WatchConnectivity
+import Foundation
+
+/// Watch-side relay: sends messages through iPhone when direct WS is unavailable.
+public final class WatchRelayClient: NSObject, WCSessionDelegate, @unchecked Sendable {
+    public var onServerMessage: ((ServerMessage) -> Void)?
+    public var isPhoneReachable: Bool { WCSession.default.isReachable }
+
+    public override init() {
+        super.init()
+    }
+
+    public func activate() {
+        guard WCSession.isSupported() else { return }
+        WCSession.default.delegate = self
+        WCSession.default.activate()
+    }
+
+    // MARK: - Send via relay
+
+    public func send(action: String, params: [String: Any] = [:]) async throws -> [String: Any] {
+        var message = params
+        message["_relay"] = "send"
+        message["action"] = action
+
+        return try await withCheckedThrowingContinuation { continuation in
+            WCSession.default.sendMessage(message, replyHandler: { reply in
+                continuation.resume(returning: reply)
+            }, errorHandler: { error in
+                continuation.resume(throwing: error)
+            })
+        }
+    }
+
+    /// Request auth token from phone
+    public func requestAuthToken() async throws -> String {
+        let reply = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[String: Any], Error>) in
+            WCSession.default.sendMessage(
+                ["_relay": "auth_token"],
+                replyHandler: { reply in continuation.resume(returning: reply) },
+                errorHandler: { error in continuation.resume(throwing: error) }
+            )
+        }
+
+        guard let token = reply["token"] as? String else {
+            throw WatchRelayError.noToken
+        }
+        return token
+    }
+
+    // MARK: - WCSessionDelegate
+
+    public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
+
+    /// Receive relayed server messages from phone
+    public func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        guard message["_relay"] as? String == "server_event",
+              let payload = message["_payload"] as? [String: Any] else { return }
+
+        // Decode the ServerMessage from the payload dict
+        do {
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let serverMsg = try JSONDecoder().decode(ServerMessage.self, from: data)
+            onServerMessage?(serverMsg)
+        } catch {
+            // Decoding failure — drop the message
+        }
+    }
+}
+
+enum WatchRelayError: Error {
+    case noToken
+    case notReachable
+}
+#endif

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/WatchRelay.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Networking/WatchRelay.swift
@@ -9,8 +9,8 @@ import Foundation
 
 /// iPhone-side relay: bridges watch messages to the Mitzo WS connection.
 /// Add to AppDelegate or a long-lived coordinator.
-public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Sendable {
-    private var wsClient: MitzoWSClient?
+public final class WatchRelayHost: NSObject, WCSessionDelegate, Sendable {
+    private let state = WatchRelayHostState()
     private let authManager: AuthManager
 
     public init(authManager: AuthManager) {
@@ -19,7 +19,7 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
     }
 
     public func activate(wsClient: MitzoWSClient) {
-        self.wsClient = wsClient
+        state.setWSClient(wsClient)
 
         guard WCSession.isSupported() else { return }
         WCSession.default.delegate = self
@@ -28,16 +28,13 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
 
     // MARK: - WCSessionDelegate
 
-    public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        // Ready to relay
-    }
+    public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
 
     public func sessionDidBecomeInactive(_ session: WCSession) {}
     public func sessionDidDeactivate(_ session: WCSession) {
         WCSession.default.activate()
     }
 
-    /// Watch sends a message dict, we forward it as a ClientMessage to the WS
     public func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
         guard let type = message["_relay"] as? String else {
             replyHandler(["error": "missing _relay type"])
@@ -49,11 +46,10 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
                 switch type {
                 case "send":
                     let clientMsg = try decodeClientMessage(from: message)
-                    try await wsClient?.send(clientMsg)
+                    try await state.getWSClient()?.send(clientMsg)
                     replyHandler(["ok": true])
 
                 case "auth_token":
-                    // Watch requests auth token from phone's keychain
                     if let token = try? await authManager.getToken() {
                         replyHandler(["token": token])
                     } else {
@@ -73,9 +69,8 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
     public func forwardToWatch(_ message: ServerMessage) {
         guard WCSession.default.isReachable else { return }
 
-        // Encode server message to JSON dict for WCSession
         do {
-            let data = try JSONEncoder().encode(ServerMessageWrapper(message: message))
+            let data = try JSONEncoder().encode(message)
             if let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] {
                 WCSession.default.sendMessage(["_relay": "server_event", "_payload": dict], replyHandler: nil)
             }
@@ -99,7 +94,11 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
             let params = SendParams(
                 sessionId: dict["sessionId"] as? String,
                 prompt: dict["prompt"] as? String ?? "",
-                clientMsgId: dict["clientMsgId"] as? String ?? UUID().uuidString
+                clientMsgId: dict["clientMsgId"] as? String ?? UUID().uuidString,
+                model: dict["model"] as? String,
+                mode: (dict["mode"] as? String).flatMap(MitzoMode.init(rawValue:)),
+                images: decodeImages(from: dict["images"]),
+                contextBlocks: dict["contextBlocks"] as? [String]
             )
             return .send(params)
 
@@ -124,7 +123,6 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
             return .permissionResponse(params)
 
         case "session_suspend":
-            // Relay suspend from watch
             if let sessions = dict["sessions"] as? [[String: Any]] {
                 let suspendSessions = sessions.compactMap { s -> SuspendSession? in
                     guard let sid = s["sessionId"] as? String,
@@ -139,88 +137,41 @@ public final class WatchRelayHost: NSObject, WCSessionDelegate, @unchecked Senda
             throw RelayError.unknownAction(action)
         }
     }
+
+    private func decodeImages(from value: Any?) -> [ImageAttachment]? {
+        guard let arr = value as? [[String: Any]] else { return nil }
+        let images = arr.compactMap { dict -> ImageAttachment? in
+            guard let data = dict["data"] as? String,
+                  let mediaType = dict["mediaType"] as? String else { return nil }
+            return ImageAttachment(data: data, mediaType: mediaType, preview: dict["preview"] as? String)
+        }
+        return images.isEmpty ? nil : images
+    }
+}
+
+/// Thread-safe state container for WatchRelayHost. WCSession callbacks
+/// arrive on a background serial queue, so we need synchronization.
+private final class WatchRelayHostState: Sendable {
+    private nonisolated(unsafe) var _wsClient: MitzoWSClient?
+    private let lock = NSLock()
+
+    func setWSClient(_ client: MitzoWSClient) {
+        lock.lock()
+        _wsClient = client
+        lock.unlock()
+    }
+
+    func getWSClient() -> MitzoWSClient? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _wsClient
+    }
 }
 
 enum RelayError: Error {
     case missingAction
     case missingSessionId
     case unknownAction(String)
-}
-
-/// Wrapper to make ServerMessage Encodable for relay
-struct ServerMessageWrapper: Encodable {
-    let message: ServerMessage
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: AnyCodingKey.self)
-
-        switch message {
-        case .welcome(let version, let connId):
-            try container.encode("welcome", forKey: AnyCodingKey("type"))
-            try container.encode(version, forKey: AnyCodingKey("protocolVersion"))
-            try container.encode(connId, forKey: AnyCodingKey("connectionId"))
-
-        case .blockDelta(let params):
-            try container.encode("block_delta", forKey: AnyCodingKey("type"))
-            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
-            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
-            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
-            try container.encode(params.delta, forKey: AnyCodingKey("delta"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
-
-        case .messageStart(let params):
-            try container.encode("message_start", forKey: AnyCodingKey("type"))
-            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
-
-        case .blockStart(let params):
-            try container.encode("block_start", forKey: AnyCodingKey("type"))
-            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
-            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
-            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
-            try container.encodeIfPresent(params.toolName, forKey: AnyCodingKey("toolName"))
-
-        case .blockEnd(let params):
-            try container.encode("block_end", forKey: AnyCodingKey("type"))
-            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
-            try container.encode(params.blockId, forKey: AnyCodingKey("blockId"))
-            try container.encode(params.blockType, forKey: AnyCodingKey("blockType"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
-            try container.encodeIfPresent(params.toolName, forKey: AnyCodingKey("toolName"))
-            try container.encodeIfPresent(params.toolId, forKey: AnyCodingKey("toolId"))
-
-        case .messageEnd(let params):
-            try container.encode("message_end", forKey: AnyCodingKey("type"))
-            try container.encode(params.messageId, forKey: AnyCodingKey("messageId"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-            try container.encode(params.seq, forKey: AnyCodingKey("seq"))
-
-        case .permissionRequest(let params):
-            try container.encode("permission_request", forKey: AnyCodingKey("type"))
-            try container.encode(params.permId, forKey: AnyCodingKey("permId"))
-            try container.encode(params.toolName, forKey: AnyCodingKey("toolName"))
-            try container.encode(params.toolInput, forKey: AnyCodingKey("toolInput"))
-            try container.encodeIfPresent(params.displayName, forKey: AnyCodingKey("displayName"))
-            try container.encodeIfPresent(params.tier, forKey: AnyCodingKey("tier"))
-
-        case .sessionEnd(let params):
-            try container.encode("session_end", forKey: AnyCodingKey("type"))
-            try container.encode(params.sessionId, forKey: AnyCodingKey("sessionId"))
-
-        case .error(let err):
-            try container.encode("error", forKey: AnyCodingKey("type"))
-            try container.encode(err, forKey: AnyCodingKey("error"))
-
-        default:
-            // For other message types, encode just the type
-            try container.encode("unknown", forKey: AnyCodingKey("type"))
-        }
-    }
 }
 
 #endif
@@ -232,12 +183,16 @@ import WatchConnectivity
 import Foundation
 
 /// Watch-side relay: sends messages through iPhone when direct WS is unavailable.
-public final class WatchRelayClient: NSObject, WCSessionDelegate, @unchecked Sendable {
-    public var onServerMessage: ((ServerMessage) -> Void)?
+public final class WatchRelayClient: NSObject, WCSessionDelegate, Sendable {
+    private let state = WatchRelayClientState()
     public var isPhoneReachable: Bool { WCSession.default.isReachable }
 
     public override init() {
         super.init()
+    }
+
+    public func setOnServerMessage(_ handler: @escaping @Sendable (ServerMessage) -> Void) {
+        state.setHandler(handler)
     }
 
     public func activate() {
@@ -282,19 +237,35 @@ public final class WatchRelayClient: NSObject, WCSessionDelegate, @unchecked Sen
 
     public func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {}
 
-    /// Receive relayed server messages from phone
     public func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
         guard message["_relay"] as? String == "server_event",
               let payload = message["_payload"] as? [String: Any] else { return }
 
-        // Decode the ServerMessage from the payload dict
         do {
             let data = try JSONSerialization.data(withJSONObject: payload)
             let serverMsg = try JSONDecoder().decode(ServerMessage.self, from: data)
-            onServerMessage?(serverMsg)
+            state.getHandler()?(serverMsg)
         } catch {
             // Decoding failure — drop the message
         }
+    }
+}
+
+/// Thread-safe state container for WatchRelayClient.
+private final class WatchRelayClientState: Sendable {
+    private nonisolated(unsafe) var _handler: (@Sendable (ServerMessage) -> Void)?
+    private let lock = NSLock()
+
+    func setHandler(_ handler: @escaping @Sendable (ServerMessage) -> Void) {
+        lock.lock()
+        _handler = handler
+        lock.unlock()
+    }
+
+    func getHandler() -> (@Sendable (ServerMessage) -> Void)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _handler
     }
 }
 

--- a/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
+++ b/frontend/ios/MitzoShared/Sources/MitzoShared/Protocol/WSMessages.swift
@@ -218,7 +218,7 @@ public enum PermissionDecision: String, Codable, Sendable {
 
 // MARK: - Server → Client Messages
 
-public enum ServerMessage: Decodable, Sendable {
+public enum ServerMessage: Codable, Sendable {
     case welcome(protocolVersion: Int, connectionId: String)
     case reconnected(sessions: [ReconnectedSession])
     case watched(sessionId: String)
@@ -334,17 +334,110 @@ public enum ServerMessage: Decodable, Sendable {
             self = .unknown(type: type)
         }
     }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: AnyCodingKey.self)
+
+        switch self {
+        case .welcome(let version, let connId):
+            try container.encode("welcome", forKey: AnyCodingKey("type"))
+            try container.encode(version, forKey: AnyCodingKey("protocolVersion"))
+            try container.encode(connId, forKey: AnyCodingKey("connectionId"))
+
+        case .reconnected(let sessions):
+            try container.encode("reconnected", forKey: AnyCodingKey("type"))
+            try container.encode(sessions, forKey: AnyCodingKey("sessions"))
+
+        case .watched(let sessionId):
+            try container.encode("watched", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+
+        case .unwatched(let sessionId):
+            try container.encode("unwatched", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+
+        case .sessionSwitched(let params):
+            try container.encode("session_switched", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .sessionCleared:
+            try container.encode("session_cleared", forKey: AnyCodingKey("type"))
+
+        case .sessionId(let sessionId, let seq, let ts):
+            try container.encode("session_id", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encodeIfPresent(seq, forKey: AnyCodingKey("seq"))
+            try container.encodeIfPresent(ts, forKey: AnyCodingKey("ts"))
+
+        case .sessionResumed(let sessionId, let replayed):
+            try container.encode("session_resumed", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(replayed, forKey: AnyCodingKey("replayed"))
+
+        case .sessionTakeover(let sessionId):
+            try container.encode("session_takeover", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+
+        case .sessionEnd(let params):
+            try container.encode("session_end", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .messageStart(let params):
+            try container.encode("message_start", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .blockStart(let params):
+            try container.encode("block_start", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .blockDelta(let params):
+            try container.encode("block_delta", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .blockEnd(let params):
+            try container.encode("block_end", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .messageEnd(let params):
+            try container.encode("message_end", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .tokenUpdate(let params):
+            try container.encode("token_update", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .permissionRequest(let params):
+            try container.encode("permission_request", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .toolResult(let params):
+            try container.encode("tool_result", forKey: AnyCodingKey("type"))
+            try params.encode(to: encoder)
+
+        case .error(let err):
+            try container.encode("error", forKey: AnyCodingKey("type"))
+            try container.encode(err, forKey: AnyCodingKey("error"))
+
+        case .modeChanged(let sessionId, let mode):
+            try container.encode("mode_changed", forKey: AnyCodingKey("type"))
+            try container.encode(sessionId, forKey: AnyCodingKey("sessionId"))
+            try container.encode(mode, forKey: AnyCodingKey("mode"))
+
+        case .unknown(let type):
+            try container.encode(type, forKey: AnyCodingKey("type"))
+        }
+    }
 }
 
 // MARK: - Server Message Params
 
-public struct ReconnectedSession: Decodable, Sendable {
+public struct ReconnectedSession: Codable, Sendable {
     public let sessionId: String
     public let replayed: Int
     public let running: Bool
 }
 
-public struct SessionSwitchedParams: Decodable, Sendable {
+public struct SessionSwitchedParams: Codable, Sendable {
     public let sessionId: String
     public let mode: MitzoMode
     public let cwd: String
@@ -353,12 +446,12 @@ public struct SessionSwitchedParams: Decodable, Sendable {
     public let tokens: TokenUsage
 }
 
-public struct SessionEndParams: Decodable, Sendable {
+public struct SessionEndParams: Codable, Sendable {
     public let sessionId: String
     public let usage: UsageStats
 }
 
-public struct UsageStats: Decodable, Sendable {
+public struct UsageStats: Codable, Sendable {
     public let inputTokens: Int
     public let outputTokens: Int
     public let cacheReadTokens: Int
@@ -369,14 +462,14 @@ public struct UsageStats: Decodable, Sendable {
     public let durationApiMs: Int
 }
 
-public struct MessageStartParams: Decodable, Sendable {
+public struct MessageStartParams: Codable, Sendable {
     public let messageId: String
     public let sessionId: String
     public let seq: Int
     public let ts: Int
 }
 
-public struct BlockStartParams: Decodable, Sendable {
+public struct BlockStartParams: Codable, Sendable {
     public let messageId: String
     public let blockId: String
     public let blockType: BlockType
@@ -386,7 +479,7 @@ public struct BlockStartParams: Decodable, Sendable {
     public let toolName: String?
 }
 
-public struct BlockDeltaParams: Decodable, Sendable {
+public struct BlockDeltaParams: Codable, Sendable {
     public let messageId: String
     public let blockId: String
     public let blockType: BlockType
@@ -396,7 +489,7 @@ public struct BlockDeltaParams: Decodable, Sendable {
     public let ts: Int
 }
 
-public struct BlockEndParams: Decodable, Sendable {
+public struct BlockEndParams: Codable, Sendable {
     public let messageId: String
     public let blockId: String
     public let blockType: BlockType
@@ -408,14 +501,14 @@ public struct BlockEndParams: Decodable, Sendable {
     public let input: String?
 }
 
-public struct MessageEndParams: Decodable, Sendable {
+public struct MessageEndParams: Codable, Sendable {
     public let messageId: String
     public let sessionId: String
     public let seq: Int
     public let ts: Int
 }
 
-public struct TokenUpdateParams: Decodable, Sendable {
+public struct TokenUpdateParams: Codable, Sendable {
     public let agentContext: Int
     public let contextCeiling: Int
     public let sessionTotal: Int
@@ -426,7 +519,7 @@ public struct TokenUpdateParams: Decodable, Sendable {
     public let ts: Int?
 }
 
-public struct PermissionRequestParams: Decodable, Sendable {
+public struct PermissionRequestParams: Codable, Sendable {
     public let permId: String
     public let toolName: String
     public let toolInput: String
@@ -437,7 +530,7 @@ public struct PermissionRequestParams: Decodable, Sendable {
     public let tier: ToolTier?
 }
 
-public struct ToolResultParams: Decodable, Sendable {
+public struct ToolResultParams: Codable, Sendable {
     public let messageId: String
     public let toolId: String
     public let result: String

--- a/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
+++ b/frontend/ios/MitzoShared/Tests/MitzoSharedTests/MitzoSharedTests.swift
@@ -248,3 +248,205 @@ import Foundation
         #expect(decoded == expected)
     }
 }
+
+// MARK: - ServerMessage Encode → Decode Round-Trip (relay simulation)
+
+@Test func testBlockDeltaRoundTrip() throws {
+    let json = """
+    {"v":2,"type":"block_delta","messageId":"m1","blockId":"b1","blockType":"text","delta":"hello ","sessionId":"s1","seq":5,"ts":1714070400}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .blockDelta(let params) = decoded else {
+        Issue.record("Expected block_delta after round-trip")
+        return
+    }
+    #expect(params.delta == "hello ")
+    #expect(params.ts == 1714070400)
+    #expect(params.seq == 5)
+    #expect(params.sessionId == "s1")
+    #expect(params.blockType == .text)
+}
+
+@Test func testMessageStartRoundTrip() throws {
+    let json = """
+    {"type":"message_start","messageId":"m1","sessionId":"s1","seq":1,"ts":1714070400}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .messageStart(let params) = decoded else {
+        Issue.record("Expected message_start after round-trip")
+        return
+    }
+    #expect(params.messageId == "m1")
+    #expect(params.ts == 1714070400)
+    #expect(params.seq == 1)
+}
+
+@Test func testBlockStartRoundTrip() throws {
+    let json = """
+    {"type":"block_start","messageId":"m1","blockId":"b1","blockType":"tool_use","sessionId":"s1","seq":2,"ts":1714070401,"toolName":"Read"}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .blockStart(let params) = decoded else {
+        Issue.record("Expected block_start after round-trip")
+        return
+    }
+    #expect(params.toolName == "Read")
+    #expect(params.ts == 1714070401)
+    #expect(params.blockType == .toolUse)
+}
+
+@Test func testBlockEndRoundTrip() throws {
+    let json = """
+    {"type":"block_end","messageId":"m1","blockId":"b1","blockType":"tool_use","sessionId":"s1","seq":3,"ts":1714070402,"toolName":"Read","toolId":"t1","input":"{\\"path\\":\\"/foo\\"}"}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .blockEnd(let params) = decoded else {
+        Issue.record("Expected block_end after round-trip")
+        return
+    }
+    #expect(params.toolName == "Read")
+    #expect(params.toolId == "t1")
+    #expect(params.input == "{\"path\":\"/foo\"}")
+    #expect(params.ts == 1714070402)
+}
+
+@Test func testMessageEndRoundTrip() throws {
+    let json = """
+    {"type":"message_end","messageId":"m1","sessionId":"s1","seq":4,"ts":1714070403}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .messageEnd(let params) = decoded else {
+        Issue.record("Expected message_end after round-trip")
+        return
+    }
+    #expect(params.ts == 1714070403)
+    #expect(params.seq == 4)
+}
+
+@Test func testToolResultRoundTrip() throws {
+    let json = """
+    {"type":"tool_result","messageId":"m1","toolId":"t1","result":"file contents","isError":false}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .toolResult(let params) = decoded else {
+        Issue.record("Expected tool_result after round-trip")
+        return
+    }
+    #expect(params.toolId == "t1")
+    #expect(params.result == "file contents")
+    #expect(params.isError == false)
+}
+
+@Test func testSessionIdRoundTrip() throws {
+    let json = """
+    {"type":"session_id","sessionId":"s-new","seq":0,"ts":1714070400}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .sessionId(let sid, let seq, let ts) = decoded else {
+        Issue.record("Expected session_id after round-trip")
+        return
+    }
+    #expect(sid == "s-new")
+    #expect(seq == 0)
+    #expect(ts == 1714070400)
+}
+
+@Test func testPermissionRequestRoundTrip() throws {
+    let json = """
+    {"type":"permission_request","permId":"p1","toolName":"Bash","toolInput":"npm test","title":"Run command","description":"Execute npm test","displayName":"Shell","decisionReason":"elevated tier","tier":"elevated"}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .permissionRequest(let params) = decoded else {
+        Issue.record("Expected permission_request after round-trip")
+        return
+    }
+    #expect(params.permId == "p1")
+    #expect(params.title == "Run command")
+    #expect(params.description == "Execute npm test")
+    #expect(params.decisionReason == "elevated tier")
+    #expect(params.tier == .elevated)
+}
+
+@Test func testModeChangedRoundTrip() throws {
+    let json = """
+    {"type":"mode_changed","sessionId":"s1","mode":"auto"}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .modeChanged(let sid, let mode) = decoded else {
+        Issue.record("Expected mode_changed after round-trip")
+        return
+    }
+    #expect(sid == "s1")
+    #expect(mode == .auto)
+}
+
+@Test func testTokenUpdateRoundTrip() throws {
+    let json = """
+    {"type":"token_update","agentContext":5000,"contextCeiling":200000,"sessionTotal":12000,"turnIndex":3,"sessionId":"s1","seq":10,"ts":1714070400}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .tokenUpdate(let params) = decoded else {
+        Issue.record("Expected token_update after round-trip")
+        return
+    }
+    #expect(params.agentContext == 5000)
+    #expect(params.contextCeiling == 200000)
+    #expect(params.ts == 1714070400)
+}
+
+@Test func testWelcomeRoundTrip() throws {
+    let json = """
+    {"type":"welcome","protocolVersion":2,"connectionId":"conn-abc"}
+    """.data(using: .utf8)!
+
+    let original = try JSONDecoder().decode(ServerMessage.self, from: json)
+    let encoded = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(ServerMessage.self, from: encoded)
+
+    guard case .welcome(let version, let connId) = decoded else {
+        Issue.record("Expected welcome after round-trip")
+        return
+    }
+    #expect(version == 2)
+    #expect(connId == "conn-abc")
+}

--- a/frontend/ios/MitzoWatch/Services/AppState.swift
+++ b/frontend/ios/MitzoWatch/Services/AppState.swift
@@ -5,8 +5,15 @@ import MitzoShared
 
 @MainActor
 final class AppState: ObservableObject {
+    enum ConnectionMode: String {
+        case direct     // Direct WS to server
+        case relay      // Via iPhone WatchConnectivity
+        case none
+    }
+
     @Published var isAuthenticated = false
     @Published var connectionState: MitzoWSClient.State = .disconnected
+    @Published var connectionMode: ConnectionMode = .none
     @Published var sessions: [Session] = []
     @Published var error: String?
 
@@ -14,6 +21,7 @@ final class AppState: ObservableObject {
     private var wsClient: MitzoWSClient?
     private var apiClient: MitzoAPIClient?
     private var activeChatVM: ChatViewModel?
+    private let relayClient = WatchRelayClient()
 
     // Configurable via UserDefaults; defaults to Tailscale hostname
     var serverURL: URL {
@@ -22,6 +30,14 @@ final class AppState: ObservableObject {
     }
 
     init() {
+        // Activate WatchConnectivity relay
+        relayClient.activate()
+        relayClient.onServerMessage = { [weak self] msg in
+            Task { @MainActor in
+                self?.activeChatVM?.handleMessage(msg)
+            }
+        }
+
         Task {
             await checkAuth()
         }
@@ -30,7 +46,21 @@ final class AppState: ObservableObject {
     // MARK: - Auth
 
     func checkAuth() async {
-        isAuthenticated = await authManager.isAuthenticated()
+        // Try shared Keychain first
+        var authenticated = await authManager.isAuthenticated()
+
+        // If no local token, try getting it from the phone via relay
+        if !authenticated && relayClient.isPhoneReachable {
+            do {
+                let token = try await relayClient.requestAuthToken()
+                try await authManager.saveToken(token)
+                authenticated = true
+            } catch {
+                // Phone didn't have a token either
+            }
+        }
+
+        isAuthenticated = authenticated
         if isAuthenticated {
             await connect()
         }
@@ -46,31 +76,78 @@ final class AppState: ObservableObject {
         }
     }
 
-    // MARK: - Connection
+    // MARK: - Connection (waterfall: direct → relay)
 
     func connect() async {
-        guard let token = try? await authManager.getToken() else { return }
+        // Try direct WS first
+        let directSuccess = await connectDirect()
+        if directSuccess { return }
 
-        // WS path is /ws/chat, not /ws
+        // Fall back to relay via iPhone
+        if relayClient.isPhoneReachable {
+            connectionMode = .relay
+            connectionState = .connected(connectionId: "relay")
+            // In relay mode, messages go through WatchRelayClient
+            await loadSessionsViaRelay()
+        } else {
+            connectionMode = .none
+            error = "Cannot reach server or iPhone"
+        }
+    }
+
+    private func connectDirect() async -> Bool {
+        guard let token = try? await authManager.getToken() else { return false }
+
         var components = URLComponents(url: serverURL, resolvingAgainstBaseURL: false)!
         components.scheme = components.scheme == "https" ? "wss" : "ws"
         components.path = "/ws/chat"
         components.queryItems = [URLQueryItem(name: "token", value: token)]
 
-        guard let wsURL = components.url else { return }
+        guard let wsURL = components.url else { return false }
 
         let client = MitzoWSClient(url: wsURL)
         wsClient = client
 
         apiClient = MitzoAPIClient(baseURL: serverURL, authManager: authManager)
 
-        await client.connect { [weak self] event in
-            Task { @MainActor in
-                self?.handleWSEvent(event)
+        // Try connecting with a timeout
+        let connected = await withCheckedContinuation { continuation in
+            var resolved = false
+
+            Task {
+                await client.connect { [weak self] event in
+                    Task { @MainActor in
+                        self?.handleWSEvent(event)
+
+                        if !resolved {
+                            if case .stateChanged(.connected) = event {
+                                resolved = true
+                                continuation.resume(returning: true)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Timeout after 5 seconds
+            Task {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                if !resolved {
+                    resolved = true
+                    continuation.resume(returning: false)
+                }
             }
         }
 
-        await loadSessions()
+        if connected {
+            connectionMode = .direct
+            await loadSessions()
+            return true
+        } else {
+            await client.disconnect()
+            wsClient = nil
+            return false
+        }
     }
 
     func suspend() async {
@@ -85,17 +162,41 @@ final class AppState: ObservableObject {
 
     func loadSessions() async {
         do {
-            let response: SessionsResponse = try await apiClient?.getSessions() ?? SessionsResponse(sessions: [], hasMore: false)
+            let response = try await apiClient?.getSessions() ?? SessionsResponse(sessions: [], hasMore: false)
             sessions = response.sessions
         } catch {
             self.error = "Failed to load sessions"
         }
     }
 
+    private func loadSessionsViaRelay() async {
+        // In relay mode, we can't use the REST API directly.
+        // The phone handles the WS connection; we just send/receive messages.
+        // Session list would need a relay message type, or we accept
+        // that relay mode starts from existing sessions only.
+    }
+
     // MARK: - Active Chat
 
     func setActiveChatVM(_ vm: ChatViewModel?) {
         activeChatVM = vm
+    }
+
+    // MARK: - Send (mode-aware)
+
+    func sendMessage(_ message: ClientMessage) async throws {
+        switch connectionMode {
+        case .direct:
+            try await wsClient?.send(message)
+
+        case .relay:
+            // Convert ClientMessage to relay dict
+            let dict = clientMessageToRelayDict(message)
+            _ = try await relayClient.send(action: dict["action"] as? String ?? "", params: dict)
+
+        case .none:
+            throw ConnectionError.notConnected
+        }
     }
 
     // MARK: - Event Handling
@@ -105,8 +206,13 @@ final class AppState: ObservableObject {
         case .stateChanged(let state):
             connectionState = state
 
+            // If direct connection drops, try relay
+            if case .disconnected = state, connectionMode == .direct {
+                connectionMode = .none
+                Task { await connect() }
+            }
+
         case .message(let msg):
-            // Forward to active ChatViewModel
             activeChatVM?.handleMessage(msg)
 
         case .error(let err):
@@ -114,8 +220,39 @@ final class AppState: ObservableObject {
         }
     }
 
+    // MARK: - Helpers
+
+    private func clientMessageToRelayDict(_ message: ClientMessage) -> [String: Any] {
+        switch message {
+        case .send(let params):
+            return [
+                "action": "send",
+                "sessionId": params.sessionId as Any,
+                "prompt": params.prompt,
+                "clientMsgId": params.clientMsgId
+            ]
+        case .stop(let sessionId):
+            return ["action": "stop", "sessionId": sessionId]
+        case .watch(let sessionId):
+            return ["action": "watch", "sessionId": sessionId]
+        case .permissionResponse(let params):
+            return [
+                "action": "permission_response",
+                "sessionId": params.sessionId as Any,
+                "permId": params.permId,
+                "decision": params.decision?.rawValue as Any
+            ]
+        default:
+            return ["action": "unknown"]
+        }
+    }
+
     // MARK: - Accessors
 
     func getWSClient() -> MitzoWSClient? { wsClient }
     func getAPIClient() -> MitzoAPIClient? { apiClient }
+}
+
+enum ConnectionError: Error {
+    case notConnected
 }

--- a/frontend/ios/MitzoWatch/Services/AppState.swift
+++ b/frontend/ios/MitzoWatch/Services/AppState.swift
@@ -22,6 +22,8 @@ final class AppState: ObservableObject {
     private var apiClient: MitzoAPIClient?
     private var activeChatVM: ChatViewModel?
     private let relayClient = WatchRelayClient()
+    private var reconnectAttempts = 0
+    private static let maxReconnectDelay: UInt64 = 30_000_000_000 // 30s
 
     // Configurable via UserDefaults; defaults to Tailscale hostname
     var serverURL: URL {
@@ -30,9 +32,8 @@ final class AppState: ObservableObject {
     }
 
     init() {
-        // Activate WatchConnectivity relay
         relayClient.activate()
-        relayClient.onServerMessage = { [weak self] msg in
+        relayClient.setOnServerMessage { [weak self] msg in
             Task { @MainActor in
                 self?.activeChatVM?.handleMessage(msg)
             }
@@ -46,10 +47,8 @@ final class AppState: ObservableObject {
     // MARK: - Auth
 
     func checkAuth() async {
-        // Try shared Keychain first
         var authenticated = await authManager.isAuthenticated()
 
-        // If no local token, try getting it from the phone via relay
         if !authenticated && relayClient.isPhoneReachable {
             do {
                 let token = try await relayClient.requestAuthToken()
@@ -79,15 +78,16 @@ final class AppState: ObservableObject {
     // MARK: - Connection (waterfall: direct → relay)
 
     func connect() async {
-        // Try direct WS first
         let directSuccess = await connectDirect()
-        if directSuccess { return }
+        if directSuccess {
+            reconnectAttempts = 0
+            return
+        }
 
-        // Fall back to relay via iPhone
         if relayClient.isPhoneReachable {
             connectionMode = .relay
             connectionState = .connected(connectionId: "relay")
-            // In relay mode, messages go through WatchRelayClient
+            reconnectAttempts = 0
             await loadSessionsViaRelay()
         } else {
             connectionMode = .none
@@ -110,7 +110,6 @@ final class AppState: ObservableObject {
 
         apiClient = MitzoAPIClient(baseURL: serverURL, authManager: authManager)
 
-        // Try connecting with a timeout
         let connected = await withCheckedContinuation { continuation in
             var resolved = false
 
@@ -129,7 +128,6 @@ final class AppState: ObservableObject {
                 }
             }
 
-            // Timeout after 5 seconds
             Task {
                 try? await Task.sleep(nanoseconds: 5_000_000_000)
                 if !resolved {
@@ -170,10 +168,10 @@ final class AppState: ObservableObject {
     }
 
     private func loadSessionsViaRelay() async {
-        // In relay mode, we can't use the REST API directly.
-        // The phone handles the WS connection; we just send/receive messages.
-        // Session list would need a relay message type, or we accept
-        // that relay mode starts from existing sessions only.
+        // Relay mode can't use the REST API directly — the phone owns the
+        // WS connection and there's no relay message type for session listing.
+        // The watch shows an empty list with a hint to open on iPhone.
+        sessions = []
     }
 
     // MARK: - Active Chat
@@ -190,7 +188,6 @@ final class AppState: ObservableObject {
             try await wsClient?.send(message)
 
         case .relay:
-            // Convert ClientMessage to relay dict
             let dict = clientMessageToRelayDict(message)
             _ = try await relayClient.send(action: dict["action"] as? String ?? "", params: dict)
 
@@ -206,10 +203,9 @@ final class AppState: ObservableObject {
         case .stateChanged(let state):
             connectionState = state
 
-            // If direct connection drops, try relay
             if case .disconnected = state, connectionMode == .direct {
                 connectionMode = .none
-                Task { await connect() }
+                reconnectWithBackoff()
             }
 
         case .message(let msg):
@@ -220,17 +216,39 @@ final class AppState: ObservableObject {
         }
     }
 
+    private func reconnectWithBackoff() {
+        reconnectAttempts += 1
+        let baseDelay: UInt64 = 1_000_000_000 // 1s
+        let delay = min(baseDelay * UInt64(1 << min(reconnectAttempts - 1, 4)), Self.maxReconnectDelay)
+
+        Task {
+            try? await Task.sleep(nanoseconds: delay)
+            await connect()
+        }
+    }
+
     // MARK: - Helpers
 
     private func clientMessageToRelayDict(_ message: ClientMessage) -> [String: Any] {
         switch message {
         case .send(let params):
-            return [
+            var dict: [String: Any] = [
                 "action": "send",
                 "sessionId": params.sessionId as Any,
                 "prompt": params.prompt,
                 "clientMsgId": params.clientMsgId
             ]
+            if let model = params.model { dict["model"] = model }
+            if let mode = params.mode { dict["mode"] = mode.rawValue }
+            if let images = params.images {
+                dict["images"] = images.map { img in
+                    var d: [String: Any] = ["data": img.data, "mediaType": img.mediaType]
+                    if let preview = img.preview { d["preview"] = preview }
+                    return d
+                }
+            }
+            if let ctx = params.contextBlocks { dict["contextBlocks"] = ctx }
+            return dict
         case .stop(let sessionId):
             return ["action": "stop", "sessionId": sessionId]
         case .watch(let sessionId):


### PR DESCRIPTION
## Summary

- Programmatically wires the watchOS target into the Xcode project (no manual Xcode UI steps needed)
- Adds MitzoShared as SPM dependency for both iOS app and MitzoWatch targets
- Implements WatchConnectivity relay for when the watch can't reach the server directly

### Xcode Project
- MitzoWatch target: watchOS 10.0, bundle ID `com.mitzo.app.watchkitapp`
- 9 Swift source files wired into Sources build phase
- Code signing, entitlements, deployment target all configured

### WatchConnectivity Relay
- **WatchRelayHost** (iOS): bridges watch messages to/from the active WS connection
- **WatchRelayClient** (watchOS): sends through iPhone when direct WS unavailable
- Auth token sharing: watch can request JWT from phone's Keychain
- **Waterfall connection**: direct WS (5s timeout) → relay via iPhone → error

### What remains manual
- Open Xcode once to let it resolve signing/provisioning
- First build may need to select a watch simulator
- The `setup_watch_target.rb` script (not committed) can re-run if pbxproj is regenerated

## Test plan

- [x] `swift build` and `swift test` pass for MitzoShared
- [ ] Open in Xcode, verify MitzoWatch target appears in scheme selector
- [ ] Build for watchOS simulator
- [ ] Test direct WS connection
- [ ] Test relay fallback (disconnect WiFi on watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)