### PR TITLE
feat(sse): health consolidation — Phase 3

### DIFF
--- a/frontend/src/components/ServiceStatus.tsx
+++ b/frontend/src/components/ServiceStatus.tsx
@@ -1,0 +1,29 @@
+// Service health indicator — shows Yapper and ContexGin status on the home page.
+
+import { useServiceHealth } from '../hooks/useServiceHealth';
+import type { ServiceHealthStatus } from '@mitzo/protocol';
+
+function ServiceDot({ service }: { service: ServiceHealthStatus | null }) {
+  if (!service) return null;
+  const color = service.ok ? '#4ade80' : '#ff6d6d';
+  return (
+    <span className="service-dot" style={{ color }}>
+      <span className="service-dot-indicator" style={{ background: color }} />
+      {service.name}
+    </span>
+  );
+}
+
+export function ServiceStatus() {
+  const { yapper, contexgin, checkedAt } = useServiceHealth();
+
+  // Don't render until first health check arrives
+  if (checkedAt === 0) return null;
+
+  return (
+    <div className="service-status">
+      <ServiceDot service={yapper} />
+      <ServiceDot service={contexgin} />
+    </div>
+  );
+}

--- a/frontend/src/components/ServiceStatus.tsx
+++ b/frontend/src/components/ServiceStatus.tsx
@@ -17,8 +17,8 @@ function ServiceDot({ service }: { service: ServiceHealthStatus | null }) {
 export function ServiceStatus() {
   const { yapper, contexgin, checkedAt } = useServiceHealth();
 
-  // Don't render until first health check arrives
-  if (checkedAt === 0) return null;
+  // Don't render until first health check arrives, or if no services are present
+  if (checkedAt === 0 || (!yapper && !contexgin)) return null;
 
   return (
     <div className="service-status">

--- a/frontend/src/components/__tests__/ServiceStatus.test.tsx
+++ b/frontend/src/components/__tests__/ServiceStatus.test.tsx
@@ -73,7 +73,6 @@ describe('ServiceStatus', () => {
   it('renders nothing when both services are null', () => {
     mockReturn = { services: [], yapper: null, contexgin: null, checkedAt: Date.now() };
     const { container } = render(<ServiceStatus />);
-    const dots = container.querySelectorAll('.service-dot');
-    expect(dots).toHaveLength(0);
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/components/__tests__/ServiceStatus.test.tsx
+++ b/frontend/src/components/__tests__/ServiceStatus.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ServiceStatus } from '../ServiceStatus';
+
+// Mock useServiceHealth
+let mockReturn = {
+  services: [] as any[],
+  yapper: null as any,
+  contexgin: null as any,
+  checkedAt: 0,
+};
+
+vi.mock('../../hooks/useServiceHealth', () => ({
+  useServiceHealth: () => mockReturn,
+}));
+
+describe('ServiceStatus', () => {
+  beforeEach(() => {
+    mockReturn = { services: [], yapper: null, contexgin: null, checkedAt: 0 };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders nothing before first health check', () => {
+    const { container } = render(<ServiceStatus />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders service dots after health check', () => {
+    mockReturn = {
+      services: [],
+      yapper: { name: 'yapper', ok: true },
+      contexgin: { name: 'contexgin', ok: false },
+      checkedAt: Date.now(),
+    };
+
+    const { container } = render(<ServiceStatus />);
+    const dots = container.querySelectorAll('.service-dot');
+    expect(dots).toHaveLength(2);
+    expect(dots[0].textContent).toBe('yapper');
+    expect(dots[1].textContent).toBe('contexgin');
+  });
+
+  it('shows green indicator for ok services', () => {
+    mockReturn = {
+      services: [],
+      yapper: { name: 'yapper', ok: true },
+      contexgin: null,
+      checkedAt: Date.now(),
+    };
+
+    const { container } = render(<ServiceStatus />);
+    const dot = container.querySelector('.service-dot') as HTMLElement;
+    expect(dot.style.color).toBe('rgb(74, 222, 128)');
+  });
+
+  it('shows red indicator for down services', () => {
+    mockReturn = {
+      services: [],
+      yapper: null,
+      contexgin: { name: 'contexgin', ok: false },
+      checkedAt: Date.now(),
+    };
+
+    const { container } = render(<ServiceStatus />);
+    const dot = container.querySelector('.service-dot') as HTMLElement;
+    expect(dot.style.color).toBe('rgb(255, 109, 109)');
+  });
+
+  it('renders nothing when both services are null', () => {
+    mockReturn = { services: [], yapper: null, contexgin: null, checkedAt: Date.now() };
+    const { container } = render(<ServiceStatus />);
+    const dots = container.querySelectorAll('.service-dot');
+    expect(dots).toHaveLength(0);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDocumentReader.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentReader.test.ts
@@ -14,75 +14,64 @@ vi.mock('../../lib/tts', () => ({
 // Mock constants
 vi.mock('../../lib/constants', () => ({
   YAPPER_URL: 'http://test-yapper',
-  YAPPER_HEALTH_POLL_MS: 30000,
   DEFAULT_TTS_VOICE: 'af_heart',
   DOCUMENT_READ_MAX_CHARS: 50_000,
+}));
+
+// Mock useServiceHealth — control yapper status per test
+let mockYapper: { ok: boolean; detail?: Record<string, unknown> } | null = null;
+vi.mock('../useServiceHealth', () => ({
+  useServiceHealth: () => ({
+    services: mockYapper ? [mockYapper] : [],
+    yapper: mockYapper,
+    contexgin: null,
+    checkedAt: mockYapper ? Date.now() : 0,
+  }),
 }));
 
 const mockFetch = vi.fn();
 
 describe('useDocumentReader', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.clearAllMocks();
     vi.stubGlobal('fetch', mockFetch);
+    mockYapper = null;
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('starts unavailable before health check', () => {
-    // Make fetch hang forever
-    mockFetch.mockReturnValue(new Promise(() => {}));
+  it('starts unavailable when no health data', () => {
+    mockYapper = null;
     const { result } = renderHook(() => useDocumentReader());
     expect(result.current.available).toBe(false);
     expect(result.current.state).toBe('idle');
   });
 
-  it('becomes available after successful health check', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: true } }),
-    });
-
+  it('becomes available when yapper health reports ok with tts', () => {
+    mockYapper = { ok: true, detail: { stt: true, tts: true } };
     const { result } = renderHook(() => useDocumentReader());
-    await act(async () => {});
-
     expect(result.current.available).toBe(true);
   });
 
-  it('stays unavailable when TTS model is not ready', async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: false } }),
-    });
-
+  it('stays unavailable when TTS model is not ready', () => {
+    mockYapper = { ok: true, detail: { stt: true, tts: false } };
     const { result } = renderHook(() => useDocumentReader());
-    await act(async () => {});
-
     expect(result.current.available).toBe(false);
   });
 
-  it('stays unavailable when health check fails', async () => {
-    mockFetch.mockRejectedValue(new Error('network'));
-
+  it('stays unavailable when yapper is down', () => {
+    mockYapper = { ok: false };
     const { result } = renderHook(() => useDocumentReader());
-    await act(async () => {});
-
     expect(result.current.available).toBe(false);
   });
 
   it('calls synthesizeDocument and playAudio on read()', async () => {
     const { synthesizeDocument, playAudio } = await import('../../lib/tts');
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ status: 'ready' }),
-    });
+    mockYapper = { ok: true, detail: { tts: true } };
 
     const { result } = renderHook(() => useDocumentReader());
-    await act(async () => {});
 
     await act(async () => {
       result.current.read('# Hello\n\nWorld');
@@ -99,22 +88,15 @@ describe('useDocumentReader', () => {
   });
 
   it('stops playback on stop()', async () => {
-    // Make play() hang so state stays 'playing' until stop() is called
     mockPlayHandle.play.mockReturnValue(new Promise(() => {}));
-
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ status: 'ready' }),
-    });
+    mockYapper = { ok: true, detail: { tts: true } };
 
     const { result } = renderHook(() => useDocumentReader());
-    await act(async () => {});
 
     act(() => {
       result.current.read('Hello');
     });
 
-    // Flush async pipeline up to playAudio()
     await act(async () => {});
 
     expect(result.current.state).toBe('playing');
@@ -126,7 +108,6 @@ describe('useDocumentReader', () => {
     expect(mockPlayHandle.stop).toHaveBeenCalled();
     expect(result.current.state).toBe('idle');
 
-    // Restore default mock for other tests
     mockPlayHandle.play.mockResolvedValue(undefined);
   });
 });

--- a/frontend/src/hooks/__tests__/useServiceHealth.test.ts
+++ b/frontend/src/hooks/__tests__/useServiceHealth.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useServiceHealth } from '../useServiceHealth';
+
+// Capture the listener registered via eventBus.on('health', ...)
+let healthListener: ((data: unknown) => void) | null = null;
+const mockUnsub = vi.fn();
+
+vi.mock('../../lib/event-bus-singleton', () => ({
+  eventBus: {
+    on: vi.fn((event: string, listener: (data: unknown) => void) => {
+      if (event === 'health') healthListener = listener;
+      return mockUnsub;
+    }),
+    onConnectionChange: vi.fn(() => vi.fn()),
+    connected: false,
+  },
+}));
+
+describe('useServiceHealth', () => {
+  beforeEach(() => {
+    healthListener = null;
+    mockUnsub.mockClear();
+  });
+
+  it('starts with empty services and checkedAt=0', () => {
+    const { result } = renderHook(() => useServiceHealth());
+    expect(result.current.services).toEqual([]);
+    expect(result.current.yapper).toBeNull();
+    expect(result.current.contexgin).toBeNull();
+    expect(result.current.checkedAt).toBe(0);
+  });
+
+  it('subscribes to health event on mount', () => {
+    renderHook(() => useServiceHealth());
+    expect(healthListener).not.toBeNull();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = renderHook(() => useServiceHealth());
+    unmount();
+    expect(mockUnsub).toHaveBeenCalled();
+  });
+
+  it('updates state when health event fires', () => {
+    const { result } = renderHook(() => useServiceHealth());
+
+    act(() => {
+      healthListener?.({
+        services: [
+          { name: 'yapper', ok: true, detail: { stt: true, tts: true } },
+          { name: 'contexgin', ok: false },
+        ],
+        checkedAt: 1234567890,
+      });
+    });
+
+    expect(result.current.services).toHaveLength(2);
+    expect(result.current.yapper).toEqual({
+      name: 'yapper',
+      ok: true,
+      detail: { stt: true, tts: true },
+    });
+    expect(result.current.contexgin).toEqual({ name: 'contexgin', ok: false });
+    expect(result.current.checkedAt).toBe(1234567890);
+  });
+
+  it('returns null for unknown service names', () => {
+    const { result } = renderHook(() => useServiceHealth());
+
+    act(() => {
+      healthListener?.({
+        services: [{ name: 'unknown-service', ok: true }],
+        checkedAt: 1000,
+      });
+    });
+
+    expect(result.current.yapper).toBeNull();
+    expect(result.current.contexgin).toBeNull();
+  });
+
+  it('updates when payload changes', () => {
+    const { result } = renderHook(() => useServiceHealth());
+
+    act(() => {
+      healthListener?.({
+        services: [{ name: 'yapper', ok: true }],
+        checkedAt: 1000,
+      });
+    });
+    expect(result.current.yapper?.ok).toBe(true);
+
+    act(() => {
+      healthListener?.({
+        services: [{ name: 'yapper', ok: false }],
+        checkedAt: 2000,
+      });
+    });
+    expect(result.current.yapper?.ok).toBe(false);
+    expect(result.current.checkedAt).toBe(2000);
+  });
+});

--- a/frontend/src/hooks/__tests__/useVoice.test.ts
+++ b/frontend/src/hooks/__tests__/useVoice.test.ts
@@ -2,7 +2,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useVoice } from '../useVoice';
-import { YAPPER_HEALTH_POLL_MS } from '../../lib/constants';
 
 // --- Mocks ---
 
@@ -58,7 +57,18 @@ vi.mock('../../lib/tts', () => ({
   unlockAudioContext: vi.fn(() => Promise.resolve()),
 }));
 
-// Mock fetch
+// Mock useServiceHealth — control yapper status per test
+let mockYapper: { ok: boolean; detail?: Record<string, unknown> } | null = null;
+vi.mock('../useServiceHealth', () => ({
+  useServiceHealth: () => ({
+    services: mockYapper ? [mockYapper] : [],
+    yapper: mockYapper,
+    contexgin: null,
+    checkedAt: mockYapper ? Date.now() : 0,
+  }),
+}));
+
+// Mock fetch (still needed for transcription + voice list)
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
@@ -76,82 +86,52 @@ beforeEach(() => {
   });
   mockGetUserMedia.mockResolvedValue(mockStream);
   mockFetch.mockReset();
+  mockYapper = null;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// Helper: mock Yapper health response
-function mockHealthy(stt = true) {
-  mockFetch.mockResolvedValueOnce({
-    ok: true,
-    json: () => Promise.resolve({ status: 'ready', models: { stt, tts: false } }),
-  });
-}
-
-function mockUnhealthy() {
-  mockFetch.mockRejectedValueOnce(new Error('Network error'));
-}
-
 // --- Tests ---
 
 describe('useVoice', () => {
-  describe('health polling', () => {
-    it('sets available=true when Yapper is healthy with STT ready', async () => {
-      mockHealthy();
+  describe('SSE-driven health', () => {
+    it('sets available=true when yapper is healthy with STT ready', () => {
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => {
-        expect(result.current.available).toBe(true);
-      });
+      expect(result.current.available).toBe(true);
     });
 
-    it('sets available=false when Yapper is unreachable', async () => {
-      mockUnhealthy();
+    it('sets available=false when yapper is null', () => {
+      mockYapper = null;
       const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => {
-        expect(result.current.available).toBe(false);
-      });
+      expect(result.current.available).toBe(false);
     });
 
-    it('sets available=false when STT model is not ready', async () => {
-      mockHealthy(false);
+    it('sets available=false when STT model is not ready', () => {
+      mockYapper = { ok: true, detail: { stt: false, tts: true } };
       const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => {
-        expect(result.current.available).toBe(false);
-      });
+      expect(result.current.available).toBe(false);
     });
 
-    it('polls health periodically', async () => {
-      vi.useFakeTimers();
-      mockHealthy();
-      renderHook(() => useVoice());
+    it('sets ttsAvailable from yapper detail', () => {
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
+      const { result } = renderHook(() => useVoice());
+      expect(result.current.ttsAvailable).toBe(true);
+    });
 
-      // Initial fetch
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      // After poll interval
-      mockHealthy();
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(YAPPER_HEALTH_POLL_MS);
-      });
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-
-      vi.useRealTimers();
+    it('ttsAvailable is false when models.tts is false', () => {
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
+      const { result } = renderHook(() => useVoice());
+      expect(result.current.ttsAvailable).toBe(false);
     });
   });
 
   describe('recording', () => {
     it('starts recording after requesting mic permission', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -162,10 +142,9 @@ describe('useVoice', () => {
     });
 
     it('sets micBlocked when permission is denied', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       mockGetUserMedia.mockRejectedValueOnce(new DOMException('denied', 'NotAllowedError'));
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -176,9 +155,8 @@ describe('useVoice', () => {
     });
 
     it('stops recording and returns transcript', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -190,7 +168,6 @@ describe('useVoice', () => {
         stopPromise = result.current.stopRecording();
       });
 
-      // Simulate final transcript from WS
       act(() => {
         mockWsClient.onTranscript?.({ type: 'final', text: 'hello world' });
       });
@@ -204,9 +181,8 @@ describe('useVoice', () => {
     });
 
     it('cancel discards recording without transcribing', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -217,7 +193,6 @@ describe('useVoice', () => {
       });
 
       expect(result.current.recording).toBe(false);
-      // No transcription fetch should have been made (only health check)
       const transcribeCalls = mockFetch.mock.calls.filter(
         (call) => typeof call[0] === 'string' && call[0].includes('/v1/transcribe'),
       );
@@ -227,21 +202,18 @@ describe('useVoice', () => {
 
   describe('transcription errors', () => {
     it('returns empty string on batch transcription failure', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
 
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
-      // Simulate WS error so it falls back to batch
       act(() => {
         mockWsClient.onError?.(new Event('error'));
       });
 
-      // Mock batch transcription failure
       mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
 
       let transcript: string | undefined;
@@ -256,29 +228,25 @@ describe('useVoice', () => {
 
   describe('streaming STT', () => {
     it('uses streaming recorder + WS client when available', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
       expect(result.current.recording).toBe(true);
-      // Streaming recorder should have been started
       expect(mockStreamingRecorder.start).toHaveBeenCalled();
     });
 
     it('shows partial transcript from WS partial events', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
-      // Simulate a partial transcript from the WS
       act(() => {
         mockWsClient.onTranscript?.({ type: 'partial', text: 'hello' });
       });
@@ -287,9 +255,8 @@ describe('useVoice', () => {
     });
 
     it('updates partial transcript on each new partial', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -307,26 +274,22 @@ describe('useVoice', () => {
     });
 
     it('stopRecording sends END and returns final transcript', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
-      // Simulate partials
       act(() => {
         mockWsClient.onTranscript?.({ type: 'partial', text: 'hello' });
       });
 
-      // Stop recording — should send END and wait for final
       let transcriptPromise: Promise<string>;
       act(() => {
         transcriptPromise = result.current.stopRecording();
       });
 
-      // Simulate the final transcript arriving
       act(() => {
         mockWsClient.onTranscript?.({ type: 'final', text: 'hello world' });
       });
@@ -342,19 +305,16 @@ describe('useVoice', () => {
     });
 
     it('sends audio chunks to WS as they arrive', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
-      // Simulate a chunk from the streaming recorder
       const chunkBlob = new Blob(['audio-chunk'], { type: 'audio/webm' });
       await act(async () => {
         mockStreamingRecorder.onChunk?.(chunkBlob);
-        // Give it a tick for the async arrayBuffer conversion
         await new Promise((r) => setTimeout(r, 0));
       });
 
@@ -362,9 +322,8 @@ describe('useVoice', () => {
     });
 
     it('sends format frame before audio', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -374,9 +333,8 @@ describe('useVoice', () => {
     });
 
     it('cancelRecording closes WS and clears partial', async () => {
-      mockHealthy();
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
@@ -398,26 +356,22 @@ describe('useVoice', () => {
     });
 
     it('falls back to batch on WS error during recording', async () => {
-      mockHealthy();
-      // Mock the batch transcription response for fallback
+      mockYapper = { ok: true, detail: { stt: true, tts: false } };
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ text: 'batch fallback', language: 'en', duration: 1.0 }),
       });
 
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.available).toBe(true));
 
       await act(async () => {
         await result.current.startRecording();
       });
 
-      // Simulate WS error
       act(() => {
         mockWsClient.onError?.(new Event('error'));
       });
 
-      // stopRecording should use batch fallback
       let transcript: string | undefined;
       await act(async () => {
         transcript = await result.current.stopRecording();
@@ -428,44 +382,14 @@ describe('useVoice', () => {
   });
 
   describe('TTS', () => {
-    // Helper: health with TTS available
-    function mockHealthyWithTts() {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ status: 'ready', models: { stt: true, tts: true } }),
-      });
-    }
-
-    it('sets ttsAvailable from health poll models.tts', async () => {
-      mockHealthyWithTts();
+    it('ttsEnabled defaults to false', () => {
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => {
-        expect(result.current.ttsAvailable).toBe(true);
-      });
-    });
-
-    it('ttsAvailable is false when models.tts is false', async () => {
-      mockHealthy(); // stt=true, tts=false
-      const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => {
-        expect(result.current.available).toBe(true);
-        expect(result.current.ttsAvailable).toBe(false);
-      });
-    });
-
-    it('ttsEnabled defaults to false', async () => {
-      mockHealthyWithTts();
-      const { result } = renderHook(() => useVoice());
-
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
       expect(result.current.ttsEnabled).toBe(false);
     });
 
     it('setTtsEnabled toggles and persists to localStorage', async () => {
-      mockHealthyWithTts();
-      // Mock voices fetch when enabling TTS
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -477,7 +401,6 @@ describe('useVoice', () => {
       });
 
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
       await act(async () => {
         result.current.setTtsEnabled(true);
@@ -488,17 +411,14 @@ describe('useVoice', () => {
     });
 
     it('fetches voices lazily on first setTtsEnabled(true)', async () => {
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
-      // No voices fetch yet
       const voiceFetchesBefore = mockFetch.mock.calls.filter(
         (call) => typeof call[0] === 'string' && call[0].includes('/v1/voices'),
       );
       expect(voiceFetchesBefore).toHaveLength(0);
 
-      // Enable TTS — should fetch voices
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -525,25 +445,20 @@ describe('useVoice', () => {
       const mockUnlock = unlockAudioContext as ReturnType<typeof vi.fn>;
       mockUnlock.mockClear();
 
-      // Simulate suspended AudioContext (page load, no user gesture yet)
       mockCtx.mockReturnValue({ state: 'suspended' });
 
-      // Pre-set ttsEnabled in localStorage before render
       localStorage.setItem('mitzo-tts-enabled', 'true');
 
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       renderHook(() => useVoice());
       await waitFor(() => {});
 
-      // unlockAudioContext should NOT have been called yet (no user gesture)
       expect(mockUnlock).not.toHaveBeenCalled();
 
-      // Simulate user click — should trigger the one-shot listener
       document.dispatchEvent(new Event('click'));
 
       expect(mockUnlock).toHaveBeenCalledTimes(1);
 
-      // Restore default mock
       mockCtx.mockReturnValue({ state: 'running' });
     });
 
@@ -556,16 +471,14 @@ describe('useVoice', () => {
       mockCtx.mockReturnValue({ state: 'suspended' });
       localStorage.setItem('mitzo-tts-enabled', 'true');
 
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       renderHook(() => useVoice());
       await waitFor(() => {});
 
-      // Simulate touch — the primary gesture on iOS Safari
       document.dispatchEvent(new Event('touchstart'));
 
       expect(mockUnlock).toHaveBeenCalledTimes(1);
 
-      // Second touch should NOT call again (listener removed)
       mockUnlock.mockClear();
       document.dispatchEvent(new Event('touchstart'));
       expect(mockUnlock).not.toHaveBeenCalled();
@@ -579,24 +492,21 @@ describe('useVoice', () => {
       const mockUnlock = unlockAudioContext as ReturnType<typeof vi.fn>;
       mockUnlock.mockClear();
 
-      // AudioContext already running (not suspended)
       mockCtx.mockReturnValue({ state: 'running' });
 
       localStorage.setItem('mitzo-tts-enabled', 'true');
 
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       renderHook(() => useVoice());
       await waitFor(() => {});
 
-      // No listener should be registered — click should NOT call unlock
       document.dispatchEvent(new Event('click'));
       expect(mockUnlock).not.toHaveBeenCalled();
     });
 
     it('setTtsEnabled(true) calls unlockAudioContext for iOS Safari', async () => {
       const { unlockAudioContext } = await import('../../lib/tts');
-      mockHealthyWithTts();
-      // Mock voices fetch
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () =>
@@ -608,7 +518,6 @@ describe('useVoice', () => {
       });
 
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
       await act(async () => {
         result.current.setTtsEnabled(true);
@@ -619,9 +528,8 @@ describe('useVoice', () => {
 
     it('speak() synthesizes and plays audio', async () => {
       const { synthesize, playAudio } = await import('../../lib/tts');
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
       await act(async () => {
         await result.current.speak('Hello world');
@@ -633,7 +541,6 @@ describe('useVoice', () => {
     });
 
     it('stopSpeaking() stops current playback', async () => {
-      // Make play() hang so we can interrupt it
       let resolvePlay!: () => void;
       mockPlayHandle.play.mockImplementationOnce(
         () =>
@@ -642,11 +549,9 @@ describe('useVoice', () => {
           }),
       );
 
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
-      // Start speaking (will hang on play)
       let speakDone = false;
       act(() => {
         result.current.speak('Hello world').then(() => {
@@ -654,10 +559,8 @@ describe('useVoice', () => {
         });
       });
 
-      // Wait for speaking state
       await waitFor(() => expect(result.current.speaking).toBe(true));
 
-      // Now stop
       act(() => {
         result.current.stopSpeaking();
       });
@@ -665,7 +568,6 @@ describe('useVoice', () => {
       expect(mockPlayHandle.stop).toHaveBeenCalled();
       expect(result.current.speaking).toBe(false);
 
-      // Clean up the hanging promise
       resolvePlay();
       await waitFor(() => expect(speakDone).toBe(true));
     });
@@ -676,36 +578,30 @@ describe('useVoice', () => {
       const mockSynth = synthesize as ReturnType<typeof vi.fn>;
       const mockPlayAudio = playAudio as ReturnType<typeof vi.fn>;
 
-      // Clear any calls from previous tests
       mockSynth.mockClear();
       mockPlayAudio.mockClear();
 
-      // 3 chunks: first succeeds, second fails, third succeeds
       mockChunk.mockReturnValueOnce(['chunk1', 'chunk2', 'chunk3']);
       const goodBlob = new Blob(['wav'], { type: 'audio/wav' });
       mockSynth
-        .mockResolvedValueOnce(goodBlob) // chunk1 ok
-        .mockRejectedValueOnce(new Error('Synthesis failed (500)')) // chunk2 fails
-        .mockResolvedValueOnce(goodBlob); // chunk3 ok
+        .mockResolvedValueOnce(goodBlob)
+        .mockRejectedValueOnce(new Error('Synthesis failed (500)'))
+        .mockResolvedValueOnce(goodBlob);
 
-      mockHealthyWithTts();
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
       await act(async () => {
         await result.current.speak('some long text');
       });
 
-      // synthesize called 3 times (didn't abort after failure)
       expect(mockSynth).toHaveBeenCalledTimes(3);
-      // playAudio called for chunk1 and chunk3 (skipped chunk2)
       expect(mockPlayAudio).toHaveBeenCalledTimes(2);
     });
 
-    it('setVoice persists to localStorage', async () => {
-      mockHealthyWithTts();
+    it('setVoice persists to localStorage', () => {
+      mockYapper = { ok: true, detail: { stt: true, tts: true } };
       const { result } = renderHook(() => useVoice());
-      await waitFor(() => expect(result.current.ttsAvailable).toBe(true));
 
       act(() => {
         result.current.setVoice('am_adam');

--- a/frontend/src/hooks/useDocumentReader.ts
+++ b/frontend/src/hooks/useDocumentReader.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  YAPPER_URL,
-  YAPPER_HEALTH_POLL_MS,
-  DEFAULT_TTS_VOICE,
-  DOCUMENT_READ_MAX_CHARS,
-} from '../lib/constants';
+import { YAPPER_URL, DEFAULT_TTS_VOICE, DOCUMENT_READ_MAX_CHARS } from '../lib/constants';
 import { synthesizeDocument, playAudio, unlockAudioContext } from '../lib/tts';
+import { useServiceHealth } from './useServiceHealth';
 
 export type ReaderState = 'idle' | 'loading' | 'playing';
 
@@ -21,36 +17,11 @@ export interface DocumentReader {
  * Checks Yapper TTS availability and manages document playback lifecycle.
  */
 export function useDocumentReader(): DocumentReader {
-  const [available, setAvailable] = useState(false);
+  const { yapper } = useServiceHealth();
+  const available = yapper?.ok === true && yapper.detail?.tts !== false;
   const [state, setState] = useState<ReaderState>('idle');
   const abortRef = useRef<AbortController | null>(null);
   const playRef = useRef<{ stop: () => void } | null>(null);
-
-  // Health poll — reuses same pattern as useVoice
-  useEffect(() => {
-    let mounted = true;
-    async function check() {
-      try {
-        const res = await fetch(`${YAPPER_URL}/health`);
-        if (!res.ok) {
-          if (mounted) setAvailable(false);
-          return;
-        }
-        const data = await res.json();
-        const ready = data.status === 'ready' || data.status === 'ok';
-        const tts = data.models ? data.models.tts === true : ready;
-        if (mounted) setAvailable(ready && tts);
-      } catch {
-        if (mounted) setAvailable(false);
-      }
-    }
-    check();
-    const timer = setInterval(check, YAPPER_HEALTH_POLL_MS);
-    return () => {
-      mounted = false;
-      clearInterval(timer);
-    };
-  }, []);
 
   const stop = useCallback(() => {
     abortRef.current?.abort();

--- a/frontend/src/hooks/useServiceHealth.ts
+++ b/frontend/src/hooks/useServiceHealth.ts
@@ -1,0 +1,33 @@
+// SSE-driven service health — replaces per-hook polling for Yapper/ContexGin.
+
+import { useState, useEffect, useMemo } from 'react';
+import { eventBus } from '../lib/event-bus-singleton';
+import type { ServiceHealthPayload, ServiceHealthStatus } from '@mitzo/protocol';
+
+export interface UseServiceHealthReturn {
+  services: ServiceHealthStatus[];
+  yapper: ServiceHealthStatus | null;
+  contexgin: ServiceHealthStatus | null;
+  checkedAt: number;
+}
+
+export function useServiceHealth(): UseServiceHealthReturn {
+  const [payload, setPayload] = useState<ServiceHealthPayload>({ services: [], checkedAt: 0 });
+
+  useEffect(() => {
+    return eventBus.on('health', (data) => {
+      setPayload(data as ServiceHealthPayload);
+    });
+  }, []);
+
+  const yapper = useMemo(
+    () => payload.services.find((s) => s.name === 'yapper') ?? null,
+    [payload],
+  );
+  const contexgin = useMemo(
+    () => payload.services.find((s) => s.name === 'contexgin') ?? null,
+    [payload],
+  );
+
+  return { services: payload.services, yapper, contexgin, checkedAt: payload.checkedAt };
+}

--- a/frontend/src/hooks/useVoice.ts
+++ b/frontend/src/hooks/useVoice.ts
@@ -1,13 +1,8 @@
 // Voice integration hook — Yapper health, mic capture, streaming + batch transcription, TTS playback.
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import {
-  YAPPER_URL,
-  YAPPER_HEALTH_POLL_MS,
-  TTS_ENABLED_KEY,
-  TTS_VOICE_KEY,
-  DEFAULT_TTS_VOICE,
-} from '../lib/constants';
+import { YAPPER_URL, TTS_ENABLED_KEY, TTS_VOICE_KEY, DEFAULT_TTS_VOICE } from '../lib/constants';
+import { useServiceHealth } from './useServiceHealth';
 import {
   negotiateMimeType,
   createRecorder,
@@ -25,11 +20,6 @@ import {
   unlockAudioContext,
   closeAudioContext,
 } from '../lib/tts';
-
-interface YapperHealth {
-  status: string;
-  models?: { stt?: boolean; tts?: boolean };
-}
 
 export interface Voice {
   id: string;
@@ -76,15 +66,16 @@ function mimeToFormat(mime: string): string {
 }
 
 export function useVoice(): UseVoiceReturn {
+  // --- Service health (SSE-driven) ---
+  const { yapper } = useServiceHealth();
+  const available = yapper?.ok === true && yapper.detail?.stt !== false;
+  const ttsAvailable = yapper?.ok === true && yapper.detail?.tts !== false;
+
   // --- STT state ---
-  const [available, setAvailable] = useState(false);
   const [recording, setRecording] = useState(false);
   const [transcribing, setTranscribing] = useState(false);
   const [micBlocked, setMicBlocked] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // --- TTS state ---
-  const [ttsAvailable, setTtsAvailable] = useState(false);
   const [ttsEnabled, setTtsEnabledState] = useState(
     () => localStorage.getItem(TTS_ENABLED_KEY) === 'true',
   );
@@ -137,45 +128,6 @@ export function useVoice(): UseVoiceReturn {
       document.removeEventListener('touchstart', unlock);
     };
   }, [ttsEnabled]);
-
-  // --- Health polling ---
-  useEffect(() => {
-    let mounted = true;
-    async function checkHealth() {
-      try {
-        const res = await fetch(`${YAPPER_URL}/health`);
-        if (!res.ok) {
-          if (mounted) {
-            setAvailable(false);
-            setTtsAvailable(false);
-          }
-          return;
-        }
-        const data: YapperHealth = await res.json();
-        if (mounted) {
-          const isReady = data.status === 'ready' || data.status === 'ok';
-          // Yapper may omit `models` — when status is ok, assume both capabilities
-          const stt = data.models ? data.models.stt === true : isReady;
-          const tts = data.models ? data.models.tts === true : isReady;
-          setAvailable(isReady && stt);
-          setTtsAvailable(isReady && tts);
-        }
-      } catch {
-        if (mounted) {
-          setAvailable(false);
-          setTtsAvailable(false);
-        }
-      }
-    }
-
-    checkHealth();
-    const timer = setInterval(checkHealth, YAPPER_HEALTH_POLL_MS);
-
-    return () => {
-      mounted = false;
-      clearInterval(timer);
-    };
-  }, []);
 
   // --- Negotiate mime type once ---
   useEffect(() => {

--- a/frontend/src/hooks/useVoice.ts
+++ b/frontend/src/hooks/useVoice.ts
@@ -68,6 +68,9 @@ function mimeToFormat(mime: string): string {
 export function useVoice(): UseVoiceReturn {
   // --- Service health (SSE-driven) ---
   const { yapper } = useServiceHealth();
+  // detail?.stt !== false: when Yapper omits `models`, detail is undefined
+  // and we assume both capabilities (matches old per-hook polling behavior).
+  // Server sets ok=false for non-ready statuses, so this only fires when healthy.
   const available = yapper?.ok === true && yapper.detail?.stt !== false;
   const ttsAvailable = yapper?.ok === true && yapper.detail?.tts !== false;
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -28,7 +28,6 @@ export const MAX_IMAGE_ATTACHMENTS = 4;
 // the page origin, so `new WebSocket('/api/yapper-ws/...')` works correctly.
 // In Capacitor, getApiBaseUrl() returns a full URL so the ws:// replace works.
 export const YAPPER_URL = import.meta.env.VITE_YAPPER_URL || `${getApiBaseUrl()}/api/yapper`;
-export const YAPPER_HEALTH_POLL_MS = 30_000;
 export const MAX_RECORDING_DURATION_MS = 120_000;
 export const MIN_RECORDING_DURATION_MS = 500;
 export const TTS_CHUNK_MAX_CHARS = 500;

--- a/frontend/src/pages/SessionList.tsx
+++ b/frontend/src/pages/SessionList.tsx
@@ -14,6 +14,7 @@ import { BriefingCard } from '../components/BriefingCard';
 import { SessionSearchBar } from '../components/SessionSearchBar';
 import { useSessionSearch } from '../hooks/useSessionSearch';
 import { SessionOverview } from '../components/SessionOverview';
+import { ServiceStatus } from '../components/ServiceStatus';
 
 function SwipeableSession({
   session,
@@ -310,6 +311,8 @@ export function SessionList() {
         <BriefingCard />
 
         <SessionOverview />
+
+        <ServiceStatus />
 
         {quickActions.length > 0 && (
           <div className="quick-section">

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -743,6 +743,27 @@ textarea:focus {
   margin-top: 2px;
 }
 
+.service-status {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+}
+
+.service-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.service-dot-indicator {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
 .quick-section {
   margin-bottom: var(--space-5);
 }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -25,6 +25,8 @@ export type {
   SessionActivityState,
   WaitReason,
   SessionActivity,
+  ServiceHealthStatus,
+  ServiceHealthPayload,
 } from './types.js';
 
 // Constants

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -133,6 +133,19 @@ export interface SessionActivity {
   taskId?: string;
 }
 
+// --- Service health (SSE event bus) ---
+
+export interface ServiceHealthStatus {
+  name: string;
+  ok: boolean;
+  detail?: Record<string, unknown>;
+}
+
+export interface ServiceHealthPayload {
+  services: ServiceHealthStatus[];
+  checkedAt: number;
+}
+
 // --- Event store types ---
 
 /** Optional logger interface — keeps the protocol package free of server dependencies. */

--- a/server/__tests__/health-monitor.test.ts
+++ b/server/__tests__/health-monitor.test.ts
@@ -190,6 +190,38 @@ describe('HealthMonitor', () => {
     monitor.destroy();
   });
 
+  it('marks service as down on fetch timeout', async () => {
+    // Simulate AbortSignal.timeout rejecting with TimeoutError
+    const timeoutErr = new DOMException('signal timed out', 'TimeoutError');
+    mockFetch.mockRejectedValueOnce(timeoutErr).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const payload = registry.broadcast.mock.calls[0]?.[1];
+    const yapper = payload?.services.find((s: any) => s.name === 'yapper');
+    expect(yapper?.ok).toBe(false);
+
+    monitor.destroy();
+  });
+
+  it('start() is idempotent — calling twice does not create duplicate intervals', async () => {
+    mockFetch.mockResolvedValue(yapperOk()).mockResolvedValue(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    monitor.start(); // second call should be a no-op
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Only one initial check, not two
+    // Each check fetches 2 services, so 2 fetch calls = 1 check
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    monitor.destroy();
+  });
+
   it('destroy clears the timer', async () => {
     mockFetch.mockResolvedValueOnce(yapperOk()).mockResolvedValueOnce(contexginOk());
 

--- a/server/__tests__/health-monitor.test.ts
+++ b/server/__tests__/health-monitor.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { HealthMonitor } from '../health-monitor';
+
+// Mock fetch
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock SseRegistry
+function createMockRegistry() {
+  return {
+    broadcast: vi.fn(),
+    sendTo: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+    size: 0,
+    destroy: vi.fn(),
+  };
+}
+
+function yapperOk(stt = true, tts = true) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ status: 'ready', models: { stt, tts } }),
+  };
+}
+
+function contexginOk() {
+  return { ok: true, json: () => Promise.resolve({ status: 'healthy' }) };
+}
+
+function serviceDown() {
+  return { ok: false, json: () => Promise.resolve({}) };
+}
+
+describe('HealthMonitor', () => {
+  let registry: ReturnType<typeof createMockRegistry>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    registry = createMockRegistry();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('broadcasts health on first check', async () => {
+    mockFetch.mockResolvedValueOnce(yapperOk()).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+
+    // Flush the initial async check
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(registry.broadcast).toHaveBeenCalledWith(
+      'health',
+      expect.objectContaining({
+        services: expect.arrayContaining([
+          expect.objectContaining({ name: 'yapper', ok: true }),
+          expect.objectContaining({ name: 'contexgin', ok: true }),
+        ]),
+        checkedAt: expect.any(Number),
+      }),
+    );
+
+    monitor.destroy();
+  });
+
+  it('does not broadcast when status is unchanged', async () => {
+    mockFetch
+      .mockResolvedValueOnce(yapperOk())
+      .mockResolvedValueOnce(contexginOk())
+      .mockResolvedValueOnce(yapperOk())
+      .mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registry.broadcast).toHaveBeenCalledTimes(1);
+
+    // Advance to next poll
+    await vi.advanceTimersByTimeAsync(30_000);
+    // No second broadcast — status unchanged
+    expect(registry.broadcast).toHaveBeenCalledTimes(1);
+
+    monitor.destroy();
+  });
+
+  it('broadcasts when status changes', async () => {
+    // First check: both ok
+    mockFetch.mockResolvedValueOnce(yapperOk()).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registry.broadcast).toHaveBeenCalledTimes(1);
+
+    // Second check: yapper down
+    mockFetch.mockResolvedValueOnce(serviceDown()).mockResolvedValueOnce(contexginOk());
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(registry.broadcast).toHaveBeenCalledTimes(2);
+
+    const lastCall = registry.broadcast.mock.calls[1];
+    expect(lastCall[1].services[0]).toEqual(expect.objectContaining({ name: 'yapper', ok: false }));
+
+    monitor.destroy();
+  });
+
+  it('parses Yapper detail with stt/tts fields', async () => {
+    mockFetch.mockResolvedValueOnce(yapperOk(true, false)).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const payload = registry.broadcast.mock.calls[0][1];
+    const yapper = payload.services.find((s: any) => s.name === 'yapper');
+    expect(yapper.detail).toEqual({ stt: true, tts: false });
+
+    monitor.destroy();
+  });
+
+  it('returns undefined detail when Yapper omits models', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ status: 'ok' }),
+      })
+      .mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const payload = registry.broadcast.mock.calls[0][1];
+    const yapper = payload.services.find((s: any) => s.name === 'yapper');
+    expect(yapper.detail).toBeUndefined();
+
+    monitor.destroy();
+  });
+
+  it('marks service as down on fetch error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED')).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const payload = registry.broadcast.mock.calls[0][1];
+    const yapper = payload.services.find((s: any) => s.name === 'yapper');
+    expect(yapper.ok).toBe(false);
+
+    monitor.destroy();
+  });
+
+  it('getSnapshot returns last payload', async () => {
+    mockFetch.mockResolvedValueOnce(yapperOk()).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    // Before start — empty snapshot
+    expect(monitor.getSnapshot()).toEqual({ services: [], checkedAt: 0 });
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const snapshot = monitor.getSnapshot();
+    expect(snapshot.services).toHaveLength(2);
+    expect(snapshot.checkedAt).toBeGreaterThan(0);
+
+    monitor.destroy();
+  });
+
+  it('broadcasts on detail change even if ok is same', async () => {
+    // First: stt=true, tts=true
+    mockFetch.mockResolvedValueOnce(yapperOk(true, true)).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registry.broadcast).toHaveBeenCalledTimes(1);
+
+    // Second: stt=true, tts=false — ok is still true but detail changed
+    mockFetch.mockResolvedValueOnce(yapperOk(true, false)).mockResolvedValueOnce(contexginOk());
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(registry.broadcast).toHaveBeenCalledTimes(2);
+
+    monitor.destroy();
+  });
+
+  it('destroy clears the timer', async () => {
+    mockFetch.mockResolvedValueOnce(yapperOk()).mockResolvedValueOnce(contexginOk());
+
+    const monitor = new HealthMonitor(registry as any);
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(0);
+    monitor.destroy();
+
+    // Advance time — no further checks
+    mockFetch.mockReset();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -524,8 +524,7 @@ app.get('/api/events', (req, res) => {
   }
 
   if (healthMonitor) {
-    const snapshot = healthMonitor.getSnapshot();
-    if (snapshot) sseRegistry.sendTo(clientId, 'health', snapshot);
+    sseRegistry.sendTo(clientId, 'health', healthMonitor.getSnapshot());
   }
 
   req.on('close', () => sseRegistry.remove(clientId));

--- a/server/app.ts
+++ b/server/app.ts
@@ -214,6 +214,7 @@ let orchestrator: TaskOrchestrator | null = null;
 let templateStore: WorkflowTemplateStore | null = null;
 let signalProcessor: SignalProcessor | null = null;
 let overviewEmitter: SessionOverviewEmitter | null = null;
+let healthMonitor: { getSnapshot: () => unknown } | null = null;
 
 export function setOrchestrator(o: TaskOrchestrator): void {
   orchestrator = o;
@@ -221,6 +222,10 @@ export function setOrchestrator(o: TaskOrchestrator): void {
 
 export function setOverviewEmitter(emitter: SessionOverviewEmitter): void {
   overviewEmitter = emitter;
+}
+
+export function setHealthMonitor(monitor: { getSnapshot: () => unknown }): void {
+  healthMonitor = monitor;
 }
 
 export function setTemplateStore(ts: WorkflowTemplateStore): void {
@@ -516,6 +521,11 @@ app.get('/api/events', (req, res) => {
 
   if (overviewEmitter) {
     sseRegistry.sendTo(clientId, 'session_activity', overviewEmitter.getSnapshot());
+  }
+
+  if (healthMonitor) {
+    const snapshot = healthMonitor.getSnapshot();
+    if (snapshot) sseRegistry.sendTo(clientId, 'health', snapshot);
   }
 
   req.on('close', () => sseRegistry.remove(clientId));

--- a/server/health-monitor.ts
+++ b/server/health-monitor.ts
@@ -1,0 +1,110 @@
+// Periodic health monitor for upstream services (Yapper, ContexGin).
+// Broadcasts a `health` SSE event when status changes.
+
+import type { SseRegistry } from '@mitzo/harness';
+import type { ServiceHealthPayload, ServiceHealthStatus } from '@mitzo/protocol';
+import { createLogger } from './logger.js';
+
+const log = createLogger('health-monitor');
+
+const POLL_INTERVAL_MS = 30_000;
+const CHECK_TIMEOUT_MS = 3_000;
+
+interface ServiceCheck {
+  name: string;
+  url: string;
+  parseDetail?: (data: unknown) => Record<string, unknown> | undefined;
+}
+
+const SERVICES: ServiceCheck[] = [
+  {
+    name: 'yapper',
+    url: process.env.YAPPER_PROXY_TARGET || 'http://localhost:8700',
+    parseDetail: (data) => {
+      const d = data as { models?: { stt?: boolean; tts?: boolean } };
+      return d.models ? { stt: !!d.models.stt, tts: !!d.models.tts } : undefined;
+    },
+  },
+  {
+    name: 'contexgin',
+    url: process.env.CONTEXGIN_URL || 'http://localhost:8321',
+  },
+];
+
+export class HealthMonitor {
+  private sseRegistry: SseRegistry;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastPayload: ServiceHealthPayload | null = null;
+
+  constructor(sseRegistry: SseRegistry) {
+    this.sseRegistry = sseRegistry;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    log.info('Starting health monitor', { intervalMs: POLL_INTERVAL_MS });
+    // Initial check immediately
+    this.check();
+    this.timer = setInterval(() => this.check(), POLL_INTERVAL_MS);
+  }
+
+  getSnapshot(): ServiceHealthPayload {
+    return this.lastPayload ?? { services: [], checkedAt: 0 };
+  }
+
+  destroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    log.info('Health monitor destroyed');
+  }
+
+  private async check(): Promise<void> {
+    const results = await Promise.all(SERVICES.map((s) => this.checkService(s)));
+    const payload: ServiceHealthPayload = {
+      services: results,
+      checkedAt: Date.now(),
+    };
+
+    if (this.hasChanged(payload)) {
+      log.info('Service health changed', {
+        services: results.map((s) => `${s.name}=${s.ok ? 'ok' : 'down'}`).join(', '),
+      });
+      this.lastPayload = payload;
+      this.sseRegistry.broadcast('health', payload);
+    } else {
+      this.lastPayload = payload;
+    }
+  }
+
+  private async checkService(service: ServiceCheck): Promise<ServiceHealthStatus> {
+    try {
+      const res = await fetch(`${service.url}/health`, {
+        signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+      });
+      if (!res.ok) return { name: service.name, ok: false };
+
+      const data = await res.json();
+      const isReady = data.status === 'ready' || data.status === 'ok' || data.status === 'healthy';
+      return {
+        name: service.name,
+        ok: isReady,
+        detail: service.parseDetail?.(data),
+      };
+    } catch {
+      return { name: service.name, ok: false };
+    }
+  }
+
+  private hasChanged(next: ServiceHealthPayload): boolean {
+    if (!this.lastPayload) return true;
+    const prev = this.lastPayload.services;
+    if (prev.length !== next.services.length) return true;
+    for (let i = 0; i < prev.length; i++) {
+      if (prev[i].ok !== next.services[i].ok) return true;
+      if (JSON.stringify(prev[i].detail) !== JSON.stringify(next.services[i].detail)) return true;
+    }
+    return false;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -52,6 +52,7 @@ import {
   setTemplateStore,
   setSignalProcessor,
   setOverviewEmitter,
+  setHealthMonitor,
   runUpdateCheck,
   buildSkillRegistry,
   NATIVE_COMMAND_NAMES,
@@ -64,6 +65,7 @@ import { WorkflowTemplateStore, seedBuiltInTemplates } from './workflow-template
 import { SignalProcessor } from './signal-processor.js';
 import { TaskOrchestrator } from './task-orchestrator.js';
 import { SessionOverviewEmitter } from './session-overview.js';
+import { HealthMonitor } from './health-monitor.js';
 import { IncomingWsMessage } from './ws-schemas.js';
 import { resolvePending } from './permissions.js';
 import { resolveSlashCommand } from './slash-commands.js';
@@ -231,6 +233,11 @@ overviewEmitter = new SessionOverviewEmitter({
   getSessionTitle: (id: string) => eventStore.getSession(id)?.summary ?? undefined,
 });
 setOverviewEmitter(overviewEmitter);
+
+// --- Health Monitor (SSE broadcast) ---
+const healthMonitor = new HealthMonitor(sseRegistry);
+setHealthMonitor(healthMonitor);
+healthMonitor.start();
 
 // Hook session lifecycle events into the overview emitter
 setSessionChangeCallback((clientId, event) => {
@@ -822,6 +829,7 @@ function shutdown(signal: string) {
   server.close();
   signalProc.unwatchAll();
   wfTemplateStore.close();
+  healthMonitor.destroy();
   overviewEmitter.destroy();
   sseRegistry.destroy();
   registry.dispose();


### PR DESCRIPTION
## Summary

- Server-side `HealthMonitor` polls Yapper + ContexGin every 30s, broadcasts `health` SSE event only on status change (not every tick)
- New `useServiceHealth` hook replaces independent 30s polling intervals in `useVoice` and `useDocumentReader` with a single SSE subscription
- `ServiceStatus` component shows service health dots on the home page
- `ServiceHealthPayload` / `ServiceHealthStatus` types added to `@mitzo/protocol`
- Removed `YAPPER_HEALTH_POLL_MS` constant (no longer needed)
- Tests updated: health assertions now use mock `useServiceHealth` instead of mock fetch

## Test plan

- [ ] Build passes (`tsc --noEmit`)
- [ ] All tests pass (`vitest run` — 2378/2378, excluding pre-existing chat.test.ts timeouts)
- [ ] Yapper/ContexGin dots appear on home page when services are running
- [ ] Dots update without page refresh when a service goes down/up
- [ ] Voice recording and TTS still work correctly
- [ ] Document reader still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)