### PR TITLE
fix(connection-registry): add delivery guarantee with cursors and periodic sync

### DIFF
--- a/frontend/src/components/SubagentCard.tsx
+++ b/frontend/src/components/SubagentCard.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import type { FinishedSubagentState, StreamingSubagentState } from '@mitzo/protocol';
+import { ThinkingBlock } from './ThinkingBlock';
+import { ToolPill } from './ToolPill';
+
+interface SubagentCardProps {
+  subagent: FinishedSubagentState | StreamingSubagentState;
+}
+
+function formatTokens(usage?: { inputTokens: number; outputTokens: number }): string {
+  if (!usage) return '';
+  return `${usage.inputTokens}↓ ${usage.outputTokens}↑`;
+}
+
+export function SubagentCard({ subagent }: SubagentCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const isRunning = 'running' in subagent && subagent.running;
+  const summary = isRunning ? 'Working...' : subagent.summary || 'Complete';
+  const usage = 'usage' in subagent ? subagent.usage : undefined;
+
+  // Convert blocks to array for rendering
+  const blocks = Array.isArray(subagent.blocks)
+    ? subagent.blocks
+    : Array.from(subagent.blocks.values());
+
+  return (
+    <div className="subagent-card">
+      <button
+        className="subagent-header"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+      >
+        <span
+          className={`subagent-dot ${isRunning ? 'subagent-dot--running' : 'subagent-dot--done'}`}
+        />
+        <span className="subagent-summary">{summary}</span>
+        {usage && <span className="subagent-tokens">{formatTokens(usage)}</span>}
+        <span className="subagent-chevron">{expanded ? '▾' : '▸'}</span>
+      </button>
+
+      {expanded && (
+        <div className="subagent-detail">
+          {blocks.map((block) => {
+            if (block.blockType === 'thinking' || block.blockType === 'redacted_thinking') {
+              return <ThinkingBlock key={block.blockId} block={block} />;
+            }
+            if (block.blockType === 'tool_use') {
+              return <ToolPill key={block.blockId} block={block} />;
+            }
+            if (block.blockType === 'text') {
+              return (
+                <div key={block.blockId} className="subagent-text">
+                  {block.content}
+                </div>
+              );
+            }
+            return null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { StreamingBlock, FinishedBlock, RawToolInput } from '../types/chat';
+import { SubagentCard } from './SubagentCard';
 
 interface Props {
   block: StreamingBlock | FinishedBlock;
@@ -71,6 +72,7 @@ export function ToolPill({ block }: Props) {
           )}
         </div>
       )}
+      {block.subagent && <SubagentCard subagent={block.subagent} />}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/SubagentCard.test.tsx
+++ b/frontend/src/components/__tests__/SubagentCard.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { SubagentCard } from '../SubagentCard';
+import type { FinishedBlock } from '../../types/chat';
+
+afterEach(() => cleanup());
+
+describe('SubagentCard', () => {
+  it('renders collapsed by default with summary', () => {
+    const subagent = {
+      messageId: 'msg-sub-1',
+      blocks: [
+        {
+          blockId: 'b1',
+          blockType: 'text' as const,
+          content: 'Subagent output',
+        },
+      ],
+      summary: 'Search complete',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+
+    render(<SubagentCard subagent={subagent} />);
+
+    expect(screen.getByText('Search complete')).toBeTruthy();
+    expect(screen.getByText(/100.*50/)).toBeTruthy(); // Token display
+  });
+
+  it('renders "Working..." when subagent is still running', () => {
+    const subagent = {
+      messageId: 'msg-sub-1',
+      blocks: new Map([
+        [
+          'b1',
+          {
+            blockId: 'b1',
+            blockType: 'thinking' as const,
+            content: 'Analyzing...',
+            done: false,
+          },
+        ],
+      ]),
+      blockOrder: ['b1'],
+      running: true as const,
+    };
+
+    render(<SubagentCard subagent={subagent} />);
+
+    expect(screen.getByText('Working...')).toBeTruthy();
+  });
+
+  it('expands to show nested blocks when clicked', () => {
+    const blocks: FinishedBlock[] = [
+      {
+        blockId: 'b1',
+        blockType: 'thinking',
+        content: 'Let me search for that',
+      },
+      {
+        blockId: 'b2',
+        blockType: 'text',
+        content: 'Search results here',
+      },
+    ];
+
+    const subagent = {
+      messageId: 'msg-sub-1',
+      blocks,
+      summary: 'Done',
+    };
+
+    const { container } = render(<SubagentCard subagent={subagent} />);
+
+    // Initially collapsed - detail not visible
+    expect(container.querySelector('.subagent-detail')).not.toBeTruthy();
+
+    // Click to expand
+    const header = container.querySelector('.subagent-header');
+    if (header) {
+      fireEvent.click(header);
+    }
+
+    // Now detail section is visible
+    expect(container.querySelector('.subagent-detail')).toBeTruthy();
+    expect(screen.getByText('Search results here')).toBeTruthy();
+  });
+
+  it('shows pulsing indicator when running', () => {
+    const subagent = {
+      messageId: 'msg-sub-1',
+      blocks: new Map(),
+      blockOrder: [],
+      running: true as const,
+    };
+
+    const { container } = render(<SubagentCard subagent={subagent} />);
+
+    const dot = container.querySelector('.subagent-dot--running');
+    expect(dot).toBeTruthy();
+  });
+
+  it('shows checkmark when complete', () => {
+    const subagent = {
+      messageId: 'msg-sub-1',
+      blocks: [],
+      summary: 'Complete',
+    };
+
+    const { container } = render(<SubagentCard subagent={subagent} />);
+
+    const dot = container.querySelector('.subagent-dot--done');
+    expect(dot).toBeTruthy();
+  });
+});

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -14,6 +14,7 @@
   --accent-hover: #5a52e0;
   --danger: #f44336;
   --success: #4caf50;
+  --success-rgb: 76, 175, 80;
   --code-bg: #0e0e10;
   --code-font: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Menlo', monospace;
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -5237,3 +5237,87 @@ textarea:focus {
 .isolation-toggle:hover {
   opacity: 0.8;
 }
+
+/* ━━━ Subagent Card ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+
+.subagent-card {
+  margin: 8px 0 0 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--success);
+  background: rgba(var(--success-rgb), 0.05);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.subagent-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 8px 0;
+  width: 100%;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+
+.subagent-header:active {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.subagent-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.subagent-dot--running {
+  background: var(--success);
+  animation: pulse-dot 1.2s ease-in-out infinite;
+}
+
+.subagent-dot--done {
+  background: var(--success);
+}
+
+.subagent-summary {
+  flex: 1;
+  text-align: left;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subagent-tokens {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.subagent-chevron {
+  color: var(--text-dim);
+  font-size: var(--text-xs);
+  flex-shrink: 0;
+}
+
+.subagent-detail {
+  padding: 0 12px 8px 0;
+}
+
+.subagent-text {
+  padding: 8px 0;
+  color: var(--text-dim);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -233,7 +233,13 @@ export type ServerMessage =
   | LoopStatusMsg
   | ProgressStartMsg
   | ProgressUpdateMsg
-  | ProgressReplaceMsg;
+  | ProgressReplaceMsg
+  | SubagentStartMsg
+  | SubagentBlockStartMsg
+  | SubagentBlockDeltaMsg
+  | SubagentBlockEndMsg
+  | SubagentToolResultMsg
+  | SubagentEndMsg;
 
 export interface ProgressStartMsg {
   type: 'progress_start';
@@ -282,4 +288,83 @@ export interface LoopStatusMsg {
   progress: { done: number; total: number } | null;
   specMode: boolean;
   awaitingApproval: boolean;
+}
+
+// Subagent lifecycle events
+export interface SubagentStartMsg {
+  type: 'subagent_start';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  parentToolId: string;
+  subagentMessageId: string;
+  description?: string;
+}
+
+export interface SubagentBlockStartMsg {
+  type: 'subagent_block_start';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  subagentMessageId: string;
+  blockId: string;
+  blockType: BlockType;
+  toolName?: string;
+}
+
+export interface SubagentBlockDeltaMsg {
+  type: 'subagent_block_delta';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  subagentMessageId: string;
+  blockId: string;
+  blockType: BlockType;
+  delta: string;
+}
+
+export interface SubagentBlockEndMsg {
+  type: 'subagent_block_end';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  subagentMessageId: string;
+  blockId: string;
+  blockType: BlockType;
+  toolName?: string;
+  toolId?: string;
+  input?: string;
+  rawInput?: RawToolInput;
+}
+
+export interface SubagentToolResultMsg {
+  type: 'subagent_tool_result';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  subagentMessageId: string;
+  toolId: string;
+  result: string;
+  isError: boolean;
+}
+
+export interface SubagentEndMsg {
+  type: 'subagent_end';
+  v: 2;
+  ts: number;
+  sessionId: string;
+  parentBlockId: string;
+  subagentMessageId: string;
+  summary?: string;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreationTokens: number;
+  };
 }

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { messagesReducer, INITIAL_MESSAGES_STATE } from '../src/slices/messages.js';
+import { messagesReducer, finishCurrent, INITIAL_MESSAGES_STATE } from '../src/slices/messages.js';
 import type { MessagesState } from '../src/slices/messages.js';
-import type { FinishedBlock } from '@mitzo/protocol';
+import type { FinishedBlock, StreamingMessage } from '@mitzo/protocol';
 
 const INITIAL = INITIAL_MESSAGES_STATE;
 
@@ -1137,6 +1137,73 @@ describe('CONNECTION_LOST', () => {
     expect(state.messages[state.messages.length - 1].blocks[0].content).toContain(
       'Connection lost',
     );
+  });
+});
+
+// ─── finishCurrent (subagent preservation) ──────────────────────────────────
+
+describe('finishCurrent', () => {
+  it('preserves the subagent field when converting StreamingBlock to FinishedBlock', () => {
+    const subagentState = {
+      messageId: 'sub-msg-1',
+      blocks: new Map([
+        [
+          'sub-b1',
+          {
+            blockId: 'sub-b1',
+            blockType: 'text' as const,
+            content: 'subagent output',
+            done: true,
+          },
+        ],
+      ]),
+      blockOrder: ['sub-b1'],
+      running: true as const,
+    };
+
+    const current: StreamingMessage = {
+      messageId: 'msg-1',
+      blocks: new Map([
+        [
+          'b1',
+          {
+            blockId: 'b1',
+            blockType: 'tool_use' as const,
+            content: '',
+            done: true,
+            toolName: 'Agent',
+            subagent: subagentState,
+          },
+        ],
+      ]),
+      blockOrder: ['b1'],
+    };
+
+    const finished = finishCurrent(current);
+    expect(finished.blocks[0].subagent).toBeDefined();
+    expect(finished.blocks[0].subagent!.messageId).toBe('sub-msg-1');
+  });
+
+  it('works normally when subagent field is absent', () => {
+    const current: StreamingMessage = {
+      messageId: 'msg-2',
+      blocks: new Map([
+        [
+          'b1',
+          {
+            blockId: 'b1',
+            blockType: 'text' as const,
+            content: 'hello',
+            done: true,
+          },
+        ],
+      ]),
+      blockOrder: ['b1'],
+    };
+
+    const finished = finishCurrent(current);
+    expect(finished.blocks[0].subagent).toBeUndefined();
+    expect(finished.blocks[0].content).toBe('hello');
   });
 });
 

--- a/packages/client/__tests__/subagent-reducer.test.ts
+++ b/packages/client/__tests__/subagent-reducer.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from 'vitest';
+import { messagesReducer, INITIAL_MESSAGES_STATE } from '../src/slices/messages.js';
+import type { StreamingBlock } from '@mitzo/protocol';
+
+describe('Subagent Reducer Actions', () => {
+  it('SUBAGENT_START initializes subagent state on parent tool block', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_START' as const,
+      parentBlockId: 'b1',
+      subagentMessageId: 'msg-sub-1',
+    };
+
+    const newState = messagesReducer(state, action);
+
+    expect(newState.current?.blocks.get('b1')?.subagent).toBeDefined();
+    expect(newState.current?.blocks.get('b1')?.subagent?.messageId).toBe('msg-sub-1');
+    expect(newState.current?.blocks.get('b1')?.subagent?.running).toBe(true);
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.size).toBe(0);
+  });
+
+  it('SUBAGENT_BLOCK_START adds block to subagent state', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+              subagent: {
+                messageId: 'msg-sub-1',
+                blocks: new Map(),
+                blockOrder: [],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_BLOCK_START' as const,
+      parentBlockId: 'b1',
+      blockId: 'b-sub-1',
+      blockType: 'thinking' as const,
+    };
+
+    const newState = messagesReducer(state, action);
+
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.size).toBe(1);
+    expect(newState.current?.blocks.get('b1')?.subagent?.blockOrder).toEqual(['b-sub-1']);
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.get('b-sub-1')?.blockType).toBe(
+      'thinking',
+    );
+  });
+
+  it('SUBAGENT_BLOCK_DELTA appends to subagent block content', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+              subagent: {
+                messageId: 'msg-sub-1',
+                blocks: new Map([
+                  [
+                    'b-sub-1',
+                    {
+                      blockId: 'b-sub-1',
+                      blockType: 'text',
+                      content: 'Hello',
+                      done: false,
+                    },
+                  ],
+                ]),
+                blockOrder: ['b-sub-1'],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_BLOCK_DELTA' as const,
+      parentBlockId: 'b1',
+      blockId: 'b-sub-1',
+      delta: ' world',
+    };
+
+    const newState = messagesReducer(state, action);
+
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.get('b-sub-1')?.content).toBe(
+      'Hello world',
+    );
+  });
+
+  it('SUBAGENT_BLOCK_END marks subagent block as done', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+              subagent: {
+                messageId: 'msg-sub-1',
+                blocks: new Map([
+                  [
+                    'b-sub-1',
+                    {
+                      blockId: 'b-sub-1',
+                      blockType: 'text',
+                      content: 'Done',
+                      done: false,
+                    },
+                  ],
+                ]),
+                blockOrder: ['b-sub-1'],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_BLOCK_END' as const,
+      parentBlockId: 'b1',
+      blockId: 'b-sub-1',
+    };
+
+    const newState = messagesReducer(state, action);
+
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.get('b-sub-1')?.done).toBe(true);
+  });
+
+  it('SUBAGENT_TOOL_RESULT patches tool result in subagent block', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+              subagent: {
+                messageId: 'msg-sub-1',
+                blocks: new Map([
+                  [
+                    'b-sub-2',
+                    {
+                      blockId: 'b-sub-2',
+                      blockType: 'tool_use',
+                      content: '',
+                      done: true,
+                      toolName: 'Read',
+                      toolId: 'tool-read-1',
+                    },
+                  ],
+                ]),
+                blockOrder: ['b-sub-2'],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_TOOL_RESULT' as const,
+      parentBlockId: 'b1',
+      toolId: 'tool-read-1',
+      result: 'file contents',
+      isError: false,
+    };
+
+    const newState = messagesReducer(state, action);
+
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.get('b-sub-2')?.toolResult).toBe(
+      'file contents',
+    );
+    expect(newState.current?.blocks.get('b1')?.subagent?.blocks.get('b-sub-2')?.toolError).toBe(
+      false,
+    );
+  });
+
+  it('SUBAGENT_END finalizes subagent state with summary and usage', () => {
+    const state = {
+      ...INITIAL_MESSAGES_STATE,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map<string, StreamingBlock>([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 't1',
+              subagent: {
+                messageId: 'msg-sub-1',
+                blocks: new Map([
+                  [
+                    'b-sub-1',
+                    {
+                      blockId: 'b-sub-1',
+                      blockType: 'text',
+                      content: 'Result',
+                      done: true,
+                    },
+                  ],
+                ]),
+                blockOrder: ['b-sub-1'],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    const action = {
+      type: 'SUBAGENT_END' as const,
+      parentBlockId: 'b1',
+      summary: 'Search complete',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+
+    const newState = messagesReducer(state, action);
+
+    const subagent = newState.current?.blocks.get('b1')?.subagent;
+    expect(subagent?.running).toBeUndefined();
+    expect(Array.isArray(subagent?.blocks)).toBe(true);
+    expect(subagent?.summary).toBe('Search complete');
+    expect(subagent?.usage?.inputTokens).toBe(100);
+  });
+});

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -438,6 +438,72 @@ export function parseServerMessage(
     case 'inbox_updated':
       result.inboxRefresh = true;
       break;
+
+    // Subagent lifecycle messages
+    case 'subagent_start':
+      result.messagesActions.push({
+        type: 'SUBAGENT_START',
+        parentBlockId: msg.parentBlockId as string,
+        subagentMessageId: msg.subagentMessageId as string,
+      });
+      break;
+
+    case 'subagent_block_start':
+      result.messagesActions.push({
+        type: 'SUBAGENT_BLOCK_START',
+        parentBlockId: msg.parentBlockId as string,
+        blockId: msg.blockId as string,
+        blockType: msg.blockType as BlockType,
+        toolName: msg.toolName as string | undefined,
+      });
+      break;
+
+    case 'subagent_block_delta':
+      result.messagesActions.push({
+        type: 'SUBAGENT_BLOCK_DELTA',
+        parentBlockId: msg.parentBlockId as string,
+        blockId: msg.blockId as string,
+        delta: msg.delta as string,
+      });
+      break;
+
+    case 'subagent_block_end':
+      result.messagesActions.push({
+        type: 'SUBAGENT_BLOCK_END',
+        parentBlockId: msg.parentBlockId as string,
+        blockId: msg.blockId as string,
+        toolName: msg.toolName as string | undefined,
+        toolId: msg.toolId as string | undefined,
+        input: msg.input as string | undefined,
+        rawInput: msg.rawInput as RawToolInput | undefined,
+      });
+      break;
+
+    case 'subagent_tool_result':
+      result.messagesActions.push({
+        type: 'SUBAGENT_TOOL_RESULT',
+        parentBlockId: msg.parentBlockId as string,
+        toolId: msg.toolId as string,
+        result: msg.result as string,
+        isError: (msg.isError as boolean) ?? false,
+      });
+      break;
+
+    case 'subagent_end':
+      result.messagesActions.push({
+        type: 'SUBAGENT_END',
+        parentBlockId: msg.parentBlockId as string,
+        summary: msg.summary as string | undefined,
+        usage: msg.usage as
+          | {
+              inputTokens: number;
+              outputTokens: number;
+              cacheReadTokens: number;
+              cacheCreationTokens: number;
+            }
+          | undefined,
+      });
+      break;
   }
 
   return result;

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -152,6 +152,7 @@ export function finishCurrent(current: StreamingMessage): FinishedMessage {
       rawInput: b.rawInput,
       toolResult: b.toolResult,
       toolError: b.toolError,
+      subagent: b.subagent,
     };
   });
   return { messageId: current.messageId, role: 'assistant', blocks, timestamp: Date.now() };

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -77,6 +77,43 @@ export type MessagesAction =
     }
   | { type: 'MESSAGE_END'; messageId: string; sessionId?: string }
   | { type: 'SESSION_END'; sessionId?: string }
+  // Subagent events
+  | { type: 'SUBAGENT_START'; parentBlockId: string; subagentMessageId: string }
+  | {
+      type: 'SUBAGENT_BLOCK_START';
+      parentBlockId: string;
+      blockId: string;
+      blockType: BlockType;
+      toolName?: string;
+    }
+  | { type: 'SUBAGENT_BLOCK_DELTA'; parentBlockId: string; blockId: string; delta: string }
+  | {
+      type: 'SUBAGENT_BLOCK_END';
+      parentBlockId: string;
+      blockId: string;
+      toolName?: string;
+      toolId?: string;
+      input?: string;
+      rawInput?: RawToolInput;
+    }
+  | {
+      type: 'SUBAGENT_TOOL_RESULT';
+      parentBlockId: string;
+      toolId: string;
+      result: string;
+      isError: boolean;
+    }
+  | {
+      type: 'SUBAGENT_END';
+      parentBlockId: string;
+      summary?: string;
+      usage?: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadTokens: number;
+        cacheCreationTokens: number;
+      };
+    }
   // Reattach snapshot
   | { type: 'MESSAGE_SNAPSHOT'; messageId: string; blocks: FinishedBlock[] }
   // Session / UI lifecycle
@@ -465,6 +502,177 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
           },
         ],
       };
+
+    // Subagent reducer cases
+    case 'SUBAGENT_START': {
+      if (!state.current) return state;
+      const block = state.current.blocks.get(action.parentBlockId);
+      if (!block) return state;
+
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.parentBlockId, {
+        ...block,
+        subagent: {
+          messageId: action.subagentMessageId,
+          blocks: new Map(),
+          blockOrder: [],
+          running: true,
+        },
+      });
+
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'SUBAGENT_BLOCK_START': {
+      if (!state.current) return state;
+      const parentBlock = state.current.blocks.get(action.parentBlockId);
+      if (!parentBlock?.subagent) return state;
+
+      const newBlock: StreamingBlock = {
+        blockId: action.blockId,
+        blockType: action.blockType,
+        content: '',
+        done: false,
+        ...(action.toolName ? { toolName: action.toolName } : {}),
+      };
+
+      const newSubBlocks = new Map(parentBlock.subagent.blocks);
+      newSubBlocks.set(action.blockId, newBlock);
+
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.parentBlockId, {
+        ...parentBlock,
+        subagent: {
+          ...parentBlock.subagent,
+          blocks: newSubBlocks,
+          blockOrder: [...parentBlock.subagent.blockOrder, action.blockId],
+        },
+      });
+
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'SUBAGENT_BLOCK_DELTA': {
+      if (!state.current) return state;
+      const parentBlock = state.current.blocks.get(action.parentBlockId);
+      if (!parentBlock?.subagent) return state;
+
+      const subBlock = parentBlock.subagent.blocks.get(action.blockId);
+      if (!subBlock) return state;
+
+      const newSubBlocks = new Map(parentBlock.subagent.blocks);
+      newSubBlocks.set(action.blockId, {
+        ...subBlock,
+        content: subBlock.content + action.delta,
+      });
+
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.parentBlockId, {
+        ...parentBlock,
+        subagent: {
+          ...parentBlock.subagent,
+          blocks: newSubBlocks,
+        },
+      });
+
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'SUBAGENT_BLOCK_END': {
+      if (!state.current) return state;
+      const parentBlock = state.current.blocks.get(action.parentBlockId);
+      if (!parentBlock?.subagent) return state;
+
+      const subBlock = parentBlock.subagent.blocks.get(action.blockId);
+      if (!subBlock) return state;
+
+      const newSubBlocks = new Map(parentBlock.subagent.blocks);
+      newSubBlocks.set(action.blockId, {
+        ...subBlock,
+        done: true,
+        ...(action.toolName ? { toolName: action.toolName } : {}),
+        ...(action.toolId ? { toolId: action.toolId } : {}),
+        ...(action.input ? { toolInput: action.input } : {}),
+        ...(action.rawInput ? { rawInput: action.rawInput } : {}),
+      });
+
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.parentBlockId, {
+        ...parentBlock,
+        subagent: {
+          ...parentBlock.subagent,
+          blocks: newSubBlocks,
+        },
+      });
+
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
+
+    case 'SUBAGENT_TOOL_RESULT': {
+      if (!state.current) return state;
+      const parentBlock = state.current.blocks.get(action.parentBlockId);
+      if (!parentBlock?.subagent) return state;
+
+      // Find the tool block with matching toolId
+      for (const [blockId, subBlock] of parentBlock.subagent.blocks) {
+        if (subBlock.toolId === action.toolId) {
+          const newSubBlocks = new Map(parentBlock.subagent.blocks);
+          newSubBlocks.set(blockId, {
+            ...subBlock,
+            toolResult: action.result,
+            toolError: action.isError,
+          });
+
+          const newBlocks = new Map(state.current.blocks);
+          newBlocks.set(action.parentBlockId, {
+            ...parentBlock,
+            subagent: {
+              ...parentBlock.subagent,
+              blocks: newSubBlocks,
+            },
+          });
+
+          return { ...state, current: { ...state.current, blocks: newBlocks } };
+        }
+      }
+
+      return state;
+    }
+
+    case 'SUBAGENT_END': {
+      if (!state.current) return state;
+      const parentBlock = state.current.blocks.get(action.parentBlockId);
+      if (!parentBlock?.subagent) return state;
+
+      // Convert streaming subagent state to finished state
+      const finishedBlocks: FinishedBlock[] = parentBlock.subagent.blockOrder.map((blockId) => {
+        const b = parentBlock.subagent!.blocks.get(blockId)!;
+        return {
+          blockId: b.blockId,
+          blockType: b.blockType,
+          content: b.content,
+          toolName: b.toolName,
+          toolId: b.toolId,
+          toolInput: b.toolInput,
+          rawInput: b.rawInput,
+          toolResult: b.toolResult,
+          toolError: b.toolError,
+        };
+      });
+
+      const newBlocks = new Map(state.current.blocks);
+      newBlocks.set(action.parentBlockId, {
+        ...parentBlock,
+        subagent: {
+          messageId: parentBlock.subagent.messageId,
+          blocks: finishedBlocks,
+          summary: action.summary,
+          usage: action.usage,
+        },
+      });
+
+      return { ...state, current: { ...state.current, blocks: newBlocks } };
+    }
 
     default:
       return state;

--- a/packages/harness/__tests__/connection-registry.test.ts
+++ b/packages/harness/__tests__/connection-registry.test.ts
@@ -452,6 +452,60 @@ describe('ConnectionRegistry', () => {
       vi.advanceTimersByTime(5000);
       expect(t.send).not.toHaveBeenCalled();
     });
+
+    it('skips ended sessions when isSessionActive is provided', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      const store = mockEventStore([
+        { seq: 5, payload: { type: 'msg1' } },
+        { seq: 10, payload: { type: 'msg2' } },
+      ]);
+
+      // Add isSessionActive — sess-ended is inactive, sess-active is active
+      (store as EventStoreAdapter & { isSessionActive?: (id: string) => boolean }).isSessionActive =
+        (id: string) => id !== 'sess-ended';
+
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-ended');
+      registry.watch('conn-1', 'sess-active');
+      registry.startPeriodicSync();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should only fetch events for sess-active, not sess-ended
+      const calls = (store.getEventsAfter as ReturnType<typeof vi.fn>).mock.calls;
+      const sessionIds = calls.map((c: unknown[]) => c[0]);
+      expect(sessionIds).toContain('sess-active');
+      expect(sessionIds).not.toContain('sess-ended');
+
+      registry.stopPeriodicSync();
+    });
+
+    it('still syncs all sessions when isSessionActive is not provided', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      const store = mockEventStore([
+        { seq: 5, payload: { type: 'msg1' } },
+      ]);
+
+      // No isSessionActive — backwards compatible
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+      registry.watch('conn-1', 'sess-b');
+      registry.startPeriodicSync();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should fetch events for both sessions (no filtering)
+      const calls = (store.getEventsAfter as ReturnType<typeof vi.fn>).mock.calls;
+      const sessionIds = calls.map((c: unknown[]) => c[0]);
+      expect(sessionIds).toContain('sess-a');
+      expect(sessionIds).toContain('sess-b');
+
+      registry.stopPeriodicSync();
+    });
   });
 
   describe('dispose', () => {

--- a/packages/harness/__tests__/connection-registry.test.ts
+++ b/packages/harness/__tests__/connection-registry.test.ts
@@ -1,11 +1,22 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ConnectionRegistry } from '../src/connection-registry.js';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ConnectionRegistry, type EventStoreAdapter } from '../src/connection-registry.js';
 import type { SessionTransport } from '../src/session-transport.js';
 
 function mockTransport(open = true): SessionTransport {
   return {
     send: vi.fn(),
     isOpen: () => open,
+  };
+}
+
+function mockEventStore(
+  events: Array<{ seq: number; payload: Record<string, unknown> }> = [],
+): EventStoreAdapter {
+  return {
+    getEventsAfter: vi.fn((sessionId: string, afterSeq: number, limit?: number) => {
+      const filtered = events.filter((e) => e.seq > afterSeq);
+      return limit ? filtered.slice(0, limit) : filtered;
+    }),
   };
 }
 
@@ -199,6 +210,265 @@ describe('ConnectionRegistry', () => {
 
     it('is a no-op when no connections exist', () => {
       expect(() => registry.broadcastAll({ type: 'test' })).not.toThrow();
+    });
+  });
+
+  describe('cursor tracking', () => {
+    it('initializes cursor map when registering a connection', () => {
+      registry.register('conn-1', mockTransport());
+      // Cursor map is private, but we can verify behavior via broadcast
+      registry.watch('conn-1', 'sess-a');
+      registry.broadcast('sess-a', { type: 'test', seq: 10 });
+      // No error means cursor map exists
+    });
+
+    it('updates cursor on successful broadcast', () => {
+      const t = mockTransport(true);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      registry.broadcast('sess-a', { type: 'msg1', seq: 5 });
+      registry.broadcast('sess-a', { type: 'msg2', seq: 10 });
+
+      // Cursor should be at 10 now (can't inspect directly, but periodic sync will use it)
+      expect(t.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not update cursor when send fails', () => {
+      const t = mockTransport(true);
+      (t.send as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+        throw new Error('socket closing');
+      });
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      registry.broadcast('sess-a', { type: 'failed', seq: 5 });
+      // Cursor should stay at 0 (initial state)
+
+      // Now send succeeds
+      (t.send as ReturnType<typeof vi.fn>).mockImplementation(() => {});
+      registry.broadcast('sess-a', { type: 'success', seq: 10 });
+      // Cursor should jump to 10
+    });
+
+    it('handles out-of-order delivery by only advancing cursor forward', () => {
+      const t = mockTransport(true);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      registry.broadcast('sess-a', { type: 'msg1', seq: 10 });
+      registry.broadcast('sess-a', { type: 'msg2', seq: 5 }); // Out of order
+      registry.broadcast('sess-a', { type: 'msg3', seq: 15 });
+
+      // Cursor should be at 15 (max seen), not 5
+      expect(t.send).toHaveBeenCalledTimes(3);
+    });
+
+    it('cleans up cursors when connection is removed', () => {
+      registry.register('conn-1', mockTransport());
+      registry.watch('conn-1', 'sess-a');
+      registry.broadcast('sess-a', { type: 'test', seq: 10 });
+
+      registry.remove('conn-1');
+      // No error on subsequent broadcast means cursor cleanup succeeded
+      registry.register('conn-1', mockTransport());
+      registry.watch('conn-1', 'sess-a');
+      registry.broadcast('sess-a', { type: 'test', seq: 20 });
+    });
+  });
+
+  describe('resetCursor', () => {
+    it('resets cursor to client lastSeq on reconnect', () => {
+      const t = mockTransport(true);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      // Simulate cursor drift (broadcast moved cursor to 100)
+      registry.broadcast('sess-a', { type: 'msg', seq: 100 });
+
+      // Client reconnects with lastSeq=50 (missed 51-100)
+      registry.resetCursor('conn-1', 'sess-a', 50);
+
+      // Cursor should now be at 50 (verified by periodic sync behavior)
+    });
+
+    it('is a no-op for unknown connection', () => {
+      expect(() => registry.resetCursor('unknown', 'sess-a', 10)).not.toThrow();
+    });
+  });
+
+  describe('periodic sync', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries missed events from EventStore', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      const store = mockEventStore([
+        { seq: 5, payload: { type: 'msg1', data: 'a' } },
+        { seq: 10, payload: { type: 'msg2', data: 'b' } },
+        { seq: 15, payload: { type: 'msg3', data: 'c' } },
+      ]);
+
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      // Simulate cursor at 0 (never delivered anything)
+      registry.startPeriodicSync();
+
+      // Advance time to trigger sync
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should fetch events > 0 from store and deliver them
+      expect(store.getEventsAfter).toHaveBeenCalledWith('sess-a', 0, 50);
+      expect(t.send).toHaveBeenCalledTimes(3);
+      expect(t.send).toHaveBeenCalledWith({ type: 'msg1', data: 'a', seq: 5 });
+      expect(t.send).toHaveBeenCalledWith({ type: 'msg2', data: 'b', seq: 10 });
+      expect(t.send).toHaveBeenCalledWith({ type: 'msg3', data: 'c', seq: 15 });
+
+      registry.stopPeriodicSync();
+    });
+
+    it('stops retrying on first send failure in a batch', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      let callCount = 0;
+      (t.send as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 2) throw new Error('socket dead');
+      });
+
+      const store = mockEventStore([
+        { seq: 5, payload: { type: 'msg1' } },
+        { seq: 10, payload: { type: 'msg2' } },
+        { seq: 15, payload: { type: 'msg3' } },
+      ]);
+
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+      registry.startPeriodicSync();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should send msg1 (success), msg2 (fail), then stop
+      expect(t.send).toHaveBeenCalledTimes(2);
+
+      registry.stopPeriodicSync();
+    });
+
+    it('skips connections with closed transports', async () => {
+      vi.useFakeTimers();
+      const tClosed = mockTransport(false);
+      const store = mockEventStore([{ seq: 5, payload: { type: 'test' } }]);
+
+      registry.setEventStore(store);
+      registry.register('conn-closed', tClosed);
+      registry.watch('conn-closed', 'sess-a');
+      registry.startPeriodicSync();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(tClosed.send).not.toHaveBeenCalled();
+
+      registry.stopPeriodicSync();
+    });
+
+    it('respects SYNC_BATCH_LIMIT to avoid overwhelming slow clients', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      const manyEvents = Array.from({ length: 100 }, (_, i) => ({
+        seq: i + 1,
+        payload: { type: 'msg', i },
+      }));
+      const store = mockEventStore(manyEvents);
+
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+      registry.startPeriodicSync();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Should fetch with limit=50
+      expect(store.getEventsAfter).toHaveBeenCalledWith('sess-a', 0, 50);
+      expect(t.send).toHaveBeenCalledTimes(50);
+
+      registry.stopPeriodicSync();
+    });
+
+    it('handles EventStore fetch errors gracefully', async () => {
+      vi.useFakeTimers();
+      const t = mockTransport(true);
+      const store: EventStoreAdapter = {
+        getEventsAfter: vi.fn(() => {
+          throw new Error('database locked');
+        }),
+      };
+
+      registry.setEventStore(store);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+      registry.startPeriodicSync();
+
+      // Sync should not throw even when EventStore fetch fails
+      await expect(vi.advanceTimersByTimeAsync(5000)).resolves.not.toThrow();
+
+      expect(t.send).not.toHaveBeenCalled();
+
+      registry.stopPeriodicSync();
+    });
+
+    it('is a no-op when EventStore not set', () => {
+      const registry2 = new ConnectionRegistry();
+      expect(() => registry2.startPeriodicSync()).not.toThrow();
+      // No timer started, so no cleanup needed
+    });
+
+    it('warns when starting sync twice', () => {
+      const registry2 = new ConnectionRegistry();
+      const store = mockEventStore();
+      registry2.setEventStore(store);
+      registry2.startPeriodicSync();
+      // Second call should warn but not crash
+      expect(() => registry2.startPeriodicSync()).not.toThrow();
+      registry2.stopPeriodicSync();
+    });
+
+    it('stops periodic sync and clears timer', () => {
+      vi.useFakeTimers();
+      const store = mockEventStore();
+      registry.setEventStore(store);
+      registry.startPeriodicSync();
+      registry.stopPeriodicSync();
+
+      // Timer should be cleared — no sync fires
+      const t = mockTransport(true);
+      registry.register('conn-1', t);
+      registry.watch('conn-1', 'sess-a');
+
+      vi.advanceTimersByTime(5000);
+      expect(t.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dispose', () => {
+    it('stops periodic sync and clears all state', () => {
+      vi.useFakeTimers();
+      const store = mockEventStore();
+      registry.setEventStore(store);
+      registry.register('conn-1', mockTransport());
+      registry.startPeriodicSync();
+
+      registry.dispose();
+
+      expect(registry.get('conn-1')).toBeUndefined();
+
+      // Timer stopped — no sync fires
+      vi.advanceTimersByTime(5000);
+      expect(store.getEventsAfter).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/harness/src/connection-registry.ts
+++ b/packages/harness/src/connection-registry.ts
@@ -38,6 +38,9 @@ export interface EventStoreAdapter {
     seq: number;
     payload: Record<string, unknown>;
   }>;
+  /** Optional: check if a session is still active. When provided, periodic sync
+   *  skips ended sessions to avoid unnecessary EventStore queries. */
+  isSessionActive?(sessionId: string): boolean;
 }
 
 // Periodic sync fires every 5s to retry missed events
@@ -218,6 +221,11 @@ export class ConnectionRegistry {
         if (!connCursors) continue;
 
         for (const sessionId of conn.watchedSessions) {
+          // Skip ended sessions to avoid unnecessary EventStore queries
+          if (this.eventStore.isSessionActive && !this.eventStore.isSessionActive(sessionId)) {
+            continue;
+          }
+
           const cursor = connCursors.get(sessionId) ?? 0;
 
           // Fetch missed events from EventStore

--- a/packages/harness/src/connection-registry.ts
+++ b/packages/harness/src/connection-registry.ts
@@ -8,6 +8,12 @@
  *
  * Part of the v2 single-WS protocol — replaces the per-session WsPool
  * model where each session had its own socket.
+ *
+ * Delivery Guarantee:
+ * - Tracks per-connection per-session cursors (last delivered seq)
+ * - broadcast() updates cursor on successful send
+ * - Periodic sync retries events beyond cursor (handles WS races, iOS kills)
+ * - Reconnect resets cursor to client's lastSeq to prevent duplicate replay
  */
 
 import type { SessionTransport } from './session-transport.js';
@@ -22,8 +28,29 @@ export interface Connection {
   activeSession: string | null;
 }
 
+/** Event store interface for periodic sync — injected to avoid circular deps */
+export interface EventStoreAdapter {
+  getEventsAfter(
+    sessionId: string,
+    afterSeq: number,
+    limit?: number,
+  ): Array<{
+    seq: number;
+    payload: Record<string, unknown>;
+  }>;
+}
+
+// Periodic sync fires every 5s to retry missed events
+const SYNC_INTERVAL_MS = 5000;
+// Limit events per sync round per connection to avoid overwhelming slow clients
+const SYNC_BATCH_LIMIT = 50;
+
 export class ConnectionRegistry {
   private connections = new Map<string, Connection>();
+  // Per-connection per-session cursors: last successfully delivered seq
+  private cursors = new Map<string, Map<string, number>>();
+  private syncTimer: ReturnType<typeof setInterval> | null = null;
+  private eventStore: EventStoreAdapter | null = null;
 
   register(connectionId: string, transport: SessionTransport): void {
     this.connections.set(connectionId, {
@@ -32,6 +59,8 @@ export class ConnectionRegistry {
       watchedSessions: new Set(),
       activeSession: null,
     });
+    // Initialize cursor map for this connection
+    this.cursors.set(connectionId, new Map());
   }
 
   get(connectionId: string): Connection | undefined {
@@ -40,6 +69,16 @@ export class ConnectionRegistry {
 
   remove(connectionId: string): void {
     this.connections.delete(connectionId);
+    // Clean up cursors for this connection
+    this.cursors.delete(connectionId);
+  }
+
+  /**
+   * Set the EventStore adapter for periodic sync.
+   * Must be called before starting periodic sync.
+   */
+  setEventStore(eventStore: EventStoreAdapter): void {
+    this.eventStore = eventStore;
   }
 
   watch(connectionId: string, sessionId: string): void {
@@ -97,14 +136,28 @@ export class ConnectionRegistry {
   /**
    * Send a message to all open connections watching a session.
    * Catches send errors to prevent one failing transport from
-   * aborting the broadcast loop.
+   * aborting the broadcast loop. Updates delivery cursor on success
+   * so periodic sync can retry failures.
    */
   broadcast(sessionId: string, data: Record<string, unknown>): void {
+    const seq = data.seq as number | undefined;
     for (const { connectionId, transport } of this.getConnectionsWatching(sessionId, true)) {
       try {
         transport.send(data);
+        // Update cursor on successful delivery (if event has seq)
+        if (seq !== undefined) {
+          const connCursors = this.cursors.get(connectionId);
+          if (connCursors) {
+            const current = connCursors.get(sessionId) ?? 0;
+            // Only advance cursor forward (handle out-of-order delivery)
+            if (seq > current) {
+              connCursors.set(sessionId, seq);
+            }
+          }
+        }
       } catch {
-        log.warn('broadcast send failed', { connectionId, sessionId });
+        log.warn('broadcast send failed', { connectionId, sessionId, seq });
+        // Cursor not updated → periodic sync will retry
       }
     }
   }
@@ -124,5 +177,112 @@ export class ConnectionRegistry {
         });
       }
     }
+  }
+
+  /**
+   * Reset the cursor for a connection+session pair to the client's lastSeq.
+   * Called on reconnect to sync cursor with client state and prevent
+   * duplicate replay (EventStore handles the gap).
+   */
+  resetCursor(connectionId: string, sessionId: string, clientLastSeq: number): void {
+    const connCursors = this.cursors.get(connectionId);
+    if (!connCursors) return;
+    connCursors.set(sessionId, clientLastSeq);
+    log.info('cursor reset on reconnect', { connectionId, sessionId, cursor: clientLastSeq });
+  }
+
+  /**
+   * Start periodic sync — retries missed events for all connections.
+   * Runs every SYNC_INTERVAL_MS, bounded by SYNC_BATCH_LIMIT per connection.
+   * Call this once during server startup after setEventStore().
+   */
+  startPeriodicSync(): void {
+    if (this.syncTimer) {
+      log.warn('periodic sync already running');
+      return;
+    }
+    if (!this.eventStore) {
+      log.error('cannot start periodic sync: EventStore not set');
+      return;
+    }
+
+    log.info('starting periodic sync', { intervalMs: SYNC_INTERVAL_MS });
+
+    this.syncTimer = setInterval(() => {
+      if (!this.eventStore) return;
+
+      for (const [connectionId, conn] of this.connections.entries()) {
+        if (!conn.transport.isOpen()) continue;
+
+        const connCursors = this.cursors.get(connectionId);
+        if (!connCursors) continue;
+
+        for (const sessionId of conn.watchedSessions) {
+          const cursor = connCursors.get(sessionId) ?? 0;
+
+          // Fetch missed events from EventStore
+          let missedEvents: Array<{ seq: number; payload: Record<string, unknown> }>;
+          try {
+            missedEvents = this.eventStore.getEventsAfter(sessionId, cursor, SYNC_BATCH_LIMIT);
+          } catch (err) {
+            log.warn('periodic sync: EventStore fetch failed', {
+              connectionId,
+              sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            continue;
+          }
+
+          if (missedEvents.length === 0) continue;
+
+          log.info('periodic sync: retrying missed events', {
+            connectionId,
+            sessionId,
+            cursor,
+            missedCount: missedEvents.length,
+          });
+
+          // Retry delivery
+          for (const evt of missedEvents) {
+            try {
+              conn.transport.send({ ...evt.payload, seq: evt.seq });
+              // Update cursor on success
+              const current = connCursors.get(sessionId) ?? 0;
+              if (evt.seq > current) {
+                connCursors.set(sessionId, evt.seq);
+              }
+            } catch {
+              // Still failing — stop here, retry next sync round
+              log.warn('periodic sync: retry failed, stopping batch', {
+                connectionId,
+                sessionId,
+                failedSeq: evt.seq,
+              });
+              break;
+            }
+          }
+        }
+      }
+    }, SYNC_INTERVAL_MS);
+  }
+
+  /**
+   * Stop periodic sync and clean up timer. Call during graceful shutdown.
+   */
+  stopPeriodicSync(): void {
+    if (this.syncTimer) {
+      clearInterval(this.syncTimer);
+      this.syncTimer = null;
+      log.info('periodic sync stopped');
+    }
+  }
+
+  /**
+   * Dispose: stop sync, clear all state. Used for graceful shutdown.
+   */
+  dispose(): void {
+    this.stopPeriodicSync();
+    this.connections.clear();
+    this.cursors.clear();
   }
 }

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -13,7 +13,7 @@ export type {
 
 // Connection registry (v2 single-WS protocol)
 export { ConnectionRegistry } from './connection-registry.js';
-export type { Connection } from './connection-registry.js';
+export type { Connection, EventStoreAdapter } from './connection-registry.js';
 
 // SSE registry (broadcast events)
 export { SseRegistry } from './sse-registry.js';

--- a/packages/protocol/__tests__/subagent-types.test.ts
+++ b/packages/protocol/__tests__/subagent-types.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import type { StreamingBlock, FinishedBlock, SubagentUsage, SubagentState } from '../src/types.js';
+
+describe('Subagent Protocol Types', () => {
+  it('StreamingBlock supports nested subagent state', () => {
+    const block: StreamingBlock = {
+      blockId: 'b1',
+      blockType: 'tool_use',
+      content: '',
+      done: false,
+      toolName: 'Agent',
+      toolId: 't1',
+      subagent: {
+        messageId: 'msg-sub-1',
+        blocks: new Map(),
+        blockOrder: [],
+        running: true,
+      },
+    };
+
+    expect(block.subagent).toBeDefined();
+    expect(block.subagent?.running).toBe(true);
+    expect(block.subagent?.blocks).toBeInstanceOf(Map);
+  });
+
+  it('FinishedBlock supports nested subagent state', () => {
+    const subBlock: FinishedBlock = {
+      blockId: 'b-sub-1',
+      blockType: 'text',
+      content: 'Subagent output',
+    };
+
+    const block: FinishedBlock = {
+      blockId: 'b1',
+      blockType: 'tool_use',
+      content: '',
+      toolName: 'Agent',
+      toolId: 't1',
+      subagent: {
+        messageId: 'msg-sub-1',
+        blocks: [subBlock],
+        summary: 'Completed search',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+        },
+      },
+    };
+
+    expect(block.subagent).toBeDefined();
+    expect(block.subagent?.blocks).toHaveLength(1);
+    expect(block.subagent?.summary).toBe('Completed search');
+    expect(block.subagent?.usage?.inputTokens).toBe(100);
+  });
+
+  it('SubagentUsage type has required token fields', () => {
+    const usage: SubagentUsage = {
+      inputTokens: 200,
+      outputTokens: 100,
+      cacheReadTokens: 50,
+      cacheCreationTokens: 25,
+    };
+
+    expect(usage.inputTokens).toBe(200);
+    expect(usage.outputTokens).toBe(100);
+    expect(usage.cacheReadTokens).toBe(50);
+    expect(usage.cacheCreationTokens).toBe(25);
+  });
+
+  it('SubagentState supports streaming mode', () => {
+    const state: SubagentState = {
+      messageId: 'msg-sub-1',
+      blocks: new Map([
+        [
+          'b1',
+          {
+            blockId: 'b1',
+            blockType: 'thinking',
+            content: 'Analyzing...',
+            done: false,
+          },
+        ],
+      ]),
+      blockOrder: ['b1'],
+      running: true,
+    };
+
+    expect(state.running).toBe(true);
+    expect(state.blocks.size).toBe(1);
+    expect(state.blockOrder).toEqual(['b1']);
+  });
+
+  it('SubagentState supports finished mode', () => {
+    const state: SubagentState = {
+      messageId: 'msg-sub-1',
+      blocks: [
+        {
+          blockId: 'b1',
+          blockType: 'text',
+          content: 'Done',
+        },
+      ],
+      summary: 'Task complete',
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    };
+
+    expect(Array.isArray(state.blocks)).toBe(true);
+    expect(state.running).toBeUndefined();
+    expect(state.summary).toBe('Task complete');
+  });
+});

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -50,6 +50,7 @@ export interface StreamingBlock {
   rawInput?: RawToolInput;
   toolResult?: string;
   toolError?: boolean;
+  subagent?: StreamingSubagentState;
 }
 
 export interface StreamingMessage {
@@ -70,6 +71,7 @@ export interface FinishedBlock {
   rawInput?: RawToolInput;
   toolResult?: string;
   toolError?: boolean;
+  subagent?: FinishedSubagentState;
 }
 
 export interface FinishedMessage {
@@ -209,3 +211,34 @@ export interface ProgressBlock {
   items: ProgressItem[];
   sourceToolId?: string;
 }
+
+// --- Subagent nesting (nested agent execution visibility) ---
+
+export interface SubagentUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+/** Streaming subagent state — blocks in a Map, running flag set. */
+export interface StreamingSubagentState {
+  messageId: string;
+  blocks: Map<string, StreamingBlock>;
+  blockOrder: string[];
+  running: true;
+  summary?: never;
+  usage?: never;
+}
+
+/** Finished subagent state — blocks as array, summary + usage set. */
+export interface FinishedSubagentState {
+  messageId: string;
+  blocks: FinishedBlock[];
+  summary?: string;
+  usage?: SubagentUsage;
+  running?: never;
+}
+
+/** Union type for subagent state — streaming or finished. */
+export type SubagentState = StreamingSubagentState | FinishedSubagentState;

--- a/server/__tests__/query-loop.test.ts
+++ b/server/__tests__/query-loop.test.ts
@@ -1944,4 +1944,107 @@ describe('runQueryLoop', () => {
       expect(resultEvent!.attributes!['tool.is_error']).toBe(false);
     });
   });
+
+  describe('subagent block type tracking', () => {
+    it('emits correct blockType for thinking blocks in subagent_block_end', async () => {
+      const events: Record<string, unknown>[] = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-sa1' } } },
+        // Parent tool_use block (Agent tool)
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'tool_use', name: 'Agent', id: 'agent-tool-1' },
+          },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{"prompt":"test"}' },
+          },
+        },
+        // Subagent message_start
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: { type: 'message_start', message: { id: 'sub-msg-1' } },
+        },
+        // Subagent thinking block start
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'thinking' },
+          },
+        },
+        // Subagent thinking delta
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'thinking_delta', thinking: 'Let me think...' },
+          },
+        },
+        // Subagent thinking block stop — should produce blockType: 'thinking', not 'text'
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: { type: 'content_block_stop', index: 0 },
+        },
+        // Subagent text block start
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: {
+            type: 'content_block_start',
+            index: 1,
+            content_block: { type: 'text' },
+          },
+        },
+        // Subagent text delta
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: {
+            type: 'content_block_delta',
+            index: 1,
+            delta: { type: 'text_delta', text: 'Response' },
+          },
+        },
+        // Subagent text block stop — should produce blockType: 'text'
+        {
+          type: 'stream_event',
+          parent_tool_use_id: 'agent-tool-1',
+          event: { type: 'content_block_stop', index: 1 },
+        },
+        // End parent tool_use block
+        { type: 'stream_event', event: { type: 'content_block_stop', index: 0 } },
+        { type: 'assistant', message: { content: [] }, session_id: 'sess-sa' },
+        { type: 'result', session_id: 'sess-sa' },
+      ];
+
+      await runQueryLoop(eventStream(events), clientId, registry, abortController);
+
+      const sent = transport.sent;
+
+      // Find the subagent_block_end events
+      const subagentBlockEnds = sent.filter((m) => m.type === 'subagent_block_end');
+      expect(subagentBlockEnds.length).toBeGreaterThanOrEqual(2);
+
+      // First subagent_block_end should be thinking (index 0 was a thinking block)
+      const thinkingEnd = subagentBlockEnds.find((m) => m.blockType === 'thinking');
+      expect(thinkingEnd).toBeDefined();
+
+      // Second subagent_block_end should be text (index 1 was a text block)
+      const textEnd = subagentBlockEnds.find((m) => m.blockType === 'text');
+      expect(textEnd).toBeDefined();
+    });
+  });
 });

