### PR TITLE
fix(client): add runtime validation for reconnected sessions field

### DIFF
--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -654,6 +654,36 @@ describe('reconnected', () => {
     const r = parseServerMessage({ type: 'reconnected' }, state, makeCallbacks(), POOL_KEY);
     expect(r.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
   });
+
+  it('no-ops when sessions has invalid shape (runtime validation)', () => {
+    const state = makeState({ currentSessionId: 'sid-1' });
+    // Invalid: sessions is not an array
+    const r1 = parseServerMessage(
+      { type: 'reconnected', sessions: { invalid: 'shape' } },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r1.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
+
+    // Invalid: array contains entries missing required fields
+    const r2 = parseServerMessage(
+      { type: 'reconnected', sessions: [{ sessionId: 'sid-1' }] }, // missing running field
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r2.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
+
+    // Invalid: running field has wrong type
+    const r3 = parseServerMessage(
+      { type: 'reconnected', sessions: [{ sessionId: 'sid-1', running: 'yes' }] },
+      state,
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r3.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
+  });
 });
 
 // ─── error handling (session expired) ────────────────────────────────────────

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -115,11 +115,24 @@ export function parseServerMessage(
 
     case 'reconnected': {
       result.connectionUpdate = { status: 'connected' };
-      // Apply authoritative running state from the server for the active session
-      const sessions = msg.sessions as Array<{ sessionId: string; running: boolean }> | undefined;
-      if (sessions && state.currentSessionId) {
+      // Apply authoritative running state from the server for the active session.
+      // Validate runtime shape: sessions must be an array, and each entry must have
+      // sessionId (string) and running (boolean). Explicit running === false check
+      // guards against undefined/missing field.
+      const sessions = msg.sessions as unknown;
+      if (
+        Array.isArray(sessions) &&
+        state.currentSessionId &&
+        sessions.every(
+          (s): s is { sessionId: string; running: boolean } =>
+            typeof s === 'object' &&
+            s !== null &&
+            typeof s.sessionId === 'string' &&
+            typeof s.running === 'boolean',
+        )
+      ) {
         const active = sessions.find((s) => s.sessionId === state.currentSessionId);
-        if (active && !active.running) {
+        if (active && active.running === false) {
           result.messagesActions.push({ type: 'SET_RUNNING', running: false });
         }
       }


### PR DESCRIPTION
## Summary

- Validates `sessions` field in `reconnected` message has the expected array shape before accessing properties
- Guards against `undefined`/missing `running` field with explicit `=== false` check (prevents incorrect `SET_RUNNING false` dispatch from older servers)
- Adds test for invalid shape handling

Follow-up to PR #295 — addresses the second Centaur review round's unsafe type cast finding.

## Test plan

- [x] Protocol parser tests pass (47/47)
- [x] Existing reconnected tests still pass (4 cases)
- [x] New test covers invalid shape no-op behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)