### PR TITLE
feat(sse): wire consumer hooks to SSE events — Phase 2

### DIFF
--- a/frontend/src/hooks/__tests__/useSessionList.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionList.test.ts
@@ -10,6 +10,14 @@ vi.mock('../../lib/api-fetch', () => ({
   apiFetch: vi.fn(),
 }));
 
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn(() => vi.fn()),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
 import { apiFetch } from '../../lib/api-fetch';
 import { useSessionList } from '../useSessionList';
 

--- a/frontend/src/hooks/__tests__/useTabBadges.test.ts
+++ b/frontend/src/hooks/__tests__/useTabBadges.test.ts
@@ -6,6 +6,14 @@ import { MitzoStoreProvider } from '@mitzo/client/hooks';
 import { createMitzoStore } from '@mitzo/client';
 import type { WebSocketLike } from '@mitzo/client';
 import { WS_READY_STATE } from '@mitzo/client';
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn(() => vi.fn()),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
 import { useTabBadges } from '../useTabBadges';
 
 class MockWebSocket implements WebSocketLike {

--- a/frontend/src/hooks/__tests__/useTaskBoard.test.ts
+++ b/frontend/src/hooks/__tests__/useTaskBoard.test.ts
@@ -6,6 +6,14 @@ import { MitzoStoreProvider } from '@mitzo/client/hooks';
 import { createMitzoStore } from '@mitzo/client';
 import type { WebSocketLike } from '@mitzo/client';
 import { WS_READY_STATE } from '@mitzo/client';
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn(() => vi.fn()),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
 import { useTaskBoard } from '../useTaskBoard';
 
 class MockWebSocket implements WebSocketLike {

--- a/frontend/src/hooks/__tests__/useTodoData.test.ts
+++ b/frontend/src/hooks/__tests__/useTodoData.test.ts
@@ -6,6 +6,14 @@ vi.mock('../../lib/api-fetch', () => ({
   apiFetch: vi.fn(),
 }));
 
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn(() => vi.fn()),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
 import { apiFetch } from '../../lib/api-fetch';
 import { useTodoData } from '../useTodoData';
 

--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Session } from '../types/chat';
 import { renameSession as renameSessionApi } from '../lib/rename-session';
 import { apiFetch } from '../lib/api-fetch';
+import { eventBus } from '../lib/event-bus-singleton';
+import type { SessionActivity } from './useSessionOverview';
 
 export interface QuickAction {
   label: string;
@@ -86,8 +88,24 @@ export function useSessionList(): UseSessionListReturn {
     };
     document.addEventListener('visibilitychange', onVisible);
 
+    // Live session dots via SSE — update isActive/isAttached without full refetch
+    const unsubActivity = eventBus.on('session_activity', (data) => {
+      const activities = data as SessionActivity[];
+      const activeIds = new Set(activities.map((a) => a.sessionId));
+      setSessions((prev) =>
+        prev.map((s) => ({
+          ...s,
+          isActive: activeIds.has(s.id),
+          isAttached: activities.some(
+            (a) => a.sessionId === s.id && a.state !== 'idle' && a.state !== 'done',
+          ),
+        })),
+      );
+    });
+
     return () => {
       document.removeEventListener('visibilitychange', onVisible);
+      unsubActivity();
     };
   }, []);
 

--- a/frontend/src/hooks/useSessionOverview.ts
+++ b/frontend/src/hooks/useSessionOverview.ts
@@ -1,24 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { eventBus } from '../lib/event-bus-singleton';
+import type { SessionActivity } from '@mitzo/protocol';
 
-// ─── Types (mirror server/session-overview.ts) ──────────────────────────────
-
-export type SessionActivityState = 'init' | 'working' | 'waiting' | 'done' | 'idle' | 'paused';
-
-export type WaitReason = 'permission' | 'review' | 'blocked';
-
-export interface SessionActivity {
-  sessionId: string;
-  clientId: string;
-  title: string;
-  repo?: string;
-  state: SessionActivityState;
-  flags: SessionActivityState[];
-  waitReason?: WaitReason;
-  progress?: { done: number; total: number };
-  lastEventAt: number;
-  taskId?: string;
-}
+export type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
 
 // ─── Tier sorting ───────────────────────────────────────────────────────────
 