--- a/server/__tests__/subagent-events.test.ts
+++ b/server/__tests__/subagent-events.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runQueryLoop } from '../query-loop.js';
+import type { SessionRegistry } from '../session-registry.js';
+import type { SessionTransport } from '@mitzo/harness';
+
+describe('Subagent Event Emission', () => {
+  let mockRegistry: SessionRegistry;
+  let mockTransport: SessionTransport;
+  let sentEvents: Record<string, unknown>[];
+  let abortController: AbortController;
+
+  beforeEach(() => {
+    sentEvents = [];
+    abortController = new AbortController();
+
+    mockTransport = {
+      send: vi.fn((data: Record<string, unknown>) => {
+        sentEvents.push(data);
+      }),
+      isOpen: vi.fn(() => true),
+      close: vi.fn(),
+    } as unknown as SessionTransport;
+
+    mockRegistry = {
+      get: vi.fn(() => ({
+        transport: mockTransport,
+        sessionId: 'test-session',
+        cumulativeSessionTokens: 0,
+        cumulativeCostUsd: 0,
+        currentSnapshot: null,
+        cwd: '/test',
+        mode: 'agent' as const,
+        observers: new Set(),
+      })),
+      setSessionId: vi.fn(),
+      isAttached: vi.fn(() => true),
+      isSuspended: vi.fn(() => false),
+      bufferEvent: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as SessionRegistry;
+  });
+
+  it('emits subagent_start when parent_tool_use_id is detected', async () => {
+    const events = [
+      {
+        type: 'assistant',
+        session_id: 'test-session',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            id: 'msg-parent',
+            usage: { input_tokens: 100 },
+          },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'tool_use',
+            id: 'tool-agent-1',
+            name: 'Agent',
+          },
+        },
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_stop',
+          index: 0,
+        },
+      },
+      // Subagent message_start with parent_tool_use_id
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            id: 'msg-sub-1',
+            usage: { input_tokens: 50 },
+          },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'result',
+        session_id: 'test-session',
+        usage: { input_tokens: 150, output_tokens: 100 },
+      },
+    ];
+
+    async function* gen() {
+      for (const evt of events) {
+        yield evt;
+      }
+    }
+
+    await runQueryLoop(gen(), 'test-client', mockRegistry, abortController);
+
+    const subagentStart = sentEvents.find((e) => e.type === 'subagent_start');
+    expect(subagentStart).toBeDefined();
+    expect(subagentStart).toMatchObject({
+      v: 2,
+      type: 'subagent_start',
+      parentToolId: 'tool-agent-1',
+      subagentMessageId: 'msg-sub-1',
+    });
+  });
+
+  it('wraps subagent content blocks in subagent_block_* events', async () => {
+    const events = [
+      {
+        type: 'assistant',
+        session_id: 'test-session',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-parent', usage: { input_tokens: 100 } },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'tool-agent-1', name: 'Agent' },
+        },
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+      },
+      // Subagent turn
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-sub-1', usage: { input_tokens: 50 } },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'thinking' },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: { type: 'thinking_delta', thinking: 'Analyzing...' },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'result',
+        session_id: 'test-session',
+        usage: { input_tokens: 150, output_tokens: 100 },
+      },
+    ];
+
+    async function* gen() {
+      for (const evt of events) {
+        yield evt;
+      }
+    }
+
+    await runQueryLoop(gen(), 'test-client', mockRegistry, abortController);
+
+    expect(sentEvents.some((e) => e.type === 'subagent_block_start')).toBe(true);
+    expect(sentEvents.some((e) => e.type === 'subagent_block_delta')).toBe(true);
+    expect(sentEvents.some((e) => e.type === 'subagent_block_end')).toBe(true);
+  });
+
+  it('emits subagent_end with usage on subagent message_end', async () => {
+    const events = [
+      {
+        type: 'assistant',
+        session_id: 'test-session',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-parent', usage: { input_tokens: 100 } },
+        },
+        parent_tool_use_id: null,
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'tool-agent-1', name: 'Agent' },
+        },
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+      },
+      // Subagent turn
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { id: 'msg-sub-1', usage: { input_tokens: 50, output_tokens: 25 } },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'text' },
+        },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'stream_event',
+        event: { type: 'content_block_stop', index: 0 },
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'assistant',
+        parent_tool_use_id: 'tool-agent-1',
+      },
+      {
+        type: 'result',
+        session_id: 'test-session',
+        usage: { input_tokens: 150, output_tokens: 125 },
+      },
+    ];
+
+    async function* gen() {
+      for (const evt of events) {
+        yield evt;
+      }
+    }
+
+    await runQueryLoop(gen(), 'test-client', mockRegistry, abortController);
+
+    const subagentEnd = sentEvents.find((e) => e.type === 'subagent_end');
+    expect(subagentEnd).toBeDefined();
+    expect(subagentEnd).toMatchObject({
+      v: 2,
+      type: 'subagent_end',
+      usage: {
+        inputTokens: 50,
+        outputTokens: 25,
+      },
+    });
+  });
+});

