### PR TITLE
feat(ui): inline markdown preview cards in chat

### DIFF
--- a/frontend/src/components/MarkdownPreviewCard.tsx
+++ b/frontend/src/components/MarkdownPreviewCard.tsx
@@ -22,11 +22,10 @@ export function MarkdownPreviewCard({ filePath }: Props) {
     const next = !expanded;
     setExpanded(next);
     if (next && content === null && !loading) {
+      setError(null);
       setLoading(true);
       try {
-        const res = await apiFetch(
-          `/api/files/read?path=${encodeURIComponent(filePath)}`,
-        );
+        const res = await apiFetch(`/api/files/read?path=${encodeURIComponent(filePath)}`);
         if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
         const data = await res.json();
         setContent(data.content);
@@ -44,9 +43,7 @@ export function MarkdownPreviewCard({ filePath }: Props) {
         <button className="md-preview-card-toggle" onClick={handleToggle}>
           <span className="md-preview-card-icon">MD</span>
           <span className="md-preview-card-name">{fileName}</span>
-          <span className="md-preview-card-chevron">
-            {expanded ? '\u25BE' : '\u25B8'}
-          </span>
+          <span className="md-preview-card-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
         </button>
         <button
           className="md-preview-card-open"
@@ -61,19 +58,11 @@ export function MarkdownPreviewCard({ filePath }: Props) {
       </div>
       {expanded && (
         <div className="md-preview-card-content">
-          {loading && (
-            <p className="md-preview-card-status">Loading...</p>
-          )}
-          {error && (
-            <p className="md-preview-card-status md-preview-card-status--error">
-              {error}
-            </p>
-          )}
+          {loading && <p className="md-preview-card-status">Loading...</p>}
+          {error && <p className="md-preview-card-status md-preview-card-status--error">{error}</p>}
           {content !== null && (
             <div className="md-preview-card-body">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                {content}
-              </ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
             </div>
           )}
         </div>

--- a/frontend/src/components/MarkdownPreviewCard.tsx
+++ b/frontend/src/components/MarkdownPreviewCard.tsx
@@ -40,26 +40,25 @@ export function MarkdownPreviewCard({ filePath }: Props) {
 
   return (
     <div className="md-preview-card">
-      <button className="md-preview-card-header" onClick={handleToggle}>
-        <span className="md-preview-card-icon">MD</span>
-        <span className="md-preview-card-name">{fileName}</span>
-        <a
+      <div className="md-preview-card-header">
+        <button className="md-preview-card-toggle" onClick={handleToggle}>
+          <span className="md-preview-card-icon">MD</span>
+          <span className="md-preview-card-name">{fileName}</span>
+          <span className="md-preview-card-chevron">
+            {expanded ? '\u25BE' : '\u25B8'}
+          </span>
+        </button>
+        <button
           className="md-preview-card-open"
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
+          onClick={() =>
             navigate(
               `/files?path=${encodeURIComponent(filePath)}&from=${encodeURIComponent(currentPath)}`,
-            );
-          }}
+            )
+          }
         >
           Open
-        </a>
-        <span className="md-preview-card-chevron">
-          {expanded ? '\u25BE' : '\u25B8'}
-        </span>
-      </button>
+        </button>
+      </div>
       {expanded && (
         <div className="md-preview-card-content">
           {loading && (

--- a/frontend/src/components/MarkdownPreviewCard.tsx
+++ b/frontend/src/components/MarkdownPreviewCard.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { apiFetch } from '../lib/api-fetch';
+
+interface Props {
+  filePath: string;
+}
+
+export function MarkdownPreviewCard({ filePath }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const currentPath = location.pathname + location.search;
+  const fileName = filePath.split('/').pop() || filePath;
+
+  const handleToggle = async () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && content === null && !loading) {
+      setLoading(true);
+      try {
+        const res = await apiFetch(
+          `/api/files/read?path=${encodeURIComponent(filePath)}`,
+        );
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        const data = await res.json();
+        setContent(data.content);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Failed to load file');
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="md-preview-card">
+      <button className="md-preview-card-header" onClick={handleToggle}>
+        <span className="md-preview-card-icon">MD</span>
+        <span className="md-preview-card-name">{fileName}</span>
+        <a
+          className="md-preview-card-open"
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            navigate(
+              `/files?path=${encodeURIComponent(filePath)}&from=${encodeURIComponent(currentPath)}`,
+            );
+          }}
+        >
+          Open
+        </a>
+        <span className="md-preview-card-chevron">
+          {expanded ? '\u25BE' : '\u25B8'}
+        </span>
+      </button>
+      {expanded && (
+        <div className="md-preview-card-content">
+          {loading && (
+            <p className="md-preview-card-status">Loading...</p>
+          )}
+          {error && (
+            <p className="md-preview-card-status md-preview-card-status--error">
+              {error}
+            </p>
+          )}
+          {content !== null && (
+            <div className="md-preview-card-body">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {content}
+              </ReactMarkdown>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -121,6 +121,8 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
                 </div>
               );
             },
+            // Detect standalone .md file links tagged by the `a` handler via
+            // data-md-preview and promote them to block-level preview cards.
             p: ({ children }) => {
               const childArray = React.Children.toArray(children);
               if (childArray.length === 1 && React.isValidElement(childArray[0])) {

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -121,15 +121,17 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
                 </div>
               );
             },
-            // Detect standalone .md file links tagged by the `a` handler via
-            // data-md-preview and promote them to block-level preview cards.
+            // When a paragraph contains a single file-path link to a .md/.mdx
+            // file, promote it to an inline preview card instead of a plain link.
+            // The `a` handler passes the resolved path via data-file-path; this
+            // handler checks the extension and decides whether to promote.
             p: ({ children }) => {
               const childArray = React.Children.toArray(children);
               if (childArray.length === 1 && React.isValidElement(childArray[0])) {
                 const el = childArray[0] as React.ReactElement<Record<string, unknown>>;
-                const mdPath = el.props?.['data-md-preview'] as string | undefined;
-                if (mdPath) {
-                  return <MarkdownPreviewCard filePath={mdPath} />;
+                const filePath = el.props?.['data-file-path'] as string | undefined;
+                if (filePath && /\.mdx?$/i.test(filePath)) {
+                  return <MarkdownPreviewCard filePath={filePath} />;
                 }
               }
               return <p>{children}</p>;
@@ -137,12 +139,11 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
             a: ({ href, children }) => {
               if (href?.startsWith(FILE_SCHEME)) {
                 const filePath = decodeURIComponent(href.slice(FILE_SCHEME.length));
-                const isMd = /\.mdx?$/i.test(filePath);
                 return (
                   <a
                     href="#"
                     className="file-path-link"
-                    data-md-preview={isMd ? filePath : undefined}
+                    data-file-path={filePath}
                     onClick={(e) => {
                       e.preventDefault();
                       navigate(

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { formatTime } from '../lib/formatTime';
 import { CopyButton } from './CopyButton';
 import { ReadAloudButton } from './ReadAloudButton';
 import { extractText } from '../lib/extractText';
+import { MarkdownPreviewCard } from './MarkdownPreviewCard';
 
 const COLLAPSE_HEIGHT = 300;
 
@@ -120,13 +121,26 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
                 </div>
               );
             },
+            p: ({ children }) => {
+              const childArray = React.Children.toArray(children);
+              if (childArray.length === 1 && React.isValidElement(childArray[0])) {
+                const el = childArray[0] as React.ReactElement<Record<string, unknown>>;
+                const mdPath = el.props?.['data-md-preview'] as string | undefined;
+                if (mdPath) {
+                  return <MarkdownPreviewCard filePath={mdPath} />;
+                }
+              }
+              return <p>{children}</p>;
+            },
             a: ({ href, children }) => {
               if (href?.startsWith(FILE_SCHEME)) {
                 const filePath = decodeURIComponent(href.slice(FILE_SCHEME.length));
+                const isMd = /\.mdx?$/i.test(filePath);
                 return (
                   <a
                     href="#"
                     className="file-path-link"
+                    data-md-preview={isMd ? filePath : undefined}
                     onClick={(e) => {
                       e.preventDefault();
                       navigate(

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -220,6 +220,52 @@ describe('TextBubble code block CopyButton', () => {
   });
 });
 
+describe('TextBubble markdown preview card promotion', () => {
+  it('provides a custom p component to ReactMarkdown', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    expect(capturedComponents).toBeDefined();
+    expect(capturedComponents!.p).toBeDefined();
+  });
+
+  it('promotes a standalone .md file-path link to MarkdownPreviewCard', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const p = capturedComponents!.p;
+    // Simulate what the a handler returns for a .md file-path link
+    const link = createElement('a', { 'data-file-path': '/tmp/notes.md' }, '/tmp/notes.md');
+
+    const result = p({ children: link });
+    // Should return a MarkdownPreviewCard, not a <p>
+    expect(result.type).not.toBe('p');
+    expect(result.props.filePath).toBe('/tmp/notes.md');
+  });
+
+  it('does not promote non-.md file-path links', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const p = capturedComponents!.p;
+    const link = createElement('a', { 'data-file-path': '/tmp/data.json' }, '/tmp/data.json');
+
+    const result = p({ children: link });
+    expect(result.type).toBe('p');
+  });
+
+  it('does not promote .md links when paragraph has other content', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const p = capturedComponents!.p;
+    const link = createElement('a', { 'data-file-path': '/tmp/notes.md' }, '/tmp/notes.md');
+
+    const result = p({ children: ['See ', link, ' for details'] });
+    expect(result.type).toBe('p');
+  });
+
+  it('a handler sets data-file-path on file-path links', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const anchor = capturedComponents!.a;
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/notes.md')}`;
+    const rendered = anchor({ href: fileHref, children: '/tmp/notes.md' });
+    expect(rendered.props['data-file-path']).toBe('/tmp/notes.md');
+  });
+});
+
 describe('MessageBubble legacy adapter forwards timestamps', () => {
   it('forwards timestamp to UserBubble for user messages', () => {
     const ts = Date.now();

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2493,18 +2493,39 @@ textarea:focus {
 .md-preview-card-body h1,
 .md-preview-card-body h2,
 .md-preview-card-body h3,
-.md-preview-card-body h4 { font-weight: 600; margin: 0.6em 0 0.3em; color: #fff; }
-.md-preview-card-body h1 { font-size: 1.1em; }
-.md-preview-card-body h2 { font-size: 1.05em; }
-.md-preview-card-body h3 { font-size: 1em; }
+.md-preview-card-body h4 {
+  font-weight: 600;
+  margin: 0.6em 0 0.3em;
+  color: #fff;
+}
+.md-preview-card-body h1 {
+  font-size: 1.1em;
+}
+.md-preview-card-body h2 {
+  font-size: 1.05em;
+}
+.md-preview-card-body h3 {
+  font-size: 1em;
+}
 .md-preview-card-body h1:first-child,
 .md-preview-card-body h2:first-child,
-.md-preview-card-body h3:first-child { margin-top: 0; }
-.md-preview-card-body p { margin-bottom: 0.4em; }
-.md-preview-card-body p:last-child { margin-bottom: 0; }
+.md-preview-card-body h3:first-child {
+  margin-top: 0;
+}
+.md-preview-card-body p {
+  margin-bottom: 0.4em;
+}
+.md-preview-card-body p:last-child {
+  margin-bottom: 0;
+}
 .md-preview-card-body ul,
-.md-preview-card-body ol { padding-left: 1.2em; margin-bottom: 0.4em; }
-.md-preview-card-body li { margin-bottom: 0.15em; }
+.md-preview-card-body ol {
+  padding-left: 1.2em;
+  margin-bottom: 0.4em;
+}
+.md-preview-card-body li {
+  margin-bottom: 0.15em;
+}
 .md-preview-card-body code {
   font-family: var(--code-font);
   font-size: 0.82em;
@@ -2521,20 +2542,44 @@ textarea:focus {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
-.md-preview-card-body pre code { background: transparent; padding: 0; }
+.md-preview-card-body pre code {
+  background: transparent;
+  padding: 0;
+}
 .md-preview-card-body blockquote {
   border-left: 2px solid var(--accent);
   padding-left: 0.6em;
   margin: 0.3em 0;
   color: var(--text-dim);
 }
-.md-preview-card-body strong { font-weight: 600; color: #fff; }
-.md-preview-card-body a { color: var(--accent); text-decoration: underline; }
-.md-preview-card-body table { border-collapse: collapse; width: 100%; font-size: 0.85em; margin: 0.3em 0; }
+.md-preview-card-body strong {
+  font-weight: 600;
+  color: #fff;
+}
+.md-preview-card-body a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.md-preview-card-body table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.85em;
+  margin: 0.3em 0;
+}
 .md-preview-card-body th,
-.md-preview-card-body td { border: 1px solid var(--border); padding: 0.25em 0.5em; }
-.md-preview-card-body th { background: rgba(255, 255, 255, 0.04); font-weight: 600; }
-.md-preview-card-body hr { border: none; border-top: 1px solid var(--border); margin: 0.5em 0; }
+.md-preview-card-body td {
+  border: 1px solid var(--border);
+  padding: 0.25em 0.5em;
+}
+.md-preview-card-body th {
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+}
+.md-preview-card-body hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0.5em 0;
+}
 /* ===== Tool Group ===== */
 
 .tool-group {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2378,6 +2378,163 @@ textarea:focus {
   color: var(--status-warn);
 }
 
+/* ===== Markdown Preview Card ===== */
+
+.md-preview-card {
+  align-self: flex-start;
+  width: 100%;
+  border-radius: 6px;
+  overflow: hidden;
+  border-left: 3px solid #7dd3fc;
+  margin: 0.4em 0;
+}
+
+.md-preview-card-header {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.md-preview-card-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+  touch-action: manipulation;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  -webkit-tap-highlight-color: transparent;
+  color: var(--text);
+  font-size: var(--text-xs);
+  font-family: inherit;
+}
+
+.md-preview-card-toggle:active {
+  background: rgba(125, 211, 252, 0.05);
+}
+
+.md-preview-card-icon {
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  color: #7dd3fc;
+  background: rgba(125, 211, 252, 0.12);
+  padding: 1px 4px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  font-family: var(--code-font);
+}
+
+.md-preview-card-name {
+  font-weight: 500;
+  color: var(--text);
+  font-family: var(--code-font);
+  font-size: var(--text-xxs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.md-preview-card-open {
+  font-size: var(--text-xxs);
+  color: var(--accent);
+  flex-shrink: 0;
+  padding: 2px 6px;
+  margin-right: 0.4rem;
+  border-radius: 3px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.md-preview-card-open:active {
+  background: rgba(99, 102, 241, 0.1);
+}
+
+.md-preview-card-chevron {
+  color: var(--text-dim);
+  font-size: 0.6rem;
+  flex-shrink: 0;
+}
+
+.md-preview-card-content {
+  border-top: 1px solid var(--border);
+  background: var(--code-bg);
+  border-radius: 0 0 6px 6px;
+}
+
+.md-preview-card-status {
+  padding: 0.4rem 0.6rem;
+  font-size: var(--text-xxs);
+  color: var(--text-dim);
+  margin: 0;
+}
+
+.md-preview-card-status--error {
+  color: #f8a0a0;
+}
+
+.md-preview-card-body {
+  padding: 0.5rem 0.6rem;
+  max-height: 50vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.md-preview-card-body h1,
+.md-preview-card-body h2,
+.md-preview-card-body h3,
+.md-preview-card-body h4 { font-weight: 600; margin: 0.6em 0 0.3em; color: #fff; }
+.md-preview-card-body h1 { font-size: 1.1em; }
+.md-preview-card-body h2 { font-size: 1.05em; }
+.md-preview-card-body h3 { font-size: 1em; }
+.md-preview-card-body h1:first-child,
+.md-preview-card-body h2:first-child,
+.md-preview-card-body h3:first-child { margin-top: 0; }
+.md-preview-card-body p { margin-bottom: 0.4em; }
+.md-preview-card-body p:last-child { margin-bottom: 0; }
+.md-preview-card-body ul,
+.md-preview-card-body ol { padding-left: 1.2em; margin-bottom: 0.4em; }
+.md-preview-card-body li { margin-bottom: 0.15em; }
+.md-preview-card-body code {
+  font-family: var(--code-font);
+  font-size: 0.82em;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.12em 0.3em;
+  border-radius: 3px;
+}
+.md-preview-card-body pre {
+  margin: 0.4em 0;
+  padding: 0.4rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.md-preview-card-body pre code { background: transparent; padding: 0; }
+.md-preview-card-body blockquote {
+  border-left: 2px solid var(--accent);
+  padding-left: 0.6em;
+  margin: 0.3em 0;
+  color: var(--text-dim);
+}
+.md-preview-card-body strong { font-weight: 600; color: #fff; }
+.md-preview-card-body a { color: var(--accent); text-decoration: underline; }
+.md-preview-card-body table { border-collapse: collapse; width: 100%; font-size: 0.85em; margin: 0.3em 0; }
+.md-preview-card-body th,
+.md-preview-card-body td { border: 1px solid var(--border); padding: 0.25em 0.5em; }
+.md-preview-card-body th { background: rgba(255, 255, 255, 0.04); font-weight: 600; }
+.md-preview-card-body hr { border: none; border-top: 1px solid var(--border); margin: 0.5em 0; }
 /* ===== Tool Group ===== */
 
 .tool-group {


### PR DESCRIPTION
## Summary
- Markdown file paths (`.md`/`.mdx`) in chat messages now render as collapsible preview cards instead of plain links
- Cards lazy-load file content on first expand via `/api/files/read` and render with ReactMarkdown + remark-gfm
- Solo-paragraph `.md` links become cards; inline references within text stay as clickable links
- "Open" button on card header navigates to FileViewer for full reading/editing
- Follows existing ToolPill/ThinkingBlock expand/collapse pattern

## Files Changed
- **New:** `frontend/src/components/MarkdownPreviewCard.tsx` — standalone card component
- **Modified:** `frontend/src/components/MessageBubble.tsx` — `p` renderer promotes solo `.md` links to cards, `a` renderer tags `.md` paths via `data-md-preview`
- **Modified:** `frontend/src/styles/global.css` — `.md-preview-card-*` styles with scoped markdown rendering

## Test plan
- [ ] Send a message that references a `.md` file path on its own line — should render as a collapsed card
- [ ] Expand card — content fetched and rendered as markdown
- [ ] Click "Open" — navigates to FileViewer with back-navigation preserved
- [ ] Reference a `.md` file inline with other text — should stay as a regular link
- [ ] Reference a non-`.md` file — should stay as a regular link
- [ ] Reference a missing `.md` file — card should show error on expand
- [ ] Verify no regressions in existing file path link behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)