### PR TITLE
feat(infra): persist Jaeger traces with badger storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ frontend/ios/local.xcconfig
 mcp-server/build/
 certs/
 logs/
+.jaeger-data/
 .DS_Store
 .claude/worktrees/
 .cursor/worktrees/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,13 @@ services:
       - '16686:16686' # Jaeger UI
     environment:
       COLLECTOR_OTLP_ENABLED: 'true'
+      SPAN_STORAGE_TYPE: badger
+      BADGER_EPHEMERAL: 'false'
+      BADGER_DIRECTORY_VALUE: /badger/data
+      BADGER_DIRECTORY_KEY: /badger/key
+      BADGER_SPAN_STORE_TTL: 336h  # 14 days retention
+    volumes:
+      - ./.jaeger-data:/badger
 
   loki:
     image: grafana/loki:3.4.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       BADGER_EPHEMERAL: 'false'
       BADGER_DIRECTORY_VALUE: /badger/data
       BADGER_DIRECTORY_KEY: /badger/key
-      BADGER_SPAN_STORE_TTL: 336h  # 14 days retention
+      BADGER_SPAN_STORE_TTL: 336h # 14 days retention
     volumes:
       - ./.jaeger-data:/badger
 

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1368,6 +1368,18 @@ async function _runQueryLoopInner(
         currentTurnSpan = null;
       }
 
+      // Ensure span attributes are set even if the SDK result event never arrived.
+      // The result handler (msg.type === 'result') sets these, but sessions that
+      // abort, timeout, or lose connection skip that path. Use live counters as fallback.
+      if (!doneSent) {
+        span.setAttribute('session.total_tokens', liveSessionTokens);
+        span.setAttribute('session.num_turns', turnIndex);
+      }
+      // Always set session.id if we resolved it (idempotent with line 472)
+      if (resolvedSessionId) {
+        span.setAttribute('session.id', resolvedSessionId);
+      }
+
       span.setStatus({ code: SpanStatusCode.OK });
       log.info('query loop ended', { clientId, doneSent });
     }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1380,7 +1380,7 @@ async function _runQueryLoopInner(
           span.setAttribute('session.cost_usd', finalSession.cumulativeCostUsd);
         }
       }
-      // Always set session.id if we resolved it (idempotent with line 472)
+      // Always set session.id if we resolved it (idempotent with first-event handler)
       if (resolvedSessionId) {
         span.setAttribute('session.id', resolvedSessionId);
       }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1374,6 +1374,11 @@ async function _runQueryLoopInner(
       if (!doneSent) {
         span.setAttribute('session.total_tokens', liveSessionTokens);
         span.setAttribute('session.num_turns', turnIndex);
+        // Cost is only available from the SDK result event. For multi-query sessions
+        // (compaction), earlier result events may have set cumulativeCostUsd before abort.
+        if (finalSession && finalSession.cumulativeCostUsd > 0) {
+          span.setAttribute('session.cost_usd', finalSession.cumulativeCostUsd);
+        }
       }
       // Always set session.id if we resolved it (idempotent with line 472)
       if (resolvedSessionId) {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1323,6 +1323,10 @@ async function _runQueryLoopInner(
       }
     } finally {
       clearTimeout(firstEventTimer);
+      // NOTE: finalSession is read before registry.remove() below. After remove(),
+      // the object reference remains valid (Map.delete doesn't mutate the value).
+      // cumulativeCostUsd is read from finalSession after remove — safe due to
+      // reference semantics, but keep the ordering if refactoring.
       const finalSession = registry.get(clientId);
       if (finalSession) {
         finalSession.currentSnapshot = null;
@@ -1385,8 +1389,8 @@ async function _runQueryLoopInner(
         span.setAttribute('session.id', resolvedSessionId);
       }
 
-      span.setStatus({ code: SpanStatusCode.OK });
-      log.info('query loop ended', { clientId, doneSent });
+      span.setStatus({ code: caughtError ? SpanStatusCode.ERROR : SpanStatusCode.OK });
+      log.info('query loop ended', { clientId, doneSent, caughtError });
     }
   } finally {
     span.end();


### PR DESCRIPTION
## Summary

- Switches Jaeger from in-memory (ephemeral, ~37h retention) to badger persistent storage
- 14-day TTL via `BADGER_SPAN_STORE_TTL=336h`
- Data persists at `.jaeger-data/` (gitignored)
- Enables the Trace Dreamer agent (dimakis/mgmt#116) to extract operational insights from historical traces

## Telemetry fixes

- **Incomplete sessions**: `session.total_tokens`, `session.num_turns`, and `session.id` now set as fallback span attributes when the SDK `result` event never fires (abort, timeout, connection loss)
- **Cost fallback**: `session.cost_usd` set from `cumulativeCostUsd` for multi-query sessions that had at least one `result` event before abort

## Test plan

- [x] Jaeger persists traces across container restarts
- [x] 50/50 query-loop tests pass
- [x] TypeScript type check passes
- [x] Prettier formatting check passes

Refs: #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)