### PR TITLE
fix(watch): add WKCompanionAppBundleIdentifier to Info.plist

### DIFF
--- a/frontend/ios/MitzoWatch/Info.plist
+++ b/frontend/ios/MitzoWatch/Info.plist
@@ -24,5 +24,7 @@
 	<string>Mitzo uses the microphone for voice input to send messages.</string>
 	<key>WKApplication</key>
 	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.mitzo.app</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- watchOS requires `WKCompanionAppBundleIdentifier` in the watch app's Info.plist to install on a physical device
- Set to `com.mitzo.app` (the iPhone app's bundle ID)

Without this key, the install fails with `MIInstallerErrorDomain code 97`.

## Test plan

- [ ] CI green
- [ ] Install MitzoWatch on physical Apple Watch


Made with [Cursor](https://cursor.com)