### PR TITLE
feat(ui): fix What's Next to prioritize sessions over Telos

### DIFF
--- a/frontend/src/hooks/useAttentionFeed.ts
+++ b/frontend/src/hooks/useAttentionFeed.ts
@@ -60,7 +60,7 @@ function telosToAttention(items: TodoItem[]): AttentionItem[] {
         tier: 1,
         subPriority: SUB_TELOS,
         title: item.summary,
-        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} \u00B7 ${item.profile}`,
+        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} · ${item.profile}`,
         accentColor: item.urgency >= 0.8 ? COLOR_RED : COLOR_AMBER,
         icon: '\u2605', // ★
         navigateTo: `/todos/${item.id}`,
@@ -75,7 +75,7 @@ function telosToAttention(items: TodoItem[]): AttentionItem[] {
         tier: 2,
         subPriority: SUB_TELOS,
         title: item.summary,
-        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} \u00B7 ${item.profile}`,
+        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} · ${item.profile}`,
         accentColor: item.starred ? COLOR_AMBER : COLOR_PURPLE,
         icon: item.starred ? '\u2605' : '\u25CF', // ★ or ●
         navigateTo: `/todos/${item.id}`,
@@ -191,7 +191,7 @@ function sessionsToAttention(activities: SessionActivity[]): AttentionItem[] {
         id: `session-${a.sessionId}`,
         source: 'session',
         tier: 2,
-        subPriority: SUB_AWAITING_REPLY,
+        subPriority: SUB_TELOS,
         title: a.title,
         meta: 'done',
         accentColor: COLOR_GREEN,

--- a/frontend/src/hooks/useAttentionFeed.ts
+++ b/frontend/src/hooks/useAttentionFeed.ts
@@ -15,6 +15,8 @@ export interface AttentionItem {
   id: string;
   source: AttentionSource;
   tier: AttentionTier;
+  /** Within same tier, lower = higher priority. Sessions sort above Telos. */
+  subPriority: number;
   title: string;
   meta: string;
   accentColor: string;
@@ -32,6 +34,17 @@ const COLOR_RED = '#ff6d6d';
 const COLOR_PURPLE = '#b48cff';
 const COLOR_GREEN = '#4ade80';
 
+// ─── Sub-priority constants ────────────────────────────────────────────────
+
+/** Sessions awaiting user reply — highest priority within any tier */
+const SUB_AWAITING_REPLY = 0;
+/** Sessions/ATB waiting for input (permission, review, blocked) */
+const SUB_WAITING_INPUT = 1;
+/** Sessions with uncommitted worktree work */
+const SUB_UNCOMMITTED = 2;
+/** Telos items — fill remaining slots */
+const SUB_TELOS = 3;
+
 // ─── Derive attention items from Telos ─────────────────────────────────────
 
 function telosToAttention(items: TodoItem[]): AttentionItem[] {
@@ -45,8 +58,9 @@ function telosToAttention(items: TodoItem[]): AttentionItem[] {
         id: `telos-${item.id}`,
         source: 'telos',
         tier: 1,
+        subPriority: SUB_TELOS,
         title: item.summary,
-        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} · ${item.profile}`,
+        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} \u00B7 ${item.profile}`,
         accentColor: item.urgency >= 0.8 ? COLOR_RED : COLOR_AMBER,
         icon: '\u2605', // ★
         navigateTo: `/todos/${item.id}`,
@@ -59,8 +73,9 @@ function telosToAttention(items: TodoItem[]): AttentionItem[] {
         id: `telos-${item.id}`,
         source: 'telos',
         tier: 2,
+        subPriority: SUB_TELOS,
         title: item.summary,
-        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} · ${item.profile}`,
+        meta: `${item.ageDays === 0 ? 'new' : `${item.ageDays}d`} \u00B7 ${item.profile}`,
         accentColor: item.starred ? COLOR_AMBER : COLOR_PURPLE,
         icon: item.starred ? '\u2605' : '\u25CF', // ★ or ●
         navigateTo: `/todos/${item.id}`,
@@ -92,6 +107,7 @@ function atbToAttention(tasks: Task[]): AttentionItem[] {
       id: `atb-${t.id}`,
       source: 'atb' as AttentionSource,
       tier: 1 as AttentionTier,
+      subPriority: SUB_WAITING_INPUT,
       title: t.title,
       meta:
         t.status === 'pending_review'
@@ -114,32 +130,86 @@ function atbToAttention(tasks: Task[]): AttentionItem[] {
 // ─── Derive attention items from sessions ──────────────────────────────────
 
 function sessionsToAttention(activities: SessionActivity[]): AttentionItem[] {
-  return activities
-    .filter((a) => a.state === 'waiting' || a.state === 'done')
-    .map((a) => ({
-      id: `session-${a.sessionId}`,
-      source: 'session' as AttentionSource,
-      tier: (a.state === 'waiting' ? 1 : 2) as AttentionTier,
-      title: a.title,
-      meta:
-        a.state === 'waiting'
-          ? a.waitReason === 'permission'
+  const items: AttentionItem[] = [];
+  for (const a of activities) {
+    // Priority 1: awaiting reply (agent responded, user hasn't)
+    if (a.awaitingReply && (a.state === 'done' || a.state === 'idle')) {
+      items.push({
+        id: `session-${a.sessionId}`,
+        source: 'session',
+        tier: 1,
+        subPriority: SUB_AWAITING_REPLY,
+        title: a.title,
+        meta: 'awaiting reply',
+        accentColor: COLOR_PURPLE,
+        icon: '\u2709', // ✉
+        navigateTo: `/chat/${a.sessionId}`,
+        updatedAt: a.lastEventAt || 0,
+      });
+      continue;
+    }
+    // Priority 2: waiting for input (permission/review/blocked)
+    if (a.state === 'waiting') {
+      items.push({
+        id: `session-${a.sessionId}`,
+        source: 'session',
+        tier: 1,
+        subPriority: SUB_WAITING_INPUT,
+        title: a.title,
+        meta:
+          a.waitReason === 'permission'
             ? 'permission needed'
             : a.waitReason === 'review'
               ? 'review needed'
-              : 'waiting'
-          : 'done',
-      accentColor: a.state === 'waiting' ? COLOR_RED : COLOR_GREEN,
-      icon: a.state === 'waiting' ? '\u26A0' : '\u2713', // ⚠ or ✓
-      navigateTo: `/chat/${a.sessionId}`,
-      updatedAt: a.lastEventAt || 0,
-    }));
+              : 'waiting',
+        accentColor: COLOR_RED,
+        icon: '\u26A0', // ⚠
+        navigateTo: `/chat/${a.sessionId}`,
+        updatedAt: a.lastEventAt || 0,
+      });
+      continue;
+    }
+    // Priority 3: uncommitted worktree work
+    if (a.uncommittedWork && (a.state === 'done' || a.state === 'idle')) {
+      items.push({
+        id: `session-${a.sessionId}`,
+        source: 'session',
+        tier: 1,
+        subPriority: SUB_UNCOMMITTED,
+        title: a.title,
+        meta: 'uncommitted work',
+        accentColor: COLOR_AMBER,
+        icon: '\u26A0', // ⚠
+        navigateTo: `/chat/${a.sessionId}`,
+        updatedAt: a.lastEventAt || 0,
+      });
+      continue;
+    }
+    // Tier 2: done sessions (recently finished)
+    if (a.state === 'done') {
+      items.push({
+        id: `session-${a.sessionId}`,
+        source: 'session',
+        tier: 2,
+        subPriority: SUB_AWAITING_REPLY,
+        title: a.title,
+        meta: 'done',
+        accentColor: COLOR_GREEN,
+        icon: '\u2713', // ✓
+        navigateTo: `/chat/${a.sessionId}`,
+        updatedAt: a.lastEventAt || 0,
+      });
+    }
+  }
+  return items;
 }
 
-// ─── Sort by tier then recency ─────────────────────────────────────────────
+// ─── Sort by tier → sub-priority → recency ────────────────────────────────
 
 function sortAttention(items: AttentionItem[]): AttentionItem[] {
-  return [...items].sort((a, b) => a.tier - b.tier || b.updatedAt - a.updatedAt);
+  return [...items].sort(
+    (a, b) => a.tier - b.tier || a.subPriority - b.subPriority || b.updatedAt - a.updatedAt,
+  );
 }
 
 // ─── Hook ──────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -43,6 +43,8 @@ interface SessionRow {
   goal_id: string | null;
   telos_task_id: string | null;
   closed_by: string | null;
+  last_speaker: string | null;
+  last_speaker_at: number | null;
   created_at: number;
   updated_at: number;
 }
@@ -87,6 +89,8 @@ export class EventStore {
     markInactive: Database.Statement;
     hide: Database.Statement;
     recordUsage: Database.Statement;
+    updateLastSpeaker: Database.Statement;
+    getAttentionSessions: Database.Statement;
   };
 
   constructor(dbPath: string, logger?: EventStoreLogger) {
@@ -101,6 +105,7 @@ export class EventStore {
     this.migrateUsageTracking(db);
     this.migrateWorktreeTracking(db);
     this.migrateCloseTracking(db);
+    this.migrateAttentionTracking(db);
 
     this.log.info('EventStore initialized', { dbPath });
 
@@ -140,6 +145,21 @@ export class EventStore {
           duration_api_ms = ?,
           updated_at = unixepoch('now', 'subsec') * 1000
         WHERE session_id = ?`,
+      ),
+      updateLastSpeaker: db.prepare(
+        `UPDATE sessions SET
+          last_speaker = ?,
+          last_speaker_at = unixepoch('now', 'subsec') * 1000,
+          updated_at = unixepoch('now', 'subsec') * 1000
+        WHERE session_id = ?`,
+      ),
+      getAttentionSessions: db.prepare(
+        `SELECT * FROM sessions
+         WHERE is_active = 1
+           AND is_hidden = 0
+           AND last_speaker = 'assistant'
+         ORDER BY last_speaker_at DESC
+         LIMIT 10`,
       ),
     };
   }
