### PR TITLE
fix(ui): markdown preview card promotion broken in ReactMarkdown v10

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { useNavigate, useLocation } from 'react-router-dom';
 import type { FinishedMessage } from '../types/chat';
@@ -106,7 +106,7 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
       <div className="msg-bubble-markdown" ref={contentRef}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          urlTransform={(url) => url}
+          urlTransform={(url) => (url.startsWith(FILE_SCHEME) ? url : defaultUrlTransform(url))}
           components={{
             table: ({ children, ...props }) => (
               <div className="table-scroll-wrapper">

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -106,6 +106,7 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
       <div className="msg-bubble-markdown" ref={contentRef}>
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
+          urlTransform={(url) => url}
           components={{
             table: ({ children, ...props }) => (
               <div className="table-scroll-wrapper">
@@ -123,15 +124,19 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
             },
             // When a paragraph contains a single file-path link to a .md/.mdx
             // file, promote it to an inline preview card instead of a plain link.
-            // The `a` handler passes the resolved path via data-file-path; this
-            // handler checks the extension and decides whether to promote.
+            // In ReactMarkdown v10, children are unrendered component instances —
+            // the `a` handler hasn't run yet — so we check `href` (the prop
+            // ReactMarkdown passes) rather than rendered DOM attributes.
             p: ({ children }) => {
               const childArray = React.Children.toArray(children);
               if (childArray.length === 1 && React.isValidElement(childArray[0])) {
                 const el = childArray[0] as React.ReactElement<Record<string, unknown>>;
-                const filePath = el.props?.['data-file-path'] as string | undefined;
-                if (filePath && /\.mdx?$/i.test(filePath)) {
-                  return <MarkdownPreviewCard filePath={filePath} />;
+                const href = el.props?.href as string | undefined;
+                if (href?.startsWith(FILE_SCHEME)) {
+                  const filePath = decodeURIComponent(href.slice(FILE_SCHEME.length));
+                  if (/\.mdx?$/i.test(filePath)) {
+                    return <MarkdownPreviewCard filePath={filePath} />;
+                  }
                 }
               }
               return <p>{children}</p>;

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -260,6 +260,26 @@ describe('TextBubble markdown preview card promotion', () => {
     expect(result.type).toBe('p');
   });
 
+  it('promotes a standalone .mdx file-path link to MarkdownPreviewCard', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const p = capturedComponents!.p;
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/design.mdx')}`;
+    const link = createElement('a', { href: fileHref }, '/tmp/design.mdx');
+
+    const result = p({ children: link });
+    expect(result.type).not.toBe('p');
+    expect(result.props.filePath).toBe('/tmp/design.mdx');
+  });
+
+  it('does not promote regular URL links in a solo paragraph', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    const p = capturedComponents!.p;
+    const link = createElement('a', { href: 'https://example.com' }, 'Example');
+
+    const result = p({ children: link });
+    expect(result.type).toBe('p');
+  });
+
   it('a handler sets data-file-path on file-path links', () => {
     renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
     const anchor = capturedComponents!.a;

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -4,18 +4,24 @@ import { describe, it, expect, vi } from 'vitest';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let capturedComponents: Record<string, any> | undefined;
 let capturedContent: string | undefined;
+
+let capturedUrlTransform: ((url: string) => string) | undefined;
 vi.mock('react-markdown', () => ({
   default: ({
     children,
     components,
+    urlTransform,
   }: {
     children: string;
     components?: Record<string, unknown>;
+    urlTransform?: (url: string) => string;
   }) => {
     capturedComponents = components;
     capturedContent = children;
+    capturedUrlTransform = urlTransform;
     return children;
   },
+  defaultUrlTransform: (url: string) => `sanitized:${url}`,
 }));
 vi.mock('remark-gfm', () => ({ default: () => {} }));
 
@@ -286,6 +292,25 @@ describe('TextBubble markdown preview card promotion', () => {
     const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/notes.md')}`;
     const rendered = anchor({ href: fileHref, children: '/tmp/notes.md' });
     expect(rendered.props['data-file-path']).toBe('/tmp/notes.md');
+  });
+});
+
+describe('TextBubble urlTransform', () => {
+  it('preserves file-path:// URLs and delegates others to defaultUrlTransform', () => {
+    renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
+    expect(capturedUrlTransform).toBeDefined();
+
+    // file-path:// URLs are preserved as-is (not passed through defaultUrlTransform)
+    const fileUrl = 'file-path://%2Ftmp%2Fnotes.md';
+    expect(capturedUrlTransform!(fileUrl)).toBe(fileUrl);
+
+    // Non-file-path URLs are delegated to defaultUrlTransform (mock prefixes with "sanitized:")
+    const httpUrl = 'https://example.com';
+    expect(capturedUrlTransform!(httpUrl)).toBe(`sanitized:${httpUrl}`);
+
+    // Dangerous schemes should also go through defaultUrlTransform, not be preserved
+    const jsUrl = 'javascript:alert(1)';
+    expect(capturedUrlTransform!(jsUrl)).toBe(`sanitized:${jsUrl}`);
   });
 });
 

--- a/frontend/src/components/__tests__/MessageBubble.test.ts
+++ b/frontend/src/components/__tests__/MessageBubble.test.ts
@@ -230,8 +230,9 @@ describe('TextBubble markdown preview card promotion', () => {
   it('promotes a standalone .md file-path link to MarkdownPreviewCard', () => {
     renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
     const p = capturedComponents!.p;
-    // Simulate what the a handler returns for a .md file-path link
-    const link = createElement('a', { 'data-file-path': '/tmp/notes.md' }, '/tmp/notes.md');
+    // Simulate what ReactMarkdown v10 passes: an unrendered component with href prop
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/notes.md')}`;
+    const link = createElement('a', { href: fileHref }, '/tmp/notes.md');
 
     const result = p({ children: link });
     // Should return a MarkdownPreviewCard, not a <p>
@@ -242,7 +243,8 @@ describe('TextBubble markdown preview card promotion', () => {
   it('does not promote non-.md file-path links', () => {
     renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
     const p = capturedComponents!.p;
-    const link = createElement('a', { 'data-file-path': '/tmp/data.json' }, '/tmp/data.json');
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/data.json')}`;
+    const link = createElement('a', { href: fileHref }, '/tmp/data.json');
 
     const result = p({ children: link });
     expect(result.type).toBe('p');
@@ -251,7 +253,8 @@ describe('TextBubble markdown preview card promotion', () => {
   it('does not promote .md links when paragraph has other content', () => {
     renderToStaticMarkup(createElement(TextBubble, { content: 'test' }));
     const p = capturedComponents!.p;
-    const link = createElement('a', { 'data-file-path': '/tmp/notes.md' }, '/tmp/notes.md');
+    const fileHref = `${FILE_SCHEME}${encodeURIComponent('/tmp/notes.md')}`;
+    const link = createElement('a', { href: fileHref }, '/tmp/notes.md');
 
     const result = p({ children: ['See ', link, ' for details'] });
     expect(result.type).toBe('p');


### PR DESCRIPTION
## Summary

- **Bug:** `.md` file paths in assistant messages rendered as plain links instead of expandable preview cards (introduced in PR #319)
- **Root cause:** Two compounding issues in ReactMarkdown v10:
  1. v10 sanitizes unknown URL schemes — `file-path://` was stripped to `""`, so the `a` handler never matched
  2. The `p` handler checked `data-file-path` on children, but in v10 children are unrendered component instances (the `a` handler hasn't executed yet), so the prop never existed
- **Fix:** Add `urlTransform` to preserve all URLs, and check `href` prop (which ReactMarkdown passes pre-render) instead of `data-file-path`

## Test plan

- [x] All 27 MessageBubble tests pass (updated 3 promotion tests to match new approach)
- [ ] Verify standalone `.md` path in chat renders as collapsible preview card
- [ ] Verify non-`.md` file paths still render as clickable links
- [ ] Verify inline `.md` paths (mixed with text) stay as links, not cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)