### PR TITLE
fix(client,server): prevent duplicate messages on iOS foreground recovery

### DIFF
--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1327,7 +1327,9 @@ describe('MESSAGE_END dedup', () => {
       ],
       current: {
         messageId: 'msg-1',
-        blocks: new Map([['b2', { blockId: 'b2', blockType: 'text', content: 'streaming', done: true }]]),
+        blocks: new Map([
+          ['b2', { blockId: 'b2', blockType: 'text', content: 'streaming', done: true }],
+        ]),
         blockOrder: ['b2'],
       },
     };
@@ -1464,6 +1466,86 @@ describe('RESTORE clears stale current', () => {
     expect(userMsgs[0].messageId).toBe('user-optimistic');
     // restored assistant messages should be present
     expect(next.messages.some((m) => m.messageId === 'asst-2')).toBe(true);
+  });
+});
+
+describe('MESSAGE_START finalizes current with subagent blocks', () => {
+  it('finishCurrent converts streaming subagent to finished when new message starts', () => {
+    // Simulate: assistant is streaming a message with a subagent tool_use block,
+    // then a new MESSAGE_START arrives — the orphaned current should be finalized
+    // with subagent blocks correctly converted from Map to array.
+    const subagentBlocks = new Map([
+      [
+        'sub-b1',
+        {
+          blockId: 'sub-b1',
+          blockType: 'text' as const,
+          content: 'subagent thinking',
+          done: true,
+        },
+      ],
+      [
+        'sub-b2',
+        {
+          blockId: 'sub-b2',
+          blockType: 'tool_use' as const,
+          content: '',
+          done: true,
+          toolName: 'Bash',
+          toolId: 'sub-tool-1',
+          toolInput: 'echo hi',
+        },
+      ],
+    ]);
+
+    const state: MessagesState = {
+      ...INITIAL,
+      current: {
+        messageId: 'msg-with-subagent',
+        blocks: new Map([
+          [
+            'b1',
+            {
+              blockId: 'b1',
+              blockType: 'tool_use' as const,
+              content: '',
+              done: true,
+              toolName: 'Agent',
+              toolId: 'agent-tool-1',
+              subagent: {
+                messageId: 'sub-msg-1',
+                blocks: subagentBlocks,
+                blockOrder: ['sub-b1', 'sub-b2'],
+                running: true as const,
+              },
+            },
+          ],
+        ]),
+        blockOrder: ['b1'],
+      },
+    };
+
+    // New MESSAGE_START should finalize the current (with subagent) and start fresh
+    const next = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-new' });
+
+    // Orphaned message with subagent should be finalized into messages[]
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0].messageId).toBe('msg-with-subagent');
+
+    // Subagent should be converted from streaming (Map) to finished (array)
+    const sub = next.messages[0].blocks[0].subagent as FinishedSubagentState;
+    expect(sub).toBeDefined();
+    expect(sub.messageId).toBe('sub-msg-1');
+    expect(Array.isArray(sub.blocks)).toBe(true);
+    expect(sub.blocks).toHaveLength(2);
+    expect(sub.blocks[0].content).toBe('subagent thinking');
+    expect(sub.blocks[1].toolName).toBe('Bash');
+    expect(sub.blocks[1].toolId).toBe('sub-tool-1');
+
+    // New current should be clean
+    expect(next.current).not.toBeNull();
+    expect(next.current!.messageId).toBe('msg-new');
+    expect(next.current!.blockOrder).toHaveLength(0);
   });
 });
 

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1277,3 +1277,266 @@ describe('SET_BOOT_CONTEXT', () => {
     expect(state.bootContext).toBeNull();
   });
 });
