### PR TITLE
feat(observability): record agent output in traces and logs

### DIFF
--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -50,8 +50,12 @@ function createTestSpan(name: string): TestSpan & OTelSpan {
     recordException: () => {},
     spanContext: () => ({ traceId: 'test', spanId: 'test', traceFlags: 1 }),
     // Expose internals for assertions
-    get _events() { return span.events; },
-    get _name() { return span.name; },
+    get _events() {
+      return span.events;
+    },
+    get _name() {
+      return span.name;
+    },
   } as unknown as TestSpan & OTelSpan;
 }
 
@@ -1806,7 +1810,11 @@ describe('runQueryLoop', () => {
         },
         {
           type: 'stream_event',
-          event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello world' } },
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'Hello world' },
+          },
         },
         { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
         { type: 'assistant', message: { content: [] }, session_id: 'sess-text' },
@@ -1832,7 +1840,11 @@ describe('runQueryLoop', () => {
         },
         {
           type: 'stream_event',
-          event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Let me reason...' } },
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: 'Let me reason...' },
+          },
         },
         { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
         { type: 'assistant', message: { content: [] }, session_id: 'sess-think' },
@@ -1907,7 +1919,12 @@ describe('runQueryLoop', () => {
           type: 'user',
           message: {
             content: [
-              { type: 'tool_result', tool_use_id: 'tool-2', content: 'file contents here', is_error: false },
+              {
+                type: 'tool_result',
+                tool_use_id: 'tool-2',
+                content: 'file contents here',
+                is_error: false,
+              },
             ],
           },
         },

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -4,6 +4,69 @@ import { ConnectionRegistry } from '../../packages/harness/src/connection-regist
 import { runQueryLoop } from '../query-loop.js';
 import type { SessionRegistry } from '../session-registry.js';
 import { EventStore } from '../event-store.js';
+import type { Span as OTelSpan } from '@opentelemetry/api';
+
+/** Lightweight in-memory span for testing OTel instrumentation. */
+interface RecordedEvent {
+  name: string;
+  attributes?: Record<string, unknown>;
+}
+interface TestSpan {
+  name: string;
+  attributes: Record<string, unknown>;
+  events: RecordedEvent[];
+  status: { code: number; message?: string };
+  ended: boolean;
+}
+
+function createTestSpan(name: string): TestSpan & OTelSpan {
+  const span: TestSpan = { name, attributes: {}, events: [], status: { code: 0 }, ended: false };
+  return {
+    ...span,
+    setAttribute(k: string, v: unknown) {
+      span.attributes[k] = v;
+      return this;
+    },
+    setAttributes(attrs: Record<string, unknown>) {
+      Object.assign(span.attributes, attrs);
+      return this;
+    },
+    addEvent(eName: string, attrs?: Record<string, unknown>) {
+      span.events.push({ name: eName, attributes: attrs });
+      return this;
+    },
+    setStatus(s: { code: number; message?: string }) {
+      span.status = s;
+      return this;
+    },
+    end() {
+      span.ended = true;
+    },
+    updateName(n: string) {
+      span.name = n;
+      return this;
+    },
+    isRecording: () => true,
+    recordException: () => {},
+    spanContext: () => ({ traceId: 'test', spanId: 'test', traceFlags: 1 }),
+    // Expose internals for assertions
+    get _events() { return span.events; },
+    get _name() { return span.name; },
+  } as unknown as TestSpan & OTelSpan;
+}
+
+/** Collects all spans created by the mocked tracer. */
+const recordedSpans: (TestSpan & OTelSpan)[] = [];
+
+vi.mock('../tracing.js', () => ({
+  tracer: {
+    startSpan(name: string) {
+      const s = createTestSpan(name);
+      recordedSpans.push(s);
+      return s;
+    },
+  },
+}));
 
 /** Create a fake SessionTransport that records sent messages */
 function fakeTransport(): SessionTransport & { sent: Record<string, unknown>[] } {
@@ -1726,6 +1789,142 @@ describe('runQueryLoop', () => {
       );
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('observability — span events for agent output', () => {
+    beforeEach(() => {
+      recordedSpans.length = 0;
+    });
+
+    it('records block.text span event on turn span for text blocks', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-t1' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Hello world' } },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-text' },
+        { type: 'result', session_id: 'sess-text' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+      const turnSpan = recordedSpans.find((s) => s.name === 'turn');
+      expect(turnSpan).toBeDefined();
+      const textEvent = turnSpan!.events.find((e) => e.name === 'block.text');
+      expect(textEvent).toBeDefined();
+      expect(textEvent!.attributes!['block.content']).toBe('Hello world');
+      expect(textEvent!.attributes!['block.truncated']).toBeUndefined();
+    });
+
+    it('records block.thinking span event on turn span for thinking blocks', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-th' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
+        },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'Let me reason...' } },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-think' },
+        { type: 'result', session_id: 'sess-think' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+      const turnSpan = recordedSpans.find((s) => s.name === 'turn');
+      expect(turnSpan).toBeDefined();
+      const thinkEvent = turnSpan!.events.find((e) => e.name === 'block.thinking');
+      expect(thinkEvent).toBeDefined();
+      expect(thinkEvent!.attributes!['block.content']).toBe('Let me reason...');
+    });
+
+    it('records tool.input span event on tool span', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-ti' } } },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'tool_use', name: 'Read', id: 'tool-1' },
+          },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{"file_path":"/tmp/test.ts"}' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-tool' },
+        { type: 'result', session_id: 'sess-tool' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+      const toolSpan = recordedSpans.find((s) => s.name === 'tool.Read');
+      expect(toolSpan).toBeDefined();
+      const inputEvent = toolSpan!.events.find((e) => e.name === 'tool.input');
+      expect(inputEvent).toBeDefined();
+      expect(inputEvent!.attributes!['tool.name']).toBe('Read');
+      expect(inputEvent!.attributes!['tool.input']).toBe('{"file_path":"/tmp/test.ts"}');
+    });
+
+    it('records tool.result span event on session span', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-tr' } } },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'tool_use', name: 'Read', id: 'tool-2' },
+          },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{}' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-tr' },
+        {
+          type: 'user',
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 'tool-2', content: 'file contents here', is_error: false },
+            ],
+          },
+        },
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-tr2' } } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-tr' },
+        { type: 'result', session_id: 'sess-tr' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+      const sessionSpan = recordedSpans.find((s) => s.name === 'session');
+      expect(sessionSpan).toBeDefined();
+      const resultEvent = sessionSpan!.events.find((e) => e.name === 'tool.result');
+      expect(resultEvent).toBeDefined();
+      expect(resultEvent!.attributes!['tool.id']).toBe('tool-2');
+      expect(resultEvent!.attributes!['tool.result']).toBe('file contents here');
+      expect(resultEvent!.attributes!['tool.is_error']).toBe(false);
     });
   });
 });

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -46,3 +46,8 @@ export const WORKTREE_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 // as unreachable (e.g. model unavailable on the configured provider) and
 // surface an error to the client instead of hanging forever.
 export const QUERY_FIRST_EVENT_TIMEOUT_MS = 90_000;
