### PR TITLE
fix(server): add sessionId to user_message echo

### DIFF
--- a/frontend/src/types/ws-messages.ts
+++ b/frontend/src/types/ws-messages.ts
@@ -170,6 +170,7 @@ interface UserMessageMsg {
   v: 2;
   messageId: string;
   text: string;
+  sessionId?: string;
 }
 
 interface SessionRenamedMsg {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -954,7 +954,7 @@ async function _startChatInner(
       });
       eventStore.updateLastSpeaker(options.resume, 'user');
       _onSessionChange?.(clientId, 'user_message');
-      const echo = { type: 'user_message', messageId, text: fullPrompt };
+      const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, sessionId: options.resume };
       send(transport, echo);
       broadcastToObservers(session.observers, echo);
     }
@@ -1081,7 +1081,7 @@ export function sendToChat(
         /* errors logged internally */
       });
     }
-    const echo = { type: 'user_message', messageId, text: fullPrompt };
+    const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, ...(session.sessionId ? { sessionId: session.sessionId } : {}) };
     send(session.transport, echo);
     broadcastToObservers(session.observers, echo);
     session.inputQueue.push(makeUserMessage(fullPrompt, 'next'));
@@ -1115,7 +1115,7 @@ export async function interruptChat(
       eventStore.updateLastSpeaker(session.sessionId, 'user');
       _onSessionChange?.(clientId, 'user_message');
     }
-    const echo = { type: 'user_message', messageId, text: fullPrompt };
+    const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, ...(session.sessionId ? { sessionId: session.sessionId } : {}) };
     send(session.transport, echo);
     broadcastToObservers(session.observers, echo);
     // Stop all active subagent tasks before interrupting the parent query.

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -954,7 +954,13 @@ async function _startChatInner(
       });
       eventStore.updateLastSpeaker(options.resume, 'user');
       _onSessionChange?.(clientId, 'user_message');
-      const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, sessionId: options.resume };
+      const echo = {
+        type: 'user_message',
+        v: 2,
+        messageId,
+        text: fullPrompt,
+        sessionId: options.resume,
+      };
       send(transport, echo);
       broadcastToObservers(session.observers, echo);
     }
@@ -1081,7 +1087,13 @@ export function sendToChat(
         /* errors logged internally */
       });
     }
-    const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, ...(session.sessionId ? { sessionId: session.sessionId } : {}) };
+    const echo = {
+      type: 'user_message',
+      v: 2,
+      messageId,
+      text: fullPrompt,
+      ...(session.sessionId ? { sessionId: session.sessionId } : {}),
+    };
     send(session.transport, echo);
     broadcastToObservers(session.observers, echo);
     session.inputQueue.push(makeUserMessage(fullPrompt, 'next'));
@@ -1115,7 +1127,13 @@ export async function interruptChat(
       eventStore.updateLastSpeaker(session.sessionId, 'user');
       _onSessionChange?.(clientId, 'user_message');
     }
-    const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt, ...(session.sessionId ? { sessionId: session.sessionId } : {}) };
+    const echo = {
+      type: 'user_message',
+      v: 2,
+      messageId,
+      text: fullPrompt,
+      ...(session.sessionId ? { sessionId: session.sessionId } : {}),
+    };
     send(session.transport, echo);
     broadcastToObservers(session.observers, echo);
     // Stop all active subagent tasks before interrupting the parent query.


### PR DESCRIPTION
## Summary

- `user_message` WebSocket events were echoed to clients without `sessionId`, bypassing the frontend's v2 session filter (`store.ts` `wsListener`)
- The filter treated them as global events (like `task_state`), causing user input from other sessions to bleed into the active session view
- Added `sessionId` + `v: 2` to the echo payload at all three emission sites in `chat.ts` (resume, send, interrupt)
- Updated `UserMessageMsg` type in `ws-messages.ts` to include optional `sessionId`

## Root cause

Every other session-scoped v2 event (`message_end`, `session_end`, etc.) goes through `sendOrBuffer()` which auto-enriches with `sessionId`. The `user_message` echo bypassed that path entirely, using direct `send()` + `broadcastToObservers()`.

## Test plan

- [ ] Open two sessions, send messages in both — verify no message bleed
- [ ] Refresh page — verify messages stay correct
- [ ] Resume a session — verify resumed user message appears in correct session only
- [ ] Interrupt a running session — verify interrupt message scoped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)