+
+// ─── Dedup: foreground recovery vs WS replay ────────────────────────────────
+
+describe('MESSAGE_START dedup', () => {
+  it('skips if messageId already exists in finished messages', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'msg-1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'done' }],
+        },
+      ],
+    };
+    const next = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    expect(next.current).toBeNull();
+    expect(next.messages).toHaveLength(1);
+  });
+
+  it('allows MESSAGE_START for a new messageId', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'msg-1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'done' }],
+        },
+      ],
+    };
+    const next = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'msg-2' });
+    expect(next.current).not.toBeNull();
+    expect(next.current!.messageId).toBe('msg-2');
+  });
+});
+
+describe('MESSAGE_END dedup', () => {
+  it('discards current without appending if messageId already in messages', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'msg-1',
+          role: 'assistant',
+          blocks: [{ blockId: 'b1', blockType: 'text', content: 'restored' }],
+        },
+      ],
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map([['b2', { blockId: 'b2', blockType: 'text', content: 'streaming', done: true }]]),
+        blockOrder: ['b2'],
+      },
+    };
+    const next = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-1' });
+    expect(next.current).toBeNull();
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0].blocks[0].content).toBe('restored');
+  });
+
+  it('appends normally when messageId is new', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      current: {
+        messageId: 'msg-2',
+        blocks: new Map([['b1', { blockId: 'b1', blockType: 'text', content: 'new', done: true }]]),
+        blockOrder: ['b1'],
+      },
+    };
+    const next = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'msg-2' });
+    expect(next.current).toBeNull();
+    expect(next.messages).toHaveLength(1);
+    expect(next.messages[0].messageId).toBe('msg-2');
+  });
+});
+
+describe('RESTORE clears stale current', () => {
+  it('nullifies current when its messageId is in the restored set', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map(),
+        blockOrder: [],
+      },
+    };
+    const restored = [
+      {
+        messageId: 'msg-1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'done' }],
+      },
+    ];
+    const next = messagesReducer(state, { type: 'RESTORE', messages: restored });
+    expect(next.current).toBeNull();
+    expect(next.messages).toHaveLength(1);
+  });
+
+  it('preserves current when its messageId is NOT in the restored set', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      current: {
+        messageId: 'msg-new',
+        blocks: new Map(),
+        blockOrder: [],
+      },
+    };
+    const restored = [
+      {
+        messageId: 'msg-old',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'done' }],
+      },
+    ];
+    const next = messagesReducer(state, { type: 'RESTORE', messages: restored });
+    expect(next.current).not.toBeNull();
+    expect(next.current!.messageId).toBe('msg-new');
+  });
+
+  it('nullifies current in interrupted RESTORE too', () => {
+    const state: MessagesState = {
+      ...INITIAL,
+      current: {
+        messageId: 'msg-1',
+        blocks: new Map(),
+        blockOrder: [],
+      },
+    };
+    const restored = [
+      {
+        messageId: 'msg-1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'done' }],
+      },
+    ];
+    const next = messagesReducer(state, { type: 'RESTORE', messages: restored, interrupted: true });
+    expect(next.current).toBeNull();
+  });
+});
+
+describe('foreground recovery race — full sequence', () => {
+  it('RESTORE then WS replay of same message does not duplicate', () => {
+    // Simulate: user sends, assistant streams, iOS backgrounds, foreground returns
+    // 1. USER_SEND adds optimistic user message
+    let state = messagesReducer(INITIAL, {
+      type: 'USER_SEND',
+      text: 'hello',
+      clientMsgId: 'user-abc',
+    });
+    // 2. MESSAGE_START creates current
+    state = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'asst-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'asst-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'asst-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'partial',
+    });
+    expect(state.messages).toHaveLength(1); // user msg
+    expect(state.current).not.toBeNull();
+
+    // 3. RESTORE fires (foreground recovery) — server has the completed conversation
+    state = messagesReducer(state, {
+      type: 'RESTORE',
+      messages: [
+        {
+          messageId: 'user-abc',
+          role: 'user' as const,
+          blocks: [{ blockId: 'u1', blockType: 'text' as const, content: 'hello' }],
+        },
+        {
+          messageId: 'asst-1',
+          role: 'assistant' as const,
+          blocks: [{ blockId: 'b1', blockType: 'text' as const, content: 'full response' }],
+        },
+      ],
+    });
+    // RESTORE should replace messages AND clear stale current
+    expect(state.messages).toHaveLength(2);
+    expect(state.current).toBeNull();
+
+    // 4. WS replay delivers the same message_start + message_end
+    state = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'asst-1' });
+    // MESSAGE_START should be a no-op (dedup)
+    expect(state.current).toBeNull();
+    expect(state.messages).toHaveLength(2);
+
+    // 5. BLOCK events after suppressed MESSAGE_START are safe no-ops
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'asst-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_DELTA',
+      messageId: 'asst-1',
+      blockId: 'b1',
+      blockType: 'text',
+      delta: 'replayed',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'asst-1',
+      blockId: 'b1',
+      blockType: 'text',
+    });
+    // Still no current, still 2 messages
+    expect(state.current).toBeNull();
+    expect(state.messages).toHaveLength(2);
+
+    // 6. MESSAGE_END for the replayed message — should be safe no-op
+    state = messagesReducer(state, { type: 'MESSAGE_END', messageId: 'asst-1' });
+    expect(state.current).toBeNull();
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[1].blocks[0].content).toBe('full response');
+  });
+
+  it('multi-turn: only the replayed message is deduplicated, earlier ones kept', () => {
+    // Start with a completed first turn
+    const state: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'user-1',
+          role: 'user',
+          blocks: [{ blockId: 'u1', blockType: 'text', content: 'first' }],
+        },
+        {
+          messageId: 'asst-1',
+          role: 'assistant',
+          blocks: [{ blockId: 'a1', blockType: 'text', content: 'reply 1' }],
+        },
+        {
+          messageId: 'user-2',
+          role: 'user',
+          blocks: [{ blockId: 'u2', blockType: 'text', content: 'second' }],
+        },
+        {
+          messageId: 'asst-2',
+          role: 'assistant',
+          blocks: [{ blockId: 'a2', blockType: 'text', content: 'reply 2' }],
+        },
+      ],
+    };
+
+    // WS replay tries to re-deliver only asst-2
+    let next = messagesReducer(state, { type: 'MESSAGE_START', messageId: 'asst-2' });
+    expect(next.current).toBeNull(); // dedup blocked it
+    expect(next.messages).toHaveLength(4); // all 4 still there
+
+    // A genuinely new message should still work
+    next = messagesReducer(next, { type: 'MESSAGE_START', messageId: 'asst-3' });
+    expect(next.current).not.toBeNull();
+    expect(next.current!.messageId).toBe('asst-3');
+  });
+});

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1415,6 +1415,56 @@ describe('RESTORE clears stale current', () => {
     const next = messagesReducer(state, { type: 'RESTORE', messages: restored, interrupted: true });
     expect(next.current).toBeNull();
   });