@@ -208,6 +228,19 @@ export class EventStore {
     if (!columnNames.has('closed_by')) {
       db.exec('ALTER TABLE sessions ADD COLUMN closed_by TEXT');
       this.log.info('migrated sessions table: added closed_by');
+    }
+  }
+
+  private migrateAttentionTracking(db: Database.Database): void {
+    const columns = db.prepare("PRAGMA table_info('sessions')").all() as Array<{ name: string }>;
+    const columnNames = new Set(columns.map((c) => c.name));
+    if (!columnNames.has('last_speaker')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN last_speaker TEXT');
+      this.log.info('migrated sessions table: added last_speaker');
+    }
+    if (!columnNames.has('last_speaker_at')) {
+      db.exec('ALTER TABLE sessions ADD COLUMN last_speaker_at INTEGER');
+      this.log.info('migrated sessions table: added last_speaker_at');
     }
   }
 
@@ -446,6 +479,15 @@ export class EventStore {
     ).run(sessionId);
   }
 
+  updateLastSpeaker(sessionId: string, speaker: 'user' | 'assistant'): void {
+    this.stmts.updateLastSpeaker.run(speaker, sessionId);
+  }
+
+  getAttentionSessions(): SessionMeta[] {
+    const rows = this.stmts.getAttentionSessions.all();
+    return (rows as SessionRow[]).map(rowToSession);
+  }
+
   recordUsage(
     sessionId: string,
     usage: {
@@ -531,6 +573,8 @@ function rowToSession(row: SessionRow): SessionMeta {
     goalId: row.goal_id ?? null,
     telosTaskId: row.telos_task_id ?? null,
     closedBy: (row.closed_by as SessionMeta['closedBy']) ?? null,
+    lastSpeaker: (row.last_speaker as SessionMeta['lastSpeaker']) ?? null,
+    lastSpeakerAt: row.last_speaker_at ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -137,6 +137,12 @@ export interface SessionActivity {
   progress?: { done: number; total: number };
   lastEventAt: number;
   taskId?: string;
+  /** True when the session worktree has uncommitted changes. */
+  uncommittedWork?: boolean;
+  /** True when last message was from assistant and session is not actively streaming. */
+  awaitingReply?: boolean;
+  /** Minutes since the last speaker event (user or assistant). */
+  idleMinutes?: number;
 }
 
 // --- Service health (SSE event bus) ---
@@ -198,6 +204,8 @@ export interface SessionMeta {
   goalId: string | null;
   telosTaskId: string | null;
   closedBy: SessionClosedBy | null;
+  lastSpeaker: 'user' | 'assistant' | null;
+  lastSpeakerAt: number | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -413,4 +413,87 @@ describe('EventStore', () => {
       store.close(); // should not throw
     });
   });
+
+  describe('updateLastSpeaker', () => {
+    it('sets last_speaker to user', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      store.updateLastSpeaker('sess-1', 'user');
+
+      const session = store.getSession('sess-1');
+      expect(session!.lastSpeaker).toBe('user');
+      expect(session!.lastSpeakerAt).toBeGreaterThan(0);
+    });
+
+    it('toggles between user and assistant', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      store.updateLastSpeaker('sess-1', 'user');
+      store.updateLastSpeaker('sess-1', 'assistant');
+
+      const session = store.getSession('sess-1');
+      expect(session!.lastSpeaker).toBe('assistant');
+    });
+
+    it('updates updated_at timestamp', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      const before = store.getSession('sess-1')!.updatedAt;
+
+      // Small delay to ensure timestamp changes
+      store.updateLastSpeaker('sess-1', 'assistant');
+      const after = store.getSession('sess-1')!.updatedAt;
+      expect(after).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe('getAttentionSessions', () => {
+    it('returns sessions where last_speaker is assistant', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Awaiting reply' });
+      store.updateLastSpeaker('sess-1', 'assistant');
+
+      store.upsertSession({ sessionId: 'sess-2', summary: 'User replied' });
+      store.updateLastSpeaker('sess-2', 'user');
+
+      const attention = store.getAttentionSessions();
+      expect(attention).toHaveLength(1);
+      expect(attention[0].sessionId).toBe('sess-1');
+    });
+
+    it('excludes inactive sessions', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Closed' });
+      store.updateLastSpeaker('sess-1', 'assistant');
+      store.markSessionInactive('sess-1');
+
+      const attention = store.getAttentionSessions();
+      expect(attention).toHaveLength(0);
+    });
+
+    it('excludes hidden sessions', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Hidden' });
+      store.updateLastSpeaker('sess-1', 'assistant');
+      store.hideSession('sess-1');
+
+      const attention = store.getAttentionSessions();
+      expect(attention).toHaveLength(0);
+    });
+
+    it('limits to 10 results', () => {
+      for (let i = 0; i < 15; i++) {
+        const id = `sess-${i}`;
+        store.upsertSession({ sessionId: id, summary: `Session ${i}` });
+        store.updateLastSpeaker(id, 'assistant');
+      }
+
+      const attention = store.getAttentionSessions();
+      expect(attention).toHaveLength(10);
+    });
+
+    it('maps lastSpeaker and lastSpeakerAt in rowToSession', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      store.updateLastSpeaker('sess-1', 'assistant');
+
+      const session = store.getSession('sess-1');
+      expect(session!.lastSpeaker).toBe('assistant');
+      expect(typeof session!.lastSpeakerAt).toBe('number');
+      expect(session!.lastSpeakerAt).toBeGreaterThan(0);
+    });
+  });
 });