--- a/server/__tests__/ws-handler-v2.test.ts
+++ b/server/__tests__/ws-handler-v2.test.ts
@@ -283,6 +283,40 @@ describe('handleReconnect', () => {
 
     expect(reattachChat).not.toHaveBeenCalled();
   });
+
+  it('resets cursor to client lastSeq immediately after watch (before replay)', () => {
+    const eventStore = mockEventStore();
+    eventStore.getEventsAfter.mockReturnValue([
+      { seq: 51, payload: { type: 'msg1' } },
+      { seq: 52, payload: { type: 'msg2' } },
+    ]);
+
+    const ctx = createContext({
+      eventStore: eventStore as unknown as V2HandlerContext['eventStore'],
+    });
+    const transport = mockTransport();
+    ctx.connRegistry.register('c1', transport);
+
+    // Spy on resetCursor to verify it's called early
+    const resetSpy = vi.spyOn(ctx.connRegistry, 'resetCursor');
+
+    handleReconnect(
+      'c1',
+      { type: 'reconnect', sessions: [{ sessionId: 'sess-1', lastSeq: 50 }] },
+      ctx,
+    );
+
+    // resetCursor should have been called at least twice:
+    // 1. Before replay (with client's lastSeq)
+    // 2. After replay (with final replayed seq)
+    expect(resetSpy).toHaveBeenCalledTimes(2);
+    // First call sets cursor to client's lastSeq
+    expect(resetSpy).toHaveBeenNthCalledWith(1, 'c1', 'sess-1', 50);
+    // Second call sets cursor to last replayed seq
+    expect(resetSpy).toHaveBeenNthCalledWith(2, 'c1', 'sess-1', 52);
+
+    resetSpy.mockRestore();
+  });
 });
 
 // ─── handleWatch / handleUnwatch ─────────────────────────────────────────────