+
+  it('interrupted RESTORE with optimistic user msgs AND stale current', () => {
+    // Simulate: user sent a follow-up (optimistic), assistant was streaming,
+    // then interrupted RESTORE arrives with the completed assistant message.
+    const state: MessagesState = {
+      ...INITIAL,
+      messages: [
+        {
+          messageId: 'restored-1',
+          role: 'assistant' as const,
+          blocks: [{ blockId: 'a1', blockType: 'text' as const, content: 'first reply' }],
+        },
+        {
+          messageId: 'user-optimistic',
+          role: 'user' as const,
+          blocks: [{ blockId: 'u1', blockType: 'text' as const, content: 'follow-up' }],
+        },
+      ],
+      current: {
+        messageId: 'asst-2',
+        blocks: new Map(),
+        blockOrder: [],
+      },
+    };
+    const restored = [
+      {
+        messageId: 'restored-1',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'a1', blockType: 'text' as const, content: 'first reply' }],
+      },
+      {
+        messageId: 'asst-2',
+        role: 'assistant' as const,
+        blocks: [{ blockId: 'a2', blockType: 'text' as const, content: 'second reply' }],
+      },
+    ];
+    const next = messagesReducer(state, {
+      type: 'RESTORE',
+      messages: restored,
+      interrupted: true,
+    });
+    // current should be cleared (asst-2 is in the restored set)
+    expect(next.current).toBeNull();
+    // optimistic user msg should be preserved and merged
+    const userMsgs = next.messages.filter((m) => m.role === 'user');
+    expect(userMsgs).toHaveLength(1);
+    expect(userMsgs[0].messageId).toBe('user-optimistic');
+    // restored assistant messages should be present
+    expect(next.messages.some((m) => m.messageId === 'asst-2')).toBe(true);
+  });
 });
 
 describe('foreground recovery race — full sequence', () => {

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -481,14 +481,14 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
           merged.splice(insertAfter + 1, 0, opt);
         }
         merged.push(notice);
-        const currentStale = state.current &&
-          merged.some((m) => m.messageId === state.current!.messageId);
+        const currentStale =
+          state.current && merged.some((m) => m.messageId === state.current!.messageId);
         return { ...state, messages: merged, current: currentStale ? null : state.current };
       }
       // Clear current if the restored set already contains it (prevents
       // MESSAGE_END from re-inserting a message that RESTORE already has).
