### PR TITLE
fix(ui): sync model preference into store on startup

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -13,6 +13,7 @@ import { registerCapacitorLifecycle } from './lib/capacitor';
 import { configureKeyboard } from './lib/keyboard';
 import { initPushNotifications } from './lib/push';
 import { eventBus } from './lib/event-bus-singleton';
+import { getPreferredModel } from './lib/model-preference';
 
 export const clientStore = createMitzoStore({
   transport: {
@@ -25,6 +26,9 @@ export const clientStore = createMitzoStore({
     suspendUrl: `${getApiBaseUrl()}/api/sessions/suspend`,
   },
 });
+
+// Sync localStorage model preference into the store so sendMessage() includes it
+clientStore.getState().setModel(getPreferredModel());
 
 // Wire Capacitor app lifecycle → force WS reconnect on resume, send suspend on background
 registerCapacitorLifecycle(


### PR DESCRIPTION
## Summary

- The Zustand store initialized `config.modelId` as `null` while the UI dropdown read the preference from localStorage
- `sendMessage()` reads from the store, so the `model` field was never included in the WS payload — the SDK silently fell back to Sonnet
- One-line fix: call `setModel(getPreferredModel())` after store creation to sync localStorage into the store

Selected model now persists across all sessions until the dropdown is changed.

## Test plan

- [ ] Select Opus in dropdown, send a message — verify commit Co-Authored-By says Opus
- [ ] Reload the app without touching the dropdown — verify the model still sends correctly
- [ ] Change to Sonnet, send a message — verify it switches
- [ ] Change back to Opus — verify it persists on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)