### PR TITLE
feat(ui): boot context pill sticky + modal view

### DIFF
--- a/docs/design/boot-context-pill-ux-fixes.md
+++ b/docs/design/boot-context-pill-ux-fixes.md
@@ -1,0 +1,105 @@
+# BootContextPill UX Fixes
+
+**Telos:** ae582634f14580e5  
+**Status:** Not started  
+**Date:** 2026-05-18
+
+## Issues
+
+### 1. Pill Disappears as Agent Replies
+
+**Problem:** The pill scrolls out of view as messages arrive, making boot context details inaccessible during long conversations.
+
+**Root cause:** `BootContextPill` is rendered inside the scrollable `.chat-messages` container (`ChatArea.tsx:155`). No sticky positioning.
+
+**Fix options:**
+
+**Option A: position: sticky (recommended)**
+
+```css
+/* global.css */
+.boot-context-pill {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg-primary);
+}
+```
+
+**Option B: Move outside scroll container**
+
+```tsx
+// ChatArea.tsx
+<div className="chat-area">
+  {bootContext && <BootContextPill context={bootContext} />}
+  <div className="chat-messages" ref={scrollRef}>
+    {/* messages, no pill */}
+  </div>
+</div>
+```
+
+**Recommendation:** Option A is less invasive.
+
+---
+
+### 2. No Modal Pop-Out for Full Markdown
+
+**Problem:** Tapping the pill header only expands inline. No way to view the full compiled markdown sent to the model.
+
+**Solution:**
+
+1. **Add modal state:**
+
+```tsx
+const [showModal, setShowModal] = useState(false);
+```
+
+2. **Add button to header:**
+
+```tsx
+<button
+  className="boot-context-pill-view-full"
+  onClick={(e) => {
+    e.stopPropagation();
+    setShowModal(true);
+  }}
+  title="View full markdown"
+>
+  ⎘
+</button>
+```
+
+3. **Render modal:**
+
+```tsx
+{
+  showModal && (
+    <div className="boot-context-modal-overlay" onClick={() => setShowModal(false)}>
+      <div className="boot-context-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="boot-context-modal-header">
+          <h3>Boot Context (Full Markdown)</h3>
+          <button onClick={() => setShowModal(false)}>✕</button>
+        </div>
+        <pre className="boot-context-modal-content">{context.fullMarkdown}</pre>
+      </div>
+    </div>
+  );
+}
+```
+
+4. **Protocol change:** Add `fullMarkdown?: string` to `BootContextMeta` (server already has compiled markdown from ContexGin).
+
+---
+
+## Files Involved
+
+- `frontend/src/components/ChatArea.tsx:155` — render location
+- `frontend/src/components/BootContextPill.tsx:40-111` — component logic
+- `frontend/src/styles/global.css:1645,2396` — styles
+- `packages/client/src/slices/messages.ts:39-47` — `BootContextMeta` type
+- `packages/protocol/src/ws-schemas-v2.ts` — protocol schema
+- `server/chat.ts:764-780` — boot context assembly
+
+## Prior Work
+
+PR #332 added rich pill with section expansion, source lists, and recipe-driven budgets. This builds on that to fix scroll behavior and add full markdown view.

