### PR TITLE
feat(session): link Telos tasks to chat sessions

### DIFF
--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -132,7 +132,11 @@ export function ChatView() {
     // Set the context block for display
     storeDispatchMessages({ type: 'SET_SESSION_CONTEXT', context: pendingSession.context });
     // Auto-send the prompt
-    storeSendMessage(pendingSession.prompt, { model: modelState, mode });
+    storeSendMessage(pendingSession.prompt, {
+      model: modelState,
+      mode,
+      ...(pendingSession.telosTaskId ? { telosTaskId: pendingSession.telosTaskId } : {}),
+    });
     clearPendingSession();
     forceScrollToBottom();
   }, [pendingSession]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/packages/client/src/api-client.ts
+++ b/packages/client/src/api-client.ts
@@ -56,6 +56,7 @@ export interface SessionMetaResponse {
   totalTokens: number;
   totalCostUsd: number;
   numTurns: number;
+  telosTaskId: string | null;
 }
 
 export interface CalendarData {

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -49,11 +49,13 @@ export interface SendMessageOptions {
   cwd?: string;
   extraTools?: string;
   isolation?: boolean;
+  telosTaskId?: string;
 }
 
 export interface PendingSession {
   prompt: string;
   context: string;
+  telosTaskId?: string;
 }
 
 export interface MitzoStoreState {
@@ -299,6 +301,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         if (opts?.cwd) msg.cwd = opts.cwd;
         if (opts?.extraTools) msg.extraTools = opts.extraTools;
         if (opts?.isolation !== undefined) msg.isolation = opts.isolation;
+        if (opts?.telosTaskId) msg.telosTaskId = opts.telosTaskId;
         return msg;
       };
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -301,7 +301,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         if (opts?.cwd) msg.cwd = opts.cwd;
         if (opts?.extraTools) msg.extraTools = opts.extraTools;
         if (opts?.isolation !== undefined) msg.isolation = opts.isolation;
-        if (opts?.telosTaskId) msg.telosTaskId = opts.telosTaskId;
+        if (opts?.telosTaskId !== undefined) msg.telosTaskId = opts.telosTaskId;
         return msg;
       };
 

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -37,6 +37,7 @@ export interface ManagedSession {
   cumulativeSessionTokens: number;
   cumulativeCostUsd: number;
   taskContext: { currentTaskId: string; goalId: string } | null;
+  telosTaskId?: string;
 }
 
 export interface ActiveSessionInfo {

--- a/packages/protocol/__tests__/event-store.test.ts
+++ b/packages/protocol/__tests__/event-store.test.ts
@@ -165,6 +165,30 @@ describe('EventStore', () => {
       expect(session!.goalId).toBe('goal-abc-123');
     });
 
+    it('persists telosTaskId on insert', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test', telosTaskId: 'telos-abc' });
+
+      const session = store.getSession('sess-1');
+      expect(session).not.toBeNull();
+      expect(session!.telosTaskId).toBe('telos-abc');
+    });
+
+    it('persists and retrieves telosTaskId via update', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      store.upsertSession({ sessionId: 'sess-1', telosTaskId: 'telos-xyz' });
+
+      const session = store.getSession('sess-1');
+      expect(session).not.toBeNull();
+      expect(session!.telosTaskId).toBe('telos-xyz');
+    });
+
+    it('defaults telosTaskId to null when not provided', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+
+      const session = store.getSession('sess-1');
+      expect(session!.telosTaskId).toBeNull();
+    });
+
     it('preserves fields not included in partial update', () => {
       store.upsertSession({
         sessionId: 'sess-1',

--- a/packages/protocol/__tests__/ws-schemas-v2.test.ts
+++ b/packages/protocol/__tests__/ws-schemas-v2.test.ts
@@ -106,6 +106,20 @@ describe('v2 send', () => {
     });
     expect(r.success).toBe(false);
   });
+
+  it('accepts send with telosTaskId', () => {
+    const r = V2SendMessage.safeParse({
+      type: 'send',
+      sessionId: null,
+      prompt: 'hello',
+      clientMsgId: 'u-1',
+      telosTaskId: 'abc123def456',
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.telosTaskId).toBe('abc123def456');
+    }
+  });
 });
 
 describe('v2 interrupt / stop / permission_response / set_mode', () => {

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -41,6 +41,7 @@ interface SessionRow {
   duration_ms: number;
   duration_api_ms: number;
   goal_id: string | null;
+  telos_task_id: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -180,6 +181,7 @@ export class EventStore {
         'ALTER TABLE sessions ADD COLUMN duration_api_ms INTEGER NOT NULL DEFAULT 0',
       ],
       ['goal_id', 'ALTER TABLE sessions ADD COLUMN goal_id TEXT'],
+      ['telos_task_id', 'ALTER TABLE sessions ADD COLUMN telos_task_id TEXT'],
     ];
     for (const [col, sql] of migrations) {
       if (!columnNames.has(col)) {
@@ -256,6 +258,10 @@ export class EventStore {
         fields.push('goal_id = ?');
         values.push(meta.goalId);
       }
+      if (meta.telosTaskId !== undefined) {
+        fields.push('telos_task_id = ?');
+        values.push(meta.telosTaskId);
+      }
       if (meta.wtId !== undefined) {
         fields.push('wt_id = ?');
         values.push(meta.wtId);
@@ -281,6 +287,7 @@ export class EventStore {
         'initial_prompt',
         'wt_id',
         'goal_id',
+        'telos_task_id',
       ];
       const vals: unknown[] = [
         meta.sessionId,
@@ -292,6 +299,7 @@ export class EventStore {
         meta.initialPrompt ?? null,
         meta.wtId ?? null,
         meta.goalId ?? null,
+        meta.telosTaskId ?? null,
       ];
       if (meta.updatedAt !== undefined) {
         cols.push('updated_at');
@@ -504,6 +512,7 @@ function rowToSession(row: SessionRow): SessionMeta {
     durationMs: row.duration_ms ?? 0,
     durationApiMs: row.duration_api_ms ?? 0,
     goalId: row.goal_id ?? null,
+    telosTaskId: row.telos_task_id ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -112,6 +112,7 @@ export interface Session {
   isAttached?: boolean;
   totalTokens?: number;
   numTurns?: number;
+  telosTaskId?: string;
 }
 
 // --- Session activity types (SSE event bus) ---
@@ -190,6 +191,7 @@ export interface SessionMeta {
   durationMs: number;
   durationApiMs: number;
   goalId: string | null;
+  telosTaskId: string | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/packages/protocol/src/ws-schemas-v2.ts
+++ b/packages/protocol/src/ws-schemas-v2.ts
@@ -82,6 +82,7 @@ export const V2SendMessage = z.object({
   isolation: z.boolean().optional(),
   images: z.array(ImageSchema).optional(),
   contextBlocks: z.array(z.string()).optional(),
+  telosTaskId: z.string().optional(),
 });
 
 export const V2InterruptMessage = z.object({

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -559,6 +559,7 @@ export async function startChat(
     contextBlocks?: string[];
     clientMsgId?: string;
     onSessionResolved?: (sessionId: string) => void;
+    telosTaskId?: string;
   },
 ) {
   return withSpanAsync(
@@ -587,6 +588,7 @@ async function _startChatInner(
     contextBlocks?: string[];
     clientMsgId?: string;
     onSessionResolved?: (sessionId: string) => void;
+    telosTaskId?: string;
   },
 ) {
   const abortController = new AbortController();

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -666,6 +666,7 @@ async function _startChatInner(
     worktreePath,
     // Set sessionId early so pre-assistant events are persisted (iOS reconnect).
     ...(options.resume ? { sessionId: options.resume } : {}),
+    ...(options.telosTaskId ? { telosTaskId: options.telosTaskId } : {}),
   });
 
   const session = registry.get(clientId)!;
@@ -690,6 +691,7 @@ async function _startChatInner(
       mode,
       branch,
       ...(worktreePath ? { wtId } : {}),
+      ...(options.telosTaskId ? { telosTaskId: options.telosTaskId } : {}),
     });
   }
 

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -388,6 +388,7 @@ async function _runQueryLoopInner(
                 branch: currentSession.branch,
                 ...(currentSession.worktreePath ? { wtId: currentSession.wtId } : {}),
                 ...(initialPrompt ? { initialPrompt } : {}),
+                ...(currentSession.telosTaskId ? { telosTaskId: currentSession.telosTaskId } : {}),
               });
               if (initialPrompt) {
                 // Store the initial prompt as a user_message event so

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -436,6 +436,7 @@ export function handleSendV2(
             images: msg.images,
             contextBlocks: msg.contextBlocks,
             clientMsgId: msg.clientMsgId,
+            telosTaskId: msg.telosTaskId,
           });
           applySkillPolicy(sessionClientId);
         } else {
@@ -455,6 +456,7 @@ export function handleSendV2(
             contextBlocks: msg.contextBlocks,
             clientMsgId: msg.clientMsgId,
             onSessionResolved,
+            telosTaskId: msg.telosTaskId,
           });
           applySkillPolicy(sessionClientId);
         }


### PR DESCRIPTION
## Summary

- Adds `telosTaskId` field across the full Mitzo stack so chat sessions can be linked to strategic Telos task items
- **Protocol**: new `telosTaskId` on `Session` and `SessionMeta` types, optional field in `V2SendMessage` schema
- **Event store**: SQLite migration adds `telos_task_id` column, wired into upsert (insert + update) and read paths
- **Server**: `startChat` accepts `telosTaskId` in its options
- **Client**: `SendMessageOptions`, `PendingSession`, and the store's message builder all propagate the field; `SessionMetaResponse` includes it in API responses

## Test plan

- [x] `event-store.test.ts` — 3 new tests: insert with telosTaskId, update via upsert, default-to-null (all pass)
- [x] `ws-schemas-v2.test.ts` — 1 new test: V2SendMessage accepts telosTaskId (passes)
- [ ] Verify session list UI renders correctly with linked Telos items (manual)
- [ ] End-to-end: send a message with telosTaskId, confirm it persists in event store and appears in session meta (manual)

**Note:** 13 pre-existing test failures in the full suite (timeouts in chat.test.ts, auth issues in routes.test.ts, frontend mocking issues) — none related to this change. The 4 new tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)