### PR TITLE
fix(ui): add Load More button to desktop session panel

### DIFF
--- a/frontend/src/components/SessionPanel.tsx
+++ b/frontend/src/components/SessionPanel.tsx
@@ -23,7 +23,7 @@ function readViewMode(): ViewMode {
 }
 
 export function SessionPanel({ activeSessionId, onSelectSession, onNewChat }: SessionPanelProps) {
-  const { sessions, loading, dismissSession } = useSessionList();
+  const { sessions, loading, loadingMore, hasMore, loadMore, dismissSession } = useSessionList();
   const { attendCount } = useSessionOverview();
   const [viewMode, setViewMode] = useState<ViewMode>(readViewMode);
 
@@ -116,6 +116,11 @@ export function SessionPanel({ activeSessionId, onSelectSession, onNewChat }: Se
                   </button>
                 </div>
               ))}
+              {hasMore && (
+                <button className="session-load-more" onClick={loadMore} disabled={loadingMore}>
+                  {loadingMore ? 'Loading...' : 'Load More'}
+                </button>
+              )}
             </div>
           )}
         </>

--- a/frontend/src/components/__tests__/SessionPanel.test.tsx
+++ b/frontend/src/components/__tests__/SessionPanel.test.tsx
@@ -7,6 +7,15 @@ vi.mock('../../hooks/useSessionList', () => ({
   useSessionList: vi.fn(),
 }));
 
+// Mock useSessionOverview to avoid EventSource dependency
+vi.mock('../../hooks/useSessionOverview', () => ({
+  useSessionOverview: vi.fn(() => ({
+    activities: [],
+    attendCount: 0,
+    connected: false,
+  })),
+}));
+
 import { SessionPanel } from '../SessionPanel';
 import { useSessionList } from '../../hooks/useSessionList';
 
@@ -32,11 +41,15 @@ function makeDefaultReturn(overrides = {}) {
 
 beforeEach(() => {
   mockUseSessionList.mockReturnValue(makeDefaultReturn());
+  // Default to "All" view so session list tests work (the "Active" view
+  // renders ActiveSessionsList which is tested separately).
+  localStorage.setItem('mitzo-session-view-mode', 'all');
 });
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  localStorage.clear();
 });
 
 describe('SessionPanel', () => {
@@ -142,5 +155,52 @@ describe('SessionPanel', () => {
     const deleteBtn = container.querySelector('.session-panel-delete')!;
     fireEvent.click(deleteBtn);
     expect(dismiss).toHaveBeenCalledWith('s1');
+  });
+
+  describe('Load More button', () => {
+    it('renders when hasMore is true', () => {
+      mockUseSessionList.mockReturnValue(
+        makeDefaultReturn({
+          sessions: [{ id: 's1', summary: 'A session', lastModified: Date.now() }],
+          hasMore: true,
+        }),
+      );
+      render(
+        <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+      );
+      expect(screen.getByText('Load More')).toBeTruthy();
+    });
+
+    it('shows disabled loading state when loadingMore is true', () => {
+      mockUseSessionList.mockReturnValue(
+        makeDefaultReturn({
+          sessions: [{ id: 's1', summary: 'A session', lastModified: Date.now() }],
+          hasMore: true,
+          loadingMore: true,
+        }),
+      );
+      render(
+        <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+      );
+      const btn = screen.getByText('Loading...');
+      expect(btn).toBeTruthy();
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('calls loadMore when clicked', () => {
+      const loadMore = vi.fn();
+      mockUseSessionList.mockReturnValue(
+        makeDefaultReturn({
+          sessions: [{ id: 's1', summary: 'A session', lastModified: Date.now() }],
+          hasMore: true,
+          loadMore,
+        }),
+      );
+      render(
+        <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('Load More'));
+      expect(loadMore).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/frontend/src/components/__tests__/SessionPanel.test.tsx
+++ b/frontend/src/components/__tests__/SessionPanel.test.tsx
@@ -158,6 +158,19 @@ describe('SessionPanel', () => {
   });
 
   describe('Load More button', () => {
+    it('does not render Load More when hasMore is false', () => {
+      mockUseSessionList.mockReturnValue(
+        makeDefaultReturn({
+          sessions: [{ id: 's1', summary: 'A session', lastModified: Date.now() }],
+          hasMore: false,
+        }),
+      );
+      render(
+        <SessionPanel activeSessionId={undefined} onSelectSession={vi.fn()} onNewChat={vi.fn()} />,
+      );
+      expect(screen.queryByText('Load More')).toBeNull();
+    });
+
     it('renders when hasMore is true', () => {
       mockUseSessionList.mockReturnValue(
         makeDefaultReturn({


### PR DESCRIPTION
## Summary
- Desktop `SessionPanel` was missing pagination — only the first 20 sessions were visible with no way to load more
- The `useSessionList` hook already exposes `hasMore`/`loadMore`/`loadingMore`; the mobile `SessionList` uses them but desktop never wired them up
- Added the same "Load More" button (reusing existing `.session-load-more` CSS class) to the desktop "All" session list

## Test plan
- [ ] Open desktop UI, switch to "All" tab in session sidebar
- [ ] Verify "Load More" appears at bottom when >20 sessions exist
- [ ] Click it — older sessions append, button disappears when no more pages
- [ ] Verify button shows "Loading..." while fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)