### PR TITLE
feat(ui): desktop page navigation + New Chat fix

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { TodoDetailView } from './pages/TodoDetailView';
 import { TaskBoard } from './pages/TaskBoard';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { MobileShell } from './components/MobileShell';
+import { DesktopShell } from './components/DesktopShell';
 import { useIsDesktop } from './hooks/useMediaQuery';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -39,6 +40,12 @@ function HomeRoute() {
 function ChatRoute() {
   const isDesktop = useIsDesktop();
   return isDesktop ? <DesktopChatView /> : <ChatView />;
+}
+
+function PageRoute({ children }: { children: React.ReactNode }) {
+  const isDesktop = useIsDesktop();
+  if (!isDesktop) return <>{children}</>;
+  return <DesktopShell center={children} />;
 }
 
 function dismissKeyboard(e: React.MouseEvent | React.TouchEvent) {
@@ -96,7 +103,9 @@ export function App() {
                 path="/inbox"
                 element={
                   <ProtectedRoute>
-                    <InboxView />
+                    <PageRoute>
+                      <InboxView />
+                    </PageRoute>
                   </ProtectedRoute>
                 }
               />
@@ -104,7 +113,9 @@ export function App() {
                 path="/calendar"
                 element={
                   <ProtectedRoute>
-                    <CalendarView />
+                    <PageRoute>
+                      <CalendarView />
+                    </PageRoute>
                   </ProtectedRoute>
                 }
               />
@@ -112,7 +123,9 @@ export function App() {
                 path="/todos"
                 element={
                   <ProtectedRoute>
-                    <TodoView />
+                    <PageRoute>
+                      <TodoView />
+                    </PageRoute>
                   </ProtectedRoute>
                 }
               />
@@ -120,7 +133,9 @@ export function App() {
                 path="/todos/:id"
                 element={
                   <ProtectedRoute>
-                    <TodoDetailView />
+                    <PageRoute>
+                      <TodoDetailView />
+                    </PageRoute>
                   </ProtectedRoute>
                 }
               />
@@ -128,7 +143,9 @@ export function App() {
                 path="/tasks"
                 element={
                   <ProtectedRoute>
-                    <TaskBoard />
+                    <PageRoute>
+                      <TaskBoard />
+                    </PageRoute>
                   </ProtectedRoute>
                 }
               />
@@ -137,7 +154,9 @@ export function App() {
                 element={
                   <ProtectedRoute>
                     <ErrorBoundary>
-                      <FileViewer />
+                      <PageRoute>
+                        <FileViewer />
+                      </PageRoute>
                     </ErrorBoundary>
                   </ProtectedRoute>
                 }

--- a/frontend/src/components/DesktopNav.tsx
+++ b/frontend/src/components/DesktopNav.tsx
@@ -1,0 +1,48 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTabBadges } from '../hooks/useTabBadges';
+
+interface NavItem {
+  label: string;
+  path: string;
+  match: (pathname: string) => boolean;
+  badge?: number;
+}
+
+export function DesktopNav() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { inboxCount, todoCount } = useTabBadges();
+
+  const items: NavItem[] = [
+    {
+      label: 'Chat',
+      path: '/',
+      match: (p) => p === '/' || p === '/chat' || p.startsWith('/chat/'),
+    },
+    { label: 'Calendar', path: '/calendar', match: (p) => p.startsWith('/calendar') },
+    { label: 'Inbox', path: '/inbox', match: (p) => p === '/inbox', badge: inboxCount },
+    {
+      label: 'Telos',
+      path: '/todos',
+      match: (p) => p === '/todos' || p.startsWith('/todos/'),
+      badge: todoCount,
+    },
+    { label: 'Tasks', path: '/tasks', match: (p) => p.startsWith('/tasks') },
+    { label: 'Files', path: '/files', match: (p) => p.startsWith('/files') },
+  ];
+
+  return (
+    <nav className="desktop-nav">
+      {items.map((item) => (
+        <button
+          key={item.label}
+          className={`desktop-nav-item${item.match(location.pathname) ? ' desktop-nav-item--active' : ''}`}
+          onClick={() => navigate(item.path)}
+        >
+          <span>{item.label}</span>
+          {item.badge ? <span className="desktop-nav-badge">{item.badge}</span> : null}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/DesktopShell.tsx
+++ b/frontend/src/components/DesktopShell.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, type ReactNode } from 'react';
+import { DesktopNav } from './DesktopNav';
 
 export interface DesktopShellProps {
-  left: ReactNode;
+  left?: ReactNode;
   center: ReactNode;
-  right: ReactNode;
+  right?: ReactNode;
   statusBar?: ReactNode;
 }
 
@@ -55,25 +56,32 @@ export function DesktopShell({ left, center, right, statusBar }: DesktopShellPro
           <button
             className="desktop-collapse-btn"
             onClick={toggleLeft}
-            title={leftCollapsed ? 'Show sessions' : 'Hide sessions'}
+            title={leftCollapsed ? 'Show sidebar' : 'Hide sidebar'}
           >
             {leftCollapsed ? '\u25B6' : '\u25C0'}
           </button>
-          {!leftCollapsed && left}
+          {!leftCollapsed && (
+            <>
+              <DesktopNav />
+              {left}
+            </>
+          )}
         </div>
         <div className="desktop-center">{center}</div>
-        <div
-          className={`desktop-sidebar-right${rightCollapsed ? ' desktop-sidebar--collapsed' : ''}`}
-        >
-          <button
-            className="desktop-collapse-btn"
-            onClick={toggleRight}
-            title={rightCollapsed ? 'Show context' : 'Hide context'}
+        {right && (
+          <div
+            className={`desktop-sidebar-right${rightCollapsed ? ' desktop-sidebar--collapsed' : ''}`}
           >
-            {rightCollapsed ? '\u25C0' : '\u25B6'}
-          </button>
-          {!rightCollapsed && right}
-        </div>
+            <button
+              className="desktop-collapse-btn"
+              onClick={toggleRight}
+              title={rightCollapsed ? 'Show context' : 'Hide context'}
+            >
+              {rightCollapsed ? '\u25C0' : '\u25B6'}
+            </button>
+            {!rightCollapsed && right}
+          </div>
+        )}
       </div>
       {statusBar && <div className="desktop-status-row">{statusBar}</div>}
     </div>

--- a/frontend/src/components/__tests__/DesktopShell.test.tsx
+++ b/frontend/src/components/__tests__/DesktopShell.test.tsx
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('../DesktopNav', () => ({
+  DesktopNav: () => <nav data-testid="desktop-nav">Nav</nav>,
+}));
+
 import { DesktopShell } from '../DesktopShell';
 
 beforeEach(() => {
@@ -31,7 +36,7 @@ describe('DesktopShell', () => {
         right={<div>Right</div>}
       />,
     );
-    const toggleBtn = screen.getByTitle('Hide sessions');
+    const toggleBtn = screen.getByTitle('Hide sidebar');
     fireEvent.click(toggleBtn);
     expect(screen.queryByText('Left Panel')).toBeNull();
     expect(localStorage.getItem('mitzo-sidebar-left-collapsed')).toBe('1');
@@ -61,7 +66,7 @@ describe('DesktopShell', () => {
       />,
     );
     expect(screen.queryByText('Left Panel')).toBeNull();
-    expect(screen.getByTitle('Show sessions')).toBeTruthy();
+    expect(screen.getByTitle('Show sidebar')).toBeTruthy();
   });
 
   it('expands collapsed sidebar on toggle', () => {
@@ -73,7 +78,7 @@ describe('DesktopShell', () => {
         right={<div>Right</div>}
       />,
     );
-    fireEvent.click(screen.getByTitle('Show sessions'));
+    fireEvent.click(screen.getByTitle('Show sidebar'));
     expect(screen.getByText('Left Panel')).toBeTruthy();
     expect(localStorage.getItem('mitzo-sidebar-left-collapsed')).toBe('0');
   });

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -202,7 +202,10 @@ export function DesktopChatView() {
   }, []);
 
   const handleSelectSession = useCallback((id: string) => navigate(`/chat/${id}`), [navigate]);
-  const handleNewChat = useCallback(() => navigate('/chat'), [navigate]);
+  const handleNewChat = useCallback(() => {
+    storeNewSession();
+    navigate('/chat');
+  }, [navigate, storeNewSession]);
 
   return (
     <DesktopShell

--- a/frontend/src/styles/desktop.css
+++ b/frontend/src/styles/desktop.css
@@ -169,6 +169,60 @@
     font-weight: 600;
   }
 
+  /* === Desktop Nav === */
+  .desktop-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: var(--space-2);
+    padding-bottom: var(--space-2);
+    margin-bottom: var(--space-1);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .desktop-nav-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-1h) var(--space-2);
+    border-radius: 6px;
+    font-size: var(--text-s);
+    color: var(--text-dim);
+    background: none;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+  }
+
+  .desktop-nav-item:hover {
+    background: var(--border);
+    color: var(--text);
+  }
+
+  .desktop-nav-item--active {
+    color: var(--accent);
+    background: rgba(108, 99, 255, 0.1);
+  }
+
+  .desktop-nav-item--active:hover {
+    background: rgba(108, 99, 255, 0.15);
+  }
+
+  .desktop-nav-badge {
+    background: var(--danger);
+    color: #fff;
+    font-size: var(--text-2xs);
+    min-width: 16px;
+    height: 16px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+  }
+
   /* === Session Panel === */
   .session-panel {
     display: flex;


### PR DESCRIPTION
## Summary
- Adds `DesktopNav` component to the left sidebar so desktop users can navigate to Calendar, Inbox, Telos, Tasks, and Files (previously only reachable by typing URLs)
- Non-chat pages now render inside `DesktopShell` on desktop via `PageRoute` wrapper — nav sidebar on the left, no right panel
- Fixes the New Chat button which was broken because `history.replaceState` desynchronized React Router — `handleNewChat` now calls `storeNewSession()` directly

## Test plan
- [x] DesktopShell tests updated and passing (7/7)
- [x] TypeScript clean (no frontend errors)
- [ ] Manual: verify nav items render in left sidebar on desktop
- [ ] Manual: verify clicking nav items navigates to correct pages
- [ ] Manual: verify active state highlighting
- [ ] Manual: verify New Chat button creates fresh session
- [ ] Manual: verify mobile layout unchanged (TabBar still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)