### PR TITLE
feat(ui): share/forward files from messages

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -6,6 +6,7 @@ import type { FinishedMessage } from '../types/chat';
 import { linkifyFilePaths, FILE_SCHEME } from '../lib/file-paths';
 import { formatTime } from '../lib/formatTime';
 import { CopyButton } from './CopyButton';
+import { ShareButton } from './ShareButton';
 import { ReadAloudButton } from './ReadAloudButton';
 import { extractText } from '../lib/extractText';
 import { MarkdownPreviewCard } from './MarkdownPreviewCard';
@@ -145,19 +146,22 @@ export function TextBubble({ content, streaming = false, timestamp, readAloud }:
               if (href?.startsWith(FILE_SCHEME)) {
                 const filePath = decodeURIComponent(href.slice(FILE_SCHEME.length));
                 return (
-                  <a
-                    href="#"
-                    className="file-path-link"
-                    data-file-path={filePath}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      navigate(
-                        `/files?path=${encodeURIComponent(filePath)}&from=${encodeURIComponent(currentPath)}`,
-                      );
-                    }}
-                  >
-                    {children}
-                  </a>
+                  <span className="file-path-group">
+                    <a
+                      href="#"
+                      className="file-path-link"
+                      data-file-path={filePath}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        navigate(
+                          `/files?path=${encodeURIComponent(filePath)}&from=${encodeURIComponent(currentPath)}`,
+                        );
+                      }}
+                    >
+                      {children}
+                    </a>
+                    <ShareButton filePath={filePath} className="file-path-share" />
+                  </span>
                 );
               }
               return (

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -41,7 +41,8 @@ export function ShareButton({ filePath, className }: ShareButtonProps) {
           ? 'Failed'
           : 'Share file';
 
-  const icon = state === 'busy' ? '...' : state === 'done' ? '\u2713' : state === 'error' ? '!' : '\u21A6';
+  const icon =
+    state === 'busy' ? '...' : state === 'done' ? '\u2713' : state === 'error' ? '!' : '\u21A6';
 
   return (
     <button

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { shareFile } from '../lib/share-file';
 
 interface ShareButtonProps {
@@ -8,13 +8,15 @@ interface ShareButtonProps {
 
 export function ShareButton({ filePath, className }: ShareButtonProps) {
   const [state, setState] = useState<'idle' | 'busy' | 'done' | 'error'>('idle');
+  const busyRef = useRef(false);
 
   const handleShare = useCallback(
     async (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      if (state === 'busy') return;
+      if (busyRef.current) return;
 
+      busyRef.current = true;
       setState('busy');
       try {
         await shareFile(filePath);
@@ -23,9 +25,11 @@ export function ShareButton({ filePath, className }: ShareButtonProps) {
       } catch {
         setState('error');
         setTimeout(() => setState('idle'), 2000);
+      } finally {
+        busyRef.current = false;
       }
     },
-    [filePath, state],
+    [filePath],
   );
 
   const label =

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,0 +1,53 @@
+import { useState, useCallback } from 'react';
+import { shareFile } from '../lib/share-file';
+
+interface ShareButtonProps {
+  filePath: string;
+  className?: string;
+}
+
+export function ShareButton({ filePath, className }: ShareButtonProps) {
+  const [state, setState] = useState<'idle' | 'busy' | 'done' | 'error'>('idle');
+
+  const handleShare = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (state === 'busy') return;
+
+      setState('busy');
+      try {
+        await shareFile(filePath);
+        setState('done');
+        setTimeout(() => setState('idle'), 1500);
+      } catch {
+        setState('error');
+        setTimeout(() => setState('idle'), 2000);
+      }
+    },
+    [filePath, state],
+  );
+
+  const label =
+    state === 'busy'
+      ? 'Sharing...'
+      : state === 'done'
+        ? 'Shared'
+        : state === 'error'
+          ? 'Failed'
+          : 'Share file';
+
+  const icon = state === 'busy' ? '...' : state === 'done' ? '\u2713' : state === 'error' ? '!' : '\u21A6';
+
+  return (
+    <button
+      className={`share-btn ${className ?? ''} ${state !== 'idle' ? `share-btn--${state}` : ''}`.trim()}
+      aria-label={label}
+      title={label}
+      onClick={handleShare}
+      disabled={state === 'busy'}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/ShareButton.test.tsx
+++ b/frontend/src/components/__tests__/ShareButton.test.tsx
@@ -53,7 +53,10 @@ describe('ShareButton', () => {
   it('is disabled while busy', async () => {
     let resolveShare: (v: boolean) => void;
     mockShareFile.mockImplementation(
-      () => new Promise<boolean>((r) => { resolveShare = r; }),
+      () =>
+        new Promise<boolean>((r) => {
+          resolveShare = r;
+        }),
     );
     render(<ShareButton filePath="/workspace/file.md" />);
 

--- a/frontend/src/components/__tests__/ShareButton.test.tsx
+++ b/frontend/src/components/__tests__/ShareButton.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../lib/share-file', () => ({
+  shareFile: vi.fn(),
+}));
+
+import { shareFile } from '../../lib/share-file';
+import { ShareButton } from '../ShareButton';
+
+const mockShareFile = vi.mocked(shareFile);
+
+describe('ShareButton', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders with share label by default', () => {
+    render(<ShareButton filePath="/workspace/file.md" />);
+    const btn = screen.getByRole('button', { name: 'Share file' });
+    expect(btn).toBeTruthy();
+    expect(btn.textContent).toBe('\u21A6');
+  });
+
+  it('shows done state after successful share', async () => {
+    mockShareFile.mockResolvedValue(true);
+    render(<ShareButton filePath="/workspace/file.md" />);
+
+    const btn = screen.getByRole('button', { name: 'Share file' });
+    await act(async () => {
+      await userEvent.click(btn);
+    });
+
+    expect(mockShareFile).toHaveBeenCalledWith('/workspace/file.md');
+    expect(screen.getByRole('button', { name: 'Shared' })).toBeTruthy();
+  });
+
+  it('shows error state when share fails', async () => {
+    mockShareFile.mockRejectedValue(new Error('Network error'));
+    render(<ShareButton filePath="/workspace/file.md" />);
+
+    const btn = screen.getByRole('button', { name: 'Share file' });
+    await act(async () => {
+      await userEvent.click(btn);
+    });
+
+    expect(screen.getByRole('button', { name: 'Failed' })).toBeTruthy();
+  });
+
+  it('is disabled while busy', async () => {
+    let resolveShare: (v: boolean) => void;
+    mockShareFile.mockImplementation(
+      () => new Promise<boolean>((r) => { resolveShare = r; }),
+    );
+    render(<ShareButton filePath="/workspace/file.md" />);
+
+    const btn = screen.getByRole('button', { name: 'Share file' });
+    await act(async () => {
+      await userEvent.click(btn);
+    });
+
+    const busyBtn = screen.getByRole('button', { name: 'Sharing...' });
+    expect((busyBtn as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      resolveShare!(true);
+    });
+  });
+
+  it('stops event propagation on click', async () => {
+    mockShareFile.mockResolvedValue(true);
+    const parentClick = vi.fn();
+
+    render(
+      <div onClick={parentClick}>
+        <ShareButton filePath="/workspace/file.md" />
+      </div>,
+    );
+
+    const btn = screen.getByRole('button', { name: 'Share file' });
+    await act(async () => {
+      await userEvent.click(btn);
+    });
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/share-file.test.ts
+++ b/frontend/src/lib/__tests__/share-file.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../api-fetch', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '../api-fetch';
+import { shareFile } from '../share-file';
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+describe('shareFile', () => {
+  let appendChildSpy: ReturnType<typeof vi.spyOn>;
+  let removeChildSpy: ReturnType<typeof vi.spyOn>;
+  let createObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.spyOn>;
+  let clickedHrefs: string[];
+
+  beforeEach(() => {
+    clickedHrefs = [];
+    appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+    createObjectURLSpy = vi.fn().mockReturnValue('blob:test-url') as unknown as ReturnType<typeof vi.spyOn>;
+    revokeObjectURLSpy = vi.fn() as unknown as ReturnType<typeof vi.spyOn>;
+    globalThis.URL.createObjectURL = createObjectURLSpy as unknown as typeof URL.createObjectURL;
+    globalThis.URL.revokeObjectURL = revokeObjectURLSpy as unknown as typeof URL.revokeObjectURL;
+
+    // Mock createElement to capture click
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        vi.spyOn(el as HTMLAnchorElement, 'click').mockImplementation(() => {
+          clickedHrefs.push((el as HTMLAnchorElement).href);
+        });
+      }
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('downloads file and triggers browser download when canShare is unavailable', async () => {
+    const blob = new Blob(['# Hello'], { type: 'application/octet-stream' });
+    mockApiFetch.mockResolvedValue(new Response(blob, { status: 200 }));
+
+    // Ensure no native share
+    Object.defineProperty(navigator, 'canShare', { value: undefined, configurable: true });
+
+    const result = await shareFile('/workspace/report.md');
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      '/api/files/download?path=%2Fworkspace%2Freport.md',
+    );
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('uses native share when canShare returns true', async () => {
+    const blob = new Blob(['data'], { type: 'text/plain' });
+    mockApiFetch.mockResolvedValue(new Response(blob, { status: 200 }));
+
+    const shareFn = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'canShare', {
+      value: () => true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'share', {
+      value: shareFn,
+      configurable: true,
+    });
+
+    const result = await shareFile('/workspace/notes.txt');
+
+    expect(shareFn).toHaveBeenCalled();
+    const callArg = shareFn.mock.calls[0][0];
+    expect(callArg.files).toHaveLength(1);
+    expect(callArg.files[0].name).toBe('notes.txt');
+    expect(result).toBe(true);
+  });
+
+  it('throws when server returns error', async () => {
+    mockApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Path not allowed' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(shareFile('/etc/passwd')).rejects.toThrow('Path not allowed');
+  });
+});

--- a/frontend/src/lib/__tests__/share-file.test.ts
+++ b/frontend/src/lib/__tests__/share-file.test.ts
@@ -93,4 +93,23 @@ describe('shareFile', () => {
 
     await expect(shareFile('/etc/passwd')).rejects.toThrow('Path not allowed');
   });
+
+  it('treats AbortError from share cancellation as success', async () => {
+    const blob = new Blob(['data'], { type: 'text/plain' });
+    mockApiFetch.mockResolvedValue(new Response(blob, { status: 200 }));
+
+    const abortError = new DOMException('Share canceled', 'AbortError');
+    const shareFn = vi.fn().mockRejectedValue(abortError);
+    Object.defineProperty(navigator, 'canShare', {
+      value: () => true,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, 'share', {
+      value: shareFn,
+      configurable: true,
+    });
+
+    const result = await shareFile('/workspace/notes.txt');
+    expect(result).toBe(true);
+  });
 });

--- a/frontend/src/lib/__tests__/share-file.test.ts
+++ b/frontend/src/lib/__tests__/share-file.test.ts
@@ -21,7 +21,9 @@ describe('shareFile', () => {
     clickedHrefs = [];
     appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
     removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
-    createObjectURLSpy = vi.fn().mockReturnValue('blob:test-url') as unknown as ReturnType<typeof vi.spyOn>;
+    createObjectURLSpy = vi.fn().mockReturnValue('blob:test-url') as unknown as ReturnType<
+      typeof vi.spyOn
+    >;
     revokeObjectURLSpy = vi.fn() as unknown as ReturnType<typeof vi.spyOn>;
     globalThis.URL.createObjectURL = createObjectURLSpy as unknown as typeof URL.createObjectURL;
     globalThis.URL.revokeObjectURL = revokeObjectURLSpy as unknown as typeof URL.revokeObjectURL;
@@ -52,9 +54,7 @@ describe('shareFile', () => {
 
     const result = await shareFile('/workspace/report.md');
 
-    expect(mockApiFetch).toHaveBeenCalledWith(
-      '/api/files/download?path=%2Fworkspace%2Freport.md',
-    );
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/files/download?path=%2Fworkspace%2Freport.md');
     expect(appendChildSpy).toHaveBeenCalled();
     expect(removeChildSpy).toHaveBeenCalled();
     expect(result).toBe(true);

--- a/frontend/src/lib/share-file.ts
+++ b/frontend/src/lib/share-file.ts
@@ -71,7 +71,12 @@ export async function shareFile(filePath: string): Promise<boolean> {
   // Try native share (mobile)
   if (canNativeShare(filename, typedBlob)) {
     const file = new File([typedBlob], filename, { type: mime });
-    await navigator.share({ files: [file] });
+    try {
+      await navigator.share({ files: [file] });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return true;
+      throw err;
+    }
     return true;
   }
 

--- a/frontend/src/lib/share-file.ts
+++ b/frontend/src/lib/share-file.ts
@@ -1,0 +1,88 @@
+import { apiFetch } from './api-fetch';
+
+/** MIME types for common file extensions. Falls back to application/octet-stream. */
+function mimeFromExt(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  const map: Record<string, string> = {
+    md: 'text/markdown',
+    txt: 'text/plain',
+    json: 'application/json',
+    yaml: 'application/x-yaml',
+    yml: 'application/x-yaml',
+    csv: 'text/csv',
+    html: 'text/html',
+    css: 'text/css',
+    js: 'text/javascript',
+    ts: 'text/typescript',
+    tsx: 'text/typescript',
+    jsx: 'text/javascript',
+    py: 'text/x-python',
+    sh: 'text/x-shellscript',
+    pdf: 'application/pdf',
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+  };
+  return map[ext] ?? 'application/octet-stream';
+}
+
+/** Extract just the filename from an absolute or relative path. */
+function filenameFromPath(filePath: string): string {
+  return filePath.split('/').pop() ?? 'file';
+}
+
+/** Download file bytes from the server. */
+async function fetchFileBlob(filePath: string): Promise<{ blob: Blob; filename: string }> {
+  const res = await apiFetch(`/api/files/download?path=${encodeURIComponent(filePath)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: 'Download failed' }));
+    throw new Error(body.error ?? `Download failed (${res.status})`);
+  }
+  const blob = await res.blob();
+  const filename = filenameFromPath(filePath);
+  return { blob, filename };
+}
+
+/** Check whether the browser supports sharing a file with the given MIME type. */
+function canNativeShare(filename: string, blob: Blob): boolean {
+  if (typeof navigator.canShare !== 'function') return false;
+  const file = new File([blob], filename, { type: blob.type });
+  return navigator.canShare({ files: [file] });
+}
+
+/**
+ * Share or download a file from the workspace.
+ *
+ * - On mobile (Web Share API available): opens the native share sheet.
+ * - On desktop (fallback): triggers a browser download.
+ *
+ * Returns true if the share/download was initiated successfully.
+ */
+export async function shareFile(filePath: string): Promise<boolean> {
+  const { blob, filename } = await fetchFileBlob(filePath);
+
+  // Re-type the blob with a proper MIME if the server sent application/octet-stream
+  const mime = blob.type === 'application/octet-stream' ? mimeFromExt(filename) : blob.type;
+  const typedBlob = mime !== blob.type ? new Blob([blob], { type: mime }) : blob;
+
+  // Try native share (mobile)
+  if (canNativeShare(filename, typedBlob)) {
+    const file = new File([typedBlob], filename, { type: mime });
+    await navigator.share({ files: [file] });
+    return true;
+  }
+
+  // Fallback: browser download
+  const url = URL.createObjectURL(typedBlob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  return true;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1902,7 +1902,10 @@ textarea:focus {
   line-height: 1;
   vertical-align: middle;
   opacity: 0;
-  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s,
+    background 0.15s;
 }
 
 .file-path-group:hover .share-btn,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1875,6 +1875,12 @@ textarea:focus {
   text-underline-offset: 2px;
 }
 
+.file-path-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .msg-bubble--assistant a.file-path-link {
   color: #7dd3fc;
   text-decoration: none;
@@ -1883,6 +1889,47 @@ textarea:focus {
   border-radius: 3px;
   font-family: var(--font-mono, monospace);
   font-size: 0.9em;
+}
+
+.share-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-dim);
+  font-size: 0.75em;
+  padding: 1px 3px;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+  line-height: 1;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.file-path-group:hover .share-btn,
+.share-btn--busy,
+.share-btn--done,
+.share-btn--error {
+  opacity: 1;
+}
+
+.share-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.share-btn--done {
+  color: var(--success);
+}
+
+.share-btn--error {
+  color: var(--error, #f87171);
+}
+
+@media (hover: none) {
+  .share-btn {
+    opacity: 0.7;
+  }
 }
 
 .msg-bubble--assistant img {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1899,7 +1899,6 @@ textarea:focus {
   font-size: 0.75em;
   padding: 1px 3px;
   border-radius: 3px;
-  transition: color 0.15s, background 0.15s;
   line-height: 1;
   vertical-align: middle;
   opacity: 0;

--- a/server/__tests__/routes.test.ts
+++ b/server/__tests__/routes.test.ts
@@ -659,6 +659,42 @@ describe('file routes', () => {
       .send({ path: '/tmp/outside/file.txt', content: 'nope' });
     expect(res.status).toBe(403);
   });
+
+  it('GET /api/files/download — downloads file with Content-Disposition', async () => {
+    const dlFile = join(TEST_REPO, 'download-test.txt');
+    writeFileSync(dlFile, 'download me');
+    const res = await request(app)
+      .get('/api/files/download')
+      .query({ path: dlFile })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-disposition']).toContain('download-test.txt');
+    expect(res.text).toBe('download me');
+  });
+
+  it('GET /api/files/download — disallowed path returns 403', async () => {
+    const res = await request(app)
+      .get('/api/files/download')
+      .query({ path: '/etc/passwd' })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /api/files/download — missing file returns 404', async () => {
+    const res = await request(app)
+      .get('/api/files/download')
+      .query({ path: join(TEST_REPO, 'gone.txt') })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/files/download — directory returns 400', async () => {
+    const res = await request(app)
+      .get('/api/files/download')
+      .query({ path: join(TEST_REPO, 'subdir') })
+      .set('Cookie', authCookie);
+    expect(res.status).toBe(400);
+  });
 });
 
 // --- Inbox Routes ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -1345,7 +1345,10 @@ app.get('/api/files/download', (req, res) => {
     }
     const filename = basename(filePath);
     const safeFilename = filename.replace(/"/g, '\\"');
-    res.setHeader('Content-Disposition', `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
+    );
     res.setHeader('Content-Length', stat.size);
     res.sendFile(resolve(filePath));
   } catch (err: unknown) {

--- a/server/app.ts
+++ b/server/app.ts
@@ -1344,7 +1344,8 @@ app.get('/api/files/download', (req, res) => {
       return;
     }
     const filename = basename(filePath);
-    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    const safeFilename = filename.replace(/"/g, '\\"');
+    res.setHeader('Content-Disposition', `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`);
     res.setHeader('Content-Length', stat.size);
     res.sendFile(resolve(filePath));
   } catch (err: unknown) {

--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,7 @@ import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { join, dirname, resolve, extname } from 'path';
+import { join, dirname, resolve, extname, basename } from 'path';
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
 import { createHash, randomUUID } from 'crypto';
@@ -1324,6 +1324,35 @@ app.get('/api/files/read', (req, res) => {
       error: err instanceof Error ? err.message : 'unknown',
     });
     res.status(500).json({ error: 'Failed to read file' });
+  }
+});
+
+app.get('/api/files/download', (req, res) => {
+  const filePath = req.query.path as string;
+  if (!filePath || !isAllowedPath(filePath)) {
+    res.status(403).json({ error: 'Path not allowed' });
+    return;
+  }
+  if (!existsSync(filePath)) {
+    res.status(404).json({ error: 'File not found' });
+    return;
+  }
+  try {
+    const stat = statSync(filePath);
+    if (stat.isDirectory()) {
+      res.status(400).json({ error: 'Cannot download a directory' });
+      return;
+    }
+    const filename = basename(filePath);
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    res.setHeader('Content-Length', stat.size);
+    res.sendFile(resolve(filePath));
+  } catch (err: unknown) {
+    log.error('failed to download file', {
+      path: filePath,
+      error: err instanceof Error ? err.message : 'unknown',
+    });
+    res.status(500).json({ error: 'Failed to download file' });
   }
 });
 


### PR DESCRIPTION
## Summary
- Adds a share button (↦) next to file path links in assistant messages
- On mobile: opens native iOS/Android share sheet via Web Share API — user picks the app (email, Slack, Messages, AirDrop, etc.)
- On desktop: falls back to browser file download
- New `GET /api/files/download` server endpoint with `isAllowedPath()` security validation

## Changes
- **server/app.ts**: `GET /api/files/download` — serves files with `Content-Disposition: attachment`
- **frontend/src/lib/share-file.ts**: `shareFile()` utility — fetches file from server, tries native share, falls back to download
- **frontend/src/components/ShareButton.tsx**: Button component with idle/busy/done/error states
- **frontend/src/components/MessageBubble.tsx**: Wraps file path links in a `<span>` group with adjacent share button
- **frontend/src/styles/global.css**: Share button styles — hidden by default, visible on hover (always visible on touch devices)

## Test plan
- [x] Server: 4 new route tests (download, 403, 404, directory rejection) — all pass
- [x] Frontend: 3 new share-file tests (download fallback, native share, error handling) — all pass
- [x] TypeScript: no new type errors
- [x] ESLint: no new lint errors
- [ ] Manual: test share sheet on iOS device
- [ ] Manual: test download fallback on desktop Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)