### PR TITLE
fix(worktree): branch from main to prevent cross-session contamination

### DIFF
--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -297,6 +297,52 @@ describe('detectDefaultBranch', () => {
     expect(detectDefaultBranch(baseRepo)).toBe('develop');
     rmSync(remoteRepo, { recursive: true, force: true });
   });
+
+  it('handles branch names with slashes correctly', () => {
+    // Create a bare "remote" repo with a slashed default branch
+    const remoteRepo = mkdtempSync(join(tmpdir(), 'mitzo-remote-slashed-'));
+    execFileSync('git', ['-C', remoteRepo, 'init', '--bare', '-b', 'release/stable'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'remote', 'add', 'origin', remoteRepo], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'push', 'origin', 'main:release/stable'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'fetch', 'origin'], { stdio: 'pipe' });
+    execFileSync(
+      'git',
+      [
+        '-C',
+        baseRepo,
+        'symbolic-ref',
+        'refs/remotes/origin/HEAD',
+        'refs/remotes/origin/release/stable',
+      ],
+      { stdio: 'pipe' },
+    );
+
+    expect(detectDefaultBranch(baseRepo)).toBe('release/stable');
+    rmSync(remoteRepo, { recursive: true, force: true });
+  });
+
+  it('falls back to HEAD when main does not exist', () => {
+    // Create a repo with master instead of main
+    const masterRepo = mkdtempSync(join(tmpdir(), 'mitzo-master-'));
+    execFileSync('git', ['-C', masterRepo, 'init', '-b', 'master'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', masterRepo, 'config', 'user.email', 'test@test.com'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', masterRepo, 'config', 'user.name', 'Test'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', masterRepo, 'commit', '--allow-empty', '-m', 'init'], {
+      stdio: 'pipe',
+    });
+
+    // No origin, 'main' doesn't exist — should fall back to 'HEAD'
+    expect(detectDefaultBranch(masterRepo)).toBe('HEAD');
+    rmSync(masterRepo, { recursive: true, force: true });
+  });
 });
 
 describe('createWorktree (sync)', () => {

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -37,7 +37,9 @@ import {
   cleanupStaleWorktrees,
   parseWorktreeAge,
   countWorktrees,
+  createWorktree,
   createWorktreeAsync,
+  detectDefaultBranch,
   symlinkRuntimeDirs,
   discoverSessionWorktrees,
 } from '../worktree.js';
@@ -124,7 +126,7 @@ describe('createWorktreeAsync', () => {
 
   beforeEach(() => {
     baseRepo = mkdtempSync(join(tmpdir(), 'mitzo-async-wt-'));
-    execFileSync('git', ['-C', baseRepo, 'init'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'init', '-b', 'main'], { stdio: 'pipe' });
     execFileSync('git', ['-C', baseRepo, 'config', 'user.email', 'test@test.com'], {
       stdio: 'pipe',
     });
@@ -244,6 +246,179 @@ describe('createWorktreeAsync', () => {
 
     // Create worktree with startPoint=main (which is now at secondCommit)
     const path = await createWorktreeAsync(sessionId, baseRepo);
+
+    // Branch should have been reset to current main (secondCommit), not old position
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(secondCommit);
+  });
+});
+
+describe('detectDefaultBranch', () => {
+  let baseRepo: string;
+
+  beforeEach(() => {
+    baseRepo = mkdtempSync(join(tmpdir(), 'mitzo-detect-branch-'));
+    execFileSync('git', ['-C', baseRepo, 'init', '-b', 'main'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'config', 'user.email', 'test@test.com'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'config', 'user.name', 'Test'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'init'], {
+      stdio: 'pipe',
+    });
+  });
+
+  afterEach(() => {
+    rmSync(baseRepo, { recursive: true, force: true });
+  });
+
+  it('falls back to main when no origin is configured', () => {
+    expect(detectDefaultBranch(baseRepo)).toBe('main');
+  });
+
+  it('detects default branch from origin symbolic-ref', () => {
+    // Create a bare "remote" repo with a non-standard default branch
+    const remoteRepo = mkdtempSync(join(tmpdir(), 'mitzo-remote-'));
+    execFileSync('git', ['-C', remoteRepo, 'init', '--bare', '-b', 'develop'], { stdio: 'pipe' });
+    // Add it as origin and fetch
+    execFileSync('git', ['-C', baseRepo, 'remote', 'add', 'origin', remoteRepo], { stdio: 'pipe' });
+    // Push main to origin as develop
+    execFileSync('git', ['-C', baseRepo, 'push', 'origin', 'main:develop'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'fetch', 'origin'], { stdio: 'pipe' });
+    // Set the symbolic ref to point to develop
+    execFileSync(
+      'git',
+      ['-C', baseRepo, 'symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/develop'],
+      { stdio: 'pipe' },
+    );
+
+    expect(detectDefaultBranch(baseRepo)).toBe('develop');
+    rmSync(remoteRepo, { recursive: true, force: true });
+  });
+});
+
+describe('createWorktree (sync)', () => {
+  let baseRepo: string;
+
+  beforeEach(() => {
+    baseRepo = mkdtempSync(join(tmpdir(), 'mitzo-sync-wt-'));
+    execFileSync('git', ['-C', baseRepo, 'init', '-b', 'main'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'config', 'user.email', 'test@test.com'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'config', 'user.name', 'Test'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'init'], {
+      stdio: 'pipe',
+    });
+  });
+
+  afterEach(() => {
+    try {
+      execFileSync('git', ['-C', baseRepo, 'worktree', 'prune'], { stdio: 'pipe' });
+    } catch {
+      // ignore
+    }
+    rmSync(baseRepo, { recursive: true, force: true });
+  });
+
+  it('creates a worktree and returns its path', () => {
+    const sessionId = 'sync-test-session';
+    const path = createWorktree(sessionId, baseRepo);
+    expect(path).toBe(join(baseRepo, '.claude', 'worktrees', sessionId));
+    expect(existsSync(path)).toBe(true);
+    // Verify it's a valid git worktree
+    execFileSync('git', ['-C', path, 'rev-parse', '--git-dir'], { stdio: 'pipe' });
+  });
+
+  it('reuses existing valid worktree', () => {
+    const sessionId = 'sync-reuse-session';
+    const first = createWorktree(sessionId, baseRepo);
+    const second = createWorktree(sessionId, baseRepo);
+    expect(first).toBe(second);
+  });
+
+  it('handles branch-already-exists fallback', () => {
+    const sessionId = 'sync-branch-exists';
+    const branch = `session/${sessionId}`;
+    // Pre-create the branch so the first `git worktree add -b` fails
+    execFileSync('git', ['-C', baseRepo, 'branch', branch], { stdio: 'pipe' });
+    const path = createWorktree(sessionId, baseRepo);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it('branches from main by default, not from HEAD', () => {
+    // Create a commit on main so we have a known ref
+    const mainCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Create a divergent branch with an extra commit (simulating a prior session)
+    execFileSync('git', ['-C', baseRepo, 'checkout', '-b', 'session/old-session'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'old session work'], {
+      stdio: 'pipe',
+    });
+
+    // HEAD is now on session/old-session, ahead of main
+    const headCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(headCommit).not.toBe(mainCommit);
+
+    // Create new worktree — should branch from main, not HEAD
+    const sessionId = 'sync-startpoint-test';
+    const path = createWorktree(sessionId, baseRepo);
+
+    // Verify the worktree's HEAD matches main, not the old session branch
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(mainCommit);
+  });
+
+  it('respects custom startPoint option', () => {
+    // Create a feature branch with an extra commit
+    execFileSync('git', ['-C', baseRepo, 'checkout', '-b', 'feature/base'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'feature base'], {
+      stdio: 'pipe',
+    });
+    const featureCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    execFileSync('git', ['-C', baseRepo, 'checkout', 'main'], { stdio: 'pipe' });
+
+    const sessionId = 'sync-custom-startpoint';
+    const path = createWorktree(sessionId, baseRepo, { startPoint: 'feature/base' });
+
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(featureCommit);
+  });
+
+  it('resets existing branch to startPoint on fallback', () => {
+    const mainCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'main'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Add a commit to main so we can create a branch at a different point
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'second commit'], {
+      stdio: 'pipe',
+    });
+    const secondCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Pre-create the session branch at the old main commit
+    const sessionId = 'sync-reset-branch';
+    const branch = `session/${sessionId}`;
+    execFileSync('git', ['-C', baseRepo, 'branch', branch, mainCommit], { stdio: 'pipe' });
+
+    // Create worktree with startPoint=main (which is now at secondCommit)
+    const path = createWorktree(sessionId, baseRepo);
 
     // Branch should have been reset to current main (secondCommit), not old position
     const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
@@ -387,7 +562,7 @@ describe('cleanupStaleWorktrees', () => {
     // Create a real temporary git repo for testing
     baseRepo = mkdtempSync(join(tmpdir(), 'mitzo-wt-test-'));
     inboxDir = join(baseRepo, 'test-inbox');
-    execFileSync('git', ['-C', baseRepo, 'init'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'init', '-b', 'main'], { stdio: 'pipe' });
     execFileSync('git', ['-C', baseRepo, 'config', 'user.email', 'test@test.com'], {
       stdio: 'pipe',
     });

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -167,6 +167,90 @@ describe('createWorktreeAsync', () => {
     const path = await createWorktreeAsync(sessionId, baseRepo);
     expect(existsSync(path)).toBe(true);
   });
+
+  it('branches from main by default, not from HEAD', async () => {
+    // Simulate the bug: checkout a session branch with extra commits,
+    // then create a new worktree. Without startPoint fix, the new worktree
+    // inherits the extra commits. With the fix, it branches from main.
+
+    // Create a commit on main so we have a known ref
+    const mainCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Create a divergent branch with an extra commit (simulating a prior session)
+    execFileSync('git', ['-C', baseRepo, 'checkout', '-b', 'session/old-session'], {
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'old session work'], {
+      stdio: 'pipe',
+    });
+
+    // HEAD is now on session/old-session, ahead of main
+    const headCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(headCommit).not.toBe(mainCommit);
+
+    // Create new worktree — should branch from main, not HEAD
+    const sessionId = 'async-startpoint-test';
+    const path = await createWorktreeAsync(sessionId, baseRepo);
+
+    // Verify the worktree's HEAD matches main, not the old session branch
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(mainCommit);
+  });
+
+  it('respects custom startPoint option', async () => {
+    // Create a feature branch with an extra commit
+    execFileSync('git', ['-C', baseRepo, 'checkout', '-b', 'feature/base'], { stdio: 'pipe' });
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'feature base'], {
+      stdio: 'pipe',
+    });
+    const featureCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    execFileSync('git', ['-C', baseRepo, 'checkout', 'main'], { stdio: 'pipe' });
+
+    const sessionId = 'async-custom-startpoint';
+    const path = await createWorktreeAsync(sessionId, baseRepo, { startPoint: 'feature/base' });
+
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(featureCommit);
+  });
+
+  it('resets existing branch to startPoint on fallback', async () => {
+    // Create a branch pointing to HEAD (main)
+    const mainCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'main'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Add a commit to main so we can create a branch at a different point
+    execFileSync('git', ['-C', baseRepo, 'commit', '--allow-empty', '-m', 'second commit'], {
+      stdio: 'pipe',
+    });
+    const secondCommit = execFileSync('git', ['-C', baseRepo, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+
+    // Pre-create the session branch at the old main commit
+    const sessionId = 'async-reset-branch';
+    const branch = `session/${sessionId}`;
+    execFileSync('git', ['-C', baseRepo, 'branch', branch, mainCommit], { stdio: 'pipe' });
+
+    // Create worktree with startPoint=main (which is now at secondCommit)
+    const path = await createWorktreeAsync(sessionId, baseRepo);
+
+    // Branch should have been reset to current main (secondCommit), not old position
+    const wtCommit = execFileSync('git', ['-C', path, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+    }).trim();
+    expect(wtCommit).toBe(secondCommit);
+  });
 });
 
 describe('symlinkRuntimeDirs', () => {

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -35,11 +35,11 @@ const log = createLogger('worktree');
  */
 export function detectDefaultBranch(repoPath: string): string {
   try {
-    const ref = execFileSync(
-      'git',
-      ['-C', repoPath, 'symbolic-ref', 'refs/remotes/origin/HEAD'],
-      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: WORKTREE_GIT_TIMEOUT_MS },
-    ).trim();
+    const ref = execFileSync('git', ['-C', repoPath, 'symbolic-ref', 'refs/remotes/origin/HEAD'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: WORKTREE_GIT_TIMEOUT_MS,
+    }).trim();
     // ref looks like "refs/remotes/origin/main" — extract the last segment
     const branch = ref.split('/').pop();
     if (branch) return branch;

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -31,7 +31,10 @@ const log = createLogger('worktree');
 /**
  * Detect the default branch of a repo (e.g. 'main' or 'master').
  * Uses `git symbolic-ref refs/remotes/origin/HEAD` when an origin exists,
- * otherwise falls back to 'main'.
+ * otherwise falls back to 'main' (verified) or HEAD.
+ *
+ * NOTE: Uses execFileSync intentionally — called during session setup (not hot path).
+ * Worktree creation is a one-time initialization per session, so blocking is acceptable.
  */
 export function detectDefaultBranch(repoPath: string): string {
   try {
@@ -40,13 +43,25 @@ export function detectDefaultBranch(repoPath: string): string {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: WORKTREE_GIT_TIMEOUT_MS,
     }).trim();
-    // ref looks like "refs/remotes/origin/main" — extract the last segment
-    const branch = ref.split('/').pop();
+    // ref looks like "refs/remotes/origin/main" or "refs/remotes/origin/release/stable"
+    const branch = ref.replace('refs/remotes/origin/', '');
     if (branch) return branch;
   } catch {
     // No origin or symbolic-ref not set — fall back
   }
-  return 'main';
+
+  // Verify 'main' exists before using it as fallback
+  try {
+    execFileSync('git', ['-C', repoPath, 'rev-parse', '--verify', 'main'], {
+      stdio: 'pipe',
+      timeout: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    return 'main';
+  } catch {
+    // 'main' doesn't exist — fall back to HEAD
+  }
+
+  return 'HEAD';
 }
 
 /** Worktrees live inside each repo at .claude/worktrees/<sessionId>. */

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -56,6 +56,8 @@ export interface CreateWorktreeOptions {
   dir?: string;
   branch?: string;
   prefix?: '.claude' | '.cursor';
+  /** Git ref to branch from. Defaults to 'main' to avoid inheriting unmerged session commits. */
+  startPoint?: string;
 }
 
 export function createWorktree(
@@ -69,6 +71,7 @@ export function createWorktree(
 
   const worktreePath = join(dir, sessionId);
   const branch = opts?.branch ?? `${WORKTREE_BRANCH_PREFIX}${sessionId}`;
+  const startPoint = opts?.startPoint ?? 'main';
 
   // If the worktree path already exists (stale from a previous session),
   // check whether it's a valid worktree we can reuse or a stale directory
@@ -96,13 +99,19 @@ export function createWorktree(
   }
 
   try {
-    execFileSync('git', ['-C', baseRepo, 'worktree', 'add', '-b', branch, worktreePath], {
-      stdio: 'pipe',
-      timeout: WORKTREE_GIT_TIMEOUT_MS,
-    });
+    execFileSync(
+      'git',
+      ['-C', baseRepo, 'worktree', 'add', '-b', branch, worktreePath, startPoint],
+      { stdio: 'pipe', timeout: WORKTREE_GIT_TIMEOUT_MS },
+    );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('already exists')) {
+      // Branch exists but no worktree — reset it to startPoint before attaching
+      execFileSync('git', ['-C', baseRepo, 'branch', '-f', branch, startPoint], {
+        stdio: 'pipe',
+        timeout: WORKTREE_GIT_TIMEOUT_MS,
+      });
       execFileSync('git', ['-C', baseRepo, 'worktree', 'add', worktreePath, branch], {
         stdio: 'pipe',
         timeout: WORKTREE_GIT_TIMEOUT_MS,
@@ -112,7 +121,7 @@ export function createWorktree(
     }
   }
 
-  log.info(`created: ${worktreePath} (${branch})`);
+  log.info(`created: ${worktreePath} (${branch}) from ${startPoint}`);
   return worktreePath;
 }
 
@@ -131,6 +140,7 @@ export async function createWorktreeAsync(
 
   const worktreePath = join(dir, sessionId);
   const branch = opts?.branch ?? `${WORKTREE_BRANCH_PREFIX}${sessionId}`;
+  const startPoint = opts?.startPoint ?? 'main';
 
   if (existsSync(worktreePath)) {
     try {
@@ -151,12 +161,18 @@ export async function createWorktreeAsync(
   }
 
   try {
-    await execFileAsync('git', ['-C', baseRepo, 'worktree', 'add', '-b', branch, worktreePath], {
-      timeout: WORKTREE_GIT_TIMEOUT_MS,
-    });
+    await execFileAsync(
+      'git',
+      ['-C', baseRepo, 'worktree', 'add', '-b', branch, worktreePath, startPoint],
+      { timeout: WORKTREE_GIT_TIMEOUT_MS },
+    );
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('already exists')) {
+      // Branch exists but no worktree — reset it to startPoint before attaching
+      await execFileAsync('git', ['-C', baseRepo, 'branch', '-f', branch, startPoint], {
+        timeout: WORKTREE_GIT_TIMEOUT_MS,
+      });
       await execFileAsync('git', ['-C', baseRepo, 'worktree', 'add', worktreePath, branch], {
         timeout: WORKTREE_GIT_TIMEOUT_MS,
       });
@@ -165,7 +181,7 @@ export async function createWorktreeAsync(
     }
   }
 
-  log.info(`created: ${worktreePath} (${branch})`);
+  log.info(`created: ${worktreePath} (${branch}) from ${startPoint}`);
   return worktreePath;
 }
 

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -28,6 +28,27 @@ import { createLogger } from './logger.js';
 
 const log = createLogger('worktree');
 
+/**
+ * Detect the default branch of a repo (e.g. 'main' or 'master').
+ * Uses `git symbolic-ref refs/remotes/origin/HEAD` when an origin exists,
+ * otherwise falls back to 'main'.
+ */
+export function detectDefaultBranch(repoPath: string): string {
+  try {
+    const ref = execFileSync(
+      'git',
+      ['-C', repoPath, 'symbolic-ref', 'refs/remotes/origin/HEAD'],
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: WORKTREE_GIT_TIMEOUT_MS },
+    ).trim();
+    // ref looks like "refs/remotes/origin/main" — extract the last segment
+    const branch = ref.split('/').pop();
+    if (branch) return branch;
+  } catch {
+    // No origin or symbolic-ref not set — fall back
+  }
+  return 'main';
+}
+
 /** Worktrees live inside each repo at .claude/worktrees/<sessionId>. */
 function worktreesDir(baseRepo: string): string {
   return join(baseRepo, '.claude', 'worktrees');
@@ -56,7 +77,7 @@ export interface CreateWorktreeOptions {
   dir?: string;
   branch?: string;
   prefix?: '.claude' | '.cursor';
-  /** Git ref to branch from. Defaults to 'main' to avoid inheriting unmerged session commits. */
+  /** Git ref to branch from. Defaults to the repo's default branch (detected dynamically, falls back to 'main'). */
   startPoint?: string;
 }
 
@@ -71,7 +92,7 @@ export function createWorktree(
 
   const worktreePath = join(dir, sessionId);
   const branch = opts?.branch ?? `${WORKTREE_BRANCH_PREFIX}${sessionId}`;
-  const startPoint = opts?.startPoint ?? 'main';
+  const startPoint = opts?.startPoint ?? detectDefaultBranch(baseRepo);
 
   // If the worktree path already exists (stale from a previous session),
   // check whether it's a valid worktree we can reuse or a stale directory
@@ -140,7 +161,7 @@ export async function createWorktreeAsync(
 
   const worktreePath = join(dir, sessionId);
   const branch = opts?.branch ?? `${WORKTREE_BRANCH_PREFIX}${sessionId}`;
-  const startPoint = opts?.startPoint ?? 'main';
+  const startPoint = opts?.startPoint ?? detectDefaultBranch(baseRepo);
 
   if (existsSync(worktreePath)) {
     try {

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -30,8 +30,9 @@ const log = createLogger('worktree');
 
 /**
  * Detect the default branch of a repo (e.g. 'main' or 'master').
- * Uses `git symbolic-ref refs/remotes/origin/HEAD` when an origin exists,
- * otherwise falls back to 'main' (verified) or HEAD.
+ * Prefers origin/HEAD (remote truth) since session worktrees should branch
+ * from the canonical default, not whatever is locally checked out.
+ * Falls back to 'main' (verified) or HEAD for repos without a remote.
  *
  * NOTE: Uses execFileSync intentionally — called during session setup (not hot path).
  * Worktree creation is a one-time initialization per session, so blocking is acceptable.


### PR DESCRIPTION
## Summary

- `createWorktree()` and `createWorktreeAsync()` called `git worktree add -b <branch> <path>` without a start-point, causing new sessions to inherit whatever HEAD was in the base repo — often another session branch with unmerged commits
- Fix: add `startPoint` option (default `'main'`) as the final argument to `git worktree add`
- When falling back to an existing branch, reset it to `startPoint` before attaching

## Context

Discovered while investigating mgmt PR #105, where a design doc PR inherited 7 unrelated `jira_process` commits from a prior session. The root cause: worktree creation branched from the repo's current HEAD (a stale session branch) instead of `main`.

## Test plan

- [x] New test: worktree branches from main, not HEAD (verifies the bug fix)
- [x] New test: custom `startPoint` option respected
- [x] New test: existing branch reset to `startPoint` on fallback
- [x] All 35 worktree tests pass
- [x] Lint + format pass (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)