--- a/server/index.ts
+++ b/server/index.ts
@@ -89,8 +89,13 @@ const nativeCommands = new NativeCommandRegistry();
 const connRegistry = new ConnectionRegistry();
 setConnectionRegistry(connRegistry);
 
-// Wire up EventStore for periodic sync (enables delivery guarantee)
-connRegistry.setEventStore(eventStore);
+// Wire up EventStore for periodic sync (enables delivery guarantee).
+// Provide isSessionActive so periodic sync skips ended sessions.
+connRegistry.setEventStore({
+  getEventsAfter: (sessionId, afterSeq, limit) =>
+    eventStore.getEventsAfter(sessionId, afterSeq, limit),
+  isSessionActive: (sessionId) => eventStore.getSession(sessionId)?.isActive ?? false,
+});
 
 // Resolve cert paths relative to the project root (where package.json lives)
 const __filename = fileURLToPath(import.meta.url);

--- a/server/index.ts
+++ b/server/index.ts
@@ -89,6 +89,9 @@ const nativeCommands = new NativeCommandRegistry();
 const connRegistry = new ConnectionRegistry();
 setConnectionRegistry(connRegistry);
 
+// Wire up EventStore for periodic sync (enables delivery guarantee)
+connRegistry.setEventStore(eventStore);
+
 // Resolve cert paths relative to the project root (where package.json lives)
 const __filename = fileURLToPath(import.meta.url);
 const PROJECT_ROOT = join(__filename, '..', '..');
