### PR TITLE
fix(apns): respect APNS_PRODUCTION env var

### DIFF
--- a/server/apns.ts
+++ b/server/apns.ts
@@ -12,6 +12,7 @@ const APNS_KEY_PATH = process.env.APNS_KEY_PATH;
 const APNS_KEY_ID = process.env.APNS_KEY_ID;
 const APNS_TEAM_ID = process.env.APNS_TEAM_ID;
 const APNS_BUNDLE_ID = process.env.APNS_BUNDLE_ID || 'com.mitzo.app';
+const APNS_PRODUCTION = process.env.APNS_PRODUCTION !== 'false';
 
 let tokens: string[] = [];
 let tokenStorePath: string | null = null;
@@ -76,8 +77,9 @@ function getProvider(): import('@parse/node-apn').Provider | null {
         keyId: APNS_KEY_ID!,
         teamId: APNS_TEAM_ID!,
       },
-      production: true,
+      production: APNS_PRODUCTION,
     });
+    log.info('APNs provider initialized', { production: APNS_PRODUCTION });
     return apnProvider;
   } catch (err: unknown) {
     log.error('failed to initialize APNs provider', {


### PR DESCRIPTION
## Summary
- APNs provider was hardcoded to `production: true`, causing sandbox token mismatches when iOS entitlements use `aps-environment: development`
- Now reads `APNS_PRODUCTION` from env — defaults to `true`, uses sandbox gateway when set to `"false"`
- Adds init log line showing which mode is active

## Test plan
- [x] Existing APNs tests pass (token registration, persistence)
- [ ] Restart Mitzo with `APNS_PRODUCTION=false`, confirm log shows `production: false`
- [ ] Open iOS app, verify device token registers to `~/.mitzo/device-tokens.json`
- [ ] Trigger agent turn, confirm push notification arrives on phone + Watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)