### PR TITLE
feat(sse): event bus + session activity overview

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -12,6 +12,7 @@ import { apiFetch, getApiBaseUrl, getWsChatUrl } from './lib/api-fetch';
 import { registerCapacitorLifecycle } from './lib/capacitor';
 import { configureKeyboard } from './lib/keyboard';
 import { initPushNotifications } from './lib/push';
+import { eventBus } from './lib/event-bus-singleton';
 
 export const clientStore = createMitzoStore({
   transport: {
@@ -27,7 +28,10 @@ export const clientStore = createMitzoStore({
 
 // Wire Capacitor app lifecycle → force WS reconnect on resume, send suspend on background
 registerCapacitorLifecycle(
-  () => clientStore.getState().forceReconnect(),
+  () => {
+    clientStore.getState().forceReconnect();
+    eventBus.ensureConnected();
+  },
   () => clientStore.getState().sendSuspend(),
 );
 

--- a/frontend/src/components/SessionOverview.tsx
+++ b/frontend/src/components/SessionOverview.tsx
@@ -28,6 +28,7 @@ function SessionActivityCard({
   onTap: (sessionId: string) => void;
 }) {
   const config = STATE_CONFIG[activity.state];
+  // Elapsed updates on each SSE event, not on a timer — acceptable staleness
   const elapsed = Date.now() - activity.lastEventAt;
   const timeLabel = formatElapsed(elapsed);
 

--- a/frontend/src/components/SessionOverview.tsx
+++ b/frontend/src/components/SessionOverview.tsx
@@ -1,0 +1,133 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  useSessionOverview,
+  type SessionActivity,
+  type SessionActivityState,
+} from '../hooks/useSessionOverview';
+import { selectionChanged } from '../lib/haptics';
+
+// ─── State visuals ──────────────────────────────────────────────────────────
+
+const STATE_CONFIG: Record<SessionActivityState, { icon: string; color: string; label: string }> = {
+  init: { icon: '\u25CB', color: '#888', label: 'init' },
+  working: { icon: '\u25CF', color: '#b48cff', label: 'working' },
+  waiting: { icon: '\u26A0', color: '#ff6d6d', label: 'waiting' },
+  done: { icon: '\u2713', color: '#4ade80', label: 'done' },
+  idle: { icon: '\u25CB', color: '#555', label: 'idle' },
+  paused: { icon: '\u23F8', color: '#888', label: 'paused' },
+};
+
+// ─── Card ───────────────────────────────────────────────────────────────────
+
+function SessionActivityCard({
+  activity,
+  onTap,
+}: {
+  activity: SessionActivity;
+  onTap: (sessionId: string) => void;
+}) {
+  const config = STATE_CONFIG[activity.state];
+  const elapsed = Date.now() - activity.lastEventAt;
+  const timeLabel = formatElapsed(elapsed);
+
+  let metaText = config.label;
+  if (activity.waitReason === 'permission') metaText = 'permission';
+  else if (activity.waitReason === 'review') metaText = 'review needed';
+  else if (activity.waitReason === 'blocked') metaText = 'blocked';
+
+  if (activity.progress) {
+    metaText += ` \u00B7 ${activity.progress.done}/${activity.progress.total}`;
+  }
+
+  metaText += ` \u00B7 ${timeLabel}`;
+
+  return (
+    <button
+      className="overview-card"
+      onClick={() => onTap(activity.sessionId)}
+      style={{ '--card-accent': config.color } as React.CSSProperties}
+    >
+      <span className="overview-card-icon" style={{ color: config.color }}>
+        {config.icon}
+      </span>
+      <div className="overview-card-content">
+        <div className="overview-card-title">
+          {activity.repo && <span className="overview-card-repo">{activity.repo}:</span>}{' '}
+          {activity.title}
+        </div>
+        <div className="overview-card-meta">{metaText}</div>
+      </div>
+    </button>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────────────
+
+export function SessionOverview() {
+  const { activities, attendCount } = useSessionOverview();
+  const navigate = useNavigate();
+
+  // Filter out idle/init — only show interesting sessions
+  const visible = activities.filter((a) => a.state !== 'idle' && a.state !== 'init');
+
+  // Auto-expand when tier 1 items exist
+  const hasUrgent = attendCount > 0;
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const isOpen = manualOpen ?? hasUrgent;
+
+  const toggleOpen = useCallback(() => {
+    setManualOpen((prev) => !(prev ?? hasUrgent));
+  }, [hasUrgent]);
+
+  const handleTap = useCallback(
+    (sessionId: string) => {
+      selectionChanged();
+      navigate(`/chat/${sessionId}`);
+    },
+    [navigate],
+  );
+
+  // Don't render at all if no interesting sessions
+  if (visible.length === 0) return null;
+
+  // Build summary line
+  const waitingCount = visible.filter((a) => a.state === 'waiting').length;
+  const workingCount = visible.filter((a) => a.state === 'working').length;
+  const doneCount = visible.filter((a) => a.state === 'done').length;
+  const parts: string[] = [];
+  if (waitingCount > 0) parts.push(`${waitingCount} waiting`);
+  if (workingCount > 0) parts.push(`${workingCount} working`);
+  if (doneCount > 0) parts.push(`${doneCount} done`);
+
+  return (
+    <div className="overview-section">
+      <button className="overview-header" onClick={toggleOpen}>
+        <span className="overview-header-title">Active Sessions</span>
+        <span className="overview-header-summary">{parts.join(' \u00B7 ')}</span>
+        {attendCount > 0 && <span className="overview-badge">{attendCount}</span>}
+        <span className={`overview-chevron${isOpen ? ' overview-chevron--open' : ''}`}>
+          &rsaquo;
+        </span>
+      </button>
+      {isOpen && (
+        <div className="overview-cards">
+          {visible.map((a) => (
+            <SessionActivityCard key={a.sessionId} activity={a} onTap={handleTap} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatElapsed(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}min ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}

--- a/frontend/src/components/__tests__/SessionOverview.test.tsx
+++ b/frontend/src/components/__tests__/SessionOverview.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { SessionActivity } from '../../hooks/useSessionOverview';
+
+// Mock navigate
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await import('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+// Mock haptics
+vi.mock('../../lib/haptics', () => ({
+  selectionChanged: vi.fn(),
+}));
+
+// Mock the hook
+const mockActivities: SessionActivity[] = [];
+let mockAttendCount = 0;
+
+vi.mock('../../hooks/useSessionOverview', () => ({
+  useSessionOverview: () => ({
+    activities: mockActivities,
+    attendCount: mockAttendCount,
+    connected: true,
+  }),
+}));
+
+import { SessionOverview } from '../SessionOverview';
+
+afterEach(() => {
+  cleanup();
+  mockNavigate.mockClear();
+  mockActivities.length = 0;
+  mockAttendCount = 0;
+});
+
+function renderOverview() {
+  return render(
+    <MemoryRouter>
+      <SessionOverview />
+    </MemoryRouter>,
+  );
+}
+
+function makeActivity(overrides: Partial<SessionActivity> = {}): SessionActivity {
+  return {
+    sessionId: 'session-1',
+    clientId: 'client-1',
+    title: 'Test Session',
+    state: 'working',
+    flags: [],
+    lastEventAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('SessionOverview', () => {
+  it('renders nothing when no interesting sessions', () => {
+    const { container } = renderOverview();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when only idle/init sessions', () => {
+    mockActivities.push(
+      makeActivity({ state: 'idle' }),
+      makeActivity({ sessionId: 's2', state: 'init' }),
+    );
+    const { container } = renderOverview();
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders header with summary when working sessions exist', () => {
+    mockActivities.push(makeActivity({ state: 'working' }));
+    renderOverview();
+    expect(screen.getByText('Active Sessions')).toBeTruthy();
+    expect(screen.getByText('1 working')).toBeTruthy();
+  });
+
+  it('shows badge when waiting sessions exist', () => {
+    mockActivities.push(makeActivity({ state: 'waiting', waitReason: 'permission' }));
+    mockAttendCount = 1;
+    renderOverview();
+    expect(screen.getByText('1')).toBeTruthy();
+  });
+
+  it('auto-expands when attend count > 0', () => {
+    mockActivities.push(makeActivity({ state: 'waiting' }));
+    mockAttendCount = 1;
+    renderOverview();
+    // Cards should be visible
+    expect(screen.getByText('Test Session')).toBeTruthy();
+  });
+
+  it('navigates on card tap', () => {
+    mockActivities.push(makeActivity({ state: 'working' }));
+    mockAttendCount = 1; // auto-expand
+    renderOverview();
+
+    const card = screen.getByText('Test Session').closest('button');
+    fireEvent.click(card!);
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/session-1');
+  });
+
+  it('shows repo prefix in card title', () => {
+    mockActivities.push(makeActivity({ state: 'working', repo: 'mitzo' }));
+    mockAttendCount = 1;
+    renderOverview();
+    expect(screen.getByText('mitzo:')).toBeTruthy();
+  });
+
+  it('shows progress in card meta', () => {
+    mockActivities.push(makeActivity({ state: 'working', progress: { done: 3, total: 7 } }));
+    mockAttendCount = 1;
+    renderOverview();
+    // The meta text should contain progress
+    const meta = document.querySelector('.overview-card-meta');
+    expect(meta?.textContent).toContain('3/7');
+  });
+
+  it('toggles expansion on header click', () => {
+    mockActivities.push(makeActivity({ state: 'working' }));
+    // No attend count, so starts collapsed
+    mockAttendCount = 0;
+    renderOverview();
+
+    // Should be collapsed initially (no card visible)
+    expect(screen.queryByText('Test Session')).toBeNull();
+
+    // Click header to expand
+    fireEvent.click(screen.getByText('Active Sessions'));
+    expect(screen.getByText('Test Session')).toBeTruthy();
+
+    // Click again to collapse
+    fireEvent.click(screen.getByText('Active Sessions'));
+    expect(screen.queryByText('Test Session')).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useSessionOverview.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionOverview.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock the event bus singleton
+const mockOn = vi.fn(() => vi.fn()); // returns unsubscribe
+const mockOnConnectionChange = vi.fn(() => vi.fn());
+const mockConnected = false;
+
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: (...args: unknown[]) => mockOn(...args),
+    onConnectionChange: (...args: unknown[]) => mockOnConnectionChange(...args),
+    get connected() {
+      return mockConnected;
+    },
+  },
+}));
+
+import { useSessionOverview, type SessionActivity } from '../useSessionOverview';
+
+beforeEach(() => {
+  mockOn.mockClear();
+  mockOnConnectionChange.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeActivity(overrides: Partial<SessionActivity> = {}): SessionActivity {
+  return {
+    sessionId: 'session-1',
+    clientId: 'client-1',
+    title: 'Test Session',
+    state: 'working',
+    flags: [],
+    lastEventAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('useSessionOverview', () => {
+  it('starts with empty activities', () => {
+    const { result } = renderHook(() => useSessionOverview());
+    expect(result.current.activities).toEqual([]);
+    expect(result.current.attendCount).toBe(0);
+  });
+
+  it('subscribes to session_activity events on mount', () => {
+    renderHook(() => useSessionOverview());
+    expect(mockOn).toHaveBeenCalledWith('session_activity', expect.any(Function));
+  });
+
+  it('subscribes to connection changes', () => {
+    renderHook(() => useSessionOverview());
+    expect(mockOnConnectionChange).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('unsubscribes on unmount', () => {
+    const unsubActivity = vi.fn();
+    const unsubConnection = vi.fn();
+    mockOn.mockReturnValue(unsubActivity);
+    mockOnConnectionChange.mockReturnValue(unsubConnection);
+
+    const { unmount } = renderHook(() => useSessionOverview());
+    unmount();
+
+    expect(unsubActivity).toHaveBeenCalled();
+    expect(unsubConnection).toHaveBeenCalled();
+  });
+
+  it('updates activities when session_activity event fires', () => {
+    let activityHandler: ((data: unknown) => void) | null = null;
+    mockOn.mockImplementation((_event: string, handler: (data: unknown) => void) => {
+      activityHandler = handler;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useSessionOverview());
+
+    const activities = [
+      makeActivity({ sessionId: 's1', state: 'working' }),
+      makeActivity({ sessionId: 's2', state: 'waiting', waitReason: 'permission' }),
+    ];
+
+    act(() => {
+      activityHandler!(activities);
+    });
+
+    expect(result.current.activities).toHaveLength(2);
+    // Waiting (tier 1) should sort before working (tier 3)
+    expect(result.current.activities[0].state).toBe('waiting');
+    expect(result.current.activities[1].state).toBe('working');
+  });
+
+  it('computes attendCount from waiting sessions', () => {
+    let activityHandler: ((data: unknown) => void) | null = null;
+    mockOn.mockImplementation((_event: string, handler: (data: unknown) => void) => {
+      activityHandler = handler;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useSessionOverview());
+
+    act(() => {
+      activityHandler!([
+        makeActivity({ sessionId: 's1', state: 'waiting' }),
+        makeActivity({ sessionId: 's2', state: 'waiting' }),
+        makeActivity({ sessionId: 's3', state: 'working' }),
+      ]);
+    });
+
+    expect(result.current.attendCount).toBe(2);
+  });
+
+  it('sorts by tier then by recency within tier', () => {
+    let activityHandler: ((data: unknown) => void) | null = null;
+    mockOn.mockImplementation((_event: string, handler: (data: unknown) => void) => {
+      activityHandler = handler;
+      return vi.fn();
+    });
+
+    const { result } = renderHook(() => useSessionOverview());
+
+    const now = Date.now();
+    act(() => {
+      activityHandler!([
+        makeActivity({ sessionId: 's1', state: 'done', lastEventAt: now - 1000 }),
+        makeActivity({ sessionId: 's2', state: 'working', lastEventAt: now }),
+        makeActivity({ sessionId: 's3', state: 'done', lastEventAt: now }),
+        makeActivity({ sessionId: 's4', state: 'waiting', lastEventAt: now }),
+      ]);
+    });
+
+    const ids = result.current.activities.map((a) => a.sessionId);
+    // Tier 1 (waiting) → Tier 2 (done, newest first) → Tier 3 (working)
+    expect(ids).toEqual(['s4', 's3', 's1', 's2']);
+  });
+});

--- a/frontend/src/hooks/__tests__/useSessionOverview.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionOverview.test.ts
@@ -3,8 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Mock the event bus singleton
-const mockOn = vi.fn(() => vi.fn()); // returns unsubscribe
-const mockOnConnectionChange = vi.fn(() => vi.fn());
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockOn: any = vi.fn(() => vi.fn());
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockOnConnectionChange: any = vi.fn(() => vi.fn());
 const mockConnected = false;
 
 vi.mock('../../lib/event-bus-singleton', () => ({

--- a/frontend/src/hooks/useSessionOverview.ts
+++ b/frontend/src/hooks/useSessionOverview.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useMemo } from 'react';
+import { eventBus } from '../lib/event-bus-singleton';
+
+// ─── Types (mirror server/session-overview.ts) ──────────────────────────────
+
+export type SessionActivityState = 'init' | 'working' | 'waiting' | 'done' | 'idle' | 'paused';
+
+export type WaitReason = 'permission' | 'review' | 'blocked';
+
+export interface SessionActivity {
+  sessionId: string;
+  clientId: string;
+  title: string;
+  repo?: string;
+  state: SessionActivityState;
+  flags: SessionActivityState[];
+  waitReason?: WaitReason;
+  progress?: { done: number; total: number };
+  lastEventAt: number;
+  taskId?: string;
+}
+
+// ─── Tier sorting ───────────────────────────────────────────────────────────
+
+type AttendTier = 1 | 2 | 3 | 4;
+
+function getTier(activity: SessionActivity): AttendTier {
+  if (activity.state === 'waiting') return 1;
+  if (activity.state === 'done') return 2;
+  if (activity.state === 'working') return 3;
+  return 4; // init, idle, paused
+}
+
+function sortByTier(activities: SessionActivity[]): SessionActivity[] {
+  return [...activities].sort((a, b) => {
+    const tierDiff = getTier(a) - getTier(b);
+    if (tierDiff !== 0) return tierDiff;
+    // Within same tier, most recent first
+    return b.lastEventAt - a.lastEventAt;
+  });
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────────────
+
+export interface UseSessionOverviewReturn {
+  /** All active sessions, sorted by attention tier. */
+  activities: SessionActivity[];
+  /** Number of Tier 1 (needs you) sessions. */
+  attendCount: number;
+  /** Whether SSE is connected. */
+  connected: boolean;
+}
+
+export function useSessionOverview(): UseSessionOverviewReturn {
+  const [activities, setActivities] = useState<SessionActivity[]>([]);
+  const [connected, setConnected] = useState(eventBus.connected);
+
+  useEffect(() => {
+    const unsubActivity = eventBus.on('session_activity', (data) => {
+      setActivities(data as SessionActivity[]);
+    });
+    const unsubConnection = eventBus.onConnectionChange((c) => setConnected(c));
+    return () => {
+      unsubActivity();
+      unsubConnection();
+    };
+  }, []);
+
+  const sorted = useMemo(() => sortByTier(activities), [activities]);
+  const attendCount = useMemo(
+    () => activities.filter((a) => a.state === 'waiting').length,
+    [activities],
+  );
+
+  return { activities: sorted, attendCount, connected };
+}

--- a/frontend/src/lib/event-bus-singleton.ts
+++ b/frontend/src/lib/event-bus-singleton.ts
@@ -1,0 +1,15 @@
+/**
+ * Global EventBus singleton for SSE events.
+ *
+ * Lazily connected on first import. Hooks subscribe via eventBus.on().
+ * On iOS resume, ensureConnected() is called to recover from CLOSED state.
+ */
+
+import { EventBus } from '@mitzo/client';
+import { getApiBaseUrl } from './api-fetch';
+
+export const eventBus = new EventBus();
+
+// Connect immediately — EventSource auto-reconnects natively
+const sseUrl = `${getApiBaseUrl()}/api/events`;
+eventBus.connect(sseUrl);

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -13,6 +13,7 @@ import { formatTokens } from '../lib/formatTokens';
 import { BriefingCard } from '../components/BriefingCard';
 import { SessionSearchBar } from '../components/SessionSearchBar';
 import { useSessionSearch } from '../hooks/useSessionSearch';
+import { SessionOverview } from '../components/SessionOverview';
 
 function SwipeableSession({
   session,
@@ -307,6 +308,8 @@ export function SessionList() {
         </button>
 
         <BriefingCard />
+
+        <SessionOverview />
 
         {quickActions.length > 0 && (
           <div className="quick-section">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -624,6 +624,125 @@ textarea:focus {
   color: #fff;
 }
 
+/* --- Session Overview --- */
+
+.overview-section {
+  margin-bottom: var(--space-4);
+}
+
+.overview-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) 0;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.overview-header-title {
+  flex-shrink: 0;
+}
+
+.overview-header-summary {
+  flex: 1;
+  text-align: right;
+  font-weight: 400;
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  opacity: 0.7;
+}
+
+.overview-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #ff6d6d;
+  color: #fff;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.overview-chevron {
+  display: inline-block;
+  font-size: var(--text-base);
+  transition: transform 0.2s;
+  transform: rotate(0deg);
+  flex-shrink: 0;
+}
+
+.overview-chevron--open {
+  transform: rotate(90deg);
+}
+
+.overview-cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+.overview-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--card-accent, var(--border));
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  color: var(--text);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.15s;
+}
+
+.overview-card:active {
+  background: var(--hover);
+}
+
+.overview-card-icon {
+  flex-shrink: 0;
+  font-size: var(--text-base);
+  line-height: 1.3;
+}
+
+.overview-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.overview-card-title {
+  font-size: var(--text-sm);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overview-card-repo {
+  color: var(--text-dim);
+  font-weight: 600;
+}
+
+.overview-card-meta {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
 .quick-section {
   margin-bottom: var(--space-5);
 }

--- a/packages/client/__tests__/event-bus.test.ts
+++ b/packages/client/__tests__/event-bus.test.ts
@@ -142,6 +142,28 @@ describe('EventBus', () => {
     expect(handler).toHaveBeenCalledOnce(); // not called again
   });
 
+  it('unsubscribe then resubscribe fires exactly once per event', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    const handler = vi.fn();
+    const unsub = bus.on('task_state', handler);
+
+    lastSource!.simulateEvent('task_state', { v: 1 });
+    expect(handler).toHaveBeenCalledOnce();
+
+    unsub();
+    handler.mockClear();
+
+    // Resubscribe — should not get duplicate dispatch
+    const handler2 = vi.fn();
+    bus.on('task_state', handler2);
+
+    lastSource!.simulateEvent('task_state', { v: 2 });
+    expect(handler).not.toHaveBeenCalled(); // old handler still unsubbed
+    expect(handler2).toHaveBeenCalledOnce(); // new handler fires exactly once
+  });
+
   it('subscribes after connect — late listeners work', () => {
     bus.connect('/api/events');
     lastSource!.simulateOpen();

--- a/packages/client/__tests__/event-bus.test.ts
+++ b/packages/client/__tests__/event-bus.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventBus } from '../src/event-bus.js';
+
+// ─── Mock EventSource ───────────────────────────────────────────────────────
+
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  private handlers = new Map<string, ((e: MessageEvent) => void)[]>();
+
+  close = vi.fn(() => {
+    this.readyState = MockEventSource.CLOSED;
+  });
+
+  addEventListener(type: string, handler: (e: MessageEvent) => void) {
+    const list = this.handlers.get(type) ?? [];
+    list.push(handler);
+    this.handlers.set(type, list);
+  }
+
+  removeEventListener(type: string, handler: (e: MessageEvent) => void) {
+    const list = this.handlers.get(type);
+    if (!list) return;
+    this.handlers.set(
+      type,
+      list.filter((h) => h !== handler),
+    );
+  }
+
+  // Test helpers
+  simulateOpen() {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.(null);
+  }
+
+  simulateEvent(type: string, data: unknown) {
+    const handlers = this.handlers.get(type) ?? [];
+    const event = { data: JSON.stringify(data) } as MessageEvent;
+    for (const h of handlers) h(event);
+  }
+
+  simulateError() {
+    this.readyState = MockEventSource.CONNECTING; // EventSource reconnects
+    this.onerror?.(new Event('error'));
+  }
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+let lastSource: MockEventSource | null = null;
+
+function createBus(): EventBus {
+  lastSource = null;
+  return new EventBus((_url: string) => {
+    const source = new MockEventSource();
+    lastSource = source;
+    return source as unknown as EventSource;
+  });
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('EventBus', () => {
+  let bus: EventBus;
+
+  beforeEach(() => {
+    bus = createBus();
+  });
+
+  afterEach(() => {
+    bus.disconnect();
+  });
+
+  it('starts disconnected', () => {
+    expect(bus.connected).toBe(false);
+  });
+
+  it('connects and reports connected state', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    expect(bus.connected).toBe(true);
+  });
+
+  it('dispatches typed events to subscribers', () => {
+    const handler = vi.fn();
+    bus.on('session_activity', handler);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    lastSource!.simulateEvent('session_activity', [{ id: 's1', state: 'working' }]);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith([{ id: 's1', state: 'working' }]);
+  });
+
+  it('supports multiple listeners per event type', () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    bus.on('todo_update', h1);
+    bus.on('todo_update', h2);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    lastSource!.simulateEvent('todo_update', { action: 'refresh' });
+
+    expect(h1).toHaveBeenCalledOnce();
+    expect(h2).toHaveBeenCalledOnce();
+  });
+
+  it('supports multiple event types independently', () => {
+    const sessionHandler = vi.fn();
+    const todoHandler = vi.fn();
+    bus.on('session_activity', sessionHandler);
+    bus.on('todo_update', todoHandler);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    lastSource!.simulateEvent('session_activity', []);
+    expect(sessionHandler).toHaveBeenCalledOnce();
+    expect(todoHandler).not.toHaveBeenCalled();
+
+    lastSource!.simulateEvent('todo_update', { action: 'refresh' });
+    expect(todoHandler).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes via returned function', () => {
+    const handler = vi.fn();
+    const unsub = bus.on('loop_status', handler);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    lastSource!.simulateEvent('loop_status', { state: 'running' });
+    expect(handler).toHaveBeenCalledOnce();
+
+    unsub();
+    lastSource!.simulateEvent('loop_status', { state: 'idle' });
+    expect(handler).toHaveBeenCalledOnce(); // not called again
+  });
+
+  it('subscribes after connect — late listeners work', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    const handler = vi.fn();
+    bus.on('health', handler);
+
+    lastSource!.simulateEvent('health', { yapper: 'ok' });
+    expect(handler).toHaveBeenCalledWith({ yapper: 'ok' });
+  });
+
+  it('disconnect closes the EventSource', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    const src = lastSource!;
+
+    bus.disconnect();
+    expect(src.close).toHaveBeenCalledOnce();
+    expect(bus.connected).toBe(false);
+  });
+
+  it('disconnect is safe to call when not connected', () => {
+    expect(() => bus.disconnect()).not.toThrow();
+  });
+
+  it('ensureConnected recreates a CLOSED EventSource', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    const firstSource = lastSource;
+
+    // Simulate EventSource giving up (CLOSED state)
+    firstSource!.readyState = MockEventSource.CLOSED;
+
+    bus.ensureConnected();
+    expect(lastSource).not.toBe(firstSource); // new instance created
+  });
+
+  it('ensureConnected no-ops when still connected', () => {
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    const firstSource = lastSource;
+
+    bus.ensureConnected();
+    expect(lastSource).toBe(firstSource); // same instance
+  });
+
+  it('ensureConnected no-ops when reconnecting (CONNECTING)', () => {
+    bus.connect('/api/events');
+    // readyState is still CONNECTING (0) — EventSource is trying to connect
+    const firstSource = lastSource;
+
+    bus.ensureConnected();
+    expect(lastSource).toBe(firstSource); // same instance
+  });
+
+  it('fires onConnectionChange callback on open', () => {
+    const onChange = vi.fn();
+    bus.onConnectionChange(onChange);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('fires onConnectionChange callback on error', () => {
+    const onChange = vi.fn();
+    bus.onConnectionChange(onChange);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+    onChange.mockClear();
+
+    lastSource!.simulateError();
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('preserves listeners across reconnect', () => {
+    const handler = vi.fn();
+    bus.on('task_state', handler);
+    bus.connect('/api/events');
+    lastSource!.simulateOpen();
+
+    // Simulate EventSource dying and being recreated
+    lastSource!.readyState = MockEventSource.CLOSED;
+    bus.ensureConnected();
+    lastSource!.simulateOpen();
+
+    lastSource!.simulateEvent('task_state', { tasks: [] });
+    expect(handler).toHaveBeenCalledWith({ tasks: [] });
+  });
+});

--- a/packages/client/src/event-bus.ts
+++ b/packages/client/src/event-bus.ts
@@ -1,0 +1,171 @@
+/**
+ * EventBus — SSE client for broadcast events.
+ *
+ * Wraps native EventSource to receive typed server-sent events (session state,
+ * task updates, health, etc.). One instance per app, lives for the app's
+ * lifetime. Complements the WebSocket (per-session, bidirectional) with a
+ * global unidirectional awareness channel.
+ *
+ * EventSource auto-reconnects natively — no custom reconnect logic needed.
+ * On reconnect, the server sends a fresh hydration snapshot.
+ */
+
+/** EventSource readyState constants — avoids referencing the global. */
+const ES_OPEN = 1;
+const ES_CLOSED = 2;
+
+export type EventBusListener = (data: unknown) => void;
+export type EventSourceFactory = (url: string) => EventSource;
+export type ConnectionChangeCallback = (connected: boolean) => void;
+
+export class EventBus {
+  private source: EventSource | null = null;
+  private url: string | null = null;
+  private listeners = new Map<string, Set<EventBusListener>>();
+  private connectionChangeListeners = new Set<ConnectionChangeCallback>();
+  private createEventSource: EventSourceFactory;
+
+  constructor(factory?: EventSourceFactory) {
+    this.createEventSource =
+      factory ?? ((url: string) => new EventSource(url, { withCredentials: true }));
+  }
+
+  /**
+   * Connect to the SSE endpoint. Call once on app mount.
+   */
+  connect(url: string): void {
+    if (this.source) return;
+    this.url = url;
+    this.createSource();
+  }
+
+  /**
+   * Subscribe to a specific event type. Returns an unsubscribe function.
+   *
+   * Listeners are tracked by the bus itself — they survive EventSource
+   * reconnects because we re-register them on each new source.
+   * The dispatch path goes through the listener set (not through
+   * individual EventSource handlers), so unsubscribe is immediate.
+   */
+  on(event: string, listener: EventBusListener): () => void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+      // First listener for this event type — register the dispatch handler
+      if (this.source) {
+        this.registerEventDispatch(event);
+      }
+    }
+    set.add(listener);
+
+    return () => {
+      set!.delete(listener);
+      if (set!.size === 0) this.listeners.delete(event);
+    };
+  }
+
+  /**
+   * Register a callback for connection state changes.
+   */
+  onConnectionChange(cb: ConnectionChangeCallback): () => void {
+    this.connectionChangeListeners.add(cb);
+    return () => this.connectionChangeListeners.delete(cb);
+  }
+
+  /**
+   * Ensure the SSE connection is alive. Call on app resume (iOS foreground).
+   * If the EventSource is in CLOSED state (gave up reconnecting), recreates it.
+   * No-op if still connected or reconnecting.
+   */
+  ensureConnected(): void {
+    if (!this.url) return;
+    if (!this.source || this.source.readyState === ES_CLOSED) {
+      if (this.source) {
+        try {
+          this.source.close();
+        } catch {
+          /* best effort */
+        }
+      }
+      this.source = null;
+      this.createSource();
+    }
+  }
+
+  /**
+   * Disconnect. Call on app unmount.
+   */
+  disconnect(): void {
+    if (this.source) {
+      try {
+        this.source.close();
+      } catch {
+        /* best effort */
+      }
+      this.source = null;
+    }
+  }
+
+  /**
+   * Whether the SSE connection is currently open.
+   */
+  get connected(): boolean {
+    return this.source?.readyState === ES_OPEN;
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private createSource(): void {
+    if (!this.url) return;
+
+    const source = this.createEventSource(this.url);
+    this.source = source;
+
+    source.onopen = () => {
+      this.notifyConnectionChange(true);
+    };
+
+    source.onerror = () => {
+      this.notifyConnectionChange(false);
+    };
+
+    // Register one dispatch handler per event type on the new source.
+    // Each handler fans out to all listeners in the set — no per-listener
+    // handlers on the EventSource, so unsubscribe is just a Set.delete().
+    for (const event of this.listeners.keys()) {
+      this.registerEventDispatch(event);
+    }
+  }
+
+  /**
+   * Register a single EventSource handler for an event type that dispatches
+   * to all listeners in the set. This indirection means unsubscribe doesn't
+   * need to touch the EventSource — it just removes from the Set.
+   */
+  private registerEventDispatch(event: string): void {
+    if (!this.source) return;
+    this.source.addEventListener(event, ((e: MessageEvent) => {
+      const set = this.listeners.get(event);
+      if (!set || set.size === 0) return;
+      try {
+        const data = JSON.parse(e.data);
+        for (const listener of set) {
+          listener(data);
+        }
+      } catch {
+        // Malformed JSON — skip
+      }
+    }) as EventListener);
+  }
+
+  private notifyConnectionChange(connected: boolean): void {
+    for (const cb of this.connectionChangeListeners) {
+      try {
+        cb(connected);
+      } catch {
+        /* listener error — don't propagate */
+      }
+    }
+  }
+}

--- a/packages/client/src/event-bus.ts
+++ b/packages/client/src/event-bus.ts
@@ -61,7 +61,6 @@ export class EventBus {
 
     return () => {
       set!.delete(listener);
-      if (set!.size === 0) this.listeners.delete(event);
     };
   }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -59,3 +59,11 @@ export type { MitzoConnectionConfig, ConnectionListener } from './connection.js'
 // WS connection (v1 — legacy, used by frontend ws-pool consumers)
 export { WsPool } from './ws-connection.js';
 export type { WsPoolConfig, WebSocketLike, MsgListener } from './ws-connection.js';
+
+// SSE event bus (broadcast events)
+export { EventBus } from './event-bus.js';
+export type {
+  EventBusListener,
+  EventSourceFactory,
+  ConnectionChangeCallback,
+} from './event-bus.js';

--- a/packages/harness/__tests__/sse-registry.test.ts
+++ b/packages/harness/__tests__/sse-registry.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SseRegistry } from '../src/sse-registry.js';
+
+function mockResponse() {
+  return {
+    write: vi.fn(),
+    end: vi.fn(),
+  } as unknown as import('express').Response;
+}
+
+describe('SseRegistry', () => {
+  let registry: SseRegistry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    registry = new SseRegistry();
+  });
+
+  afterEach(() => {
+    registry.destroy();
+    vi.useRealTimers();
+  });
+
+  it('starts with size 0', () => {
+    expect(registry.size).toBe(0);
+  });
+
+  it('tracks added clients', () => {
+    registry.add('c1', mockResponse());
+    expect(registry.size).toBe(1);
+
+    registry.add('c2', mockResponse());
+    expect(registry.size).toBe(2);
+  });
+
+  it('removes clients', () => {
+    registry.add('c1', mockResponse());
+    registry.remove('c1');
+    expect(registry.size).toBe(0);
+  });
+
+  it('remove is a no-op for unknown id', () => {
+    registry.remove('nonexistent');
+    expect(registry.size).toBe(0);
+  });
+
+  it('broadcasts to all clients', () => {
+    const r1 = mockResponse();
+    const r2 = mockResponse();
+    registry.add('c1', r1);
+    registry.add('c2', r2);
+
+    registry.broadcast('test_event', { foo: 'bar' });
+
+    const expected = 'event: test_event\ndata: {"foo":"bar"}\n\n';
+    expect(r1.write).toHaveBeenCalledWith(expected);
+    expect(r2.write).toHaveBeenCalledWith(expected);
+  });
+
+  it('skips broadcast when no clients', () => {
+    // Should not throw
+    registry.broadcast('test_event', {});
+  });
+
+  it('removes dead clients on broadcast failure', () => {
+    const r1 = mockResponse();
+    const r2 = mockResponse();
+    (r1.write as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('connection reset');
+    });
+
+    registry.add('c1', r1);
+    registry.add('c2', r2);
+    registry.broadcast('test_event', {});
+
+    expect(registry.size).toBe(1);
+    expect(r2.write).toHaveBeenCalled();
+  });
+
+  it('sendTo delivers to a specific client', () => {
+    const r1 = mockResponse();
+    const r2 = mockResponse();
+    registry.add('c1', r1);
+    registry.add('c2', r2);
+
+    const result = registry.sendTo('c1', 'hydrate', [1, 2, 3]);
+
+    expect(result).toBe(true);
+    expect(r1.write).toHaveBeenCalledWith('event: hydrate\ndata: [1,2,3]\n\n');
+    expect(r2.write).not.toHaveBeenCalled();
+  });
+
+  it('sendTo returns false for unknown client', () => {
+    expect(registry.sendTo('missing', 'test', {})).toBe(false);
+  });
+
+  it('sendTo removes client on write failure', () => {
+    const res = mockResponse();
+    (res.write as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('broken');
+    });
+    registry.add('c1', res);
+
+    const result = registry.sendTo('c1', 'test', {});
+    expect(result).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('starts heartbeat on first client', () => {
+    const res = mockResponse();
+    registry.add('c1', res);
+
+    vi.advanceTimersByTime(30_000);
+    expect(res.write).toHaveBeenCalledWith(':heartbeat\n\n');
+  });
+
+  it('stops heartbeat when last client disconnects', () => {
+    const res = mockResponse();
+    registry.add('c1', res);
+    registry.remove('c1');
+
+    vi.advanceTimersByTime(30_000);
+    // Only the initial add, no heartbeat write
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  it('cleans up dead connections during heartbeat', () => {
+    const r1 = mockResponse();
+    const r2 = mockResponse();
+    (r1.write as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('dead');
+    });
+
+    registry.add('c1', r1);
+    registry.add('c2', r2);
+
+    vi.advanceTimersByTime(30_000);
+
+    expect(registry.size).toBe(1);
+  });
+
+  it('destroy closes all connections and stops heartbeat', () => {
+    const r1 = mockResponse();
+    const r2 = mockResponse();
+    registry.add('c1', r1);
+    registry.add('c2', r2);
+
+    registry.destroy();
+
+    expect(r1.end).toHaveBeenCalled();
+    expect(r2.end).toHaveBeenCalled();
+    expect(registry.size).toBe(0);
+
+    // Heartbeat should be stopped — no writes after destroy
+    vi.advanceTimersByTime(30_000);
+    expect(r1.write).not.toHaveBeenCalled();
+  });
+});

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -26,6 +26,7 @@ export {
   removePending,
   hasPending,
   denyPendingBySession,
+  getPendingCountBySession,
 } from './permissions.js';
 
 // Tool tiers

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -15,6 +15,10 @@ export type {
 export { ConnectionRegistry } from './connection-registry.js';
 export type { Connection } from './connection-registry.js';
 
+// SSE registry (broadcast events)
+export { SseRegistry } from './sse-registry.js';
+export type { SseClient } from './sse-registry.js';
+
 // Permissions
 export {
   registerPending,

--- a/packages/harness/src/permissions.ts
+++ b/packages/harness/src/permissions.ts
@@ -63,12 +63,7 @@ export function hasPending(permId: string): boolean {
 }
 
 /**
- * Deny all pending permission requests associated with a session.
- * Used during session takeover to clean up stale prompts on the old device.
- */
-/**
  * Count pending permission requests for a specific session.
- * Used by session-overview to derive the 'waiting' state.
  */
 export function getPendingCountBySession(sessionId: string): number {
   let count = 0;
@@ -78,6 +73,9 @@ export function getPendingCountBySession(sessionId: string): number {
   return count;
 }
 
+/**
+ * Deny all pending permission requests associated with a session.
+ */
 export function denyPendingBySession(sessionId: string): number {
   let denied = 0;
   for (const [permId, entry] of pending) {

--- a/packages/harness/src/permissions.ts
+++ b/packages/harness/src/permissions.ts
@@ -66,6 +66,18 @@ export function hasPending(permId: string): boolean {
  * Deny all pending permission requests associated with a session.
  * Used during session takeover to clean up stale prompts on the old device.
  */
+/**
+ * Count pending permission requests for a specific session.
+ * Used by session-overview to derive the 'waiting' state.
+ */
+export function getPendingCountBySession(sessionId: string): number {
+  let count = 0;
+  for (const entry of pending.values()) {
+    if (entry.sessionId === sessionId) count++;
+  }
+  return count;
+}
+
 export function denyPendingBySession(sessionId: string): number {
   let denied = 0;
   for (const [permId, entry] of pending) {

--- a/packages/harness/src/sse-registry.ts
+++ b/packages/harness/src/sse-registry.ts
@@ -127,7 +127,8 @@ export class SseRegistry {
         try {
           client.res.write(payload);
         } catch {
-          // Write failed — connection dead, will be cleaned up on next broadcast
+          // Write failed — clean up dead connection immediately
+          this.remove(client.id);
         }
       }
     }, HEARTBEAT_INTERVAL_MS);

--- a/packages/harness/src/sse-registry.ts
+++ b/packages/harness/src/sse-registry.ts
@@ -1,0 +1,162 @@
+/**
+ * SseRegistry — manages Server-Sent Events connections for broadcast events.
+ *
+ * Unlike WebSocket (bidirectional, per-session), SSE is unidirectional
+ * (server → client) and global (not tied to a specific session). It delivers
+ * broadcast data like session state changes, task updates, todo changes, and
+ * health status.
+ *
+ * Auto-reconnects natively via EventSource (client-side) — no custom reconnect
+ * logic needed. Each client gets a fresh snapshot on connect (hydration).
+ */
+
+import type { Response } from 'express';
+import { createLogger } from './logger.js';
+
+const log = createLogger('sse');
+
+const HEARTBEAT_INTERVAL_MS = 30_000; // 30s — keeps connection alive through proxies
+
+export interface SseClient {
+  id: string;
+  res: Response;
+}
+
+export class SseRegistry {
+  private clients = new Map<string, SseClient>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Register a new SSE client. Starts heartbeat if this is the first client.
+   * The response object must have headers already written
+   * (Content-Type: text/event-stream, etc.) before calling this.
+   */
+  add(id: string, res: Response): void {
+    this.clients.set(id, { id, res });
+    log.info('SSE client connected', { id, total: this.clients.size });
+
+    if (this.clients.size === 1) {
+      this.startHeartbeat();
+    }
+  }
+
+  /**
+   * Remove a client (on close/error). Stops heartbeat if this was the last client.
+   */
+  remove(id: string): void {
+    if (!this.clients.has(id)) return;
+
+    this.clients.delete(id);
+    log.info('SSE client disconnected', { id, total: this.clients.size });
+
+    if (this.clients.size === 0) {
+      this.stopHeartbeat();
+    }
+  }
+
+  /**
+   * Send a typed event to all connected clients.
+   * SSE format:
+   *   event: <type>\n
+   *   data: <json>\n
+   *   \n
+   */
+  broadcast(event: string, data: unknown): void {
+    if (this.clients.size === 0) return;
+
+    const payload = this.formatEvent(event, data);
+    let sent = 0;
+    const failures: string[] = [];
+
+    for (const [id, client] of this.clients) {
+      try {
+        client.res.write(payload);
+        sent++;
+      } catch (err) {
+        failures.push(id);
+        log.warn('SSE broadcast write failed', { id, event, error: String(err) });
+      }
+    }
+
+    log.debug('SSE broadcast', { event, sent, failures: failures.length });
+
+    // Clean up dead connections
+    for (const id of failures) {
+      this.remove(id);
+    }
+  }
+
+  /**
+   * Send a typed event to a specific client (for hydration on connect).
+   */
+  sendTo(clientId: string, event: string, data: unknown): boolean {
+    const client = this.clients.get(clientId);
+    if (!client) return false;
+
+    const payload = this.formatEvent(event, data);
+    try {
+      client.res.write(payload);
+      return true;
+    } catch (err) {
+      log.warn('SSE sendTo failed', { clientId, event, error: String(err) });
+      this.remove(clientId);
+      return false;
+    }
+  }
+
+  /**
+   * Number of connected clients.
+   */
+  get size(): number {
+    return this.clients.size;
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private formatEvent(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+
+    log.info('Starting SSE heartbeat', { intervalMs: HEARTBEAT_INTERVAL_MS });
+    this.heartbeatTimer = setInterval(() => {
+      const payload = ':heartbeat\n\n'; // SSE comment line — ignored by EventSource
+      for (const [, client] of this.clients) {
+        try {
+          client.res.write(payload);
+        } catch {
+          // Write failed — connection dead, will be cleaned up on next broadcast
+        }
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+
+    log.info('Stopping SSE heartbeat');
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  /**
+   * Cleanup: close all connections and stop heartbeat.
+   * Call on server shutdown.
+   */
+  destroy(): void {
+    log.info('Destroying SSE registry', { clients: this.clients.size });
+    this.stopHeartbeat();
+
+    for (const [, client] of this.clients) {
+      try {
+        client.res.end();
+      } catch {
+        // Best effort
+      }
+    }
+
+    this.clients.clear();
+  }
+}

--- a/server/__tests__/session-overview.test.ts
+++ b/server/__tests__/session-overview.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionOverviewEmitter, type SessionOverviewDeps } from '../session-overview.js';
+import type { ActiveSessionInfo } from '@mitzo/harness';
+import type { LoopStatus } from '../task-orchestrator.js';
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function makeActiveSession(overrides: Partial<ActiveSessionInfo> = {}): ActiveSessionInfo {
+  return {
+    clientId: 'client-1',
+    sessionId: 'session-1',
+    mode: 'auto',
+    cwd: '/Users/test/tools/mitzo',
+    attached: true,
+    cumulativeSessionTokens: 0,
+    cumulativeCostUsd: 0,
+    hasSnapshot: false,
+    taskContext: null,
+    observerCount: 0,
+    ...overrides,
+  };
+}
+
+function idleLoopStatus(): LoopStatus {
+  return {
+    state: 'idle',
+    goalId: null,
+    activeTaskId: null,
+    progress: null,
+    specMode: false,
+    awaitingApproval: false,
+  };
+}
+
+function makeDeps(overrides: Partial<SessionOverviewDeps> = {}): SessionOverviewDeps {
+  return {
+    registry: {
+      getActiveSessions: vi.fn(() => []),
+    } as unknown as SessionOverviewDeps['registry'],
+    sseRegistry: {
+      broadcast: vi.fn(),
+      sendTo: vi.fn(),
+    } as unknown as SessionOverviewDeps['sseRegistry'],
+    getLoopStatus: vi.fn(() => idleLoopStatus()),
+    taskStore: {
+      getTree: vi.fn(() => []),
+    } as unknown as SessionOverviewDeps['taskStore'],
+    getSessionTitle: vi.fn(() => undefined),
+    ...overrides,
+  };
+}
+
+// ─── Mock the permissions module ──────────────────────────────────────────────
+
+vi.mock('@mitzo/harness', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getPendingCountBySession: vi.fn(() => 0),
+  };
+});
+
+import { getPendingCountBySession } from '@mitzo/harness';
+const mockGetPending = getPendingCountBySession as ReturnType<typeof vi.fn>;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SessionOverviewEmitter', () => {
+  let emitter: SessionOverviewEmitter;
+  let deps: SessionOverviewDeps;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetPending.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    emitter?.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // ─── getSnapshot ──────────────────────────────────────────────────────────
+
+  it('returns empty array when no active sessions', () => {
+    deps = makeDeps();
+    emitter = new SessionOverviewEmitter(deps);
+
+    expect(emitter.getSnapshot()).toEqual([]);
+  });
+
+  it('skips sessions without sessionId', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ sessionId: undefined })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    expect(emitter.getSnapshot()).toEqual([]);
+  });
+
+  it('derives "working" state when session has snapshot', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: true })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].state).toBe('working');
+  });
+
+  it('derives "done" state when session just finished', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: false, attached: true })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    // Touch with recent timestamp
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].state).toBe('done');
+  });
+
+  it('derives "idle" state when done timeout expired', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: false, attached: true })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    // Touch, then advance time past DONE_TIMEOUT_MS (5 min)
+    emitter.touch('client-1');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].state).toBe('idle');
+  });
+
+  it('derives "waiting" state with permission reason', () => {
+    mockGetPending.mockReturnValue(1);
+
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: true })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].state).toBe('waiting');
+    expect(activities[0].waitReason).toBe('permission');
+    // "working" should be in flags since snapshot is true
+    expect(activities[0].flags).toContain('working');
+  });
+
+  it('derives "paused" state from ATB loop', () => {
+    const goalId = 'goal-1';
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ taskContext: { currentTaskId: 'task-1', goalId } }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+      getLoopStatus: vi.fn(() => ({
+        ...idleLoopStatus(),
+        state: 'paused' as const,
+        goalId,
+      })),
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('paused');
+  });
+
+  it('includes ATB progress when loop is running', () => {
+    const goalId = 'goal-1';
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ taskContext: { currentTaskId: 'task-1', goalId } }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+      getLoopStatus: vi.fn(() => ({
+        ...idleLoopStatus(),
+        state: 'running' as const,
+        goalId,
+        progress: { done: 2, total: 5 },
+      })),
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('working');
+    expect(activities[0].progress).toEqual({ done: 2, total: 5 });
+  });
+
+  it('derives "waiting" with review reason from ATB awaiting approval', () => {
+    const goalId = 'goal-1';
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ taskContext: { currentTaskId: 'task-1', goalId } }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+      getLoopStatus: vi.fn(() => ({
+        ...idleLoopStatus(),
+        state: 'running' as const,
+        goalId,
+        awaitingApproval: true,
+      })),
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('waiting');
+    expect(activities[0].waitReason).toBe('review');
+  });
+
+  it('derives repo name from cwd', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/tools/mitzo' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].repo).toBe('mitzo');
+  });
+
+  it('strips worktree suffix from repo name', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({
+            cwd: '/Users/test/redhat/mgmt/.claude/worktrees/abc123',
+          }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].repo).toBe('mgmt');
+  });
+
+  it('uses session title from eventStore', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession()]),
+      } as unknown as SessionOverviewDeps['registry'],
+      getSessionTitle: vi.fn(() => 'Fix auth bug'),
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].title).toBe('Fix auth bug');
+  });
+
+  it('falls back to session ID suffix when no title', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ sessionId: 'abcdef12-3456-7890' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      getSessionTitle: vi.fn(() => undefined),
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].title).toBe('456-7890');
+  });
+
+  // ─── Coalescing ───────────────────────────────────────────────────────────
+
+  it('coalesces multiple scheduleBroadcast calls within 200ms', () => {
+    deps = makeDeps();
+    emitter = new SessionOverviewEmitter(deps);
+    const broadcast = deps.sseRegistry.broadcast as ReturnType<typeof vi.fn>;
+
+    emitter.scheduleBroadcast();
+    emitter.scheduleBroadcast();
+    emitter.scheduleBroadcast();
+
+    expect(broadcast).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(200);
+
+    expect(broadcast).toHaveBeenCalledTimes(1);
+    expect(broadcast).toHaveBeenCalledWith('session_activity', []);
+  });
+
+  it('broadcasts again after coalesce window', () => {
+    deps = makeDeps();
+    emitter = new SessionOverviewEmitter(deps);
+    const broadcast = deps.sseRegistry.broadcast as ReturnType<typeof vi.fn>;
+
+    emitter.scheduleBroadcast();
+    vi.advanceTimersByTime(200);
+    expect(broadcast).toHaveBeenCalledTimes(1);
+
+    emitter.scheduleBroadcast();
+    vi.advanceTimersByTime(200);
+    expect(broadcast).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── touch / forget ───────────────────────────────────────────────────────
+
+  it('forget removes tracked session', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession()]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    emitter.touch('client-1');
+    emitter.forget('client-1');
+
+    // After forget, lastEventAt defaults to now → state depends on current time
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    // Session still shows (from registry), just with fresh timestamp
+  });
+
+  // ─── Task wait state ──────────────────────────────────────────────────────
+
+  it('derives "waiting" with blocked reason from task store', () => {
+    const goalId = 'goal-1';
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ taskContext: { currentTaskId: 'task-1', goalId } }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+      taskStore: {
+        getTree: vi.fn(() => [
+          { id: goalId, parentId: null, status: 'active' },
+          { id: 'child-1', parentId: goalId, status: 'blocked' },
+        ]),
+      } as unknown as SessionOverviewDeps['taskStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('waiting');
+    expect(activities[0].waitReason).toBe('blocked');
+  });
+
+  it('derives "waiting" with review reason from pending_review task', () => {
+    const goalId = 'goal-1';
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ taskContext: { currentTaskId: 'task-1', goalId } }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+      taskStore: {
+        getTree: vi.fn(() => [
+          { id: goalId, parentId: null, status: 'active' },
+          { id: 'child-1', parentId: goalId, status: 'pending_review' },
+        ]),
+      } as unknown as SessionOverviewDeps['taskStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('waiting');
+    expect(activities[0].waitReason).toBe('review');
+  });
+
+  // ─── Detached sessions ────────────────────────────────────────────────────
+
+  it('derives "done" for recently detached session', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ attached: false, hasSnapshot: false }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('done');
+  });
+
+  it('derives "idle" for detached session past timeout', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [
+          makeActiveSession({ attached: false, hasSnapshot: false }),
+        ]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('idle');
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { join, dirname, resolve, extname } from 'path';
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { fileURLToPath } from 'url';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { login, authMiddleware, verifyToken, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
@@ -82,6 +82,7 @@ import { SkillRegistry } from './skills.js';
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { TaskStore, type TaskCreateInput, type TaskUpdateInput } from './task-store.js';
+import { SseRegistry } from '@mitzo/harness';
 import { WorkloadStore, type WorkSignal, type TodoItemUpdateInput } from './workload-store.js';
 
 const log = createLogger('server');
@@ -236,6 +237,8 @@ export const taskStore = new TaskStore(join(mitzoDir, 'tasks.db'));
 setTaskStore(taskStore);
 export const workloadStore = new WorkloadStore(taskStore.getDatabase());
 setTokenStorePath(join(mitzoDir, 'device-tokens.json'));
+
+export const sseRegistry = new SseRegistry();
 
 export function setUpdateBroadcast(fn: () => void) {
   onUpdateAvailable = fn;
@@ -486,6 +489,27 @@ app.post('/api/sessions/suspend', (req, res) => {
 });
 
 app.use('/api', authMiddleware);
+
+// --- SSE Event Bus ---
+
+app.get('/api/events', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no', // nginx: don't buffer SSE
+  });
+
+  const clientId = randomUUID();
+  sseRegistry.add(clientId, res);
+
+  // Hydrate: send server version on connect
+  sseRegistry.sendTo(clientId, 'connected', {
+    serverVersion: buildHash,
+  });
+
+  req.on('close', () => sseRegistry.remove(clientId));
+});
 
 // --- Task Board API ---
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -66,6 +66,7 @@ import {
   WorkloadPromoteBody,
 } from './api-schemas.js';
 import type { TaskOrchestrator } from './task-orchestrator.js';