-      const currentStale = state.current &&
-        valid.some((m) => m.messageId === state.current!.messageId);
+      const currentStale =
+        state.current && valid.some((m) => m.messageId === state.current!.messageId);
       return { ...state, messages: valid, current: currentStale ? null : state.current };
     }
 

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -237,6 +237,10 @@ export function patchToolResult(
 export function messagesReducer(state: MessagesState, action: MessagesAction): MessagesState {
   switch (action.type) {
     case 'MESSAGE_START': {
+      // Dedup: skip if this message was already restored (e.g. WS replay after RESTORE)
+      if (state.messages.some((m) => m.messageId === action.messageId)) {
+        return state;
+      }
       const base = state.current
         ? { ...state, messages: [...state.messages, finishCurrent(state.current)] }
         : state;
@@ -309,6 +313,10 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
 
     case 'MESSAGE_END': {
       if (!state.current) return { ...state };
+      // Dedup: if this message was already restored, discard the streaming copy
+      if (state.messages.some((m) => m.messageId === state.current!.messageId)) {
+        return { ...state, current: null };
+      }
       const finished = finishCurrent(state.current);
       return { ...state, messages: [...state.messages, finished], current: null };
     }
@@ -473,9 +481,15 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
           merged.splice(insertAfter + 1, 0, opt);
         }
         merged.push(notice);
-        return { ...state, messages: merged };
+        const currentStaleI = state.current &&
+          merged.some((m) => m.messageId === state.current!.messageId);
+        return { ...state, messages: merged, ...(currentStaleI ? { current: null } : {}) };
       }
-      return { ...state, messages: valid };
+      // Clear current if the restored set already contains it (prevents
+      // MESSAGE_END from re-inserting a message that RESTORE already has).
+      const currentStale = state.current &&
+        valid.some((m) => m.messageId === state.current!.messageId);
+      return { ...state, messages: valid, ...(currentStale ? { current: null } : {}) };
     }
 
     case 'USER_MESSAGE_RECEIVED': {

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -312,7 +312,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
     }
 
     case 'MESSAGE_END': {
-      if (!state.current) return { ...state };
+      if (!state.current) return state;
       // Dedup: if this message was already restored, discard the streaming copy
       if (state.messages.some((m) => m.messageId === state.current!.messageId)) {
         return { ...state, current: null };
@@ -481,15 +481,15 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
           merged.splice(insertAfter + 1, 0, opt);
         }
         merged.push(notice);
-        const currentStaleI = state.current &&
+        const currentStale = state.current &&
           merged.some((m) => m.messageId === state.current!.messageId);
-        return { ...state, messages: merged, ...(currentStaleI ? { current: null } : {}) };
+        return { ...state, messages: merged, current: currentStale ? null : state.current };
       }
       // Clear current if the restored set already contains it (prevents
       // MESSAGE_END from re-inserting a message that RESTORE already has).
       const currentStale = state.current &&
         valid.some((m) => m.messageId === state.current!.messageId);
-      return { ...state, messages: valid, ...(currentStale ? { current: null } : {}) };
+      return { ...state, messages: valid, current: currentStale ? null : state.current };
     }
 
     case 'USER_MESSAGE_RECEIVED': {

--- a/server/__tests__/reconstruct-messages.test.ts
+++ b/server/__tests__/reconstruct-messages.test.ts
@@ -290,4 +290,33 @@ describe('replayEventsToMessages — user_message events', () => {
       blocks: [{ content: 'Hello from empty session' }],
     });
   });