+
+// --- Observability ---
+// Max characters for agent content recorded in OTel span events and log lines.
+// Keeps Jaeger/Loki payloads bounded while preserving enough for debugging.
+export const TRACE_CONTENT_MAX_CHARS = 16_384;

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -50,4 +50,6 @@ export const QUERY_FIRST_EVENT_TIMEOUT_MS = 90_000;
 // --- Observability ---
 // Max characters for agent content recorded in OTel span events and log lines.
 // Keeps Jaeger/Loki payloads bounded while preserving enough for debugging.
-export const TRACE_CONTENT_MAX_CHARS = 16_384;
+// Configurable via env var for runtime tuning without code changes.
+export const TRACE_CONTENT_MAX_CHARS =
+  parseInt(process.env.TRACE_CONTENT_MAX_CHARS ?? '', 10) || 16_384;

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -22,6 +22,12 @@ import { context, trace, SpanStatusCode, type Span } from '@opentelemetry/api';
 import { ProgressTracker } from './progress-tracker.js';
 const log = createLogger('query-loop');
 
+/** Truncate text for trace/log payloads, returning a truncated flag when clipped. */
+function truncateForTrace(text: string): { text: string; truncated?: true } {
+  if (text.length <= TRACE_CONTENT_MAX_CHARS) return { text };
+  return { text: text.slice(0, TRACE_CONTENT_MAX_CHARS), truncated: true };
+}
+
 /** Send data via transport, guarding on isOpen(). */
 function send(transport: SessionTransport, data: Record<string, unknown>) {
   if (transport.isOpen()) transport.send(data);
@@ -699,22 +705,17 @@ async function _runQueryLoopInner(
               const summarized = summarizeToolInput(toolEntry.name, toolInput);
               const rawInput = getRawInput(toolEntry.name, toolInput);
 
-              log.info('tool call', {
-                clientId,
-                tool: toolEntry.name,
-                toolId: toolEntry.id,
-                input: toolEntry.inputBuf.slice(0, TRACE_CONTENT_MAX_CHARS),
-              });
+              const trInput = truncateForTrace(toolEntry.inputBuf);
+              log.info('tool call', { clientId, tool: toolEntry.name, toolId: toolEntry.id });
+              log.debug('tool call input', { clientId, toolId: toolEntry.id, input: trInput.text });
 
               // End tool span — record raw input before closing
               const toolSpan = toolSpans.get(blockId);
               if (toolSpan) {
                 toolSpan.addEvent('tool.input', {
                   'tool.name': toolEntry.name,
-                  'tool.input': toolEntry.inputBuf.slice(0, TRACE_CONTENT_MAX_CHARS),
-                  ...(toolEntry.inputBuf.length > TRACE_CONTENT_MAX_CHARS
-                    ? { 'tool.input.truncated': true }
-                    : {}),
+                  'tool.input': trInput.text,
+                  ...(trInput.truncated ? { 'tool.input.truncated': true } : {}),
                 });
                 toolSpan.setStatus({ code: SpanStatusCode.OK });
                 toolSpan.end();
@@ -765,14 +766,12 @@ async function _runQueryLoopInner(
 
                 // Record content in turn span and logs
                 if (block.content && (bt === 'thinking' || bt === 'text')) {
-                  const truncated = block.content.slice(0, TRACE_CONTENT_MAX_CHARS);
+                  const tr = truncateForTrace(block.content);
                   if (currentTurnSpan) {
                     currentTurnSpan.addEvent(`block.${bt}`, {
                       'block.id': blockId,
-                      'block.content': truncated,
-                      ...(block.content.length > TRACE_CONTENT_MAX_CHARS
-                        ? { 'block.truncated': true }
-                        : {}),
+                      'block.content': tr.text,
+                      ...(tr.truncated ? { 'block.truncated': true } : {}),
                     });
                   }
                   log.info(`${bt} block complete`, {
@@ -780,8 +779,8 @@ async function _runQueryLoopInner(
                     blockId,
                     blockType: bt,
                     contentLength: block.content.length,
-                    content: truncated,
                   });
+                  log.debug(`${bt} block content`, { clientId, blockId, content: tr.text });
                 }
 
                 emit(
@@ -817,23 +816,25 @@ async function _runQueryLoopInner(
             for (const block of content) {
               if (block.type === 'tool_result') {
                 const resultText = extractToolResultText(block.content);
-                const truncResult = resultText.slice(0, TRACE_CONTENT_MAX_CHARS);
+                const trResult = truncateForTrace(resultText);
 
                 // Record tool result in session span and logs
                 span.addEvent('tool.result', {
                   'tool.id': block.tool_use_id || '',
-                  'tool.result': truncResult,
+                  'tool.result': trResult.text,
                   'tool.is_error': block.is_error === true,
-                  ...(resultText.length > TRACE_CONTENT_MAX_CHARS
-                    ? { 'tool.result.truncated': true }
-                    : {}),
+                  ...(trResult.truncated ? { 'tool.result.truncated': true } : {}),
                 });
                 log.info('tool result', {
                   clientId,
                   toolId: block.tool_use_id || '',
                   isError: block.is_error === true,
                   resultLength: resultText.length,
-                  result: truncResult,
+                });
+                log.debug('tool result content', {
+                  clientId,
+                  toolId: block.tool_use_id || '',
+                  result: trResult.text,
                 });
 
                 emit(

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -5,6 +5,7 @@ import {
   TOOL_RESULT_MAX_CHARS,
   CONTEXT_CEILING_TOKENS,
   QUERY_FIRST_EVENT_TIMEOUT_MS,
+  TRACE_CONTENT_MAX_CHARS,
 } from './constants.js';
 import { createLogger } from './logger.js';
 import type { SessionRegistry, SnapshotBlock } from './session-registry.js';
@@ -698,11 +699,23 @@ async function _runQueryLoopInner(
               const summarized = summarizeToolInput(toolEntry.name, toolInput);
               const rawInput = getRawInput(toolEntry.name, toolInput);
 
-              log.info('tool call', { clientId, tool: toolEntry.name, toolId: toolEntry.id });
+              log.info('tool call', {
+                clientId,
+                tool: toolEntry.name,
+                toolId: toolEntry.id,
+                input: toolEntry.inputBuf.slice(0, TRACE_CONTENT_MAX_CHARS),
+              });
 
-              // End tool span
+              // End tool span — record raw input before closing
               const toolSpan = toolSpans.get(blockId);
               if (toolSpan) {
+                toolSpan.addEvent('tool.input', {
+                  'tool.name': toolEntry.name,
+                  'tool.input': toolEntry.inputBuf.slice(0, TRACE_CONTENT_MAX_CHARS),
+                  ...(toolEntry.inputBuf.length > TRACE_CONTENT_MAX_CHARS
+                    ? { 'tool.input.truncated': true }
+                    : {}),
+                });
                 toolSpan.setStatus({ code: SpanStatusCode.OK });
                 toolSpan.end();
                 toolSpans.delete(blockId);
@@ -742,13 +755,35 @@ async function _runQueryLoopInner(
                 }
               }
             } else if (blockId) {
-              // Text or thinking block — mark done in snapshot.
+              // Text or thinking block — mark done in snapshot, record in traces + logs.
               const block = currentSession.currentSnapshot?.blocks.find(
                 (b) => b.blockId === blockId,
               );
               if (block) {
                 const bt = block.blockType;
                 block.done = true;
+
+                // Record content in turn span and logs
+                if (block.content && (bt === 'thinking' || bt === 'text')) {
+                  const truncated = block.content.slice(0, TRACE_CONTENT_MAX_CHARS);
+                  if (currentTurnSpan) {
+                    currentTurnSpan.addEvent(`block.${bt}`, {
+                      'block.id': blockId,
+                      'block.content': truncated,
+                      ...(block.content.length > TRACE_CONTENT_MAX_CHARS
+                        ? { 'block.truncated': true }
+                        : {}),
+                    });
+                  }
+                  log.info(`${bt} block complete`, {
+                    clientId,
+                    blockId,
+                    blockType: bt,
+                    contentLength: block.content.length,
+                    content: truncated,
+                  });
+                }
+
                 emit(
                   v2('block_end', {
                     messageId: currentMessageId,
@@ -782,6 +817,25 @@ async function _runQueryLoopInner(
             for (const block of content) {
               if (block.type === 'tool_result') {
                 const resultText = extractToolResultText(block.content);
+                const truncResult = resultText.slice(0, TRACE_CONTENT_MAX_CHARS);
+
+                // Record tool result in session span and logs
+                span.addEvent('tool.result', {
+                  'tool.id': block.tool_use_id || '',
+                  'tool.result': truncResult,
+                  'tool.is_error': block.is_error === true,
+                  ...(resultText.length > TRACE_CONTENT_MAX_CHARS
+                    ? { 'tool.result.truncated': true }
+                    : {}),
+                });
+                log.info('tool result', {
+                  clientId,
+                  toolId: block.tool_use_id || '',
+                  isError: block.is_error === true,
+                  resultLength: resultText.length,
+                  result: truncResult,
+                });
+
                 emit(
                   v2('tool_result', {
                     messageId: currentMessageId,


### PR DESCRIPTION
## Summary

- Adds thinking blocks, text blocks, tool inputs, and tool results to OTel span events (visible in Jaeger)
- Adds info-level log lines for all agent output (visible in Loki/server logs)
- Introduces `TRACE_CONTENT_MAX_CHARS` (16KB) constant to cap payload size

## Test plan

- [x] All 43 query-loop tests pass
- [ ] Deploy, run a session, verify thinking/text/tool content appears in Jaeger spans
- [ ] Check server logs for new `thinking block complete`, `text block complete`, `tool result` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)