+import type { SessionOverviewEmitter } from './session-overview.js';
 import type { WorkflowTemplateStore, TemplateCreateInput } from './workflow-templates.js';
 import { instantiateTemplate } from './workflow-templates.js';
 import type { SignalProcessor } from './signal-processor.js';
@@ -212,9 +213,14 @@ let onWorkloadBroadcast: ((event: Record<string, unknown>) => void) | null = nul
 let orchestrator: TaskOrchestrator | null = null;
 let templateStore: WorkflowTemplateStore | null = null;
 let signalProcessor: SignalProcessor | null = null;
+let overviewEmitter: SessionOverviewEmitter | null = null;
 
 export function setOrchestrator(o: TaskOrchestrator): void {
   orchestrator = o;
+}
+
+export function setOverviewEmitter(emitter: SessionOverviewEmitter): void {
+  overviewEmitter = emitter;
 }
 
 export function setTemplateStore(ts: WorkflowTemplateStore): void {
@@ -503,10 +509,14 @@ app.get('/api/events', (req, res) => {
   const clientId = randomUUID();
   sseRegistry.add(clientId, res);
 
-  // Hydrate: send server version on connect
+  // Hydrate: send server version + session overview on connect
   sseRegistry.sendTo(clientId, 'connected', {
     serverVersion: buildHash,
   });
+
+  if (overviewEmitter) {
+    sseRegistry.sendTo(clientId, 'session_activity', overviewEmitter.getSnapshot());
+  }
 
   req.on('close', () => sseRegistry.remove(clientId));
 });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -44,6 +44,12 @@ let _connRegistry: ConnectionRegistry | null = null;
 export function setConnectionRegistry(registry: ConnectionRegistry): void {
   _connRegistry = registry;
 }
+
+type SessionChangeCallback = (clientId: string, event: 'start' | 'end' | 'turn_end') => void;
+let _onSessionChange: SessionChangeCallback | null = null;
+export function setSessionChangeCallback(cb: SessionChangeCallback): void {
+  _onSessionChange = cb;
+}
 import { EventStore } from './event-store.js';
 import { capturePromptComparison } from './prompt-compare.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
@@ -660,6 +666,7 @@ async function _startChatInner(
 
   const session = registry.get(clientId)!;
   session.inputQueue = inputQueue as { push: (msg: unknown) => void; close: () => void };
+  _onSessionChange?.(clientId, 'start');
 
   // Copy all repo worktrees into the session for cleanup tracking
   for (const [name, info] of repoWorktrees) {
@@ -779,6 +786,9 @@ async function _startChatInner(
             /* errors logged internally */
           });
         },
+        onTurnEnd: (cId: string) => {
+          _onSessionChange?.(cId, 'turn_end');
+        },
       },
     );
   } catch (err: unknown) {
@@ -797,8 +807,7 @@ async function _startChatInner(
     if (failedSession) cleanupSessionWorktrees(failedSession);
     registry.abort(clientId);
   } finally {
-    // Phase 2e: worktrees survive until explicit close or stale GC.
-    // Only failed sessions (caught above) clean up their worktrees.
+    _onSessionChange?.(clientId, 'end');
   }
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -819,6 +819,7 @@ function shutdown(signal: string) {
   signalProc.unwatchAll();
   wfTemplateStore.close();
   overviewEmitter.destroy();
+  sseRegistry.destroy();
   registry.dispose();
   for (const client of wss.clients) {
     client.close(1001, 'Server shutting down');

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import {
   eventStore,
   getRepoConfig,
   setConnectionRegistry,
+  setSessionChangeCallback,
   reconcileSessionsBackground,
 } from './chat.js';
 import { cleanupStaleWorktrees, countWorktrees } from './worktree.js';
@@ -50,6 +51,7 @@ import {
   setOrchestrator,
   setTemplateStore,
   setSignalProcessor,
+  setOverviewEmitter,
   runUpdateCheck,
   buildSkillRegistry,
   NATIVE_COMMAND_NAMES,
@@ -61,6 +63,7 @@ import {
 import { WorkflowTemplateStore, seedBuiltInTemplates } from './workflow-templates.js';
 import { SignalProcessor } from './signal-processor.js';
 import { TaskOrchestrator } from './task-orchestrator.js';
+import { SessionOverviewEmitter } from './session-overview.js';
 import { IncomingWsMessage } from './ws-schemas.js';
 import { resolvePending } from './permissions.js';
 import { resolveSlashCommand } from './slash-commands.js';
@@ -127,6 +130,7 @@ setTaskBroadcast((event) => {
   });
   connRegistry.broadcastAll(event as Record<string, unknown>);
   sseRegistry.broadcast('task_state', event);
+  overviewEmitter.scheduleBroadcast();
 });
 
 setWorkloadBroadcast((event) => {
@@ -189,6 +193,7 @@ const orchestrator = new TaskOrchestrator({
     });
     connRegistry.broadcastAll(data);
     sseRegistry.broadcast('loop_status', status);
+    overviewEmitter.scheduleBroadcast();
   },
   broadcastTasks: () => {
     const tree = taskStore.getTree();
@@ -212,6 +217,28 @@ const orchestrator = new TaskOrchestrator({
 });
 orchestratorRef = orchestrator;
 setOrchestrator(orchestrator);
+
+// --- Session Overview Emitter (SSE broadcast) ---
+const overviewEmitter = new SessionOverviewEmitter({
+  registry,
+  sseRegistry,
+  getLoopStatus: () => orchestrator.getStatus(),
+  taskStore,
+  getSessionTitle: (id: string) => eventStore.getSession(id)?.summary ?? undefined,
+});
+setOverviewEmitter(overviewEmitter);
+
+// Hook session lifecycle events into the overview emitter
+setSessionChangeCallback((clientId, event) => {
+  if (event === 'start') {
+    overviewEmitter.touch(clientId);
+  } else if (event === 'end') {
+    overviewEmitter.forget(clientId);
+  } else if (event === 'turn_end') {
+    overviewEmitter.touch(clientId);
+  }
+  overviewEmitter.scheduleBroadcast();
+});
 
 server.on('upgrade', async (req, socket, head) => {
   const url = new URL(req.url || '', `http://${req.headers.host}`);
@@ -351,6 +378,8 @@ function handleChatWsV2(ws: WebSocket, connectionId: string) {
           { 'session.sessionId': sessionId, 'ws.connectionId': connectionId },
           () => {
             detachChat(found.clientId);
+            overviewEmitter.touch(found.clientId);
+            overviewEmitter.scheduleBroadcast();
             log.info('v2 session detached (surviving)', { connectionId, sessionId });
           },
         );
@@ -770,6 +799,8 @@ function handleChatWs(
       (span) => {
         if (isActive(clientId)) {
           detachChat(clientId);
+          overviewEmitter.touch(clientId);
+          overviewEmitter.scheduleBroadcast();
           span.setAttribute('ws.disconnect.detached', true);
           log.info('session detached (surviving)', { clientId });
         }
@@ -787,6 +818,7 @@ function shutdown(signal: string) {
   server.close();
   signalProc.unwatchAll();
   wfTemplateStore.close();
+  overviewEmitter.destroy();
   registry.dispose();
   for (const client of wss.clients) {
     client.close(1001, 'Server shutting down');

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import {
 import { createLogger } from './logger.js';
 import {
   app,
+  sseRegistry,
   setUpdateBroadcast,
   setInboxBroadcast,
   setTaskBroadcast,
@@ -104,6 +105,7 @@ setUpdateBroadcast(() => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(data);
+  sseRegistry.broadcast('update_available', {});
 });
 
 setInboxBroadcast(() => {
@@ -114,6 +116,7 @@ setInboxBroadcast(() => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(data);
+  sseRegistry.broadcast('inbox_updated', {});
 });
 
 setTaskBroadcast((event) => {
@@ -123,6 +126,7 @@ setTaskBroadcast((event) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(event as Record<string, unknown>);
+  sseRegistry.broadcast('task_state', event);
 });
 
 setWorkloadBroadcast((event) => {
@@ -132,6 +136,7 @@ setWorkloadBroadcast((event) => {
     if (client.readyState === client.OPEN) client.send(msg);
   });
   connRegistry.broadcastAll(event as Record<string, unknown>);
+  sseRegistry.broadcast('todo_update', { action: 'refresh' });
 });
 
 // --- Workflow layer ---
@@ -183,6 +188,7 @@ const orchestrator = new TaskOrchestrator({
       if (client.readyState === client.OPEN) client.send(msg);
     });
     connRegistry.broadcastAll(data);
+    sseRegistry.broadcast('loop_status', status);
   },
   broadcastTasks: () => {
     const tree = taskStore.getTree();
@@ -193,6 +199,7 @@ const orchestrator = new TaskOrchestrator({
       if (client.readyState === client.OPEN) client.send(msg);
     });
     connRegistry.broadcastAll(data as Record<string, unknown>);
+    sseRegistry.broadcast('task_state', data);
   },
   getActiveSessionIds: () => {
     const ids = new Set<string>();

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -126,6 +126,8 @@ export interface QueryLoopOptions {
   onSessionResolved?: (sessionId: string) => void;
   /** Called after the initial prompt is registered, enabling auto-rename on prompt 1. */
   onInitialPrompt?: (sessionId: string) => void;
+  /** Called when an assistant turn completes (snapshot cleared). */
+  onTurnEnd?: (clientId: string) => void;
 }
 
 export async function runQueryLoop(
@@ -231,6 +233,7 @@ async function _runQueryLoopInner(
         currentTurnSpan.end();
         currentTurnSpan = null;
       }
+      options?.onTurnEnd?.(clientId);
     }
   }
 

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -1,0 +1,283 @@
+/**
+ * Session Overview — computes SessionActivity[] from server-side registries
+ * and broadcasts via SSE with coalescing.
+ *
+ * State is derived lazily at broadcast time — no stored state, no timers for
+ * timeout transitions. This avoids divergence across multiple clients.
+ */
+
+import type { SessionRegistry, ActiveSessionInfo } from '@mitzo/harness';
+import type { SseRegistry } from '@mitzo/harness';
+import { getPendingCountBySession } from '@mitzo/harness';
+import type { LoopStatus } from './task-orchestrator.js';
+import type { TaskStore } from './task-store.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('session-overview');
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SessionActivityState = 'init' | 'working' | 'waiting' | 'done' | 'idle' | 'paused';
+
+export type WaitReason = 'permission' | 'review' | 'blocked';
+
+export interface SessionActivity {
+  sessionId: string;
+  clientId: string;
+  title: string;
+  repo?: string;
+  state: SessionActivityState;
+  flags: SessionActivityState[];
+  waitReason?: WaitReason;
+  progress?: { done: number; total: number };
+  lastEventAt: number;
+  taskId?: string;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Done → Idle after 5 minutes of inactivity. */
+const DONE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Coalesce broadcasts within this window to avoid re-render storms. */
+const COALESCE_MS = 200;
+
+// ─── State priority for "highest wins" ────────────────────────────────────────
+
+const STATE_PRIORITY: Record<SessionActivityState, number> = {
+  idle: 0,
+  init: 1,
+  paused: 2,
+  done: 3,
+  working: 4,
+  waiting: 5,
+};
+
+// ─── Dependencies ─────────────────────────────────────────────────────────────
+
+export interface SessionOverviewDeps {
+  registry: SessionRegistry;
+  sseRegistry: SseRegistry;
+  getLoopStatus: () => LoopStatus;
+  taskStore: TaskStore;
+  /** Resolve session title. Typically eventStore.getSession(id)?.summary */
+  getSessionTitle: (sessionId: string) => string | undefined;
+}
+
+// ─── Emitter ──────────────────────────────────────────────────────────────────
+
+export class SessionOverviewEmitter {
+  private deps: SessionOverviewDeps;
+  private coalesceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Track last assistant event time per clientId for timeout derivation. */
+  private lastEventTimes = new Map<string, number>();
+
+  constructor(deps: SessionOverviewDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Record an event time for a session (call on turn start/end, attach, etc.).
+   * Used for Done → Idle timeout derivation.
+   */
+  touch(clientId: string): void {
+    this.lastEventTimes.set(clientId, Date.now());
+  }
+
+  /**
+   * Clean up tracking for a removed session.
+   */
+  forget(clientId: string): void {
+    this.lastEventTimes.delete(clientId);
+  }
+
+  /**
+   * Schedule a coalesced broadcast. Multiple calls within COALESCE_MS
+   * collapse into a single broadcast.
+   */
+  scheduleBroadcast(): void {
+    if (this.coalesceTimer) return;
+    this.coalesceTimer = setTimeout(() => {
+      this.coalesceTimer = null;
+      this.broadcast();
+    }, COALESCE_MS);
+  }
+
+  /**
+   * Compute the current snapshot and broadcast immediately.
+   * Used for hydration (new SSE client).
+   */
+  getSnapshot(): SessionActivity[] {
+    return this.compute();
+  }
+
+  /**
+   * Broadcast the current snapshot to all SSE clients.
+   */
+  private broadcast(): void {
+    const activities = this.compute();
+    this.deps.sseRegistry.broadcast('session_activity', activities);
+    log.debug('broadcast session_activity', { count: activities.length });
+  }
+
+  /**
+   * Compute SessionActivity[] from all active sessions.
+   * State is derived purely from current data — no stored state.
+   */
+  private compute(): SessionActivity[] {
+    const now = Date.now();
+    const activeSessions = this.deps.registry.getActiveSessions();
+    const loopStatus = this.deps.getLoopStatus();
+
+    return activeSessions
+      .filter((s) => s.sessionId) // Skip sessions without SDK IDs
+      .map((s) => this.deriveActivity(s, loopStatus, now));
+  }
+
+  private deriveActivity(
+    session: ActiveSessionInfo,
+    loopStatus: LoopStatus,
+    now: number,
+  ): SessionActivity {
+    const sessionId = session.sessionId!;
+    const lastEventAt = this.lastEventTimes.get(session.clientId) ?? now;
+    const elapsed = now - lastEventAt;
+
+    // Collect all applicable states
+    const states: SessionActivityState[] = [];
+    let waitReason: WaitReason | undefined;
+    let progress: { done: number; total: number } | undefined;
+    let taskId: string | undefined;
+
+    // 1. Permission check — "Waiting" for permission
+    const pendingCount = getPendingCountBySession(sessionId);
+    if (pendingCount > 0) {
+      states.push('waiting');
+      waitReason = 'permission';
+    }
+
+    // 2. Task board — check for blocked/pending_review tasks linked to this session
+    if (session.taskContext) {
+      taskId = session.taskContext.goalId;
+      const taskWait = this.checkTaskWaitState(session.taskContext.goalId);
+      if (taskWait) {
+        states.push('waiting');
+        if (!waitReason) waitReason = taskWait;
+      }
+    }
+
+    // 3. ATB loop — check if this session is running the loop
+    if (loopStatus.state === 'running' && loopStatus.goalId) {
+      // Check if this session is the loop's pinned session
+      if (session.taskContext?.goalId === loopStatus.goalId) {
+        states.push('working');
+        if (loopStatus.progress) {
+          progress = loopStatus.progress;
+        }
+        if (loopStatus.awaitingApproval) {
+          states.push('waiting');
+          if (!waitReason) waitReason = 'review';
+        }
+      }
+    }
+
+    if (loopStatus.state === 'paused' && session.taskContext?.goalId === loopStatus.goalId) {
+      states.push('paused');
+    }
+
+    // 4. Transport/streaming state
+    if (session.attached) {
+      if (session.hasSnapshot) {
+        // Currently streaming a response
+        states.push('working');
+      } else if (states.length === 0) {
+        // Attached but not streaming — either just finished or init
+        if (elapsed < DONE_TIMEOUT_MS) {
+          states.push('done');
+        } else {
+          states.push('idle');
+        }
+      }
+    } else {
+      // Detached
+      if (elapsed < DONE_TIMEOUT_MS) {
+        states.push('done');
+      } else {
+        states.push('idle');
+      }
+    }
+
+    // Fallback: if no states collected, it's init
+    if (states.length === 0) {
+      states.push('init');
+    }
+
+    // Highest-priority state wins as primary
+    const primaryState = states.reduce((best, s) =>
+      STATE_PRIORITY[s] > STATE_PRIORITY[best] ? s : best,
+    );
+
+    // Secondary flags = all other states (excluding primary, deduplicated)
+    const flags = [...new Set(states.filter((s) => s !== primaryState))];
+
+    // Derive title
+    const title = this.deps.getSessionTitle(sessionId) || sessionId.slice(-8);
+
+    // Derive repo from cwd
+    const repo = session.cwd ? extractRepoName(session.cwd) : undefined;
+
+    return {
+      sessionId,
+      clientId: session.clientId,
+      title,
+      repo,
+      state: primaryState,
+      flags,
+      waitReason: primaryState === 'waiting' ? waitReason : undefined,
+      progress,
+      lastEventAt,
+      taskId,
+    };
+  }
+
+  /**
+   * Check if any child task of a goal is blocked or pending_review.
+   */
+  private checkTaskWaitState(goalId: string): WaitReason | null {
+    const tree = this.deps.taskStore.getTree();
+    const goal = tree.find((t) => t.id === goalId);
+    if (!goal) return null;
+
+    // Check the goal and its children (flat tree — children follow parent)
+    for (const task of tree) {
+      if (task.id === goalId || task.parentId === goalId) {
+        if (task.status === 'pending_review') return 'review';
+        if (task.status === 'blocked') return 'blocked';
+      }
+    }
+    return null;
+  }
+
+  destroy(): void {
+    if (this.coalesceTimer) {
+      clearTimeout(this.coalesceTimer);
+      this.coalesceTimer = null;
+    }
+    this.lastEventTimes.clear();
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Extract a short repo name from a cwd path.
+ * e.g. "/Users/foo/tools/mitzo" → "mitzo"
+ *      "/Users/foo/redhat/mgmt/.claude/worktrees/abc123" → "mgmt"
+ */
+function extractRepoName(cwd: string): string {
+  // Strip worktree suffix: .claude/worktrees/<id> or .cursor/worktrees/<id>
+  const worktreeMatch = cwd.match(/^(.+?)\/\.(claude|cursor)\/worktrees\//);
+  const base = worktreeMatch ? worktreeMatch[1] : cwd;
+  const parts = base.split('/').filter(Boolean);
+  return parts[parts.length - 1] || 'unknown';
+}

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -248,7 +248,7 @@ export class SessionOverviewEmitter {
     const goal = tree.find((t) => t.id === goalId);
     if (!goal) return null;
 
-    // Check the goal and its children (flat tree — children follow parent)
+    // Check the goal and direct children only (single-level task decomposition)
     for (const task of tree) {
       if (task.id === goalId || task.parentId === goalId) {
         if (task.status === 'pending_review') return 'review';
@@ -276,7 +276,7 @@ export class SessionOverviewEmitter {
  */
 function extractRepoName(cwd: string): string {
   // Strip worktree suffix: .claude/worktrees/<id> or .cursor/worktrees/<id>
-  const worktreeMatch = cwd.match(/^(.+?)\/\.(claude|cursor)\/worktrees\//);
+  const worktreeMatch = cwd.match(/^(.+)\/\.(claude|cursor)\/worktrees\//);
   const base = worktreeMatch ? worktreeMatch[1] : cwd;
   const parts = base.split('/').filter(Boolean);
   return parts[parts.length - 1] || 'unknown';


### PR DESCRIPTION
## Summary

### Phase 1 — SSE Infrastructure
- **SseRegistry** (harness): server-side SSE connection manager with heartbeat (30s), broadcast to all clients, per-client `sendTo` for hydration, and graceful cleanup
- **GET /api/events** route: SSE endpoint with auth, `connected` event on hydration, proper headers (`text/event-stream`, `X-Accel-Buffering: no`)
- **Broadcast wiring**: all 6 server broadcast callbacks (`update_available`, `inbox_updated`, `task_state` x2, `todo_update`, `loop_status`) now also push to SSE
- **EventBus** (client): typed EventSource wrapper with `on(event, listener)` dispatch, `ensureConnected()` for iOS resume recovery, connection state tracking

### Phase 2 — Session Activity Overview
- **SessionOverviewEmitter** (server): derives session state (`working`, `waiting`, `done`, `idle`, `paused`) from registry + permissions + task store. Broadcasts via SSE with 200ms coalescing to prevent re-render storms
- **getPendingCountBySession** (harness): new permissions API to query pending permission count per session
- **Session change callbacks**: wired into chat lifecycle (start/end/turn_end) and query-loop for real-time state updates
- **useSessionOverview** hook (frontend): subscribes to `session_activity` SSE events, sorts by attend tier (waiting → done → working), computes `attendCount`
- **SessionOverview** component: collapsible card section on home page — auto-expands when sessions need attention, shows state icons, repo prefix, progress, elapsed time, red badge for attend count. Tap navigates to session

State is derived lazily at broadcast time — no stored state, no client-side timers. Server owns all timeout logic (Done → Idle after 5min).

Design doc: `mgmt/local_features/session-overview-widget/sse-event-bus.md`

## Test plan

- [x] 15 EventBus unit tests (Phase 1)
- [x] 20 SessionOverviewEmitter unit tests (state derivation, coalescing, timeouts, permissions, ATB progress, repo extraction)
- [x] 6 useSessionOverview hook tests (subscribe/unsubscribe, tier sorting, attend count)
- [x] 8 SessionOverview component tests (render states, badge, auto-expand, navigation, toggle)
- [x] Full test suite: 2351 passed, 2 failed (pre-existing timeout in chat.test.ts)
- [x] TypeScript compiles clean
- [ ] Manual: open home page → see active sessions widget
- [ ] Manual: start a session → card appears with "working" state
- [ ] Manual: trigger permission prompt → card switches to "waiting" with badge
- [ ] Manual: iOS background/foreground → SSE reconnects, widget updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)