### PR TITLE
fix(client): restore running state on reconnect + keyboard interrupt

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -151,7 +151,11 @@ export function ChatInput({
   function handleKeyDown(e: KeyboardEvent) {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleSend();
+      if (running && onInterrupt) {
+        handleInterrupt();
+      } else {
+        handleSend();
+      }
     }
   }
 

--- a/packages/client/__tests__/protocol-parser.test.ts
+++ b/packages/client/__tests__/protocol-parser.test.ts
@@ -627,15 +627,17 @@ describe('reconnected', () => {
     expect(r.messagesActions).toContainEqual({ type: 'SET_RUNNING', running: false });
   });
 
-  it('does not dispatch SET_RUNNING when active session is still running', () => {
+  it('dispatches SET_RUNNING true when active session is still running', () => {
+    const setWsRunning = vi.fn();
     const state = makeState({ currentSessionId: 'sid-1' });
     const r = parseServerMessage(
       { type: 'reconnected', sessions: [{ sessionId: 'sid-1', replayed: 0, running: true }] },
       state,
-      makeCallbacks(),
+      makeCallbacks({ setWsRunning }),
       POOL_KEY,
     );
-    expect(r.messagesActions).not.toContainEqual(expect.objectContaining({ type: 'SET_RUNNING' }));
+    expect(r.messagesActions).toContainEqual({ type: 'SET_RUNNING', running: true });
+    expect(setWsRunning).toHaveBeenCalledWith(POOL_KEY, true);
   });
 
   it('no-ops when no currentSessionId', () => {

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -139,8 +139,9 @@ export function parseServerMessage(
         )
       ) {
         const active = sessions.find((s) => s.sessionId === state.currentSessionId);
-        if (active && active.running === false) {
-          result.messagesActions.push({ type: 'SET_RUNNING', running: false });
+        if (active) {
+          result.messagesActions.push({ type: 'SET_RUNNING', running: active.running });
+          if (active.running) callbacks.setWsRunning?.(poolKey, true);
         }
       }
       callbacks.onReconnected?.();


### PR DESCRIPTION
## Summary

- **Running state lost on reconnect:** `protocol-parser.ts` only dispatched `SET_RUNNING` for `running === false`, silently dropping the `true` case. After iOS WS reconnect, the UI showed idle send button instead of interrupt/queue/stop — so messages queued via `sendToChat()` with no `stopTask()` cascade, leaving subagents stuck indefinitely.
- **iOS keyboard bypass:** The keyboard Send/Enter key always called `handleSend()`, bypassing the on-screen interrupt/queue/stop buttons. Now `handleKeyDown` routes through `handleInterrupt()` when the session is running.

## Test plan

- [x] `protocol-parser.test.ts` updated — `reconnected` with `running: true` now asserts `SET_RUNNING: true` + `setWsRunning` called
- [ ] Manual: background iOS app while subagent is running → reopen → verify interrupt/stop buttons appear
- [ ] Manual: type message + tap iOS keyboard Send while agent is running → verify it interrupts (not queues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)