--- a/frontend/src/hooks/useTabBadges.ts
+++ b/frontend/src/hooks/useTabBadges.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useMitzoStore } from '@mitzo/client/hooks';
+import { eventBus } from '../lib/event-bus-singleton';
 
 export interface TabBadges {
   inboxCount: number;
@@ -23,7 +24,15 @@ export function useTabBadges(): TabBadges {
       }
     };
     document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
+
+    const unsubInbox = eventBus.on('inbox_updated', () => loadInbox());
+    const unsubTodo = eventBus.on('todo_update', () => loadTodos());
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      unsubInbox();
+      unsubTodo();
+    };
   }, [loadInbox, loadTodos]);
 
   const todoCount = useMemo(

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useMitzoStore } from '@mitzo/client/hooks';
 import type { Task, LoopStatus } from '../types/task';
+import { eventBus } from '../lib/event-bus-singleton';
 
 export interface TaskCreateInput {
   title: string;
@@ -62,6 +63,20 @@ export function useTaskBoard(): UseTaskBoardResult {
   useEffect(() => {
     Promise.all([loadTasks(), loadLoopStatus()]).finally(() => setLoading(false));
   }, [loadTasks, loadLoopStatus]);
+
+  // Live updates via SSE
+  useEffect(() => {
+    const unsubLoop = eventBus.on('loop_status', () => {
+      loadLoopStatus();
+    });
+    const unsubTask = eventBus.on('task_state', () => {
+      refreshTasks();
+    });
+    return () => {
+      unsubLoop();
+      unsubTask();
+    };
+  }, [loadLoopStatus, refreshTasks]);
 
   return {
     loading,

--- a/frontend/src/hooks/useTodoData.ts
+++ b/frontend/src/hooks/useTodoData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { TodoItem, TodoData } from '../types/todo';
 import { apiFetch } from '../lib/api-fetch';
+import { eventBus } from '../lib/event-bus-singleton';
 
 export interface UseTodoDataResult {
   loading: boolean;
@@ -82,6 +83,13 @@ export function useTodoData(profile?: string): UseTodoDataResult {
       cancelled = true;
     };
   }, [profile, refreshKey]);
+
+  // Live update: SSE todo_update signals a refetch
+  useEffect(() => {
+    return eventBus.on('todo_update', () => {
+      setRefreshKey((k) => k + 1);
+    });
+  }, []);
 
   const performAction = useCallback(async (id: string, action: string, days?: number) => {
     const body: Record<string, unknown> = { action };

--- a/frontend/src/pages/__tests__/SessionList.test.tsx
+++ b/frontend/src/pages/__tests__/SessionList.test.tsx
@@ -3,6 +3,14 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { createElement, act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn(() => vi.fn()),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
 import { SessionList } from '../SessionList';
 
 function mockFetchResponses(overrides: Record<string, unknown> = {}) {

--- a/packages/client/src/event-bus.ts
+++ b/packages/client/src/event-bus.ts
@@ -1,15 +1,3 @@
-/**
- * EventBus — SSE client for broadcast events.
- *
- * Wraps native EventSource to receive typed server-sent events (session state,
- * task updates, health, etc.). One instance per app, lives for the app's
- * lifetime. Complements the WebSocket (per-session, bidirectional) with a
- * global unidirectional awareness channel.
- *
- * EventSource auto-reconnects natively — no custom reconnect logic needed.
- * On reconnect, the server sends a fresh hydration snapshot.
- */
-
 /** EventSource readyState constants — avoids referencing the global. */
 const ES_OPEN = 1;
 const ES_CLOSED = 2;
@@ -30,23 +18,12 @@ export class EventBus {
       factory ?? ((url: string) => new EventSource(url, { withCredentials: true }));
   }
 
-  /**
-   * Connect to the SSE endpoint. Call once on app mount.
-   */
   connect(url: string): void {
     if (this.source) return;
     this.url = url;
     this.createSource();
   }
 
-  /**
-   * Subscribe to a specific event type. Returns an unsubscribe function.
-   *
-   * Listeners are tracked by the bus itself — they survive EventSource
-   * reconnects because we re-register them on each new source.
-   * The dispatch path goes through the listener set (not through
-   * individual EventSource handlers), so unsubscribe is immediate.
-   */
   on(event: string, listener: EventBusListener): () => void {
     let set = this.listeners.get(event);
     if (!set) {
@@ -64,19 +41,12 @@ export class EventBus {
     };
   }
 
-  /**
-   * Register a callback for connection state changes.
-   */
   onConnectionChange(cb: ConnectionChangeCallback): () => void {
     this.connectionChangeListeners.add(cb);
     return () => this.connectionChangeListeners.delete(cb);
   }
 
-  /**
-   * Ensure the SSE connection is alive. Call on app resume (iOS foreground).
-   * If the EventSource is in CLOSED state (gave up reconnecting), recreates it.
-   * No-op if still connected or reconnecting.
-   */
+  // Recreates EventSource if CLOSED (gave up); no-op if connected/reconnecting.
   ensureConnected(): void {
     if (!this.url) return;
     if (!this.source || this.source.readyState === ES_CLOSED) {
@@ -92,9 +62,6 @@ export class EventBus {
     }
   }
 
-  /**
-   * Disconnect. Call on app unmount.
-   */
   disconnect(): void {
     if (this.source) {
       try {
@@ -106,9 +73,6 @@ export class EventBus {
     }
   }
 
-  /**
-   * Whether the SSE connection is currently open.
-   */
   get connected(): boolean {
     return this.source?.readyState === ES_OPEN;
   }
@@ -129,19 +93,11 @@ export class EventBus {
       this.notifyConnectionChange(false);
     };
 
-    // Register one dispatch handler per event type on the new source.
-    // Each handler fans out to all listeners in the set — no per-listener
-    // handlers on the EventSource, so unsubscribe is just a Set.delete().
     for (const event of this.listeners.keys()) {
       this.registerEventDispatch(event);
     }
   }
 
-  /**
-   * Register a single EventSource handler for an event type that dispatches
-   * to all listeners in the set. This indirection means unsubscribe doesn't
-   * need to touch the EventSource — it just removes from the Set.
-   */
   private registerEventDispatch(event: string): void {
     if (!this.source) return;
     this.source.addEventListener(event, ((e: MessageEvent) => {

--- a/packages/client/src/event-bus.ts
+++ b/packages/client/src/event-bus.ts
@@ -1,4 +1,6 @@
-/** EventSource readyState constants — avoids referencing the global. */
+// SSE client for broadcast events (session state, tasks, health).
+
+// EventSource readyState constants.
 const ES_OPEN = 1;
 const ES_CLOSED = 2;
 
@@ -24,6 +26,7 @@ export class EventBus {
     this.createSource();
   }
 
+  // Listeners survive EventSource reconnects — dispatch goes through the Set.
   on(event: string, listener: EventBusListener): () => void {
     let set = this.listeners.get(event);
     if (!set) {
@@ -46,7 +49,7 @@ export class EventBus {
     return () => this.connectionChangeListeners.delete(cb);
   }
 
-  // Recreates EventSource if CLOSED (gave up); no-op if connected/reconnecting.
+  // Recreate EventSource if CLOSED (gave up). No-op if still alive.
   ensureConnected(): void {
     if (!this.url) return;
     if (!this.source || this.source.readyState === ES_CLOSED) {

--- a/packages/client/src/event-bus.ts
+++ b/packages/client/src/event-bus.ts
@@ -96,8 +96,8 @@ export class EventBus {
       this.notifyConnectionChange(false);
     };
 
-    for (const event of this.listeners.keys()) {
-      this.registerEventDispatch(event);
+    for (const [event, set] of this.listeners) {
+      if (set.size > 0) this.registerEventDispatch(event);
     }
   }
 

--- a/packages/harness/src/sse-registry.ts
+++ b/packages/harness/src/sse-registry.ts
@@ -1,15 +1,3 @@
-/**
- * SseRegistry — manages Server-Sent Events connections for broadcast events.
- *
- * Unlike WebSocket (bidirectional, per-session), SSE is unidirectional
- * (server → client) and global (not tied to a specific session). It delivers
- * broadcast data like session state changes, task updates, todo changes, and
- * health status.
- *
- * Auto-reconnects natively via EventSource (client-side) — no custom reconnect
- * logic needed. Each client gets a fresh snapshot on connect (hydration).
- */
-
 import type { Response } from 'express';
 import { createLogger } from './logger.js';
 
@@ -26,11 +14,6 @@ export class SseRegistry {
   private clients = new Map<string, SseClient>();
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
-  /**
-   * Register a new SSE client. Starts heartbeat if this is the first client.
-   * The response object must have headers already written
-   * (Content-Type: text/event-stream, etc.) before calling this.
-   */
   add(id: string, res: Response): void {
     this.clients.set(id, { id, res });
     log.info('SSE client connected', { id, total: this.clients.size });
@@ -40,9 +23,6 @@ export class SseRegistry {
     }
   }
 
-  /**
-   * Remove a client (on close/error). Stops heartbeat if this was the last client.
-   */
   remove(id: string): void {
     if (!this.clients.has(id)) return;
 
@@ -54,13 +34,6 @@ export class SseRegistry {
     }
   }
 
-  /**
-   * Send a typed event to all connected clients.
-   * SSE format:
-   *   event: <type>\n
-   *   data: <json>\n
-   *   \n
-   */
   broadcast(event: string, data: unknown): void {
     if (this.clients.size === 0) return;
 
@@ -86,9 +59,6 @@ export class SseRegistry {
     }
   }
 
-  /**
-   * Send a typed event to a specific client (for hydration on connect).
-   */
   sendTo(clientId: string, event: string, data: unknown): boolean {
     const client = this.clients.get(clientId);
     if (!client) return false;
@@ -104,9 +74,6 @@ export class SseRegistry {
     }
   }
 
-  /**
-   * Number of connected clients.
-   */
   get size(): number {
     return this.clients.size;
   }
@@ -142,10 +109,6 @@ export class SseRegistry {
     this.heartbeatTimer = null;
   }
 
-  /**
-   * Cleanup: close all connections and stop heartbeat.
-   * Call on server shutdown.
-   */
   destroy(): void {
     log.info('Destroying SSE registry', { clients: this.clients.size });
     this.stopHeartbeat();

--- a/packages/harness/src/sse-registry.ts
+++ b/packages/harness/src/sse-registry.ts
@@ -90,13 +90,16 @@ export class SseRegistry {
     log.info('Starting SSE heartbeat', { intervalMs: HEARTBEAT_INTERVAL_MS });
     this.heartbeatTimer = setInterval(() => {
       const payload = ':heartbeat\n\n'; // SSE comment line — ignored by EventSource
+      const failures: string[] = [];
       for (const [, client] of this.clients) {
         try {
           client.res.write(payload);
         } catch {
-          // Write failed — clean up dead connection immediately
-          this.remove(client.id);
+          failures.push(client.id);
         }
+      }
+      for (const id of failures) {
+        this.remove(id);
       }
     }, HEARTBEAT_INTERVAL_MS);
   }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -22,6 +22,9 @@ export type {
   ProgressItemStatus,
   ProgressItem,
   ProgressBlock,
+  SessionActivityState,
+  WaitReason,
+  SessionActivity,
 } from './types.js';
 
 // Constants

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -114,6 +114,25 @@ export interface Session {
   numTurns?: number;
 }
 
+// --- Session activity types (SSE event bus) ---
+
+export type SessionActivityState = 'init' | 'working' | 'waiting' | 'done' | 'idle' | 'paused';
+
+export type WaitReason = 'permission' | 'review' | 'blocked';
+
+export interface SessionActivity {
+  sessionId: string;
+  clientId: string;
+  title: string;
+  repo?: string;
+  state: SessionActivityState;
+  flags: SessionActivityState[];
+  waitReason?: WaitReason;
+  progress?: { done: number; total: number };
+  lastEventAt: number;
+  taskId?: string;
+}
+
 // --- Event store types ---
 
 /** Optional logger interface — keeps the protocol package free of server dependencies. */

--- a/server/index.ts
+++ b/server/index.ts
@@ -100,6 +100,10 @@ const server = USE_TLS
   : createServer(app);
 const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
 
+// Declared early so broadcast closures can reference it safely (assigned after orchestrator init)
+// eslint-disable-next-line prefer-const
+let overviewEmitter: SessionOverviewEmitter;
+
 setUpdateBroadcast(() => {
   const data = { type: 'update_available' };
   const msg = JSON.stringify(data);
@@ -219,7 +223,7 @@ orchestratorRef = orchestrator;
 setOrchestrator(orchestrator);
 
 // --- Session Overview Emitter (SSE broadcast) ---
-const overviewEmitter = new SessionOverviewEmitter({
+overviewEmitter = new SessionOverviewEmitter({
   registry,
   sseRegistry,
   getLoopStatus: () => orchestrator.getStatus(),

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -9,30 +9,14 @@
 import type { SessionRegistry, ActiveSessionInfo } from '@mitzo/harness';
 import type { SseRegistry } from '@mitzo/harness';
 import { getPendingCountBySession } from '@mitzo/harness';
+import type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
 import type { LoopStatus } from './task-orchestrator.js';
 import type { TaskStore } from './task-store.js';
 import { createLogger } from './logger.js';
 
+export type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
+
 const log = createLogger('session-overview');
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-export type SessionActivityState = 'init' | 'working' | 'waiting' | 'done' | 'idle' | 'paused';
-
-export type WaitReason = 'permission' | 'review' | 'blocked';
-
-export interface SessionActivity {
-  sessionId: string;
-  clientId: string;
-  title: string;
-  repo?: string;
-  state: SessionActivityState;
-  flags: SessionActivityState[];
-  waitReason?: WaitReason;
-  progress?: { done: number; total: number };
-  lastEventAt: number;
-  taskId?: string;
-}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -139,7 +123,7 @@ export class SessionOverviewEmitter {
     loopStatus: LoopStatus,
     now: number,
   ): SessionActivity {
-    const sessionId = session.sessionId!;
+    const sessionId = session.sessionId ?? '';
     const lastEventAt = this.lastEventTimes.get(session.clientId) ?? now;
     const elapsed = now - lastEventAt;
 


### PR DESCRIPTION
## Summary

- **useTodoData**: subscribes to `todo_update` SSE → auto-refetch (replaces stale one-shot fetch)
- **useTaskBoard**: subscribes to `loop_status` → reload status, `task_state` → refresh tasks (supplements existing WS)
- **useTabBadges**: subscribes to `inbox_updated` → reload inbox count, `todo_update` → reload todo count (replaces visibility-change-only updates)
- **useSessionList**: subscribes to `session_activity` → live `isActive`/`isAttached` dots without full refetch (replaces stale session list)

Also addresses Centaur review findings from PR #304:
- Fix EventBus handler leak on unsub/resub cycles
- Add `sseRegistry.destroy()` to server shutdown
- Fix orphaned JSDoc in permissions.ts
- Clean up dead SSE connections during heartbeat
- Add SseRegistry tests (13 tests)
- Add EventBus unsub/resub cycle test
- Greedy regex in `extractRepoName`, clarified `checkTaskWaitState` scope

## Test plan

- [x] All 649 frontend tests pass (71 files)
- [x] All server tests pass
- [x] TypeScript compiles clean
- [x] Event bus mock added to 5 test files that transitively import event-bus-singleton
- [ ] Manual: open home page → modify a Telos item via CLI → Telos view auto-updates
- [ ] Manual: start ATB loop → task board shows live loop status without page refresh
- [ ] Manual: inbox item arrives → tab badge updates immediately
- [ ] Manual: session starts/stops → session list dots update in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)