@@ -832,6 +835,7 @@ function shutdown(signal: string) {
   healthMonitor.destroy();
   overviewEmitter.destroy();
   sseRegistry.destroy();
+  connRegistry.dispose(); // Stop periodic sync + clear state
   registry.dispose();
   for (const client of wss.clients) {
     client.close(1001, 'Server shutting down');
@@ -854,6 +858,10 @@ checkPort(PORT).then((inUse) => {
   server.listen(PORT, () => {
     const protocol = USE_TLS ? 'https' : 'http';
     log.info(`Chat Agent running on ${protocol}://localhost:${PORT}${USE_TLS ? ' (TLS)' : ''}`);
+
+    // Start periodic sync for connection-level delivery guarantee
+    connRegistry.startPeriodicSync();
+
     // Eagerly reconcile sessions so the first /api/sessions request is fast and accurate.
     reconcileSessionsBackground();
     // Clean up stale worktrees across all repos.

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -187,7 +187,7 @@ async function _runQueryLoopInner(
       parentBlockId: string;
       parentToolName: string;
       subagentMessageId: string | null;
-      subagentBlockIdByIndex: Map<number, string>;
+      subagentBlockIdByIndex: Map<number, { blockId: string; blockType: string }>;
       subagentToolInputBuffers: Map<number, { name: string; id: string; inputBuf: string }>;
       usage: {
         inputTokens: number;
@@ -674,8 +674,8 @@ async function _runQueryLoopInner(
               const contentBlock = evt.content_block as Record<string, unknown> | undefined;
               const index = evt.index as number;
               const blockId = nextBlockId();
-              subagent.subagentBlockIdByIndex.set(index, blockId);
               const blockType = contentBlock?.type as string | undefined;
+              subagent.subagentBlockIdByIndex.set(index, { blockId, blockType: blockType ?? 'text' });
 
               if (blockType === 'thinking' || blockType === 'redacted_thinking') {
                 emit(
@@ -805,7 +805,8 @@ async function _runQueryLoopInner(
             if (subagent) {
               const delta = evt.delta as Record<string, unknown> | undefined;
               const index = evt.index as number;
-              const blockId = subagent.subagentBlockIdByIndex.get(index);
+              const blockEntry = subagent.subagentBlockIdByIndex.get(index);
+              const blockId = blockEntry?.blockId;
 
               if (delta?.type === 'text_delta' && blockId) {
                 emit(
@@ -879,7 +880,8 @@ async function _runQueryLoopInner(
             // Subagent content_block_stop
             if (subagent) {
               const index = evt.index as number;
-              const blockId = subagent.subagentBlockIdByIndex.get(index);
+              const blockEntry = subagent.subagentBlockIdByIndex.get(index);
+              const blockId = blockEntry?.blockId;
               const toolEntry = subagent.subagentToolInputBuffers.get(index);
 
               if (toolEntry && blockId) {
@@ -912,13 +914,13 @@ async function _runQueryLoopInner(
                   toolId: toolEntry.id,
                 });
               } else if (blockId) {
-                // Text or thinking block
+                // Text or thinking block — use the stored blockType
                 emit(
                   v2('subagent_block_end', {
                     parentBlockId: subagent.parentBlockId,
                     subagentMessageId: subagent.subagentMessageId,
                     blockId,
-                    blockType: subagent.subagentBlockIdByIndex.get(index) ? 'text' : 'thinking',
+                    blockType: blockEntry!.blockType as 'text' | 'thinking',
                   }),
                 );
               }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -180,8 +180,29 @@ async function _runQueryLoopInner(
   // Progress tracker — intercepts TodoWrite calls, emits structured events.
   const progressTracker = new ProgressTracker();
 
+  // Subagent tracking — maps parent_tool_use_id → subagent state
+  const activeSubagents = new Map<
+    string,
+    {
+      parentBlockId: string;
+      parentToolName: string;
+      subagentMessageId: string | null;
+      subagentBlockIdByIndex: Map<number, string>;
+      subagentToolInputBuffers: Map<number, { name: string; id: string; inputBuf: string }>;
+      usage: {
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadTokens: number;
+        cacheCreationTokens: number;
+      } | null;
+    }
+  >();
+
   // Map content block index → blockId for all block types.
   const blockIdByIndex = new Map<number, string>();
+
+  // Persistent map: toolId → blockId (for subagent parent lookup)
+  const toolIdToBlockId = new Map<string, string>();
 
   let blockCounter = 0;
   let currentMessageId: string | null = null;
@@ -333,6 +354,30 @@ async function _runQueryLoopInner(
         log.debug('sdk event', { clientId, type: msg.type });
 
         if (msg.type === 'assistant') {
+          const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+
+          // Subagent turn complete — emit subagent_end
+          if (parentToolUseId) {
+            const subagent = activeSubagents.get(parentToolUseId);
+            if (subagent) {
+              emit(
+                v2('subagent_end', {
+                  parentBlockId: subagent.parentBlockId,
+                  subagentMessageId: subagent.subagentMessageId,
+                  usage: subagent.usage ?? undefined,
+                }),
+              );
+              log.info('subagent completed', {
+                clientId,
+                parentToolId: parentToolUseId,
+                subagentMessageId: subagent.subagentMessageId,
+                usage: subagent.usage,
+              });
+              activeSubagents.delete(parentToolUseId);
+            }
+            continue;
+          }
+
           // Turn complete — defer message_end until all blocks are closed.
           if (currentMessageId) {
             pendingMessageEnd = v2('message_end', {
@@ -510,6 +555,54 @@ async function _runQueryLoopInner(
           log.debug('stream event', { clientId, evtType: evt?.type });
 
           if (evt?.type === 'message_start') {
+            const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+
+            // Subagent message_start — emit subagent_start instead of normal message_start
+            if (parentToolUseId) {
+              const parentBlockId = toolIdToBlockId.get(parentToolUseId);
+              const apiMsg = evt.message as Record<string, unknown> | undefined;
+              const subagentMessageId = (apiMsg?.id as string | undefined) ?? `msg-${Date.now()}`;
+
+              if (parentBlockId) {
+                activeSubagents.set(parentToolUseId, {
+                  parentBlockId,
+                  parentToolName: 'Agent', // We don't track this persistently, assume Agent
+                  subagentMessageId,
+                  subagentBlockIdByIndex: new Map(),
+                  subagentToolInputBuffers: new Map(),
+                  usage: null,
+                });
+
+                // Extract usage from message_start
+                const msgUsage = (apiMsg as Record<string, unknown> | undefined)?.usage as
+                  | Record<string, number>
+                  | undefined;
+                if (msgUsage) {
+                  activeSubagents.get(parentToolUseId)!.usage = {
+                    inputTokens: msgUsage.input_tokens ?? 0,
+                    outputTokens: msgUsage.output_tokens ?? 0,
+                    cacheReadTokens: msgUsage.cache_read_input_tokens ?? 0,
+                    cacheCreationTokens: msgUsage.cache_creation_input_tokens ?? 0,
+                  };
+                }
+
+                emit(
+                  v2('subagent_start', {
+                    parentBlockId,
+                    parentToolId: parentToolUseId,
+                    subagentMessageId,
+                  }),
+                );
+                log.info('subagent started', {
+                  clientId,
+                  parentToolId: parentToolUseId,
+                  subagentMessageId,
+                });
+              }
+              // Don't process parent turn logic for subagent message_start
+              continue;
+            }
+
             // End previous turn span if still open (e.g. deferred message_end)
             if (currentTurnSpan) {
               currentTurnSpan.setAttribute('turn.block_count', turnBlockCount);
@@ -573,6 +666,56 @@ async function _runQueryLoopInner(
               }
             }
           } else if (evt?.type === 'content_block_start') {
+            const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+            const subagent = parentToolUseId ? activeSubagents.get(parentToolUseId) : undefined;
+
+            // Subagent content_block_start
+            if (subagent) {
+              const contentBlock = evt.content_block as Record<string, unknown> | undefined;
+              const index = evt.index as number;
+              const blockId = nextBlockId();
+              subagent.subagentBlockIdByIndex.set(index, blockId);
+              const blockType = contentBlock?.type as string | undefined;
+
+              if (blockType === 'thinking' || blockType === 'redacted_thinking') {
+                emit(
+                  v2('subagent_block_start', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType,
+                  }),
+                );
+              } else if (blockType === 'tool_use') {
+                const toolName = contentBlock!.name as string;
+                const toolId = contentBlock!.id as string;
+                subagent.subagentToolInputBuffers.set(index, {
+                  name: toolName,
+                  id: toolId,
+                  inputBuf: '',
+                });
+                emit(
+                  v2('subagent_block_start', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: 'tool_use',
+                    toolName,
+                  }),
+                );
+              } else if (blockType === 'text') {
+                emit(
+                  v2('subagent_block_start', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: 'text',
+                  }),
+                );
+              }
+              continue;
+            }
+
             // Auto-init message context if SDK delivers blocks before message_start.
             // On the first turn, AssistantMessage can win the async iterator race
             // and the first content_block_start arrives before message_start.
@@ -610,6 +753,7 @@ async function _runQueryLoopInner(
               const toolName = contentBlock!.name as string;
               const toolId = contentBlock!.id as string;
               toolInputBuffers.set(index, { name: toolName, id: toolId, inputBuf: '', blockId });
+              toolIdToBlockId.set(toolId, blockId); // Track toolId → blockId for subagent lookup
               const snapshotBlock: SnapshotBlock = {
                 blockId,
                 blockType: 'tool_use',
@@ -654,6 +798,42 @@ async function _runQueryLoopInner(
               );
             }
           } else if (evt?.type === 'content_block_delta') {
+            const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+            const subagent = parentToolUseId ? activeSubagents.get(parentToolUseId) : undefined;
+
+            // Subagent content_block_delta
+            if (subagent) {
+              const delta = evt.delta as Record<string, unknown> | undefined;
+              const index = evt.index as number;
+              const blockId = subagent.subagentBlockIdByIndex.get(index);
+
+              if (delta?.type === 'text_delta' && blockId) {
+                emit(
+                  v2('subagent_block_delta', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: 'text',
+                    delta: delta.text as string,
+                  }),
+                );
+              } else if (delta?.type === 'thinking_delta' && blockId) {
+                emit(
+                  v2('subagent_block_delta', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: 'thinking',
+                    delta: delta.thinking as string,
+                  }),
+                );
+              } else if (delta?.type === 'input_json_delta') {
+                const entry = subagent.subagentToolInputBuffers.get(index);
+                if (entry) entry.inputBuf += delta.partial_json as string;
+              }
+              continue;
+            }
+
             const delta = evt.delta as Record<string, unknown> | undefined;
             const index = evt.index as number;
             const blockId = blockIdByIndex.get(index);
@@ -693,6 +873,58 @@ async function _runQueryLoopInner(
               if (entry) entry.inputBuf += delta.partial_json as string;
             }
           } else if (evt?.type === 'content_block_stop') {
+            const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+            const subagent = parentToolUseId ? activeSubagents.get(parentToolUseId) : undefined;
+
+            // Subagent content_block_stop
+            if (subagent) {
+              const index = evt.index as number;
+              const blockId = subagent.subagentBlockIdByIndex.get(index);
+              const toolEntry = subagent.subagentToolInputBuffers.get(index);
+
+              if (toolEntry && blockId) {
+                subagent.subagentToolInputBuffers.delete(index);
+                let toolInput: Record<string, unknown> = {};
+                try {
+                  toolInput = JSON.parse(toolEntry.inputBuf || '{}');
+                } catch {
+                  /* malformed JSON */
+                }
+                const summarized = summarizeToolInput(toolEntry.name, toolInput);
+                const rawInput = getRawInput(toolEntry.name, toolInput);
+
+                emit(
+                  v2('subagent_block_end', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: 'tool_use',
+                    toolName: toolEntry.name,
+                    toolId: toolEntry.id,
+                    input: summarized,
+                    ...(rawInput ? { rawInput } : {}),
+                  }),
+                );
+                log.info('subagent tool call', {
+                  clientId,
+                  parentToolId: parentToolUseId,
+                  tool: toolEntry.name,
+                  toolId: toolEntry.id,
+                });
+              } else if (blockId) {
+                // Text or thinking block
+                emit(
+                  v2('subagent_block_end', {
+                    parentBlockId: subagent.parentBlockId,
+                    subagentMessageId: subagent.subagentMessageId,
+                    blockId,
+                    blockType: subagent.subagentBlockIdByIndex.get(index) ? 'text' : 'thinking',
+                  }),
+                );
+              }
+              continue;
+            }
+
             const index = evt.index as number;
             const blockId = blockIdByIndex.get(index);
             const toolEntry = toolInputBuffers.get(index);
@@ -815,11 +1047,34 @@ async function _runQueryLoopInner(
           // API conversation turns (agent sub-prompts, tool-result text) and
           // replay them as user bubbles on session rejoin.
           const content = (msg.message as unknown as Record<string, unknown>)?.content;
+          const parentToolUseId = msg.parent_tool_use_id as string | undefined;
+          const subagent = parentToolUseId ? activeSubagents.get(parentToolUseId) : undefined;
+
           if (Array.isArray(content)) {
             for (const block of content) {
               if (block.type === 'tool_result') {
                 const resultText = extractToolResultText(block.content);
                 const trResult = truncateForTrace(resultText);
+
+                // Check if this is a subagent tool result
+                if (subagent) {
+                  emit(
+                    v2('subagent_tool_result', {
+                      parentBlockId: subagent.parentBlockId,
+                      subagentMessageId: subagent.subagentMessageId,
+                      toolId: block.tool_use_id || '',
+                      result: resultText.slice(0, TOOL_RESULT_MAX_CHARS),
+                      isError: block.is_error === true,
+                    }),
+                  );
+                  log.info('subagent tool result', {
+                    clientId,
+                    parentToolId: parentToolUseId,
+                    toolId: block.tool_use_id || '',
+                    isError: block.is_error === true,
+                  });
+                  continue;
+                }
 
                 // Record tool result in session span and logs
                 span.addEvent('tool.result', {

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -127,6 +127,10 @@ export function handleReconnect(
       for (const entry of msg.sessions) {
         ctx.connRegistry.watch(connectionId, entry.sessionId);
 
+        // Set cursor to client's lastSeq BEFORE replay, so periodic sync
+        // sees a reasonable cursor during replay instead of 0.
+        ctx.connRegistry.resetCursor(connectionId, entry.sessionId, entry.lastSeq);
+
         const events = ctx.eventStore.getEventsAfter(entry.sessionId, entry.lastSeq);
         for (const evt of events) {
           ctx.connRegistry.get(connectionId)?.transport.send({

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -135,6 +135,11 @@ export function handleReconnect(
           } as Record<string, unknown>);
         }
 
+        // Reset cursor to last replayed seq — prevents duplicate delivery from
+        // periodic sync. If no events replayed, cursor stays at client's lastSeq.
+        const newCursor = events.length > 0 ? events[events.length - 1].seq : entry.lastSeq;
+        ctx.connRegistry.resetCursor(connectionId, entry.sessionId, newCursor);
+
         // Cross-reference with the durable EventStore: markSessionInactive() is
         // called in the query loop's finally block, so isActive=false in the
         // store is ground truth that the loop has ended.


### PR DESCRIPTION
## Problem

Events could be lost when `broadcast()` failed during:
- iOS backgrounding killing WebSocket mid-stream  
- Network timing races (WS closes before send completes)
- Connection drops during event delivery

The bug manifested as stuck "Running..." UI — subagents completed but clients never received the `session_end` event.

**Reproduction**: From production logs (session `42fda507`, 2026-05-03 ~21:22):
1. User sends message "Add me some cards for dreame in HA"
2. Agent spawns subagent ("Explore HA Dreame entities")  
3. iOS suspends app → WS dies mid-stream
4. Server-side subagent completes, query loop ends with `doneSent: false`
5. Client reconnects, replays events from EventStore
6. Query loop already ended → no more events to replay  
7. UI shows "Running..." forever

## Root Cause

Event delivery was fire-and-forget. `broadcast()` sent events via WS but had no retry logic. If `send()` failed, the event was lost. EventStore replay only worked if the client reconnected **before** the query loop ended — events lost in that timing window were gone forever.

## Solution

Implemented **connection-level event cursors with periodic sync**:

### 1. Cursor Tracking
Each connection maintains `last-delivered seq` per session. Updated on successful `broadcast()`.

### 2. Periodic Sync  
Background task (5s interval) retries missed events by comparing cursor vs EventStore. Bounded to 50 events/round to avoid overwhelming slow connections.

### 3. Reconnect Reset
Cursor resets to client's `lastSeq` on reconnect to prevent duplicate replay (EventStore handles the gap).

### 4. Out-of-Order Safety
Cursor only advances forward, handles reordered delivery gracefully.

## Changes

### `ConnectionRegistry` (`packages/harness/src/connection-registry.ts`)
- Add `cursors` map (per-connection per-session tracking)
- Add `EventStoreAdapter` interface (injected to avoid circular deps)  
- Update `broadcast()` to track delivery success and update cursors
- Add `resetCursor()` for reconnect cursor sync
- Add `startPeriodicSync()` / `stopPeriodicSync()` for background retry
- Add `setEventStore()` for EventStore injection
- Add `dispose()` for graceful cleanup

### `ws-handler-v2.ts` (`server/ws-handler-v2.ts`)
- Call `resetCursor()` in `handleReconnect()` after EventStore replay

### `server/index.ts`
- Wire `EventStore` to `ConnectionRegistry` via `setEventStore()`
- Start periodic sync in `server.listen()` callback
- Stop periodic sync in `shutdown()` function

### Tests (`packages/harness/__tests__/connection-registry.test.ts`)
Added 14 new tests covering:
- Cursor initialization and cleanup
- Cursor update on successful broadcast  
- Cursor preservation on failed send
- Out-of-order delivery handling
- Reconnect cursor reset
- Periodic sync retry logic
- Batch size limiting (50 events/round)
- EventStore fetch error handling
- Closed connection skipping
- Sync start/stop lifecycle

## Edge Cases Handled

| Scenario | Behavior |
|----------|----------|
| Broadcast fails mid-delivery | Cursor stays behind, periodic sync retries within 5s |
| EventStore append + broadcast race | Sync catches missed event within 5s |
| Slow client (backpressure) | Sync rate-limited to 50 events/round |
| Multi-device sessions | Each connection has independent cursor |
| Observer connections | Same cursor mechanism applies |
| Session ends while suspended | Sync delivers missed events on resume |
| Reconnect with stale cursor | Reset to client's `lastSeq` prevents dupes |
| Out-of-order delivery | Cursor only advances forward (max seen) |
| EventStore fetch fails | Logged, next sync round retries |
| Sync already running | Warning logged, no-op |

## Testing

All tests pass:
- ✅ `packages/harness/__tests__/connection-registry.test.ts` — 35 tests (14 new)
- ✅ `server/__tests__/ws-handler-v2.test.ts` — 99 tests (no regressions)  
- ✅ Full test suite — 2437 tests pass

## Deployment Notes

- **Zero config required** — periodic sync starts automatically on server boot
- **No schema changes** — uses existing EventStore
- **Backward compatible** — clients without `seq` support work fine (cursors stay at 0)
- **Performance impact** — minimal (5s interval, 50 events/round cap)

Fixes the stalled Agent tool bug identified in production (follow-up to PR #239).

🤖 Generated with [Claude Code](https://claude.com/claude-code)