### PR TITLE
fix(sessions): live-refresh session list via SSE

### DIFF
--- a/frontend/src/hooks/useSessionList.ts
+++ b/frontend/src/hooks/useSessionList.ts
@@ -88,6 +88,19 @@ export function useSessionList(): UseSessionListReturn {
     };
     document.addEventListener('visibilitychange', onVisible);
 
+    // Refetch session list when sessions are created, renamed, or deleted
+    const unsubChanged = eventBus.on('sessions_changed', () => {
+      apiFetch('/api/sessions')
+        .then((r) => r.json())
+        .then((data) => {
+          const { sessions: page, hasMore: more } = parseSessionsResponse(data);
+          setSessions(page);
+          setHasMore(more);
+          nextOffset.current = page.length;
+        })
+        .catch(() => {});
+    });
+
     // Live session dots via SSE — update isActive/isAttached without full refetch
     const unsubActivity = eventBus.on('session_activity', (data) => {
       const activities = data as SessionActivity[];
@@ -105,6 +118,7 @@ export function useSessionList(): UseSessionListReturn {
 
     return () => {
       document.removeEventListener('visibilitychange', onVisible);
+      unsubChanged();
       unsubActivity();
     };
   }, []);

--- a/server/app.ts
+++ b/server/app.ts
@@ -492,6 +492,8 @@ async function handleSessionCreate(
       log.info('headless session started', { sessionId: wtId, prompt: initialPrompt });
     }
 
+    sseRegistry.broadcast('sessions_changed', {});
+
     res.status(initialPrompt ? 201 : 200).json({
       sessionId: wtId,
       worktrees,
@@ -1103,6 +1105,7 @@ app.get('/api/sessions/:id/messages', async (req, res) => {
 
 app.delete('/api/sessions/:id', (req, res) => {
   hideSession(req.params.id as string);
+  sseRegistry.broadcast('sessions_changed', {});
   res.json({ ok: true });
 });
 
@@ -1139,6 +1142,7 @@ app.get('/api/sessions/:id/events', (req, res) => {
 
 app.delete('/api/sessions', (_req, res) => {
   hideAllSessions();
+  sseRegistry.broadcast('sessions_changed', {});
   res.json({ ok: true });
 });
 
@@ -1150,6 +1154,7 @@ app.put('/api/sessions/:id/rename', async (req, res) => {
   }
   try {
     await renameSessionById(req.params.id, title.slice(0, 200));
+    sseRegistry.broadcast('sessions_changed', {});
     res.json({ ok: true });
   } catch {
     res.status(404).json({ error: 'Session not found' });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -61,6 +61,11 @@ let _onSessionChange: SessionChangeCallback | null = null;
 export function setSessionChangeCallback(cb: SessionChangeCallback): void {
   _onSessionChange = cb;
 }
+
+let _onSessionsChanged: (() => void) | null = null;
+export function setSessionsChangedCallback(cb: () => void): void {
+  _onSessionsChanged = cb;
+}
 import { EventStore } from './event-store.js';
 import { capturePromptComparison } from './prompt-compare.js';
 import { shouldAutoRename, extractRecentPrompts, generateSessionName } from './auto-rename.js';
@@ -1015,6 +1020,7 @@ async function tryAutoRename(sessionId: string, clientId: string): Promise<void>
 
     // Persist to EventStore first — survives SDK rename failures.
     eventStore.upsertSession({ sessionId, summary: newName });
+    _onSessionsChanged?.();
 
     // Update the SDK session name (best-effort, fire-and-forget)
     renameSessionById(sessionId, newName, false).catch((err: unknown) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import {
   getRepoConfig,
   setConnectionRegistry,
   setSessionChangeCallback,
+  setSessionsChangedCallback,
   reconcileSessionsBackground,
 } from './chat.js';
 import { cleanupStaleWorktrees, countWorktrees } from './worktree.js';
@@ -269,6 +270,10 @@ setSessionChangeCallback((clientId, event, sessionId) => {
     }
   }
   overviewEmitter.scheduleBroadcast();
+});
+
+setSessionsChangedCallback(() => {
+  sseRegistry.broadcast('sessions_changed', {});
 });
 
 server.on('upgrade', async (req, socket, head) => {


### PR DESCRIPTION
## Summary

- The "all sessions" list in desktop only refreshed on page visibility change — new sessions, renames, and deletions were invisible until navigating away and back
- Added a `sessions_changed` SSE event broadcast from every session mutation point (create, delete, delete-all, rename, auto-rename)
- Frontend `useSessionList` hook subscribes to the event and refetches the list

## Test plan

- [ ] Create a new session → session list updates without manual refresh
- [ ] Rename a session → title updates in the list immediately
- [ ] Delete a session → disappears from the list immediately
- [ ] Auto-rename (send first message) → title updates in the list
- [ ] Open session list on two tabs → both update when either mutates

🤖 Generated with [Claude Code](https://claude.com/claude-code)