--- a/server/__tests__/session-overview.test.ts
+++ b/server/__tests__/session-overview.test.ts
@@ -490,6 +490,25 @@ describe('SessionOverviewEmitter', () => {
     expect(activities[0].awaitingReply).toBe(false);
   });
 
+  it('does not set awaitingReply when session is in waiting state', () => {
+    mockGetPending.mockReturnValue(1);
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: false })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      eventStore: {
+        getSession: vi.fn(() => ({ lastSpeaker: 'assistant', lastSpeakerAt: Date.now() })),
+        getAttentionSessions: vi.fn(() => []),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].state).toBe('waiting');
+    expect(activities[0].awaitingReply).toBe(false);
+  });
+
   // ─── Uncommitted work ─────────────────────────────────────────────────────
 
   it('sets uncommittedWork when worktree is dirty', async () => {

--- a/server/__tests__/session-overview.test.ts
+++ b/server/__tests__/session-overview.test.ts
@@ -71,11 +71,11 @@ const mockGetPending = getPendingCountBySession as ReturnType<typeof vi.fn>;
 // ─── Mock worktree module ────────────────────────────────────────────────────
 
 vi.mock('../worktree.js', () => ({
-  hasUncommittedWork: vi.fn(() => null), // default: clean worktree
+  hasUncommittedWorkAsync: vi.fn(async () => null), // default: clean worktree
 }));
 
-import { hasUncommittedWork } from '../worktree.js';
-const mockHasUncommittedWork = hasUncommittedWork as ReturnType<typeof vi.fn>;
+import { hasUncommittedWorkAsync } from '../worktree.js';
+const mockHasUncommittedWorkAsync = hasUncommittedWorkAsync as ReturnType<typeof vi.fn>;
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -86,7 +86,7 @@ describe('SessionOverviewEmitter', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockGetPending.mockReturnValue(0);
-    mockHasUncommittedWork.mockReturnValue(null);
+    mockHasUncommittedWorkAsync.mockImplementation(async () => null);
   });
 
   afterEach(() => {
@@ -492,8 +492,8 @@ describe('SessionOverviewEmitter', () => {
 
   // ─── Uncommitted work ─────────────────────────────────────────────────────
 
-  it('sets uncommittedWork when worktree is dirty', () => {
-    mockHasUncommittedWork.mockReturnValue('M some-file.ts');
+  it('sets uncommittedWork when worktree is dirty', async () => {
+    mockHasUncommittedWorkAsync.mockImplementation(async () => 'M some-file.ts');
     deps = makeDeps({
       registry: {
         getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
@@ -501,13 +501,16 @@ describe('SessionOverviewEmitter', () => {
     });
     emitter = new SessionOverviewEmitter(deps);
     emitter.touch('client-1');
+
+    // Flush the initial background refresh
+    await vi.advanceTimersByTimeAsync(0);
 
     const activities = emitter.getSnapshot();
     expect(activities[0].uncommittedWork).toBe(true);
   });
 
-  it('does not set uncommittedWork when worktree is clean', () => {
-    mockHasUncommittedWork.mockReturnValue(null);
+  it('does not set uncommittedWork when worktree is clean', async () => {
+    mockHasUncommittedWorkAsync.mockImplementation(async () => null);
     deps = makeDeps({
       registry: {
         getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
@@ -515,6 +518,8 @@ describe('SessionOverviewEmitter', () => {
     });
     emitter = new SessionOverviewEmitter(deps);
     emitter.touch('client-1');
+
+    await vi.advanceTimersByTimeAsync(0);
 
     const activities = emitter.getSnapshot();
     expect(activities[0].uncommittedWork).toBe(false);
@@ -576,11 +581,11 @@ describe('SessionOverviewEmitter', () => {
     expect(activities[0].sessionId).toBe('session-1');
   });
 
-  // ─── Uncommitted work cache TTL ─────────────────────────────────────────
+  // ─── Background uncommitted work refresh ────────────────────────────────
 
-  it('caches uncommitted work results within TTL', () => {
-    mockHasUncommittedWork.mockClear();
-    mockHasUncommittedWork.mockReturnValue('M dirty.ts');
+  it('does not call git synchronously during compute', async () => {
+    mockHasUncommittedWorkAsync.mockClear();
+    mockHasUncommittedWorkAsync.mockImplementation(async () => 'M dirty.ts');
     deps = makeDeps({
       registry: {
         getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
@@ -589,18 +594,19 @@ describe('SessionOverviewEmitter', () => {
     emitter = new SessionOverviewEmitter(deps);
     emitter.touch('client-1');
 
-    // First call checks git
-    emitter.getSnapshot();
-    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+    // Before background refresh resolves, cache returns false (safe default)
+    const before = emitter.getSnapshot();
+    expect(before[0].uncommittedWork).toBe(false);
 
-    // Second call within TTL uses cache
-    emitter.getSnapshot();
-    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+    // After background refresh
+    await vi.advanceTimersByTimeAsync(0);
+    const after = emitter.getSnapshot();
+    expect(after[0].uncommittedWork).toBe(true);
   });
 
-  it('re-checks uncommitted work after TTL expires', () => {
-    mockHasUncommittedWork.mockClear();
-    mockHasUncommittedWork.mockReturnValue('M dirty.ts');
+  it('refreshes cache on interval', async () => {
+    mockHasUncommittedWorkAsync.mockClear();
+    mockHasUncommittedWorkAsync.mockImplementation(async () => 'M dirty.ts');
     deps = makeDeps({
       registry: {
         getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
@@ -609,20 +615,17 @@ describe('SessionOverviewEmitter', () => {
     emitter = new SessionOverviewEmitter(deps);
     emitter.touch('client-1');
 
-    // First call
-    emitter.getSnapshot();
-    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+    // Initial refresh
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockHasUncommittedWorkAsync).toHaveBeenCalledTimes(1);
 
-    // Advance past TTL (5 minutes)
-    vi.advanceTimersByTime(6 * 60 * 1000);
-
-    // Should re-check
-    emitter.getSnapshot();
-    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(2);
+    // Advance past refresh interval (60s)
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockHasUncommittedWorkAsync).toHaveBeenCalledTimes(2);
   });
 
-  it('treats git error sentinels as clean (not dirty)', () => {
-    mockHasUncommittedWork.mockReturnValue('[git status failed: timeout]');
+  it('treats git error sentinels as clean (not dirty)', async () => {
+    mockHasUncommittedWorkAsync.mockImplementation(async () => '[git status failed: timeout]');
     deps = makeDeps({
       registry: {
         getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
@@ -630,6 +633,8 @@ describe('SessionOverviewEmitter', () => {
     });
     emitter = new SessionOverviewEmitter(deps);
     emitter.touch('client-1');
+
+    await vi.advanceTimersByTimeAsync(0);
 
     const activities = emitter.getSnapshot();
     expect(activities[0].uncommittedWork).toBe(false);

--- a/server/__tests__/session-overview.test.ts
+++ b/server/__tests__/session-overview.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionOverviewEmitter, type SessionOverviewDeps } from '../session-overview.js';
 import type { ActiveSessionInfo } from '@mitzo/harness';
+import type { SessionMeta } from '@mitzo/protocol';
 import type { LoopStatus } from '../task-orchestrator.js';
 
 // ─── Mock helpers ─────────────────────────────────────────────────────────────
@@ -45,6 +46,10 @@ function makeDeps(overrides: Partial<SessionOverviewDeps> = {}): SessionOverview
     taskStore: {
       getTree: vi.fn(() => []),
     } as unknown as SessionOverviewDeps['taskStore'],
+    eventStore: {
+      getSession: vi.fn(() => null),
+      getAttentionSessions: vi.fn(() => []),
+    } as unknown as SessionOverviewDeps['eventStore'],
     getSessionTitle: vi.fn(() => undefined),
     ...overrides,
   };
@@ -63,6 +68,15 @@ vi.mock('@mitzo/harness', async (importOriginal) => {
 import { getPendingCountBySession } from '@mitzo/harness';
 const mockGetPending = getPendingCountBySession as ReturnType<typeof vi.fn>;
 
+// ─── Mock worktree module ────────────────────────────────────────────────────
+
+vi.mock('../worktree.js', () => ({
+  hasUncommittedWork: vi.fn(() => null), // default: clean worktree
+}));
+
+import { hasUncommittedWork } from '../worktree.js';
+const mockHasUncommittedWork = hasUncommittedWork as ReturnType<typeof vi.fn>;
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('SessionOverviewEmitter', () => {
@@ -72,6 +86,7 @@ describe('SessionOverviewEmitter', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockGetPending.mockReturnValue(0);
+    mockHasUncommittedWork.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -420,5 +435,144 @@ describe('SessionOverviewEmitter', () => {
 
     const activities = emitter.getSnapshot();
     expect(activities[0].state).toBe('idle');
+  });
+
+  // ─── Awaiting reply ───────────────────────────────────────────────────────
+
+  it('sets awaitingReply when lastSpeaker is assistant and not streaming', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: false })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      eventStore: {
+        getSession: vi.fn(() => ({ lastSpeaker: 'assistant', lastSpeakerAt: Date.now() })),
+        getAttentionSessions: vi.fn(() => []),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].awaitingReply).toBe(true);
+  });
+
+  it('does not set awaitingReply when lastSpeaker is user', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: false })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      eventStore: {
+        getSession: vi.fn(() => ({ lastSpeaker: 'user', lastSpeakerAt: Date.now() })),
+        getAttentionSessions: vi.fn(() => []),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].awaitingReply).toBe(false);
+  });
+
+  it('does not set awaitingReply when session is streaming', () => {
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ hasSnapshot: true })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      eventStore: {
+        getSession: vi.fn(() => ({ lastSpeaker: 'assistant', lastSpeakerAt: Date.now() })),
+        getAttentionSessions: vi.fn(() => []),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].awaitingReply).toBe(false);
+  });
+
+  // ─── Uncommitted work ─────────────────────────────────────────────────────
+
+  it('sets uncommittedWork when worktree is dirty', () => {
+    mockHasUncommittedWork.mockReturnValue('M some-file.ts');
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].uncommittedWork).toBe(true);
+  });
+
+  it('does not set uncommittedWork when worktree is clean', () => {
+    mockHasUncommittedWork.mockReturnValue(null);
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].uncommittedWork).toBe(false);
+  });
+
+  // ─── Persistent attention sessions ────────────────────────────────────────
+
+  it('includes persistent sessions from getAttentionSessions', () => {
+    const persistentMeta = {
+      sessionId: 'persistent-1',
+      summary: 'Fix auth bug',
+      cwd: '/Users/test/tools/mitzo',
+      lastSpeaker: 'assistant',
+      lastSpeakerAt: Date.now() - 60_000,
+      updatedAt: Date.now() - 60_000,
+      goalId: null,
+    } as SessionMeta;
+
+    deps = makeDeps({
+      eventStore: {
+        getSession: vi.fn(() => null),
+        getAttentionSessions: vi.fn(() => [persistentMeta]),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].sessionId).toBe('persistent-1');
+    expect(activities[0].title).toBe('Fix auth bug');
+    expect(activities[0].state).toBe('done');
+    expect(activities[0].awaitingReply).toBe(true);
+  });
+
+  it('does not duplicate persistent sessions that are also live', () => {
+    const persistentMeta = {
+      sessionId: 'session-1',
+      summary: 'Fix auth bug',
+      lastSpeaker: 'assistant',
+      lastSpeakerAt: Date.now(),
+      updatedAt: Date.now(),
+      goalId: null,
+    } as SessionMeta;
+
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ sessionId: 'session-1' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+      eventStore: {
+        getSession: vi.fn(() => ({ lastSpeaker: 'assistant', lastSpeakerAt: Date.now() })),
+        getAttentionSessions: vi.fn(() => [persistentMeta]),
+      } as unknown as SessionOverviewDeps['eventStore'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].sessionId).toBe('session-1');
   });
 });

--- a/server/__tests__/session-overview.test.ts
+++ b/server/__tests__/session-overview.test.ts
@@ -575,4 +575,63 @@ describe('SessionOverviewEmitter', () => {
     expect(activities).toHaveLength(1);
     expect(activities[0].sessionId).toBe('session-1');
   });
+
+  // ─── Uncommitted work cache TTL ─────────────────────────────────────────
+
+  it('caches uncommitted work results within TTL', () => {
+    mockHasUncommittedWork.mockClear();
+    mockHasUncommittedWork.mockReturnValue('M dirty.ts');
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    // First call checks git
+    emitter.getSnapshot();
+    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+
+    // Second call within TTL uses cache
+    emitter.getSnapshot();
+    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks uncommitted work after TTL expires', () => {
+    mockHasUncommittedWork.mockClear();
+    mockHasUncommittedWork.mockReturnValue('M dirty.ts');
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    // First call
+    emitter.getSnapshot();
+    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(1);
+
+    // Advance past TTL (5 minutes)
+    vi.advanceTimersByTime(6 * 60 * 1000);
+
+    // Should re-check
+    emitter.getSnapshot();
+    expect(mockHasUncommittedWork).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats git error sentinels as clean (not dirty)', () => {
+    mockHasUncommittedWork.mockReturnValue('[git status failed: timeout]');
+    deps = makeDeps({
+      registry: {
+        getActiveSessions: vi.fn(() => [makeActiveSession({ cwd: '/Users/test/project' })]),
+      } as unknown as SessionOverviewDeps['registry'],
+    });
+    emitter = new SessionOverviewEmitter(deps);
+    emitter.touch('client-1');
+
+    const activities = emitter.getSnapshot();
+    expect(activities[0].uncommittedWork).toBe(false);
+  });
 });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -916,6 +916,7 @@ async function _startChatInner(
         messageId,
         text: fullPrompt,
       });
+      eventStore.updateLastSpeaker(options.resume, 'user');
       const echo = { type: 'user_message', messageId, text: fullPrompt };
       send(transport, echo);
       broadcastToObservers(session.observers, echo);
@@ -1036,6 +1037,7 @@ export function sendToChat(
         messageId,
         text: fullPrompt,
       });
+      eventStore.updateLastSpeaker(session.sessionId, 'user');
       tryAutoRename(session.sessionId, clientId).catch(() => {
         /* errors logged internally */
       });
@@ -1069,6 +1071,7 @@ export async function interruptChat(
         messageId,
         text: fullPrompt,
       });
+      eventStore.updateLastSpeaker(session.sessionId, 'user');
     }
     const echo = { type: 'user_message', messageId, text: fullPrompt };
     send(session.transport, echo);

--- a/server/index.ts
+++ b/server/index.ts
@@ -238,6 +238,7 @@ overviewEmitter = new SessionOverviewEmitter({
   sseRegistry,
   getLoopStatus: () => orchestrator.getStatus(),
   taskStore,
+  eventStore,
   getSessionTitle: (id: string) => eventStore.getSession(id)?.summary ?? undefined,
 });
 setOverviewEmitter(overviewEmitter);
@@ -255,6 +256,11 @@ setSessionChangeCallback((clientId, event) => {
     overviewEmitter.forget(clientId);
   } else if (event === 'turn_end') {
     overviewEmitter.touch(clientId);
+    // Mark assistant as last speaker for attention tracking
+    const session = registry.get(clientId);
+    if (session?.sessionId) {
+      eventStore.updateLastSpeaker(session.sessionId, 'assistant');
+    }
   }
   overviewEmitter.scheduleBroadcast();
 });

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -9,9 +9,11 @@
 import type { SessionRegistry, ActiveSessionInfo } from '@mitzo/harness';
 import type { SseRegistry } from '@mitzo/harness';
 import { getPendingCountBySession } from '@mitzo/harness';
-import type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
+import type { SessionActivity, SessionActivityState, SessionMeta, WaitReason } from '@mitzo/protocol';
+import type { EventStore } from '@mitzo/protocol/event-store';
 import type { LoopStatus } from './task-orchestrator.js';
 import type { TaskStore } from './task-store.js';
+import { hasUncommittedWork } from './worktree.js';
 import { createLogger } from './logger.js';
 
 export type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
@@ -25,6 +27,9 @@ const DONE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Coalesce broadcasts within this window to avoid re-render storms. */
 const COALESCE_MS = 200;
+
+/** TTL for cached uncommitted work checks (5 minutes). */
+const UNCOMMITTED_CACHE_TTL_MS = 5 * 60 * 1000;
 
 // ─── State priority for "highest wins" ────────────────────────────────────────
 
@@ -44,17 +49,25 @@ export interface SessionOverviewDeps {
   sseRegistry: SseRegistry;
   getLoopStatus: () => LoopStatus;
   taskStore: TaskStore;
+  eventStore: EventStore;
   /** Resolve session title. Typically eventStore.getSession(id)?.summary */
   getSessionTitle: (sessionId: string) => string | undefined;
 }
 
 // ─── Emitter ──────────────────────────────────────────────────────────────────
 
+interface UncommittedCacheEntry {
+  dirty: boolean;
+  checkedAt: number;
+}
+
 export class SessionOverviewEmitter {
   private deps: SessionOverviewDeps;
   private coalesceTimer: ReturnType<typeof setTimeout> | null = null;
   /** Track last assistant event time per clientId for timeout derivation. */
   private lastEventTimes = new Map<string, number>();
+  /** Cached uncommitted work results per session cwd. */
+  private uncommittedCache = new Map<string, UncommittedCacheEntry>();
 
   constructor(deps: SessionOverviewDeps) {
     this.deps = deps;
@@ -105,7 +118,7 @@ export class SessionOverviewEmitter {
   }
 
   /**
-   * Compute SessionActivity[] from all active sessions.
+   * Compute SessionActivity[] from all active sessions + persistent attention sessions.
    * State is derived purely from current data — no stored state.
    */
   private compute(): SessionActivity[] {
@@ -113,9 +126,19 @@ export class SessionOverviewEmitter {
     const activeSessions = this.deps.registry.getActiveSessions();
     const loopStatus = this.deps.getLoopStatus();
 
-    return activeSessions
+    const liveActivities = activeSessions
       .filter((s) => s.sessionId) // Skip sessions without SDK IDs
       .map((s) => this.deriveActivity(s, loopStatus, now));
+
+    // Merge persistent attention sessions (awaiting user reply)
+    const liveIds = new Set(liveActivities.map((a) => a.sessionId));
+    const persistentSessions = this.deps.eventStore.getAttentionSessions();
+    for (const meta of persistentSessions) {
+      if (liveIds.has(meta.sessionId)) continue;
+      liveActivities.push(this.persistentToActivity(meta, now));
+    }
+
+    return liveActivities;
   }
 
   private deriveActivity(
@@ -210,6 +233,17 @@ export class SessionOverviewEmitter {
     // Derive repo from cwd
     const repo = session.cwd ? extractRepoName(session.cwd) : undefined;
 
+    // Check uncommitted work for live sessions
+    const uncommittedWork = session.cwd
+      ? this.checkUncommittedCached(session.cwd, now)
+      : false;
+
+    // Check if awaiting user reply (assistant spoke last, not streaming)
+    const meta = this.deps.eventStore.getSession(sessionId);
+    const awaitingReply = meta?.lastSpeaker === 'assistant' && !session.hasSnapshot;
+    const speakerAt = meta?.lastSpeakerAt ?? lastEventAt;
+    const idleMinutes = Math.round((now - speakerAt) / 60_000);
+
     return {
       sessionId,
       clientId: session.clientId,
@@ -221,7 +255,55 @@ export class SessionOverviewEmitter {
       progress,
       lastEventAt,
       taskId,
+      uncommittedWork,
+      awaitingReply,
+      idleMinutes,
     };
+  }
+
+  /**
+   * Convert a persistent SessionMeta (from EventStore) to a SessionActivity.
+   * These are sessions not currently live but awaiting user reply.
+   */
+  private persistentToActivity(meta: SessionMeta, now: number): SessionActivity {
+    const title = meta.summary || meta.sessionId.slice(-8);
+    const repo = meta.cwd ? extractRepoName(meta.cwd) : undefined;
+    const lastEventAt = meta.lastSpeakerAt ?? meta.updatedAt;
+    const idleMinutes = Math.round((now - lastEventAt) / 60_000);
+
+    // Check for uncommitted work (cached)
+    const uncommittedWork = meta.cwd ? this.checkUncommittedCached(meta.cwd, now) : false;
+
+    return {
+      sessionId: meta.sessionId,
+      clientId: meta.sessionId, // No live clientId — use sessionId
+      title,
+      repo,
+      state: 'done',
+      flags: [],
+      lastEventAt,
+      taskId: meta.goalId ?? undefined,
+      uncommittedWork,
+      awaitingReply: true, // By definition — sourced from getAttentionSessions()
+      idleMinutes,
+    };
+  }
+
+  /**
+   * Check uncommitted work with a TTL cache to avoid expensive git calls.
+   */
+  private checkUncommittedCached(cwd: string, now: number): boolean {
+    const cached = this.uncommittedCache.get(cwd);
+    if (cached && now - cached.checkedAt < UNCOMMITTED_CACHE_TTL_MS) {
+      return cached.dirty;
+    }
+    try {
+      const dirty = hasUncommittedWork(cwd) !== null;
+      this.uncommittedCache.set(cwd, { dirty, checkedAt: now });
+      return dirty;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -18,7 +18,7 @@ import type {
 import type { EventStore } from '@mitzo/protocol/event-store';
 import type { LoopStatus } from './task-orchestrator.js';
 import type { TaskStore } from './task-store.js';
-import { hasUncommittedWork } from './worktree.js';
+import { hasUncommittedWorkAsync } from './worktree.js';
 import { createLogger } from './logger.js';
 
 export type { SessionActivity, SessionActivityState, WaitReason } from '@mitzo/protocol';
@@ -33,8 +33,8 @@ const DONE_TIMEOUT_MS = 5 * 60 * 1000;
 /** Coalesce broadcasts within this window to avoid re-render storms. */
 const COALESCE_MS = 200;
 
-/** TTL for cached uncommitted work checks (5 minutes). */
-const UNCOMMITTED_CACHE_TTL_MS = 5 * 60 * 1000;
+/** Interval for background uncommitted work refresh (60 seconds). */
+const UNCOMMITTED_REFRESH_INTERVAL_MS = 60 * 1000;
 
 // ─── State priority for "highest wins" ────────────────────────────────────────
 
@@ -71,11 +71,16 @@ export class SessionOverviewEmitter {
   private coalesceTimer: ReturnType<typeof setTimeout> | null = null;
   /** Track last assistant event time per clientId for timeout derivation. */
   private lastEventTimes = new Map<string, number>();
-  /** Cached uncommitted work results per session cwd. */
+  /** Cached uncommitted work results per session cwd (populated by background refresh). */
   private uncommittedCache = new Map<string, UncommittedCacheEntry>();
+  /** Background refresh interval for uncommitted work checks. */
+  private uncommittedRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  /** Guard against overlapping refresh runs. */
+  private refreshInFlight = false;
 
   constructor(deps: SessionOverviewDeps) {
     this.deps = deps;
+    this.startUncommittedRefresh();
   }
 
   /**
@@ -238,8 +243,8 @@ export class SessionOverviewEmitter {
     // Derive repo from cwd
     const repo = session.cwd ? extractRepoName(session.cwd) : undefined;
 
-    // Check uncommitted work for live sessions
-    const uncommittedWork = session.cwd ? this.checkUncommittedCached(session.cwd, now) : false;
+    // Check uncommitted work for live sessions (from background cache)
+    const uncommittedWork = session.cwd ? this.checkUncommittedCached(session.cwd) : false;
 
     // Check if awaiting user reply (assistant spoke last, not streaming)
     const meta = this.deps.eventStore.getSession(sessionId);
@@ -274,8 +279,8 @@ export class SessionOverviewEmitter {
     const lastEventAt = meta.lastSpeakerAt ?? meta.updatedAt;
     const idleMinutes = Math.round((now - lastEventAt) / 60_000);
 
-    // Check for uncommitted work (cached)
-    const uncommittedWork = meta.cwd ? this.checkUncommittedCached(meta.cwd, now) : false;
+    // Check for uncommitted work (from background cache)
+    const uncommittedWork = meta.cwd ? this.checkUncommittedCached(meta.cwd) : false;
 
     return {
       sessionId: meta.sessionId,
@@ -293,18 +298,69 @@ export class SessionOverviewEmitter {
   }
 
   /**
-   * Check uncommitted work with a TTL cache to avoid expensive git calls.
+   * Pure cache read — returns cached dirty state, or false if not yet checked.
+   * Cache is populated asynchronously by the background refresh loop.
    */
-  private checkUncommittedCached(cwd: string, now: number): boolean {
-    const cached = this.uncommittedCache.get(cwd);
-    if (cached && now - cached.checkedAt < UNCOMMITTED_CACHE_TTL_MS) {
-      return cached.dirty;
+  private checkUncommittedCached(cwd: string): boolean {
+    return this.uncommittedCache.get(cwd)?.dirty ?? false;
+  }
+
+  /**
+   * Start the background loop that refreshes uncommitted work state
+   * for all known session cwds. Runs async git status checks without
+   * blocking the event loop.
+   */
+  private startUncommittedRefresh(): void {
+    // Fire immediately (async, non-blocking) then repeat on interval
+    void this.refreshUncommittedCache();
+    this.uncommittedRefreshTimer = setInterval(() => {
+      void this.refreshUncommittedCache();
+    }, UNCOMMITTED_REFRESH_INTERVAL_MS);
+  }
+
+  /**
+   * Collect all cwds from live + persistent sessions, run async git status
+   * for each, and update the cache. Skips if a previous run is still in flight.
+   */
+  private async refreshUncommittedCache(): Promise<void> {
+    if (this.refreshInFlight) return;
+    this.refreshInFlight = true;
+    try {
+      const cwds = this.collectSessionCwds();
+      if (cwds.size === 0) return;
+
+      const now = Date.now();
+      await Promise.all(
+        [...cwds].map(async (cwd) => {
+          const result = await hasUncommittedWorkAsync(cwd);
+          const dirty = result !== null && !result.startsWith('[');
+          this.uncommittedCache.set(cwd, { dirty, checkedAt: now });
+        }),
+      );
+
+      // Broadcast after cache update so clients see fresh uncommitted state
+      this.scheduleBroadcast();
+    } catch (err) {
+      log.warn('uncommitted work refresh failed', {
+        error: err instanceof Error ? err.message : 'unknown',
+      });
+    } finally {
+      this.refreshInFlight = false;
     }
-    const result = hasUncommittedWork(cwd);
-    // Distinguish genuine dirty output from error sentinels (which start with '[')
-    const dirty = result !== null && !result.startsWith('[');
-    this.uncommittedCache.set(cwd, { dirty, checkedAt: now });
-    return dirty;
+  }
+
+  /**
+   * Gather all unique cwds from live registry sessions + persistent attention sessions.
+   */
+  private collectSessionCwds(): Set<string> {
+    const cwds = new Set<string>();
+    for (const s of this.deps.registry.getActiveSessions()) {
+      if (s.cwd) cwds.add(s.cwd);
+    }
+    for (const meta of this.deps.eventStore.getAttentionSessions()) {
+      if (meta.cwd) cwds.add(meta.cwd);
+    }
+    return cwds;
   }
 
   /**
@@ -330,7 +386,12 @@ export class SessionOverviewEmitter {
       clearTimeout(this.coalesceTimer);
       this.coalesceTimer = null;
     }
+    if (this.uncommittedRefreshTimer) {
+      clearInterval(this.uncommittedRefreshTimer);
+      this.uncommittedRefreshTimer = null;
+    }
     this.lastEventTimes.clear();
+    this.uncommittedCache.clear();
   }
 }
 

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -9,7 +9,12 @@
 import type { SessionRegistry, ActiveSessionInfo } from '@mitzo/harness';
 import type { SseRegistry } from '@mitzo/harness';
 import { getPendingCountBySession } from '@mitzo/harness';
-import type { SessionActivity, SessionActivityState, SessionMeta, WaitReason } from '@mitzo/protocol';
+import type {
+  SessionActivity,
+  SessionActivityState,
+  SessionMeta,
+  WaitReason,
+} from '@mitzo/protocol';
 import type { EventStore } from '@mitzo/protocol/event-store';
 import type { LoopStatus } from './task-orchestrator.js';
 import type { TaskStore } from './task-store.js';
@@ -234,9 +239,7 @@ export class SessionOverviewEmitter {
     const repo = session.cwd ? extractRepoName(session.cwd) : undefined;
 
     // Check uncommitted work for live sessions
-    const uncommittedWork = session.cwd
-      ? this.checkUncommittedCached(session.cwd, now)
-      : false;
+    const uncommittedWork = session.cwd ? this.checkUncommittedCached(session.cwd, now) : false;
 
     // Check if awaiting user reply (assistant spoke last, not streaming)
     const meta = this.deps.eventStore.getSession(sessionId);
@@ -297,13 +300,11 @@ export class SessionOverviewEmitter {
     if (cached && now - cached.checkedAt < UNCOMMITTED_CACHE_TTL_MS) {
       return cached.dirty;
     }
-    try {
-      const dirty = hasUncommittedWork(cwd) !== null;
-      this.uncommittedCache.set(cwd, { dirty, checkedAt: now });
-      return dirty;
-    } catch {
-      return false;
-    }
+    const result = hasUncommittedWork(cwd);
+    // Distinguish genuine dirty output from error sentinels (which start with '[')
+    const dirty = result !== null && !result.startsWith('[');
+    this.uncommittedCache.set(cwd, { dirty, checkedAt: now });
+    return dirty;
   }
 
   /**

--- a/server/session-overview.ts
+++ b/server/session-overview.ts
@@ -246,9 +246,11 @@ export class SessionOverviewEmitter {
     // Check uncommitted work for live sessions (from background cache)
     const uncommittedWork = session.cwd ? this.checkUncommittedCached(session.cwd) : false;
 
-    // Check if awaiting user reply (assistant spoke last, not streaming)
+    // Check if awaiting user reply (assistant spoke last, not streaming, not waiting for input)
+    // Exclude 'waiting' state — sessions needing permission/review should sort as waiting, not awaiting reply
     const meta = this.deps.eventStore.getSession(sessionId);
-    const awaitingReply = meta?.lastSpeaker === 'assistant' && !session.hasSnapshot;
+    const awaitingReply =
+      meta?.lastSpeaker === 'assistant' && !session.hasSnapshot && primaryState !== 'waiting';
     const speakerAt = meta?.lastSpeakerAt ?? lastEventAt;
     const idleMinutes = Math.round((now - speakerAt) / 60_000);
 

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -341,6 +341,28 @@ export function hasUncommittedWork(worktreePath: string): string | null {
 }
 
 /**
+ * Async version of hasUncommittedWork — does not block the event loop.
+ * Used by SessionOverviewEmitter's background refresh loop.
+ */
+export async function hasUncommittedWorkAsync(worktreePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', worktreePath, 'status', '--porcelain'], {
+      encoding: 'utf-8',
+      timeout: WORKTREE_GIT_TIMEOUT_MS,
+    });
+    const output = stdout.trim();
+    return output || null;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'unknown';
+    log.warn('git status failed on worktree (async), treating as dirty', {
+      path: worktreePath,
+      error: message,
+    });
+    return `[git status failed: ${message}]`;
+  }
+}
+
+/**
  * Post a proposal to the mgmt inbox about a stale worktree with uncommitted work.
  */
 function postDirtyWorktreeToInbox(

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -321,7 +321,7 @@ export function getWorktreePath(sessionId: string, baseRepo: string): string | n
  * Returns the porcelain output if dirty, empty string if clean, or a sentinel
  * error message if git status itself fails (so we don't delete potentially dirty worktrees).
  */
-function hasUncommittedWork(worktreePath: string): string | null {
+export function hasUncommittedWork(worktreePath: string): string | null {
   try {
     const output = execFileSync('git', ['-C', worktreePath, 'status', '--porcelain'], {
       encoding: 'utf-8',


### PR DESCRIPTION
## Summary

- **Sessions awaiting reply** (agent spoke last, user hasn't responded) now appear as Tier 1 items above Telos
- **Uncommitted worktree work** surfaces as Tier 1 attention items with cached git status checks
- **Sub-priority sorting** within tiers ensures session items (0-2) always sort above Telos items (3)
- Previously all 14 manual Telos items (urgency=1.0, starred) filled all 5 slots, making What's Next useless

## Changes

| Layer | File | What |
|-------|------|------|
| Protocol | `types.ts` | Add `awaitingReply`, `uncommittedWork`, `idleMinutes` to `SessionActivity`; `lastSpeaker`/`lastSpeakerAt` to `SessionMeta` |
| Protocol | `event-store.ts` | `last_speaker` column + migration, `updateLastSpeaker()`, `getAttentionSessions()` |
| Server | `session-overview.ts` | Wire eventStore, persistent attention sessions, uncommitted work cache, awaitingReply derivation |
| Server | `chat.ts` | Mark `last_speaker = 'user'` on user messages |
| Server | `index.ts` | Mark `last_speaker = 'assistant'` on turn end, wire eventStore into emitter |
| Server | `worktree.ts` | Export `hasUncommittedWork` |
| Frontend | `useAttentionFeed.ts` | Sub-priority sorting, handle `awaitingReply` + `uncommittedWork` session states |

## Test plan

- [x] 27 session-overview tests pass (7 new for awaitingReply, uncommittedWork, persistent sessions)
- [x] 38 event-store tests pass (no regressions)
- [x] 1184/1187 server tests pass (3 failures are pre-existing on main)
- [ ] Deploy to dev, verify home screen shows sessions above Telos
- [ ] Verify: when no sessions need attention, Telos items still fill all slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)