### PR TITLE
fix(client): recover SSE on browser visibilitychange

### DIFF
--- a/frontend/src/lib/__tests__/event-bus-singleton.test.ts
+++ b/frontend/src/lib/__tests__/event-bus-singleton.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+// Tests for the global SSE EventBus singleton's visibilitychange recovery.
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock EventSource (jsdom doesn't provide it)
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  readyState = MockEventSource.CONNECTING;
+  onopen: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  close = vi.fn();
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+}
+
+// Must be set before module loads — static imports are hoisted above beforeAll
+global.EventSource = MockEventSource as unknown as typeof EventSource;
+
+// Dynamic import so the module-level side effects run after EventSource is defined
+const { eventBus } = await import('../event-bus-singleton');
+
+describe('event-bus-singleton visibilitychange recovery', () => {
+  it('calls ensureConnected when page becomes visible', () => {
+    const ensureConnectedSpy = vi.spyOn(eventBus, 'ensureConnected');
+
+    // Simulate page becoming visible
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(ensureConnectedSpy).toHaveBeenCalled();
+    ensureConnectedSpy.mockRestore();
+  });
+
+  it('does not call ensureConnected when page becomes hidden', () => {
+    const ensureConnectedSpy = vi.spyOn(eventBus, 'ensureConnected');
+
+    // Simulate page becoming hidden
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      writable: true,
+      configurable: true,
+    });
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(ensureConnectedSpy).not.toHaveBeenCalled();
+    ensureConnectedSpy.mockRestore();
+  });
+});

--- a/frontend/src/lib/event-bus-singleton.ts
+++ b/frontend/src/lib/event-bus-singleton.ts
@@ -3,6 +3,7 @@
  *
  * Lazily connected on first import. Hooks subscribe via eventBus.on().
  * On iOS resume, ensureConnected() is called to recover from CLOSED state.
+ * On page visibility change, ensureConnected() reconnects if connection died.
  */
 
 import { EventBus } from '@mitzo/client';
@@ -13,3 +14,13 @@ export const eventBus = new EventBus();
 // Connect immediately — EventSource auto-reconnects natively
 const sseUrl = `${getApiBaseUrl()}/api/events`;
 eventBus.connect(sseUrl);
+
+// Recover from dead SSE connections when page becomes visible again
+// (e.g., iOS Safari backgrounding kills EventSource without firing error)
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      eventBus.ensureConnected();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- iOS Safari kills EventSource connections when the tab is backgrounded without firing an error event
- The Capacitor lifecycle hook already handled this, but browser clients (e.g. phone via Safari PWA) had no recovery
- This caused the health SSE stream to die permanently after a single background cycle, hiding the voice mic button

## Fix
Add a `visibilitychange` listener in `event-bus-singleton.ts` that calls `ensureConnected()` when the page becomes visible.

## Test plan
- [x] New test: `event-bus-singleton.test.ts` — verifies `ensureConnected` called on visible, not called on hidden
- [x] Full test suite passes (5 pre-existing failures unrelated to this change)
- [ ] Manual: open Mitzo in mobile Safari, background the tab, return — mic button should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)