### PR TITLE
fix(server): buffer pre-sessionId v2 events for iOS reconnect

### DIFF
--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -987,6 +987,78 @@ describe('runQueryLoop', () => {
       expect(userMsgs[0].payload).toMatchObject({ text: 'Follow-up question' });
     });
 
+    it('flushes pre-sessionId events to store when sessionId resolves (new session)', async () => {
+      // Simulate a brand-new session: no sessionId pre-set on the registry.
+      // Events emitted before the `assistant` completion should be buffered
+      // and retroactively persisted once the sessionId is known.
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-flush' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'buffered content' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-flush' },
+        { type: 'result', session_id: 'sess-flush' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, store);
+
+      const stored = store.getSessionEvents('sess-flush');
+      // All event types should be present — including those emitted before sessionId
+      expect(stored.some((e) => e.type === 'message_start')).toBe(true);
+      expect(stored.some((e) => e.type === 'block_start')).toBe(true);
+      expect(stored.some((e) => e.type === 'block_delta')).toBe(true);
+      expect(stored.some((e) => e.type === 'block_end')).toBe(true);
+      expect(stored.some((e) => e.type === 'message_end')).toBe(true);
+    });
+
+    it('persists events immediately when sessionId is pre-set (resumed session)', async () => {
+      // Simulate a resumed session: sessionId is known before the query loop
+      // starts (set by startChat passing options.resume to registry.register).
+      const session = registry.get(clientId)!;
+      session.sessionId = 'sess-resume-persist';
+
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-rp' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_start', index: 0, content_block: { type: 'text' } },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'text_delta', text: 'resumed content' },
+          },
+        },
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-resume-persist' },
+        { type: 'result', session_id: 'sess-resume-persist' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController, store);
+
+      const stored = store.getSessionEvents('sess-resume-persist');
+      expect(stored.some((e) => e.type === 'message_start')).toBe(true);
+      expect(stored.some((e) => e.type === 'block_delta')).toBe(true);
+      expect(stored.some((e) => e.type === 'message_end')).toBe(true);
+
+      // All v2 events should have the sessionId tag
+      for (const e of stored) {
+        expect(e.payload.sessionId).toBe('sess-resume-persist');
+      }
+    });
+
     it('works without a store (backward compatible)', async () => {
       const events: Record<string, unknown>[] = [
         { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-nostore' } } },

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -656,6 +656,12 @@ async function _startChatInner(
     wtId,
     sessionAllowList: new Set<string>(),
     worktreePath,
+    // For resumed sessions, set sessionId immediately so runQueryLoop can
+    // persist events from the very first SDK event. Without this, events
+    // emitted before the SDK's `assistant` completion (message_start,
+    // block_delta, etc.) are silently dropped from the EventStore — making
+    // assistant messages invisible after iOS WS reconnect.
+    ...(options.resume ? { sessionId: options.resume } : {}),
   });
 
   const session = registry.get(clientId)!;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -656,11 +656,7 @@ async function _startChatInner(
     wtId,
     sessionAllowList: new Set<string>(),
     worktreePath,
-    // For resumed sessions, set sessionId immediately so runQueryLoop can
-    // persist events from the very first SDK event. Without this, events
-    // emitted before the SDK's `assistant` completion (message_start,
-    // block_delta, etc.) are silently dropped from the EventStore — making
-    // assistant messages invisible after iOS WS reconnect.
+    // Set sessionId early so pre-assistant events are persisted (iOS reconnect).
     ...(options.resume ? { sessionId: options.resume } : {}),
   });
 

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -209,9 +209,29 @@ async function _runQueryLoopInner(
     durationApiMs: 0,
   };
 
+  // Buffer v2 events emitted before sessionId is known (first turn of new
+  // sessions). Once the sessionId resolves, these are flushed to the durable
+  // store so reconnecting clients can reconstruct the full message.
+  const preSessionBuffer: Record<string, unknown>[] = [];
+
   /** Wrapper that auto-injects store + sessionId + connRegistry into sendOrBuffer */
   function emit(data: Record<string, unknown>) {
+    if (!resolvedSessionId && data.v === 2) {
+      preSessionBuffer.push(data);
+    }
     sendOrBuffer(data, clientId, registry, store, resolvedSessionId, connRegistry);
+  }
+
+  /** Flush buffered pre-sessionId events to the durable store. */
+  function flushPreSessionBuffer() {
+    if (!store || !resolvedSessionId || preSessionBuffer.length === 0) return;
+    for (const event of preSessionBuffer) {
+      store.append(resolvedSessionId, event.type as string, {
+        ...event,
+        sessionId: resolvedSessionId,
+      });
+    }
+    preSessionBuffer.length = 0;
   }
 
   function nextBlockId(): string {
@@ -307,6 +327,7 @@ async function _runQueryLoopInner(
         if (!currentSession) break;
         if (!resolvedSessionId && currentSession.sessionId) {
           resolvedSessionId = currentSession.sessionId;
+          flushPreSessionBuffer();
           // Resumed sessions: load goalId from store so usage reporting works
           if (store && !resolvedGoalId) {
             const existingSession = store.getSession(resolvedSessionId);
@@ -334,6 +355,7 @@ async function _runQueryLoopInner(
           // Capture session ID on first assistant event.
           if (!currentSession.sessionId && msg.session_id) {
             resolvedSessionId = msg.session_id as string;
+            flushPreSessionBuffer();
             span.setAttribute('session.id', resolvedSessionId);
             registry.setSessionId(clientId, resolvedSessionId);
             onSessionResolved?.(resolvedSessionId);


### PR DESCRIPTION
## Summary

- **Adds a pre-session buffer** in the query loop that captures v2 events (message_start, block_delta, block_end, etc.) emitted before the sessionId resolves. Once the sessionId is known, the buffer flushes to the durable EventStore.
- **Passes sessionId immediately for resumed sessions** — `startChat` now sets `sessionId` on the registry entry when `options.resume` is provided, so events are persisted from the very first SDK event.
- **Adds two new tests** covering both new-session (buffer + flush) and resumed-session (immediate persist) scenarios. All 44 query-loop tests pass.

### Problem

On iOS, when a WebSocket reconnects and the session resumes, assistant messages could become invisible. Events emitted before the SDK's `assistant` completion (message_start, block_delta, etc.) were silently dropped from the EventStore because no sessionId was available yet to key the store append.

### Fix

1. **`server/query-loop.ts`**: Buffer v2 events in `preSessionBuffer[]` when `resolvedSessionId` is null. Call `flushPreSessionBuffer()` at both sessionId resolution points (resumed session path and new session path).
2. **`server/chat.ts`**: When starting a resumed session, spread `{ sessionId: options.resume }` into the registry entry so `resolvedSessionId` is non-null from the start.

## Test plan

- [x] `npx vitest run server/__tests__/query-loop.test.ts` — 44/44 pass
- [ ] Manual iOS test: start a session, kill the WS (background app), reconnect, verify assistant messages are visible
- [ ] Verify no duplicate events in EventStore after flush

🤖 Generated with [Claude Code](https://claude.com/claude-code)