### PR TITLE
Fix session list timestamp reset and missing new sessions

### DIFF
--- a/server/__tests__/session-cache.test.ts
+++ b/server/__tests__/session-cache.test.ts
@@ -217,6 +217,51 @@ describe('getSessionsCached', () => {
       cwd: '/projects/bar',
     });
   });
+
+  it('keeps a recent zero-turn inactive session within the grace period', async () => {
+    const thirtyMinutesAgo = Date.now() - 30 * 60 * 1000;
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-recent-zero',
+        summary: 'Just created',
+        numTurns: 0,
+        promptCount: 0,
+        isActive: false,
+        createdAt: thirtyMinutesAgo,
+        updatedAt: thirtyMinutesAgo,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe('sess-recent-zero');
+  });
+
+  it('hides an old zero-turn inactive session past the grace period', async () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    mockListSessionsMeta.mockReturnValue([
+      {
+        sessionId: 'sess-old-zero',
+        summary: 'Stale empty session',
+        numTurns: 0,
+        promptCount: 0,
+        isActive: false,
+        createdAt: twoHoursAgo,
+        updatedAt: twoHoursAgo,
+        branch: null,
+        cwd: null,
+      },
+    ]);
+
+    const { getSessionsCached } = await import('../chat.js');
+    const { sessions } = getSessionsCached();
+
+    expect(sessions).toHaveLength(0);
+  });
 });
 
 describe('syncSessionTimestamps', () => {
@@ -344,6 +389,63 @@ describe('syncSessionTimestamps', () => {
     await syncSessionTimestamps();
 
     expect(mockUpsertSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('resume timestamp preservation', () => {
+  it('preserves updatedAt when resuming an existing session', async () => {
+    const originalUpdatedAt = Date.now() - 3600_000; // 1 hour ago
+    const existingMeta = {
+      sessionId: 'sess-resume',
+      summary: 'Old session',
+      updatedAt: originalUpdatedAt,
+      createdAt: originalUpdatedAt - 7200_000,
+      numTurns: 5,
+      promptCount: 3,
+      isActive: false,
+      branch: 'main',
+      cwd: '/projects/foo',
+      manuallyRenamed: false,
+    };
+    mockGetSession.mockReturnValue(existingMeta);
+
+    // Simulate the resume upsert pattern from startSession (chat.ts L688-701):
+    //   const existingMeta = eventStore.getSession(id);
+    //   eventStore.upsertSession({ ..., ...(existingMeta ? { updatedAt: existingMeta.updatedAt } : {}) });
+    const sessionId = 'sess-resume';
+    const retrieved = mockEventStore.getSession(sessionId);
+    mockEventStore.upsertSession({
+      sessionId,
+      cwd: '/projects/foo',
+      mode: 'code',
+      branch: 'main',
+      ...(retrieved ? { updatedAt: retrieved.updatedAt } : {}),
+    });
+
+    expect(mockUpsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-resume',
+        updatedAt: originalUpdatedAt,
+      }),
+    );
+  });
+
+  it('omits updatedAt when resuming a session with no prior metadata', async () => {
+    mockGetSession.mockReturnValue(null);
+
+    const sessionId = 'sess-new-resume';
+    const retrieved = mockEventStore.getSession(sessionId);
+    mockEventStore.upsertSession({
+      sessionId,
+      cwd: '/projects/foo',
+      mode: 'code',
+      branch: 'main',
+      ...(retrieved ? { updatedAt: retrieved.updatedAt } : {}),
+    });
+
+    const call = mockUpsertSession.mock.calls[0][0];
+    expect(call.sessionId).toBe('sess-new-resume');
+    expect(call).not.toHaveProperty('updatedAt');
   });
 });
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -689,7 +689,9 @@ async function _startChatInner(
 
   // Pre-register resumed sessions in EventStore so they're discoverable
   // even if the query loop dies before the first assistant event.
+  // Preserve existing updatedAt so server restarts don't reset all timestamps.
   if (options.resume) {
+    const existingMeta = eventStore.getSession(options.resume);
     eventStore.upsertSession({
       sessionId: options.resume,
       cwd,
@@ -698,6 +700,7 @@ async function _startChatInner(
       isActive: true,
       ...(worktreePath ? { wtId } : {}),
       ...(options.telosTaskId ? { telosTaskId: options.telosTaskId } : {}),
+      ...(existingMeta ? { updatedAt: existingMeta.updatedAt } : {}),
     });
   }
 
@@ -1509,10 +1512,12 @@ export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
   const all = eventStore.listSessions().filter((m) => {
     // Hide sessions that were never used through Mitzo (e.g. automated
     // code review sessions discovered from filesystem).  Active sessions
-    // always show regardless of turn count.
-    // Note: new sessions are created with is_active=1 by default (see EventStore
-    // schema), so a brand-new session will never be filtered out here.
-    if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) return false;
+    // always show regardless of turn count.  Recently created sessions
+    // (< 1 hour) are kept even with no turns — they may still be starting.
+    if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) {
+      const ONE_HOUR = 60 * 60 * 1000;
+      return Date.now() - m.createdAt < ONE_HOUR;
+    }
     return true;
   });
   const page = all.slice(offset, offset + limit);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -40,6 +40,9 @@ import { INTERNAL_TOKEN } from './internal-token.js';
 import { buildTaskSystemPrompt } from './task-context.js';
 import type { TaskStore } from './task-store.js';
 
+/** Grace period for zero-turn inactive sessions — recently created ones stay visible. */
+const ZERO_TURN_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
 let _taskStore: TaskStore | null = null;
 export function setTaskStore(store: TaskStore): void {
   _taskStore = store;
@@ -1515,8 +1518,7 @@ export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
     // always show regardless of turn count.  Recently created sessions
     // (< 1 hour) are kept even with no turns — they may still be starting.
     if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) {
-      const ONE_HOUR = 60 * 60 * 1000;
-      return Date.now() - m.createdAt < ONE_HOUR;
+      return Date.now() - m.createdAt < ZERO_TURN_GRACE_MS;
     }
     return true;
   });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -35,13 +35,11 @@ import {
   SESSION_PAGE_SIZE,
   SESSION_MESSAGES_LIMIT,
   USER_CLOSEOUT_TIMEOUT_MS,
+  ZERO_TURN_GRACE_MS,
 } from './constants.js';
 import { INTERNAL_TOKEN } from './internal-token.js';
 import { buildTaskSystemPrompt } from './task-context.js';
 import type { TaskStore } from './task-store.js';
-
-/** Grace period for zero-turn inactive sessions — recently created ones stay visible. */
-const ZERO_TURN_GRACE_MS = 60 * 60 * 1000; // 1 hour
 
 let _taskStore: TaskStore | null = null;
 export function setTaskStore(store: TaskStore): void {
@@ -1512,13 +1510,14 @@ export async function getSessions(offset = 0, limit = SESSION_PAGE_SIZE) {
  * Returns the same shape as getSessions() for API compatibility.
  */
 export function getSessionsCached(offset = 0, limit = SESSION_PAGE_SIZE) {
+  const now = Date.now();
   const all = eventStore.listSessions().filter((m) => {
     // Hide sessions that were never used through Mitzo (e.g. automated
     // code review sessions discovered from filesystem).  Active sessions
     // always show regardless of turn count.  Recently created sessions
     // (< 1 hour) are kept even with no turns — they may still be starting.
     if (m.numTurns === 0 && m.promptCount === 0 && !m.isActive) {
-      return Date.now() - m.createdAt < ZERO_TURN_GRACE_MS;
+      return now - m.createdAt < ZERO_TURN_GRACE_MS;
     }
     return true;
   });

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -42,6 +42,10 @@ export const SHUTDOWN_GRACE_MS = 5_000;
 export const GUARD_STATS_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 export const WORKTREE_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
+// --- Session List ---
+/** Grace period for zero-turn inactive sessions — recently created ones stay visible. */
+export const ZERO_TURN_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
 // --- Query loop ---
 // If the Agent SDK yields no events within this window, we treat the turn
 // as unreachable (e.g. model unavailable on the configured provider) and


### PR DESCRIPTION
## Summary

Fixes two bugs in the session list:

1. **All sessions show same timestamp after server restart** — when sessions are resumed (e.g., after a server restart), their `updated_at` timestamps were being reset to "now" instead of being preserved. This caused all recently-resumed sessions to show identical relative times like "18m ago".

2. **Newly created sessions disappear from list** — sessions with zero turns and zero prompts that aren't currently active were being filtered out, hiding newly created sessions that hadn't completed their first turn yet.

## Changes

**`server/chat.ts:687-697`** — Resume timestamp preservation
- Read existing session metadata via `eventStore.getSession()` before calling `upsertSession()` on resume
- Pass existing `updatedAt` explicitly to prevent EventStore from defaulting to current time
- Only applies when session already exists (resume path); new sessions get natural timestamp

**`server/chat.ts:1354-1358`** — Grace period for new sessions
- Keep zero-turn, zero-prompt, inactive sessions visible for 1 hour after creation
- After 1 hour with no activity, apply the filter as before (hides automated/discovered sessions)
- Handles race conditions where session is created but query loop hasn't finished first turn

## Test Plan

- [ ] Verify session list shows correct relative timestamps (not all identical)
- [ ] Verify newly created sessions appear in list immediately
- [ ] Verify sessions created >1h ago with no turns are still filtered out
- [ ] Restart server and confirm session timestamps don't reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)