--- a/frontend/src/components/BootContextPill.tsx
+++ b/frontend/src/components/BootContextPill.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { BootContextMeta, SectionMeta } from '@mitzo/client';
 
 interface Props {
@@ -54,71 +54,84 @@ export function BootContextPill({ context }: Props) {
       : String(context.tokenBudget);
   const label = `${context.sourceCount} sources \u00b7 ${tokenLabel} / ${budgetLabel}`;
 
+  // Escape key handler for modal
+  useEffect(() => {
+    if (!showModal) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowModal(false);
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [showModal]);
+
   return (
-    <div className="boot-context-pill">
-      <button className="boot-context-pill-header" onClick={() => setExpanded((e) => !e)}>
-        <span className={`boot-context-pill-dot ${dotClass}`} />
-        <span className="boot-context-pill-label">{label}</span>
-        <span className="boot-context-pill-engine">{isContexgin ? 'ContexGin' : 'Fallback'}</span>
-        <span className="boot-context-pill-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
-        {context.fullMarkdown && (
-          <button
-            className="boot-context-pill-view-full"
-            onClick={(e) => {
-              e.stopPropagation();
-              setShowModal(true);
-            }}
-            title="View full markdown"
-          >
-            ⧉
+    <>
+      <div className="boot-context-pill">
+        <div className="boot-context-pill-header-wrapper">
+          <button className="boot-context-pill-header" onClick={() => setExpanded((e) => !e)}>
+            <span className={`boot-context-pill-dot ${dotClass}`} />
+            <span className="boot-context-pill-label">{label}</span>
+            <span className="boot-context-pill-engine">
+              {isContexgin ? 'ContexGin' : 'Fallback'}
+            </span>
+            <span className="boot-context-pill-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
           </button>
-        )}
-      </button>
-      {expanded && (
-        <div className="boot-context-pill-content">
-          <div className="boot-context-pill-section-label">Sources</div>
-          {context.sources.map((src, idx) => (
-            <div key={idx} className="boot-context-pill-source-row">
-              <span className={`boot-context-pill-kind boot-context-pill-kind--${src.kind}`}>
-                {KIND_LABELS[src.kind] ?? src.kind}
-              </span>
-              <span className="boot-context-pill-source-path">{src.path}</span>
-            </div>
-          ))}
-
-          {context.included.length > 0 && (
-            <>
-              <div className="boot-context-pill-section-label">
-                Included ({context.included.length})
-              </div>
-              {context.included.map((section, idx) => (
-                <SectionRow key={idx} section={section} />
-              ))}
-            </>
-          )}
-
-          {context.trimmed.length > 0 && (
-            <>
-              <button
-                className="boot-context-pill-trimmed-toggle"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowTrimmed((t) => !t);
-                }}
-              >
-                {context.trimmed.length} section{context.trimmed.length !== 1 ? 's' : ''} trimmed
-                <span className="boot-context-pill-chevron-inline">
-                  {showTrimmed ? '\u25BE' : '\u25B8'}
-                </span>
-              </button>
-              {showTrimmed &&
-                context.trimmed.map((section, idx) => (
-                  <SectionRow key={idx} section={section} dimmed />
-                ))}
-            </>
+          {context.fullMarkdown && (
+            <button
+              className="boot-context-pill-view-full"
+              onClick={() => setShowModal(true)}
+              title="View full markdown"
+            >
+              ⧉
+            </button>
           )}
         </div>
-      )}
+        {expanded && (
+          <div className="boot-context-pill-content">
+            <div className="boot-context-pill-section-label">Sources</div>
+            {context.sources.map((src, idx) => (
+              <div key={idx} className="boot-context-pill-source-row">
+                <span className={`boot-context-pill-kind boot-context-pill-kind--${src.kind}`}>
+                  {KIND_LABELS[src.kind] ?? src.kind}
+                </span>
+                <span className="boot-context-pill-source-path">{src.path}</span>
+              </div>
+            ))}
+
+            {context.included.length > 0 && (
+              <>
+                <div className="boot-context-pill-section-label">
+                  Included ({context.included.length})
+                </div>
+                {context.included.map((section, idx) => (
+                  <SectionRow key={idx} section={section} />
+                ))}
+              </>
+            )}
+
+            {context.trimmed.length > 0 && (
+              <>
+                <button
+                  className="boot-context-pill-trimmed-toggle"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowTrimmed((t) => !t);
+                  }}
+                >
+                  {context.trimmed.length} section{context.trimmed.length !== 1 ? 's' : ''} trimmed
+                  <span className="boot-context-pill-chevron-inline">
+                    {showTrimmed ? '\u25BE' : '\u25B8'}
+                  </span>
+                </button>
+                {showTrimmed &&
+                  context.trimmed.map((section, idx) => (
+                    <SectionRow key={idx} section={section} dimmed />
+                  ))}
+              </>
+            )}
+          </div>
+        )}
+      </div>
 
       {showModal && context.fullMarkdown && (
         <div
@@ -126,7 +139,13 @@ export function BootContextPill({ context }: Props) {
           onClick={() => setShowModal(false)}
           onTouchStart={(e) => e.stopPropagation()}
         >
-          <div className="boot-context-modal" onClick={(e) => e.stopPropagation()}>
+          <div
+            className="boot-context-modal"
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Boot context full markdown"
+          >
             <div className="boot-context-modal-header">
               <h3>Boot Context (Full Markdown)</h3>
               <button onClick={() => setShowModal(false)} className="boot-context-modal-close">
@@ -137,6 +156,6 @@ export function BootContextPill({ context }: Props) {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/BootContextPill.tsx
+++ b/frontend/src/components/BootContextPill.tsx
@@ -70,7 +70,7 @@ export function BootContextPill({ context }: Props) {
             }}
             title="View full markdown"
           >
-            ⎘
+            ⧉
           </button>
         )}
       </button>

--- a/frontend/src/components/BootContextPill.tsx
+++ b/frontend/src/components/BootContextPill.tsx
@@ -40,6 +40,7 @@ function SectionRow({ section, dimmed }: { section: SectionMeta; dimmed?: boolea
 export function BootContextPill({ context }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [showTrimmed, setShowTrimmed] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
   const isContexgin = context.source === 'contexgin';
   const dotClass = isContexgin ? 'boot-context-pill-dot--ok' : 'boot-context-pill-dot--warn';
@@ -60,6 +61,18 @@ export function BootContextPill({ context }: Props) {
         <span className="boot-context-pill-label">{label}</span>
         <span className="boot-context-pill-engine">{isContexgin ? 'ContexGin' : 'Fallback'}</span>
         <span className="boot-context-pill-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>
+        {context.fullMarkdown && (
+          <button
+            className="boot-context-pill-view-full"
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowModal(true);
+            }}
+            title="View full markdown"
+          >
+            ⎘
+          </button>
+        )}
       </button>
       {expanded && (
         <div className="boot-context-pill-content">
@@ -104,6 +117,24 @@ export function BootContextPill({ context }: Props) {
                 ))}
             </>
           )}
+        </div>
+      )}
+
+      {showModal && context.fullMarkdown && (
+        <div
+          className="boot-context-modal-overlay"
+          onClick={() => setShowModal(false)}
+          onTouchStart={(e) => e.stopPropagation()}
+        >
+          <div className="boot-context-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="boot-context-modal-header">
+              <h3>Boot Context (Full Markdown)</h3>
+              <button onClick={() => setShowModal(false)} className="boot-context-modal-close">
+                ✕
+              </button>
+            </div>
+            <pre className="boot-context-modal-content">{context.fullMarkdown}</pre>
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2405,13 +2405,19 @@ textarea:focus {
   background: var(--bg-primary);
 }
 
+.boot-context-pill-header-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
 .boot-context-pill-header {
   display: flex;
   align-items: center;
   gap: 0.4rem;
   touch-action: manipulation;
   padding: 0.25rem 0.6rem;
-  width: 100%;
+  flex: 1;
   cursor: pointer;
   background: transparent;
   border: none;
@@ -2602,19 +2608,21 @@ textarea:focus {
 }
 
 .boot-context-pill-view-full {
-  margin-left: auto;
-  padding: 0.2rem 0.4rem;
+  padding: 0.25rem 0.6rem;
   background: transparent;
   border: none;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
   cursor: pointer;
   font-size: 0.9rem;
   color: var(--text-dim);
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
+  flex-shrink: 0;
 }
 
 .boot-context-pill-view-full:active {
   color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 /* Modal overlay */

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2399,6 +2399,10 @@ textarea:focus {
   border-radius: 6px;
   overflow: hidden;
   margin-bottom: 0.3rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg-primary);
 }
 
 .boot-context-pill-header {
@@ -2595,6 +2599,94 @@ textarea:focus {
 .boot-context-pill-chevron-inline {
   font-size: 0.55rem;
   opacity: 0.7;
+}
+
+.boot-context-pill-view-full {
+  margin-left: auto;
+  padding: 0.2rem 0.4rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--text-dim);
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.boot-context-pill-view-full:active {
+  color: var(--text-primary);
+}
+
+/* Modal overlay */
+.boot-context-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+}
+
+.boot-context-modal {
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  max-width: 900px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+}
+
+.boot-context-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.boot-context-modal-header h3 {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.boot-context-modal-close {
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.boot-context-modal-close:active {
+  color: var(--text-primary);
+}
+
+.boot-context-modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  margin: 0;
+  font-family: var(--code-font);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* ===== Markdown Preview Card ===== */

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2403,6 +2403,9 @@ textarea:focus {
   top: 0;
   z-index: 10;
   background: var(--bg-primary);
+  margin-inline: calc(-1 * var(--space-3));
+  padding-inline: var(--space-3);
+  width: calc(100% + 2 * var(--space-3));
 }
 
 .boot-context-pill-header-wrapper {

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -849,6 +849,57 @@ describe('boot_context', () => {
         sources: [],
         included: [],
         trimmed: [],
+        fullMarkdown: undefined,
+      },
+    });
+  });
+
+  it('passes through fullMarkdown when present', () => {
+    const r = parseServerMessage(
+      {
+        type: 'boot_context',
+        source: 'contexgin',
+        sourceCount: 1,
+        tokenCount: 100,
+        tokenBudget: 8000,
+        sources: [],
+        included: [],
+        trimmed: [],
+        fullMarkdown: '# Boot Context\n\nFull markdown content here',
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'SET_BOOT_CONTEXT',
+      bootContext: {
+        fullMarkdown: '# Boot Context\n\nFull markdown content here',
+      },
+    });
+  });
+
+  it('omits fullMarkdown when non-string', () => {
+    const r = parseServerMessage(
+      {
+        type: 'boot_context',
+        source: 'contexgin',
+        sourceCount: 0,
+        tokenCount: 0,
+        tokenBudget: 0,
+        sources: [],
+        included: [],
+        trimmed: [],
+        fullMarkdown: 12345,
+      },
+      makeState(),
+      makeCallbacks(),
+      POOL_KEY,
+    );
+    expect(r.messagesActions[0]).toMatchObject({
+      type: 'SET_BOOT_CONTEXT',
+      bootContext: {
+        fullMarkdown: undefined,
       },
     });
   });

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -248,10 +248,20 @@ export function parseServerMessage(
 
       const included = parseSections(Array.isArray(msg.included) ? msg.included : []);
       const trimmed = parseSections(Array.isArray(msg.trimmed) ? msg.trimmed : []);
+      const fullMarkdown = typeof msg.fullMarkdown === 'string' ? msg.fullMarkdown : undefined;
 
       result.messagesActions.push({
         type: 'SET_BOOT_CONTEXT',
-        bootContext: { source, sourceCount, tokenCount, tokenBudget, sources, included, trimmed },
+        bootContext: {
+          source,
+          sourceCount,
+          tokenCount,
+          tokenBudget,
+          sources,
+          included,
+          trimmed,
+          fullMarkdown,
+        },
       });
       break;
     }

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -44,6 +44,7 @@ export interface BootContextMeta {
   sources: BootSourceMeta[];
   included: SectionMeta[];
   trimmed: SectionMeta[];
+  fullMarkdown?: string;
 }
 
 export interface MessagesState {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -851,7 +851,7 @@ async function _startChatInner(
 
       const included = extractSections(rawIncluded);
       const trimmed = extractSections(rawTrimmed);
-      const fullMarkdown = typeof obj.result === 'string' ? obj.result : undefined;
+      const fullMarkdown = typeof obj.bootPayload === 'string' ? obj.bootPayload : undefined;
 
       send(transport, {
         type: 'boot_context',

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -851,6 +851,7 @@ async function _startChatInner(
 
       const included = extractSections(rawIncluded);
       const trimmed = extractSections(rawTrimmed);
+      const fullMarkdown = typeof obj.result === 'string' ? obj.result : undefined;
 
       send(transport, {
         type: 'boot_context',
@@ -861,6 +862,7 @@ async function _startChatInner(
         sources,
         included,
         trimmed,
+        fullMarkdown,
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Fixes two UX issues with the boot context pill reported in Telos ae582634f14580e5:

1. ✅ **Pill disappears as messages scroll** → Now sticky at top of chat
2. ✅ **No way to view full markdown** → New ⎘ button opens modal overlay

## Changes

### 1. Sticky Positioning

The pill now uses `position: sticky; top: 0; z-index: 10;` to stay visible as messages scroll. Maintains context visibility throughout long conversations.

**Before:** Pill scrolls out of view after 3-4 agent responses  
**After:** Pill stays pinned at top, always accessible

### 2. Modal Pop-Out

New ⎘ button in pill header opens full-screen modal showing complete boot context markdown sent to the model.

**Features:**
- Click outside or ✕ button to close
- Full markdown with proper formatting
- Scrollable for long contexts
- Touch-optimized overlay with blur backdrop

### Protocol Extension

- Added `fullMarkdown?: string` to `BootContextMeta` type
- Server extracts `result` field from ContexGin compilation
- Protocol parser handles optional field (backward compatible)
- Falls back gracefully if ContexGin doesn't provide full markdown

## Files Changed

- `frontend/src/components/BootContextPill.tsx` — modal state + UI
- `frontend/src/styles/global.css` — sticky + modal styles  
- `packages/client/src/slices/messages.ts` — BootContextMeta type
- `packages/client/src/protocol-parser.ts` — extract fullMarkdown
- `server/chat.ts` — send fullMarkdown from ContexGin
- `docs/design/boot-context-pill-ux-fixes.md` — design doc

## Test Plan

- [ ] Start new Mitzo session, verify pill stays at top as messages scroll
- [ ] Tap ⎘ button, verify modal opens with full markdown
- [ ] Click outside modal or ✕ button, verify it closes
- [ ] Verify pill still expands inline to show sources/sections
- [ ] Test on mobile (iOS) for touch interactions
- [ ] Verify backward compat if ContexGin doesn't send fullMarkdown

## Related

- **Telos:** ae582634f14580e5 (parent task)
- **Design:** `docs/design/boot-context-pill-ux-fixes.md`
- **PR #332:** Prior work adding rich pill metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)