+
+  it('reuses stored messageId for initial prompt (deterministic across calls)', () => {
+    const events: StoredEvent[] = [
+      evt(1, 'user_message', { messageId: 'umsg-12345-init', text: 'Hello Claude' }),
+      evt(2, 'message_start', { messageId: 'msg-a1' }),
+      evt(3, 'block_start', { messageId: 'msg-a1', blockId: 'b0', blockType: 'text' }),
+      evt(4, 'block_delta', { messageId: 'msg-a1', blockId: 'b0', delta: 'Hi!' }),
+      evt(5, 'block_end', { messageId: 'msg-a1', blockId: 'b0', blockType: 'text' }),
+      evt(6, 'message_end', { messageId: 'msg-a1' }),
+    ];
+    const result1 = replayEventsToMessages(events, 'Hello Claude');
+    const result2 = replayEventsToMessages(events, 'Hello Claude');
+    expect(result1[0].messageId).toBe('umsg-12345-init');
+    expect(result2[0].messageId).toBe('umsg-12345-init');
+    // Same ID across calls — no Date.now() instability
+    expect(result1[0].messageId).toBe(result2[0].messageId);
+  });
+
+  it('falls back to stable umsg-initial when no matching event exists', () => {
+    const events: StoredEvent[] = [
+      evt(1, 'message_start', { messageId: 'msg-a1' }),
+      evt(2, 'block_start', { messageId: 'msg-a1', blockId: 'b0', blockType: 'text' }),
+      evt(3, 'block_delta', { messageId: 'msg-a1', blockId: 'b0', delta: 'Hi!' }),
+      evt(4, 'block_end', { messageId: 'msg-a1', blockId: 'b0', blockType: 'text' }),
+      evt(5, 'message_end', { messageId: 'msg-a1' }),
+    ];
+    const result = replayEventsToMessages(events, 'Hello Claude');
+    expect(result[0].messageId).toBe('umsg-initial');
+  });
 });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1543,9 +1543,14 @@ export function replayEventsToMessages(
   // Inject the initial prompt as the first message.
   // Priority: initialPrompt param (from session metadata) > legacy out-of-order event
   if (initialPrompt) {
+    // Reuse the stored messageId so REST recovery and WS replay agree on IDs
+    const matchingEvt = events.find(
+      (e) => e.type === 'user_message' && e.payload.text === initialPrompt,
+    );
+    const messageId = matchingEvt ? (matchingEvt.payload.messageId as string) : 'umsg-initial';
     const firstTs = events[0]?.createdAt;
     messages.push({
-      messageId: `umsg-initial-${Date.now()}`,
+      messageId,
       role: 'user',
       timestamp: firstTs,
       blocks: [{ blockId: 'user-initial', blockType: 'text', content: initialPrompt }],


### PR DESCRIPTION
## Summary

- **Bug:** Messages (user prompt + assistant reply) render twice in the UI after iOS foreground recovery. Self-heals on next session re-entry.
- **Root cause:** `_foreground` (REST RESTORE) and WS reconnect replay both fire simultaneously, each inserting messages without deduplicating against the other.
- **Fix:** Three surgical changes:
  - `MESSAGE_START`/`MESSAGE_END`: skip if messageId already exists in `messages[]`
  - `replayEventsToMessages`: use stored messageId instead of `Date.now()` so REST and WS agree
  - `RESTORE`: clear `current` when its messageId conflicts with the restored set

## Test plan

- [x] Unit tests: MESSAGE_START/END dedup guards (positive + negative)
- [x] Unit tests: RESTORE clears stale `current` (normal + interrupted paths)
- [x] Unit tests: deterministic initial prompt messageId (reuse stored + fallback)
- [x] Integration test: full foreground recovery sequence (RESTORE → WS replay → no duplication)
- [x] Integration test: multi-turn dedup (only replayed message suppressed, earlier ones kept)
- [ ] Manual: iOS foreground recovery — send message, background, return, verify no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)