### PR TITLE
refactor(server): fetch boot context from ContexGin HTTP API

### DIFF
--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -5,6 +5,25 @@ import type { BootContextMessage } from '../chat.js';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// Mock child_process for local fallback tests
+const mockExecFile = vi.fn();
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(),
+  execFile: mockExecFile,
+}));
+
+// Mock util.promisify to return our mock
+vi.mock('util', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    promisify: (fn: unknown) => {
+      if (fn === mockExecFile) return mockExecFile;
+      return (actual.promisify as (fn: unknown) => unknown)(fn);
+    },
+  };
+});
+
 // Mock logger to suppress output
 vi.mock('../logger.js', () => ({
   createLogger: () => ({
@@ -93,38 +112,66 @@ describe('fetchBootContext', () => {
     });
   });
 
-  it('returns local-fallback when ContexGin is unreachable', async () => {
+  it('falls back to local Python script when ContexGin is unreachable', async () => {
     mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    mockExecFile.mockResolvedValueOnce({
+      stdout: JSON.stringify({ additionalContext: '# Local boot context\nFallback content.' }),
+    });
 
-    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL, '/fake/repo');
 
     expect(result.source).toBe('local-fallback');
-    expect(result.sourceCount).toBe(0);
-    expect(result.tokenCount).toBe(0);
+    expect(result.sourceCount).toBe(5);
+    expect(result.fullMarkdown).toBe('# Local boot context\nFallback content.');
+    expect(result.tokenCount).toBeGreaterThan(0);
+    expect(result.sources).toHaveLength(5);
+    expect(result.sources[0]).toEqual({
+      path: 'memory/Profile/Working Style.md',
+      kind: 'profile',
+    });
   });
 
-  it('returns local-fallback on non-200 response', async () => {
+  it('falls back to local Python script on non-200 response', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
       text: async () => '{"error":"Agent not found"}',
     });
+    mockExecFile.mockResolvedValueOnce({
+      stdout: JSON.stringify({ additionalContext: 'fallback content' }),
+    });
 
-    const result = await fetchBootContext('nonexistent-agent', CONTEXGIN_URL);
+    const result = await fetchBootContext('nonexistent-agent', CONTEXGIN_URL, '/fake/repo');
 
     expect(result.source).toBe('local-fallback');
-    expect(result.sourceCount).toBe(0);
+    expect(result.fullMarkdown).toBe('fallback content');
   });
 
-  it('returns local-fallback when response lacks boot field', async () => {
+  it('falls back to local Python script when response lacks boot field', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ agent: 'test', identity: {} }),
     });
+    mockExecFile.mockResolvedValueOnce({
+      stdout: JSON.stringify({ additionalContext: 'fallback' }),
+    });
 
-    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL, '/fake/repo');
 
     expect(result.source).toBe('local-fallback');
+    expect(result.fullMarkdown).toBe('fallback');
+  });
+
+  it('returns zero-value fallback when both ContexGin and Python script fail', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    mockExecFile.mockRejectedValueOnce(new Error('script not found'));
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL, '/fake/repo');
+
+    expect(result.source).toBe('local-fallback');
+    expect(result.sourceCount).toBe(0);
+    expect(result.tokenCount).toBe(0);
+    expect(result.fullMarkdown).toBeUndefined();
   });
 
   it('handles empty sources array', async () => {
@@ -169,6 +216,7 @@ describe('fetchBootContext', () => {
     process.env.CONTEXGIN_URL = 'http://test-host:9999';
 
     mockFetch.mockRejectedValueOnce(new Error('timeout'));
+    mockExecFile.mockRejectedValueOnce(new Error('no script'));
 
     await fetchBootContext('mitzo-conversational');
 

--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { BootContextMessage } from '../chat.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock logger to suppress output
+vi.mock('../logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock the event store to avoid SQLite initialization
+class FakeEventStore {
+  recordEvent = vi.fn();
+  getEvents = vi.fn().mockReturnValue([]);
+  getSession = vi.fn().mockReturnValue(null);
+  upsertSession = vi.fn();
+}
+vi.mock('../event-store.js', () => ({
+  EventStore: FakeEventStore,
+}));
+
+// Mock repo-config
+vi.mock('../repo-config.js', () => ({
+  loadRepoConfig: vi.fn(() => ({
+    contextBlocks: {},
+    quickActions: [],
+    venvPaths: [],
+    resolvedVenvPaths: [],
+    allowedPaths: [],
+    roots: [],
+    toolTierOverrides: {},
+    inboxPath: '',
+    resolvedInboxPath: '',
+    repos: {},
+    isolation: true,
+  })),
+}));
+
+const { fetchBootContext } = await import('../chat.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchBootContext', () => {
+  const CONTEXGIN_URL = 'http://localhost:4195';
+
+  it('returns contexgin boot context on successful response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        agent: 'mitzo-conversational',
+        boot: {
+          content: '# Boot payload\nContext here.',
+          tokens: 11297,
+          sources: ['CONSTITUTION.md', 'memory/Profile/Principles.md'],
+        },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${CONTEXGIN_URL}/api/agents/mitzo-conversational/context`,
+      { signal: expect.any(AbortSignal) },
+    );
+
+    expect(result).toEqual<BootContextMessage>({
+      type: 'boot_context',
+      source: 'contexgin',
+      sourceCount: 2,
+      tokenCount: 11297,
+      tokenBudget: 11297,
+      sources: [
+        { path: 'CONSTITUTION.md', kind: 'reference' },
+        { path: 'memory/Profile/Principles.md', kind: 'reference' },
+      ],
+      included: [],
+      trimmed: [],
+      fullMarkdown: '# Boot payload\nContext here.',
+    });
+  });
+
+  it('returns local-fallback when ContexGin is unreachable', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.source).toBe('local-fallback');
+    expect(result.sourceCount).toBe(0);
+    expect(result.tokenCount).toBe(0);
+  });
+
+  it('returns local-fallback on non-200 response', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: async () => '{"error":"Agent not found"}',
+    });
+
+    const result = await fetchBootContext('nonexistent-agent', CONTEXGIN_URL);
+
+    expect(result.source).toBe('local-fallback');
+    expect(result.sourceCount).toBe(0);
+  });
+
+  it('returns local-fallback when response lacks boot field', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ agent: 'test', identity: {} }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.source).toBe('local-fallback');
+  });
+
+  it('handles empty sources array', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: { content: 'minimal', tokens: 100, sources: [] },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.source).toBe('contexgin');
+    expect(result.sourceCount).toBe(0);
+    expect(result.sources).toEqual([]);
+    expect(result.tokenCount).toBe(100);
+  });
+
+  it('filters non-string sources gracefully', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: {
+          content: 'payload',
+          tokens: 500,
+          sources: ['valid.md', null, 42, 'also-valid.md'],
+        },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.sources).toEqual([
+      { path: 'valid.md', kind: 'reference' },
+      { path: 'also-valid.md', kind: 'reference' },
+    ]);
+    expect(result.sourceCount).toBe(2);
+  });
+
+  it('uses default URL from env when not provided', async () => {
+    const origUrl = process.env.CONTEXGIN_URL;
+    process.env.CONTEXGIN_URL = 'http://test-host:9999';
+
+    mockFetch.mockRejectedValueOnce(new Error('timeout'));
+
+    await fetchBootContext('mitzo-conversational');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://test-host:9999/api/agents/mitzo-conversational/context',
+      expect.any(Object),
+    );
+
+    if (origUrl !== undefined) {
+      process.env.CONTEXGIN_URL = origUrl;
+    } else {
+      delete process.env.CONTEXGIN_URL;
+    }
+  });
+});

--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -211,24 +211,43 @@ describe('fetchBootContext', () => {
     expect(result.sourceCount).toBe(2);
   });
 
+  it('falls back to local script when response body is malformed JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON');
+      },
+    });
+    mockExecFile.mockResolvedValueOnce({
+      stdout: JSON.stringify({ additionalContext: 'json fallback' }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL, '/fake/repo');
+
+    expect(result.source).toBe('local-fallback');
+    expect(result.fullMarkdown).toBe('json fallback');
+  });
+
   it('uses default URL from env when not provided', async () => {
     const origUrl = process.env.CONTEXGIN_URL;
     process.env.CONTEXGIN_URL = 'http://test-host:9999';
 
-    mockFetch.mockRejectedValueOnce(new Error('timeout'));
-    mockExecFile.mockRejectedValueOnce(new Error('no script'));
+    try {
+      mockFetch.mockRejectedValueOnce(new Error('timeout'));
+      mockExecFile.mockRejectedValueOnce(new Error('no script'));
 
-    await fetchBootContext('mitzo-conversational');
+      await fetchBootContext('mitzo-conversational');
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'http://test-host:9999/api/agents/mitzo-conversational/context',
-      expect.any(Object),
-    );
-
-    if (origUrl !== undefined) {
-      process.env.CONTEXGIN_URL = origUrl;
-    } else {
-      delete process.env.CONTEXGIN_URL;
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test-host:9999/api/agents/mitzo-conversational/context',
+        expect.any(Object),
+      );
+    } finally {
+      if (origUrl !== undefined) {
+        process.env.CONTEXGIN_URL = origUrl;
+      } else {
+        delete process.env.CONTEXGIN_URL;
+      }
     }
   });
 });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -118,13 +118,56 @@ const FALLBACK_BOOT_CONTEXT: BootContextMessage = {
 };
 
 /**
+ * Local fallback: run build_boot_context.py --json to get deterministic boot context.
+ * This is the "old way" — reads canonical source files directly, no server dependency.
+ */
+async function localBootContextFallback(repoRoot: string): Promise<BootContextMessage> {
+  const scriptPath = join(repoRoot, 'scripts', 'build_boot_context.py');
+  try {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const execFileAsync = promisify(execFile);
+    const { stdout } = await execFileAsync('python3', [scriptPath, '--json'], {
+      cwd: repoRoot,
+      timeout: 5000,
+    });
+    const parsed = JSON.parse(stdout) as { additionalContext?: string };
+    const content = parsed.additionalContext ?? '';
+    // Rough token estimate: ~4 chars per token
+    const tokens = Math.ceil(content.length / 4);
+    return {
+      type: 'boot_context',
+      source: 'local-fallback',
+      sourceCount: 5, // hardcoded source count from build_boot_context.py SOURCE_PATHS
+      tokenCount: tokens,
+      tokenBudget: tokens,
+      sources: [
+        { path: 'memory/Profile/Working Style.md', kind: 'profile' },
+        { path: 'memory/Profile/Communication Style.md', kind: 'profile' },
+        { path: 'memory/Profile/Principles.md', kind: 'profile' },
+        { path: 'CONSTITUTION.md', kind: 'constitution' },
+        { path: 'SERVICES.md', kind: 'reference' },
+      ],
+      included: [],
+      trimmed: [],
+      fullMarkdown: content,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn('Local boot context fallback failed', { error: msg });
+    return { ...FALLBACK_BOOT_CONTEXT };
+  }
+}
+
+/**
  * Fetch boot context from the running ContexGin server.
- * Returns a BootContextMessage ready to send to the client.
+ * Falls back to build_boot_context.py if the server is unreachable.
  * Never throws — returns a local-fallback message on any error.
  */
 export async function fetchBootContext(
   agentName: string,
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
+  repoRoot: string = BASE_REPO,
 ): Promise<BootContextMessage> {
   try {
     const url = `${contexginUrl}/api/agents/${agentName}/context`;
@@ -134,19 +177,21 @@ export async function fetchBootContext(
 
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      log.warn('ContexGin agent context request failed', {
+      log.warn('ContexGin agent context request failed, trying local fallback', {
         status: res.status,
         body: body.slice(0, 200),
       });
-      return { ...FALLBACK_BOOT_CONTEXT };
+      return localBootContextFallback(repoRoot);
     }
 
     const data = (await res.json()) as Record<string, unknown>;
     const boot = data.boot as Record<string, unknown> | undefined;
 
     if (!boot) {
-      log.warn('ContexGin response missing boot field', { keys: Object.keys(data) });
-      return { ...FALLBACK_BOOT_CONTEXT };
+      log.warn('ContexGin response missing boot field, trying local fallback', {
+        keys: Object.keys(data),
+      });
+      return localBootContextFallback(repoRoot);
     }
 
     const bootTokens = typeof boot.tokens === 'number' ? boot.tokens : 0;
@@ -171,8 +216,8 @@ export async function fetchBootContext(
     };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.info('ContexGin not reachable, boot context unavailable', { error: msg });
-    return { ...FALLBACK_BOOT_CONTEXT };
+    log.info('ContexGin not reachable, trying local fallback', { error: msg });
+    return localBootContextFallback(repoRoot);
   }
 }
 

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -163,7 +163,7 @@ async function localBootContextFallback(repoRoot: string): Promise<BootContextMe
 /**
  * Fetch boot context from the running ContexGin server.
  * Falls back to build_boot_context.py if the server is unreachable.
- * Never throws — returns a local-fallback message on any error.
+ * Never throws — returns a local-fallback BootContextMessage on any error.
  */
 export async function fetchBootContext(
   agentName: string,
@@ -894,7 +894,9 @@ async function _startChatInner(
     buildTaskPromptForSession(clientId);
 
   // Fire-and-forget: fetch boot context from running ContexGin server
-  fetchBootContext(agentName).then((msg) => send(transport, msg)).catch(() => {});
+  fetchBootContext(agentName)
+    .then((msg) => send(transport, msg as unknown as Record<string, unknown>))
+    .catch(() => {});
   capturePromptComparison(wtId, cwd, systemPromptAppend, repoWorktrees).catch(() => {});
 
   // Resolve SDK session UUID for resume — worktree IDs are not valid SDK session IDs

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -93,6 +93,89 @@ export const eventStore = initEventStore();
 
 export type { MitzoMode } from './session-registry.js';
 
+// ── Boot context via ContexGin HTTP API ──────────────────────────
+export interface BootContextMessage {
+  type: 'boot_context';
+  source: 'contexgin' | 'local-fallback';
+  sourceCount: number;
+  tokenCount: number;
+  tokenBudget: number;
+  sources: Array<{ path: string; kind: string }>;
+  included: Array<{ source: string; heading: string; tokens: number; content: string }>;
+  trimmed: Array<{ source: string; heading: string; tokens: number; content: string }>;
+  fullMarkdown?: string;
+}
+
+const FALLBACK_BOOT_CONTEXT: BootContextMessage = {
+  type: 'boot_context',
+  source: 'local-fallback',
+  sourceCount: 0,
+  tokenCount: 0,
+  tokenBudget: 0,
+  sources: [],
+  included: [],
+  trimmed: [],
+};
+
+/**
+ * Fetch boot context from the running ContexGin server.
+ * Returns a BootContextMessage ready to send to the client.
+ * Never throws — returns a local-fallback message on any error.
+ */
+export async function fetchBootContext(
+  agentName: string,
+  contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
+): Promise<BootContextMessage> {
+  try {
+    const url = `${contexginUrl}/api/agents/${agentName}/context`;
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      log.warn('ContexGin agent context request failed', {
+        status: res.status,
+        body: body.slice(0, 200),
+      });
+      return { ...FALLBACK_BOOT_CONTEXT };
+    }
+
+    const data = (await res.json()) as Record<string, unknown>;
+    const boot = data.boot as Record<string, unknown> | undefined;
+
+    if (!boot) {
+      log.warn('ContexGin response missing boot field', { keys: Object.keys(data) });
+      return { ...FALLBACK_BOOT_CONTEXT };
+    }
+
+    const bootTokens = typeof boot.tokens === 'number' ? boot.tokens : 0;
+    const rawSources = Array.isArray(boot.sources) ? boot.sources : [];
+
+    const sources: Array<{ path: string; kind: string }> = rawSources
+      .filter((s): s is string => typeof s === 'string')
+      .map((s) => ({ path: s, kind: 'reference' }));
+
+    const fullMarkdown = typeof boot.content === 'string' ? (boot.content as string) : undefined;
+
+    return {
+      type: 'boot_context',
+      source: 'contexgin',
+      sourceCount: sources.length,
+      tokenCount: bootTokens,
+      tokenBudget: bootTokens, // server compiles to its own budget — report actual
+      sources,
+      included: [],
+      trimmed: [],
+      fullMarkdown,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.info('ContexGin not reachable, boot context unavailable', { error: msg });
+    return { ...FALLBACK_BOOT_CONTEXT };
+  }
+}
+
 let mcpServers: Record<string, McpServerConfig> = {};
 try {
   mcpServers = loadMcpServers();
@@ -764,147 +847,8 @@ async function _startChatInner(
     buildWorktreeSystemPrompt(repoWorktrees) +
     buildTaskPromptForSession(clientId);
 
-  // Fire-and-forget: emit boot context metadata to client + capture prompt comparison
-  const DEFAULT_TOKEN_BUDGET = 8000;
-  (async () => {
-    // Step 1: dynamically import contexgin (optional dependency)
-    let compileModule: {
-      compile: (opts: { workspaceRoot: string; tokenBudget: number }) => Promise<unknown>;
-      loadAgentDefinition?: (path: string) => Promise<unknown>;
-    };
-    try {
-      compileModule = await import('contexgin');
-    } catch (importErr: unknown) {
-      const msg = importErr instanceof Error ? importErr.message : String(importErr);
-      log.info('contexgin not available, using fallback', { error: msg });
-      send(transport, {
-        type: 'boot_context',
-        source: 'local-fallback',
-        sourceCount: 0,
-        tokenCount: 0,
-        tokenBudget: DEFAULT_TOKEN_BUDGET,
-        sources: [],
-        included: [],
-        trimmed: [],
-      });
-      return;
-    }
-
-    // Step 1b: read token budget from agent recipe if available
-    let tokenBudget = DEFAULT_TOKEN_BUDGET;
-    try {
-      if (compileModule.loadAgentDefinition) {
-        const recipePath = join(cwd, '.agents', `${agentName}.yaml`);
-        const def = (await compileModule.loadAgentDefinition(recipePath)) as Record<
-          string,
-          unknown
-        >;
-        const ctx = def.context as Record<string, unknown> | undefined;
-        const boot = ctx?.boot as Record<string, unknown> | undefined;
-        if (typeof boot?.tokenBudget === 'number') {
-          tokenBudget = boot.tokenBudget as number;
-        }
-      }
-    } catch {
-      // Recipe not found or invalid — use default
-    }
-
-    // Step 2: compile — runtime errors propagate (not swallowed as import failure)
-    try {
-      const compiled = await compileModule.compile({
-        workspaceRoot: cwd,
-        tokenBudget,
-      });
-
-      // Validate the compiled object shape
-      if (!compiled || typeof compiled !== 'object') {
-        log.warn('contexgin compile() returned unexpected shape', { compiled });
-        send(transport, {
-          type: 'boot_context',
-          source: 'local-fallback',
-          sourceCount: 0,
-          tokenCount: 0,
-          tokenBudget: tokenBudget,
-          sources: [],
-          included: [],
-          trimmed: [],
-        });
-        return;
-      }
-
-      const obj = compiled as Record<string, unknown>;
-      const rawSources = Array.isArray(obj.sources) ? obj.sources : [];
-      const rawIncluded = Array.isArray(obj.included) ? obj.included : [];
-      const rawTrimmed = Array.isArray(obj.trimmed) ? obj.trimmed : [];
-      const bootTokens = typeof obj.bootTokens === 'number' ? obj.bootTokens : 0;
-
-      // Extract rich source metadata (path + kind)
-      const sources: Array<{ path: string; kind: string }> = [];
-      for (const s of rawSources) {
-        if (s && typeof s === 'object') {
-          const so = s as Record<string, unknown>;
-          if (typeof so.relativePath === 'string') {
-            sources.push({
-              path: so.relativePath as string,
-              kind: typeof so.kind === 'string' ? (so.kind as string) : 'reference',
-            });
-          }
-        }
-      }
-
-      // Helper to extract section metadata from ExtractedSection objects
-      const extractSections = (
-        raw: unknown[],
-      ): Array<{ source: string; heading: string; tokens: number; content: string }> => {
-        const result: Array<{ source: string; heading: string; tokens: number; content: string }> =
-          [];
-        for (const t of raw) {
-          if (t && typeof t === 'object') {
-            const to = t as Record<string, unknown>;
-            const src = to.source as Record<string, unknown> | undefined;
-            const headingPath = Array.isArray(to.headingPath) ? to.headingPath : [];
-            result.push({
-              source:
-                src && typeof src.relativePath === 'string' ? (src.relativePath as string) : '',
-              heading: headingPath.filter((h: unknown) => typeof h === 'string').join(' > '),
-              tokens: typeof to.tokenEstimate === 'number' ? (to.tokenEstimate as number) : 0,
-              content: typeof to.content === 'string' ? (to.content as string) : '',
-            });
-          }
-        }
-        return result;
-      };
-
-      const included = extractSections(rawIncluded);
-      const trimmed = extractSections(rawTrimmed);
-      const fullMarkdown = typeof obj.bootPayload === 'string' ? obj.bootPayload : undefined;
-
-      send(transport, {
-        type: 'boot_context',
-        source: 'contexgin',
-        sourceCount: sources.length,
-        tokenCount: bootTokens,
-        tokenBudget: tokenBudget,
-        sources,
-        included,
-        trimmed,
-        fullMarkdown,
-      });
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn('boot context compilation failed', { error: msg });
-      send(transport, {
-        type: 'boot_context',
-        source: 'local-fallback',
-        sourceCount: 0,
-        tokenCount: 0,
-        tokenBudget: tokenBudget,
-        sources: [],
-        included: [],
-        trimmed: [],
-      });
-    }
-  })();
+  // Fire-and-forget: fetch boot context from running ContexGin server
+  fetchBootContext(agentName).then((msg) => send(transport, msg)).catch(() => {});
   capturePromptComparison(wtId, cwd, systemPromptAppend, repoWorktrees).catch(() => {});
 
   // Resolve SDK session UUID for resume — worktree IDs are not valid SDK session IDs

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -138,7 +138,8 @@ async function localBootContextFallback(repoRoot: string): Promise<BootContextMe
     return {
       type: 'boot_context',
       source: 'local-fallback',
-      sourceCount: 5, // hardcoded source count from build_boot_context.py SOURCE_PATHS
+      // Coupled to SOURCE_PATHS in scripts/build_boot_context.py — update if that list changes
+      sourceCount: 5,
       tokenCount: tokens,
       tokenBudget: tokens,
       sources: [
@@ -170,7 +171,7 @@ export async function fetchBootContext(
   repoRoot: string = BASE_REPO,
 ): Promise<BootContextMessage> {
   try {
-    const url = `${contexginUrl}/api/agents/${agentName}/context`;
+    const url = `${contexginUrl}/api/agents/${encodeURIComponent(agentName)}/context`;
     const res = await fetch(url, {
       signal: AbortSignal.timeout(5000),
     });
@@ -201,7 +202,7 @@ export async function fetchBootContext(
       .filter((s): s is string => typeof s === 'string')
       .map((s) => ({ path: s, kind: 'reference' }));
 
-    const fullMarkdown = typeof boot.content === 'string' ? (boot.content as string) : undefined;
+    const fullMarkdown = typeof boot.content === 'string' ? boot.content : undefined;
 
     return {
       type: 'boot_context',


### PR DESCRIPTION
## Summary

- Replace inline `import('contexgin')` library call with HTTP fetch to running ContexGin server (`GET /api/agents/:name/context`)
- The old approach used a hardcoded 8k token budget fallback and read the agent recipe from the worktree path (often stale/missing). The server already compiles correctly with the recipe's 12k budget.
- Extract `fetchBootContext()` as a testable function, reducing ~140 lines of library import + recipe parsing + response mapping to a single HTTP call

## Root cause

`chat.ts` imported `contexgin` as a Node library and called the legacy `compile()` function with `DEFAULT_TOKEN_BUDGET = 8000`. It attempted to read `tokenBudget` from `.agents/mitzo-conversational.yaml` in `cwd` (the worktree), which often didn't have the file or had a stale version. Meanwhile, the running ContexGin server at `CONTEXGIN_URL` was already compiling correctly with 12k. Mitzo was bypassing its own infrastructure.

## Test plan

- [x] 7 new tests: success path, unreachable server, non-200 response, missing boot field, empty sources, non-string source filtering, env var URL
- [x] Existing `contexgin-smoke`, `context-baseline`, and `prompt-compare` tests still pass (21/21)
- [x] Full test suite: no new failures (2 pre-existing on main)
- [ ] Manual: start a Mitzo session, verify boot context shows >8k budget in source explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)