### PR TITLE
feat(server): agent-definition loader (Phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "helmet": "^8.1.0",
         "http-proxy-middleware": "^3.0.5",
         "jose": "^5.9.0",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.2.0",
         "nanoid": "^5.0.9",
         "pino": "^10.3.1",
         "pino-loki": "^3.0.0",
@@ -7654,9 +7654,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12895,10 +12905,14 @@
       },
       "peerDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.87",
-        "@anthropic-ai/sdk": "^0.85.0"
+        "@anthropic-ai/sdk": "^0.85.0",
+        "@anthropic-ai/vertex-sdk": "^0.15.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@anthropic-ai/vertex-sdk": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "helmet": "^8.1.0",
     "http-proxy-middleware": "^3.0.5",
     "jose": "^5.9.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "nanoid": "^5.0.9",
     "pino": "^10.3.1",
     "pino-loki": "^3.0.0",

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -9,12 +9,21 @@ import {
 } from './constants.js';
 import { createLogger } from './logger.js';
 
-export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
-
 const log = createLogger('session-registry');
 
-export type { MitzoMode, SnapshotBlock, MessageSnapshot, RawToolInput } from '@mitzo/protocol';
-import type { MitzoMode, MessageSnapshot } from '@mitzo/protocol';
+export type {
+  MitzoMode,
+  SnapshotBlock,
+  MessageSnapshot,
+  RawToolInput,
+  AgentDefinitionSource,
+} from '@mitzo/protocol';
+import type {
+  MitzoMode,
+  MessageSnapshot,
+  AgentDefinitionSource,
+  AgentDefinition,
+} from '@mitzo/protocol';
 
 export interface ManagedSession {
   transport: SessionTransport;
@@ -53,7 +62,7 @@ export interface ManagedSession {
   /** Cached boot_context payload for replay on reconnect/switch. */
   bootContext?: Record<string, unknown>;
   /** Parsed agent definition (recipe). Populated asynchronously after session start. */
-  agentDefinition?: Record<string, unknown> | null;
+  agentDefinition?: AgentDefinition | null;
   /** Source of the agent definition: 'contexgin' | 'local' | 'fallback'. */
   agentDefinitionSource?: AgentDefinitionSource;
 }

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -52,8 +52,8 @@ export interface ManagedSession {
   agentName?: string;
   /** Cached boot_context payload for replay on reconnect/switch. */
   bootContext?: Record<string, unknown>;
-  /** Parsed agent definition (recipe). Null if loading failed. */
-  agentDefinition: Record<string, unknown> | null;
+  /** Parsed agent definition (recipe). Populated asynchronously after session start. */
+  agentDefinition?: Record<string, unknown> | null;
   /** Source of the agent definition: 'contexgin' | 'local' | 'fallback'. */
   agentDefinitionSource?: AgentDefinitionSource;
 }

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -9,6 +9,8 @@ import {
 } from './constants.js';
 import { createLogger } from './logger.js';
 
+export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
+
 const log = createLogger('session-registry');
 
 export type { MitzoMode, SnapshotBlock, MessageSnapshot, RawToolInput } from '@mitzo/protocol';
@@ -53,7 +55,7 @@ export interface ManagedSession {
   /** Parsed agent definition (recipe). Null if loading failed. */
   agentDefinition: Record<string, unknown> | null;
   /** Source of the agent definition: 'contexgin' | 'local' | 'fallback'. */
-  agentDefinitionSource?: string;
+  agentDefinitionSource?: AgentDefinitionSource;
 }
 
 export interface ActiveSessionInfo {

--- a/packages/harness/src/session-registry.ts
+++ b/packages/harness/src/session-registry.ts
@@ -50,6 +50,10 @@ export interface ManagedSession {
   agentName?: string;
   /** Cached boot_context payload for replay on reconnect/switch. */
   bootContext?: Record<string, unknown>;
+  /** Parsed agent definition (recipe). Null if loading failed. */
+  agentDefinition: Record<string, unknown> | null;
+  /** Source of the agent definition: 'contexgin' | 'local' | 'fallback'. */
+  agentDefinitionSource?: string;
 }
 
 export interface ActiveSessionInfo {
@@ -114,6 +118,8 @@ export class SessionRegistry {
       | 'cumulativeCostUsd'
       | 'taskContext'
       | 'activeTaskIds'
+      | 'agentDefinition'
+      | 'agentDefinitionSource'
     > & {
       sessionId?: string;
     },
@@ -128,6 +134,8 @@ export class SessionRegistry {
       cumulativeCostUsd: 0,
       taskContext: null,
       activeTaskIds: new Map(),
+      agentDefinition: null,
+      agentDefinitionSource: undefined,
     });
     this.attached.add(clientId);
   }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -35,6 +35,18 @@ export type {
   FinishedSubagentState,
   SubagentState,
   SubagentUsage,
+  AgentDefinitionSource,
+  AgentDefinition,
+  AgentIdentity,
+  AgentProvider,
+  AgentProviderTiering,
+  AgentContextConfig,
+  AgentGovernance,
+  GovernanceBoundary,
+  GovernanceApproval,
+  AgentMemoryConfig,
+  AgentOutput,
+  AgentOutputConventions,
 } from './types.js';
 
 // Constants

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -7,6 +7,74 @@
 export type MitzoMode = 'ask' | 'agent' | 'auto';
 export type BlockType = 'text' | 'thinking' | 'redacted_thinking' | 'tool_use';
 export type ToolTier = 'safe' | 'standard' | 'elevated' | 'unknown';
+export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
+
+// --- Agent definition (shared between agent-loader and session-registry) ---
+
+export interface AgentIdentity {
+  name: string;
+  description: string;
+  mode?: 'narrow' | 'dynamic';
+  role?: string;
+}
+
+export interface AgentProviderTiering {
+  fast?: string | null;
+  standard?: string | null;
+  capable?: string | null;
+}
+
+export interface AgentProvider {
+  default: string;
+  tiering?: AgentProviderTiering;
+}
+
+export interface AgentContextConfig {
+  budget?: number;
+  sources?: { hubs?: Array<{ path: string; spokes?: string[] }> };
+  priority?: string[];
+  exclude?: string[];
+  profile?: string;
+}
+
+export interface GovernanceBoundary {
+  spoke: string;
+  access: 'none' | 'read' | 'write';
+}
+
+export interface GovernanceApproval {
+  required_for?: string[];
+  auto_allow?: string[];
+}
+
+export interface AgentGovernance {
+  boundaries?: GovernanceBoundary[];
+  approval?: GovernanceApproval;
+}
+
+export interface AgentMemoryConfig {
+  scope: 'none' | 'read' | 'read-write';
+  vault?: string;
+}
+
+export interface AgentOutputConventions {
+  commit_style?: string;
+  response_format?: string | null;
+}
+
+export interface AgentOutput {
+  conventions?: AgentOutputConventions;
+  guides?: string[];
+}
+
+export interface AgentDefinition {
+  identity: AgentIdentity;
+  provider: AgentProvider;
+  context?: AgentContextConfig;
+  governance?: AgentGovernance;
+  memory?: AgentMemoryConfig;
+  output?: AgentOutput;
+}
 
 // --- Tool input ---
 

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -239,6 +239,18 @@ describe('loadAgentDef', () => {
       expect(result.source).toBe('fallback');
     });
 
+    it('rejects local YAML with wrong kind value', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFile.mockResolvedValueOnce('yaml');
+      mockYamlParse.mockReturnValueOnce({
+        ...VALID_LOCAL_YAML,
+        kind: 'SomethingElse',
+      });
+
+      const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
+      expect(result.source).toBe('fallback');
+    });
+
     it('handles local YAML missing identity fields', async () => {
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
       mockReadFile.mockResolvedValueOnce('yaml');
@@ -273,6 +285,8 @@ describe('loadAgentDef', () => {
       expect(mockFetch).not.toHaveBeenCalled();
       expect(mockReadFile).not.toHaveBeenCalled();
       expect(result.source).toBe('fallback');
+      // Invalid names return DEFAULT_AGENT_DEFINITION identity (not overridden with agentName)
+      expect(result.definition.identity.name).toBe('mitzo-conversational');
     });
   });
 
@@ -334,6 +348,29 @@ describe('loadAgentDef', () => {
       vi.advanceTimersByTime(5 * 60 * 1000 + 1);
 
       await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('uses shorter 30s TTL for fallback results so recovery is faster', async () => {
+      vi.useFakeTimers();
+
+      // All sources fail → fallback
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+      mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+      await loadAgentDef('my-agent', '/fake', 'http://localhost:8321');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Before 30s — still cached
+      vi.advanceTimersByTime(29_000);
+      await loadAgentDef('my-agent', '/fake', 'http://localhost:8321');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // After 30s — re-fetches
+      vi.advanceTimersByTime(2_000);
+      await loadAgentDef('my-agent', '/fake', 'http://localhost:8321');
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
       vi.useRealTimers();

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -14,20 +14,20 @@ vi.mock('../logger.js', () => ({
   }),
 }));
 
-// Mock fs.readFileSync for local file loading
-const mockReadFileSync = vi.fn();
-vi.mock('fs', async (importOriginal) => {
+// Mock fs/promises.readFile for local file loading
+const mockReadFile = vi.fn();
+vi.mock('fs/promises', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+    readFile: (...args: unknown[]) => mockReadFile(...args),
   };
 });
 
-// Mock yaml parser
+// Mock js-yaml parser
 const mockYamlParse = vi.fn();
-vi.mock('yaml', () => ({
-  parse: (s: string) => mockYamlParse(s),
+vi.mock('js-yaml', () => ({
+  load: (s: string) => mockYamlParse(s),
 }));
 
 const { loadAgentDef, clearCache } = await import('../agent-loader.js');
@@ -86,7 +86,11 @@ describe('loadAgentDef', () => {
         json: async () => VALID_CONTEXGIN_RESPONSE,
       });
 
-      const result = await loadAgentDef('mitzo-conversational', '/fake/cwd', 'http://localhost:8321');
+      const result = await loadAgentDef(
+        'mitzo-conversational',
+        '/fake/cwd',
+        'http://localhost:8321',
+      );
 
       expect(mockFetch).toHaveBeenCalledOnce();
       expect(mockFetch).toHaveBeenCalledWith(
@@ -109,7 +113,11 @@ describe('loadAgentDef', () => {
         json: async () => VALID_CONTEXGIN_RESPONSE,
       });
 
-      const result = await loadAgentDef('mitzo-conversational', '/fake/cwd', 'http://localhost:8321');
+      const result = await loadAgentDef(
+        'mitzo-conversational',
+        '/fake/cwd',
+        'http://localhost:8321',
+      );
 
       expect(result.definition.context?.budget).toBe(12000);
     });
@@ -118,7 +126,7 @@ describe('loadAgentDef', () => {
   describe('local override source', () => {
     it('falls back to local .agents/ when ContexGin is unreachable', async () => {
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      mockReadFileSync.mockReturnValueOnce('yaml content');
+      mockReadFile.mockResolvedValueOnce('yaml content');
       mockYamlParse.mockReturnValueOnce(VALID_LOCAL_YAML);
 
       const result = await loadAgentDef('test-agent', '/workspace', 'http://localhost:8321');
@@ -127,31 +135,24 @@ describe('loadAgentDef', () => {
       expect(result.definition.identity.name).toBe('test-agent');
       expect(result.definition.identity.mode).toBe('narrow');
       expect(result.definition.context?.budget).toBe(8000);
-      expect(result.definition.governance?.boundaries).toEqual([
-        { spoke: 'data', access: 'none' },
-      ]);
+      expect(result.definition.governance?.boundaries).toEqual([{ spoke: 'data', access: 'none' }]);
     });
 
     it('reads from correct local path', async () => {
       mockFetch.mockRejectedValueOnce(new Error('timeout'));
-      mockReadFileSync.mockReturnValueOnce('yaml');
+      mockReadFile.mockResolvedValueOnce('yaml');
       mockYamlParse.mockReturnValueOnce(VALID_LOCAL_YAML);
 
       await loadAgentDef('my-agent', '/my/workspace', 'http://localhost:8321');
 
-      expect(mockReadFileSync).toHaveBeenCalledWith(
-        '/my/workspace/.agents/my-agent.yaml',
-        'utf-8',
-      );
+      expect(mockReadFile).toHaveBeenCalledWith('/my/workspace/.agents/my-agent.yaml', 'utf-8');
     });
   });
 
   describe('bundled fallback', () => {
     it('returns DEFAULT_AGENT_DEFINITION when all sources fail', async () => {
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      mockReadFileSync.mockImplementationOnce(() => {
-        throw new Error('ENOENT');
-      });
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
 
       const result = await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
 
@@ -212,9 +213,7 @@ describe('loadAgentDef', () => {
   describe('error handling', () => {
     it('handles ContexGin 404 gracefully', async () => {
       mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
-      mockReadFileSync.mockImplementationOnce(() => {
-        throw new Error('ENOENT');
-      });
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
 
       const result = await loadAgentDef('unknown', '/fake', 'http://localhost:8321');
       expect(result.source).toBe('fallback');
@@ -225,9 +224,7 @@ describe('loadAgentDef', () => {
         ok: true,
         json: async () => ({ boot: { tokens: 100 } }), // no identity
       });
-      mockReadFileSync.mockImplementationOnce(() => {
-        throw new Error('ENOENT');
-      });
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
 
       const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
       expect(result.source).toBe('fallback');
@@ -235,7 +232,7 @@ describe('loadAgentDef', () => {
 
     it('handles malformed local YAML', async () => {
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      mockReadFileSync.mockReturnValueOnce('not: valid: yaml: {{');
+      mockReadFile.mockResolvedValueOnce('not: valid: yaml: {{');
       mockYamlParse.mockReturnValueOnce(null);
 
       const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
@@ -244,7 +241,7 @@ describe('loadAgentDef', () => {
 
     it('handles local YAML missing identity fields', async () => {
       mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-      mockReadFileSync.mockReturnValueOnce('yaml');
+      mockReadFile.mockResolvedValueOnce('yaml');
       mockYamlParse.mockReturnValueOnce({ identity: { name: 'test' } }); // missing description
 
       const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
@@ -253,7 +250,7 @@ describe('loadAgentDef', () => {
 
     it('never throws — all errors result in fallback', async () => {
       mockFetch.mockRejectedValueOnce(new Error('network error'));
-      mockReadFileSync.mockImplementationOnce(() => {
+      mockReadFile.mockImplementationOnce(() => {
         throw new Error('fs error');
       });
 

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -285,10 +285,9 @@ describe('loadAgentDef', () => {
 
       await loadAgentDef('MyAgent', '/fake', 'http://localhost:8321');
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8321/api/agents/myagent/context',
-        { signal: expect.any(AbortSignal) },
-      );
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:8321/api/agents/myagent/context', {
+        signal: expect.any(AbortSignal),
+      });
     });
 
     it('normalizes underscores to hyphens', async () => {
@@ -299,10 +298,9 @@ describe('loadAgentDef', () => {
 
       await loadAgentDef('my_agent', '/fake', 'http://localhost:8321');
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:8321/api/agents/my-agent/context',
-        { signal: expect.any(AbortSignal) },
-      );
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:8321/api/agents/my-agent/context', {
+        signal: expect.any(AbortSignal),
+      });
     });
 
     it('normalizes mixed case + underscores', async () => {

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// Mock logger to suppress output
+vi.mock('../logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// Mock fs.readFileSync for local file loading
+const mockReadFileSync = vi.fn();
+vi.mock('fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  };
+});
+
+// Mock yaml parser
+const mockYamlParse = vi.fn();
+vi.mock('yaml', () => ({
+  parse: (s: string) => mockYamlParse(s),
+}));
+
+const { loadAgentDef, clearCache } = await import('../agent-loader.js');
+
+const VALID_CONTEXGIN_RESPONSE = {
+  agent: 'mitzo-conversational',
+  identity: {
+    name: 'mitzo-conversational',
+    description: 'Primary conversational assistant via Mitzo iOS',
+    mode: 'dynamic',
+  },
+  provider: {
+    default: 'claude-opus-4',
+  },
+  boot: {
+    content: '# Boot payload',
+    tokens: 12000,
+    sources: ['CONSTITUTION.md'],
+  },
+  governance: {
+    boundaries: [{ spoke: 'career', access: 'read' }],
+    approval: { required_for: ['Bash'], auto_allow: ['Read', 'Write'] },
+  },
+  memory: { scope: 'read-write', vault: 'memory/' },
+};
+
+const VALID_LOCAL_YAML = {
+  kind: 'AgentDefinition',
+  version: '0.1',
+  identity: {
+    name: 'test-agent',
+    description: 'A test agent',
+    mode: 'narrow',
+  },
+  provider: { default: 'claude-sonnet-4' },
+  context: { budget: 8000 },
+  governance: {
+    boundaries: [{ spoke: 'data', access: 'none' }],
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadAgentDef', () => {
+  describe('ContexGin source', () => {
+    it('loads agent definition from ContexGin API', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      const result = await loadAgentDef('mitzo-conversational', '/fake/cwd', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8321/api/agents/mitzo-conversational/context',
+        { signal: expect.any(AbortSignal) },
+      );
+
+      expect(result.source).toBe('contexgin');
+      expect(result.definition.identity.name).toBe('mitzo-conversational');
+      expect(result.definition.identity.description).toBe(
+        'Primary conversational assistant via Mitzo iOS',
+      );
+      expect(result.definition.governance).toEqual(VALID_CONTEXGIN_RESPONSE.governance);
+      expect(result.definition.memory).toEqual(VALID_CONTEXGIN_RESPONSE.memory);
+    });
+
+    it('extracts token budget from boot.tokens', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      const result = await loadAgentDef('mitzo-conversational', '/fake/cwd', 'http://localhost:8321');
+
+      expect(result.definition.context?.budget).toBe(12000);
+    });
+  });
+
+  describe('local override source', () => {
+    it('falls back to local .agents/ when ContexGin is unreachable', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFileSync.mockReturnValueOnce('yaml content');
+      mockYamlParse.mockReturnValueOnce(VALID_LOCAL_YAML);
+
+      const result = await loadAgentDef('test-agent', '/workspace', 'http://localhost:8321');
+
+      expect(result.source).toBe('local');
+      expect(result.definition.identity.name).toBe('test-agent');
+      expect(result.definition.identity.mode).toBe('narrow');
+      expect(result.definition.context?.budget).toBe(8000);
+      expect(result.definition.governance?.boundaries).toEqual([
+        { spoke: 'data', access: 'none' },
+      ]);
+    });
+
+    it('reads from correct local path', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('timeout'));
+      mockReadFileSync.mockReturnValueOnce('yaml');
+      mockYamlParse.mockReturnValueOnce(VALID_LOCAL_YAML);
+
+      await loadAgentDef('my-agent', '/my/workspace', 'http://localhost:8321');
+
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        '/my/workspace/.agents/my-agent.yaml',
+        'utf-8',
+      );
+    });
+  });
+
+  describe('bundled fallback', () => {
+    it('returns DEFAULT_AGENT_DEFINITION when all sources fail', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFileSync.mockImplementationOnce(() => {
+        throw new Error('ENOENT');
+      });
+
+      const result = await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+
+      expect(result.source).toBe('fallback');
+      expect(result.definition.identity.name).toBe('mitzo-conversational');
+      expect(result.definition.identity.description).toContain('conversational assistant');
+    });
+  });
+
+  describe('caching', () => {
+    it('caches results and returns cached on second call', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      const first = await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+      const second = await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledOnce(); // only one fetch
+      expect(second).toBe(first); // same reference
+    });
+
+    it('uses separate cache keys per agent+cwd', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => VALID_CONTEXGIN_RESPONSE,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ...VALID_CONTEXGIN_RESPONSE,
+            identity: { ...VALID_CONTEXGIN_RESPONSE.identity, name: 'other-agent' },
+          }),
+        });
+
+      await loadAgentDef('agent-a', '/cwd1', 'http://localhost:8321');
+      await loadAgentDef('agent-b', '/cwd2', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('refetches after cache clear', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+      clearCache();
+      await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles ContexGin 404 gracefully', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+      mockReadFileSync.mockImplementationOnce(() => {
+        throw new Error('ENOENT');
+      });
+
+      const result = await loadAgentDef('unknown', '/fake', 'http://localhost:8321');
+      expect(result.source).toBe('fallback');
+    });
+
+    it('handles ContexGin response missing identity', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ boot: { tokens: 100 } }), // no identity
+      });
+      mockReadFileSync.mockImplementationOnce(() => {
+        throw new Error('ENOENT');
+      });
+
+      const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
+      expect(result.source).toBe('fallback');
+    });
+
+    it('handles malformed local YAML', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFileSync.mockReturnValueOnce('not: valid: yaml: {{');
+      mockYamlParse.mockReturnValueOnce(null);
+
+      const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
+      expect(result.source).toBe('fallback');
+    });
+
+    it('handles local YAML missing identity fields', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFileSync.mockReturnValueOnce('yaml');
+      mockYamlParse.mockReturnValueOnce({ identity: { name: 'test' } }); // missing description
+
+      const result = await loadAgentDef('bad', '/fake', 'http://localhost:8321');
+      expect(result.source).toBe('fallback');
+    });
+
+    it('never throws — all errors result in fallback', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network error'));
+      mockReadFileSync.mockImplementationOnce(() => {
+        throw new Error('fs error');
+      });
+
+      // Should not throw
+      const result = await loadAgentDef('anything', '/fake', 'http://localhost:8321');
+      expect(result).toBeDefined();
+      expect(result.source).toBe('fallback');
+    });
+  });
+});

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -259,5 +259,44 @@ describe('loadAgentDef', () => {
       expect(result).toBeDefined();
       expect(result.source).toBe('fallback');
     });
+
+    it.each([
+      ['../evil', 'path traversal'],
+      ['UPPER', 'uppercase'],
+      ['has.dot', 'dot in name'],
+      ['-starts-with-dash', 'leading dash'],
+      ['has spaces', 'spaces'],
+      ['has/slash', 'slash'],
+    ])('rejects invalid agent name %s (%s)', async (name, _reason) => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const result = await loadAgentDef(name, '/fake', 'http://localhost:8321');
+
+      // Should skip local and fall through to fallback — readFile never called
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(result.source).toBe('fallback');
+    });
+  });
+
+  describe('cache TTL expiration', () => {
+    it('re-fetches after cache entry expires', async () => {
+      vi.useFakeTimers();
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Advance past 5-minute TTL
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+      await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -268,11 +268,10 @@ describe('loadAgentDef', () => {
       ['has spaces', 'spaces'],
       ['has/slash', 'slash'],
     ])('rejects invalid agent name %s (%s)', async (name, _reason) => {
-      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-
       const result = await loadAgentDef(name, '/fake', 'http://localhost:8321');
 
-      // Should skip local and fall through to fallback — readFile never called
+      // Validation at entry point — no source attempted
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockReadFile).not.toHaveBeenCalled();
       expect(result.source).toBe('fallback');
     });
@@ -297,6 +296,74 @@ describe('loadAgentDef', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('chat.ts wiring contract', () => {
+    // chat.ts fire-and-forget does: s.agentDefinition = loaded.definition;
+    // s.agentDefinitionSource = loaded.source; — these tests verify the contract.
+
+    it('ContexGin result has identity.description for session log line', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      const result = await loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321');
+
+      // chat.ts logs: loaded.definition.identity.description
+      expect(typeof result.definition.identity.description).toBe('string');
+      expect(result.definition.identity.description.length).toBeGreaterThan(0);
+    });
+
+    it('fallback result has identity.description for session log line', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await loadAgentDef('my-agent', '/fake', 'http://localhost:8321');
+
+      expect(typeof result.definition.identity.description).toBe('string');
+      expect(result.definition.identity.description.length).toBeGreaterThan(0);
+    });
+
+    it('source is always a valid AgentDefinitionSource', async () => {
+      // ContexGin path
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+      const cg = await loadAgentDef('agent-a', '/fake', 'http://localhost:8321');
+      expect(['contexgin', 'local', 'fallback']).toContain(cg.source);
+
+      clearCache();
+
+      // Fallback path
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+      const fb = await loadAgentDef('agent-b', '/fake', 'http://localhost:8321');
+      expect(['contexgin', 'local', 'fallback']).toContain(fb.source);
+    });
+
+    it('definition.provider always has a default model', async () => {
+      // ContexGin with explicit provider
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+      const cg = await loadAgentDef('agent-a', '/fake', 'http://localhost:8321');
+      expect(typeof cg.definition.provider.default).toBe('string');
+
+      clearCache();
+
+      // ContexGin without provider (should default)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          identity: { name: 'minimal', description: 'Minimal agent' },
+        }),
+      });
+      const minimal = await loadAgentDef('agent-b', '/fake', 'http://localhost:8321');
+      expect(typeof minimal.definition.provider.default).toBe('string');
     });
   });
 });

--- a/server/__tests__/agent-loader.test.ts
+++ b/server/__tests__/agent-loader.test.ts
@@ -262,7 +262,6 @@ describe('loadAgentDef', () => {
 
     it.each([
       ['../evil', 'path traversal'],
-      ['UPPER', 'uppercase'],
       ['has.dot', 'dot in name'],
       ['-starts-with-dash', 'leading dash'],
       ['has spaces', 'spaces'],
@@ -274,6 +273,50 @@ describe('loadAgentDef', () => {
       expect(mockFetch).not.toHaveBeenCalled();
       expect(mockReadFile).not.toHaveBeenCalled();
       expect(result.source).toBe('fallback');
+    });
+  });
+
+  describe('name normalization', () => {
+    it('normalizes uppercase names from WS protocol', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      await loadAgentDef('MyAgent', '/fake', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8321/api/agents/myagent/context',
+        { signal: expect.any(AbortSignal) },
+      );
+    });
+
+    it('normalizes underscores to hyphens', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      await loadAgentDef('my_agent', '/fake', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8321/api/agents/my-agent/context',
+        { signal: expect.any(AbortSignal) },
+      );
+    });
+
+    it('normalizes mixed case + underscores', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      await loadAgentDef('My_Agent_Name', '/fake', 'http://localhost:8321');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8321/api/agents/my-agent-name/context',
+        { signal: expect.any(AbortSignal) },
+      );
     });
   });
 
@@ -364,6 +407,25 @@ describe('loadAgentDef', () => {
       });
       const minimal = await loadAgentDef('agent-b', '/fake', 'http://localhost:8321');
       expect(typeof minimal.definition.provider.default).toBe('string');
+    });
+  });
+
+  describe('concurrent requests', () => {
+    it('both concurrent calls succeed even without deduplication', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => VALID_CONTEXGIN_RESPONSE,
+      });
+
+      const [a, b] = await Promise.all([
+        loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321'),
+        loadAgentDef('mitzo-conversational', '/fake', 'http://localhost:8321'),
+      ]);
+
+      // Both get valid results — two fetches fire (no dedup yet)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(a.source).toBe('contexgin');
+      expect(b.source).toBe('contexgin');
     });
   });
 });

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -634,8 +634,11 @@ describe('agent definition wiring', () => {
     // Verify the fire-and-forget contract: loadAgentDef returns a shape
     // that chat.ts can assign directly to session.agentDefinition and
     // session.agentDefinitionSource without casts.
-    const { loadAgentDef } = await import('../agent-loader.js');
-    const loaded = await loadAgentDef('test-agent', '/fake');
+    const { DEFAULT_AGENT_DEFINITION } = await import('../constants.js');
+    const loaded = {
+      definition: structuredClone(DEFAULT_AGENT_DEFINITION),
+      source: 'fallback' as const,
+    };
 
     // Simulate what chat.ts does in the fire-and-forget block
     const session: Partial<ManagedSession> = {};

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -628,3 +628,24 @@ describe('resolveSshAuthSock', () => {
     expect(resolveSshAuthSock()).toBeNull();
   });
 });
+
+describe('agent definition wiring', () => {
+  it('loadAgentDef result is assignable to ManagedSession fields', async () => {
+    // Verify the fire-and-forget contract: loadAgentDef returns a shape
+    // that chat.ts can assign directly to session.agentDefinition and
+    // session.agentDefinitionSource without casts.
+    const { loadAgentDef } = await import('../agent-loader.js');
+    const loaded = await loadAgentDef('test-agent', '/fake');
+
+    // Simulate what chat.ts does in the fire-and-forget block
+    const session: Partial<ManagedSession> = {};
+    session.agentDefinition = loaded.definition;
+    session.agentDefinitionSource = loaded.source;
+
+    expect(session.agentDefinition).toBeDefined();
+    expect(session.agentDefinition!.identity).toBeDefined();
+    expect(session.agentDefinition!.identity.description).toBeTruthy();
+    expect(session.agentDefinition!.provider.default).toBeTruthy();
+    expect(['contexgin', 'local', 'fallback']).toContain(session.agentDefinitionSource);
+  });
+});

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -116,7 +116,6 @@ const ContexGinResponseSchema = z.object({
       content: z.string().optional(),
       sources: z.array(z.string()).optional(),
     })
-    .passthrough()
     .optional(),
 });
 
@@ -281,13 +280,9 @@ export async function loadAgentDef(
 
   // 3. Bundled fallback — shorter TTL so we recover faster when ContexGin comes back
   log.info('using bundled agent definition fallback', { agent: name });
-  const fallback: LoadedAgentDefinition = {
-    definition: {
-      ...DEFAULT_AGENT_DEFINITION,
-      identity: { ...DEFAULT_AGENT_DEFINITION.identity, name },
-    },
-    source: 'fallback',
-  };
+  const definition = structuredClone(DEFAULT_AGENT_DEFINITION) as AgentDefinition;
+  definition.identity.name = name;
+  const fallback: LoadedAgentDefinition = { definition, source: 'fallback' };
   cache.set(cacheKey, { result: fallback, expiresAt: Date.now() + FALLBACK_CACHE_TTL_MS });
   return fallback;
 }

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -86,7 +86,8 @@ export interface AgentDefinition {
   output?: AgentOutput;
 }
 
-export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
+// Re-export from harness to avoid duplicate definition
+export type { AgentDefinitionSource } from '@mitzo/harness';
 
 export interface LoadedAgentDefinition {
   definition: AgentDefinition;
@@ -164,7 +165,9 @@ async function loadFromLocal(
   cwd: string,
 ): Promise<LoadedAgentDefinition | null> {
   try {
-    // Path traversal guard: ensure resolved path stays under .agents/
+    // Validate agent name to prevent path traversal
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(agentName)) return null;
+
     const agentsDir = resolve(cwd, '.agents');
     const filePath = resolve(agentsDir, `${agentName}.yaml`);
     if (!filePath.startsWith(agentsDir + '/')) return null;
@@ -212,7 +215,7 @@ export async function loadAgentDef(
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
 ): Promise<LoadedAgentDefinition> {
   // Check cache
-  const cacheKey = `${agentName}:${cwd}:${contexginUrl ?? 'default'}`;
+  const cacheKey = `${agentName}:${cwd}:${contexginUrl}`;
   const cached = cache.get(cacheKey);
   if (cached && Date.now() < cached.expiresAt) {
     return cached.result;

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -121,6 +121,8 @@ const ContexGinResponseSchema = z.object({
 });
 
 const LocalYamlSchema = z.object({
+  kind: z.literal('AgentDefinition').optional(),
+  version: z.string().optional(),
   identity: IdentitySchema,
   provider: z.object({ default: z.string() }).optional(),
   context: ContextSchema,

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -33,17 +33,68 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const FALLBACK_CACHE_TTL_MS = 30 * 1000; // 30 seconds — allow faster recovery
 const cache = new Map<string, CacheEntry>();
 
-// ─── Zod schemas for ContexGin response validation ─────────────────────────
+// ─── Shared Zod sub-schemas ────────────────────────────────────────────────
 
-const ContexGinIdentitySchema = z.object({
+const IdentitySchema = z.object({
   name: z.string().min(1),
   description: z.string().min(1),
   mode: z.enum(['narrow', 'dynamic']).optional(),
   role: z.string().optional(),
 });
 
+const GovernanceSchema = z
+  .object({
+    boundaries: z
+      .array(z.object({ spoke: z.string(), access: z.enum(['none', 'read', 'write']) }))
+      .optional(),
+    approval: z
+      .object({
+        required_for: z.array(z.string()).optional(),
+        auto_allow: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+const MemorySchema = z
+  .object({
+    scope: z.enum(['none', 'read', 'read-write']),
+    vault: z.string().optional(),
+  })
+  .optional();
+
+const OutputSchema = z
+  .object({
+    conventions: z
+      .object({
+        commit_style: z.string().optional(),
+        response_format: z.string().nullable().optional(),
+      })
+      .optional(),
+    guides: z.array(z.string()).optional(),
+  })
+  .optional();
+
+const ContextSchema = z
+  .object({
+    budget: z.number().optional(),
+    sources: z
+      .object({
+        hubs: z
+          .array(z.object({ path: z.string(), spokes: z.array(z.string()).optional() }))
+          .optional(),
+      })
+      .optional(),
+    priority: z.array(z.string()).optional(),
+    exclude: z.array(z.string()).optional(),
+    profile: z.string().optional(),
+  })
+  .optional();
+
+// ─── Composite schemas ────────────────────────────────────────────────────
+
 const ContexGinResponseSchema = z.object({
-  identity: ContexGinIdentitySchema,
+  identity: IdentitySchema,
   provider: z
     .object({
       default: z.string(),
@@ -56,36 +107,9 @@ const ContexGinResponseSchema = z.object({
         .optional(),
     })
     .optional(),
-  governance: z
-    .object({
-      boundaries: z
-        .array(z.object({ spoke: z.string(), access: z.enum(['none', 'read', 'write']) }))
-        .optional(),
-      approval: z
-        .object({
-          required_for: z.array(z.string()).optional(),
-          auto_allow: z.array(z.string()).optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  memory: z
-    .object({
-      scope: z.enum(['none', 'read', 'read-write']),
-      vault: z.string().optional(),
-    })
-    .optional(),
-  output: z
-    .object({
-      conventions: z
-        .object({
-          commit_style: z.string().optional(),
-          response_format: z.string().nullable().optional(),
-        })
-        .optional(),
-      guides: z.array(z.string()).optional(),
-    })
-    .optional(),
+  governance: GovernanceSchema,
+  memory: MemorySchema,
+  output: OutputSchema,
   boot: z
     .object({
       tokens: z.number().optional(),
@@ -97,39 +121,12 @@ const ContexGinResponseSchema = z.object({
 });
 
 const LocalYamlSchema = z.object({
-  identity: ContexGinIdentitySchema,
-  provider: z.object({ default: z.string() }).passthrough().optional(),
-  context: z.object({ budget: z.number().optional() }).passthrough().optional(),
-  governance: z
-    .object({
-      boundaries: z
-        .array(z.object({ spoke: z.string(), access: z.enum(['none', 'read', 'write']) }))
-        .optional(),
-      approval: z
-        .object({
-          required_for: z.array(z.string()).optional(),
-          auto_allow: z.array(z.string()).optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  memory: z
-    .object({
-      scope: z.enum(['none', 'read', 'read-write']),
-      vault: z.string().optional(),
-    })
-    .optional(),
-  output: z
-    .object({
-      conventions: z
-        .object({
-          commit_style: z.string().optional(),
-          response_format: z.string().nullable().optional(),
-        })
-        .optional(),
-      guides: z.array(z.string()).optional(),
-    })
-    .optional(),
+  identity: IdentitySchema,
+  provider: z.object({ default: z.string() }).optional(),
+  context: ContextSchema,
+  governance: GovernanceSchema,
+  memory: MemorySchema,
+  output: OutputSchema,
 });
 
 /** Clear the agent definition cache (for testing). */
@@ -239,28 +236,30 @@ export async function loadAgentDef(
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
 ): Promise<LoadedAgentDefinition> {
   // Normalize name from WS protocol format (uppercase, underscores) to loader format.
-  const normalized = normalizeAgentName(agentName);
-  if (!AGENT_NAME_RE.test(normalized)) {
-    log.warn('invalid agent name rejected', { agent: agentName, normalized });
+  const name = normalizeAgentName(agentName);
+  if (!AGENT_NAME_RE.test(name)) {
+    log.warn('invalid agent name rejected', { agent: agentName, normalized: name });
     return {
-      definition: DEFAULT_AGENT_DEFINITION,
+      definition: {
+        ...DEFAULT_AGENT_DEFINITION,
+        identity: { ...DEFAULT_AGENT_DEFINITION.identity },
+      },
       source: 'fallback',
     };
   }
-  agentName = normalized;
 
   // Check cache
-  const cacheKey = `${agentName}:${cwd}:${contexginUrl}`;
+  const cacheKey = `${name}:${cwd}:${contexginUrl}`;
   const cached = cache.get(cacheKey);
   if (cached && Date.now() < cached.expiresAt) {
     return cached.result;
   }
 
   // 1. Try ContexGin
-  const fromContexGin = await loadFromContexGin(agentName, contexginUrl);
+  const fromContexGin = await loadFromContexGin(name, contexginUrl);
   if (fromContexGin) {
     log.info('agent definition loaded from ContexGin', {
-      agent: agentName,
+      agent: name,
       identity: fromContexGin.definition.identity.description,
     });
     cache.set(cacheKey, { result: fromContexGin, expiresAt: Date.now() + CACHE_TTL_MS });
@@ -268,10 +267,10 @@ export async function loadAgentDef(
   }
 
   // 2. Try local override
-  const fromLocal = await loadFromLocal(agentName, cwd);
+  const fromLocal = await loadFromLocal(name, cwd);
   if (fromLocal) {
     log.info('agent definition loaded from local .agents/', {
-      agent: agentName,
+      agent: name,
       identity: fromLocal.definition.identity.description,
     });
     cache.set(cacheKey, { result: fromLocal, expiresAt: Date.now() + CACHE_TTL_MS });
@@ -279,11 +278,11 @@ export async function loadAgentDef(
   }
 
   // 3. Bundled fallback — shorter TTL so we recover faster when ContexGin comes back
-  log.info('using bundled agent definition fallback', { agent: agentName });
+  log.info('using bundled agent definition fallback', { agent: name });
   const fallback: LoadedAgentDefinition = {
     definition: {
       ...DEFAULT_AGENT_DEFINITION,
-      identity: { ...DEFAULT_AGENT_DEFINITION.identity, name: agentName },
+      identity: { ...DEFAULT_AGENT_DEFINITION.identity, name },
     },
     source: 'fallback',
   };

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -10,7 +10,7 @@
  */
 
 import { readFile } from 'fs/promises';
-import { resolve } from 'path';
+import path from 'path';
 import { load as parseYaml } from 'js-yaml';
 import { createLogger } from './logger.js';
 import { DEFAULT_AGENT_DEFINITION } from './constants.js';
@@ -86,6 +86,7 @@ export interface AgentDefinition {
   output?: AgentOutput;
 }
 
+/** @see packages/harness/src/session-registry.ts for the canonical copy. */
 export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
 
 export interface LoadedAgentDefinition {
@@ -164,12 +165,13 @@ async function loadFromLocal(
   cwd: string,
 ): Promise<LoadedAgentDefinition | null> {
   try {
-    // Validate agent name to prevent path traversal
+    // Validate agent name format (alphanumeric + hyphens only)
     if (!/^[a-z0-9][a-z0-9-]*$/.test(agentName)) return null;
 
-    const agentsDir = resolve(cwd, '.agents');
-    const filePath = resolve(agentsDir, `${agentName}.yaml`);
-    if (!filePath.startsWith(agentsDir + '/')) return null;
+    const agentsDir = path.resolve(cwd, '.agents');
+    const filePath = path.resolve(agentsDir, `${agentName}.yaml`);
+    const rel = path.relative(agentsDir, filePath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
 
     const raw = await readFile(filePath, 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -1,13 +1,4 @@
-/**
- * Agent definition loader — discover, load, and cache agent recipes.
- *
- * Resolution order:
- * 1. ContexGin API — GET /api/agents/:name/context (preferred)
- * 2. Local override — .agents/{name}.yaml in workspace root (dev/testing)
- * 3. Bundled fallback — DEFAULT_AGENT_DEFINITION from constants
- *
- * Never blocks session start. All failures are graceful.
- */
+// Agent definition loader — ContexGin → local .agents/ → bundled fallback.
 
 import { readFile } from 'fs/promises';
 import path from 'path';
@@ -15,33 +6,16 @@ import { load as parseYaml } from 'js-yaml';
 import { z } from 'zod';
 import { createLogger } from './logger.js';
 import { DEFAULT_AGENT_DEFINITION } from './constants.js';
-import type {
-  AgentDefinitionSource,
-  AgentDefinition,
-  AgentIdentity,
-  AgentProvider,
-  AgentContextConfig,
-  AgentGovernance,
-  AgentMemoryConfig,
-  AgentOutput,
-} from '@mitzo/protocol';
-
-// Re-export from @mitzo/protocol — single source of truth
-export type {
-  AgentDefinitionSource,
-  AgentDefinition,
-  AgentIdentity,
-  AgentProvider,
-  AgentContextConfig,
-  AgentGovernance,
-  AgentMemoryConfig,
-  AgentOutput,
-} from '@mitzo/protocol';
+import type { AgentDefinitionSource, AgentDefinition, AgentContextConfig } from '@mitzo/protocol';
 
 const log = createLogger('agent-loader');
 
-/** Validates agent names: lowercase alphanumeric + hyphens, no leading dash. */
 const AGENT_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Normalize agent names from WS protocol (uppercase, underscores) to loader format. */
+function normalizeAgentName(name: string): string {
+  return name.toLowerCase().replace(/_/g, '-');
+}
 
 export interface LoadedAgentDefinition {
   definition: AgentDefinition;
@@ -122,6 +96,42 @@ const ContexGinResponseSchema = z.object({
     .optional(),
 });
 
+const LocalYamlSchema = z.object({
+  identity: ContexGinIdentitySchema,
+  provider: z.object({ default: z.string() }).passthrough().optional(),
+  context: z.object({ budget: z.number().optional() }).passthrough().optional(),
+  governance: z
+    .object({
+      boundaries: z
+        .array(z.object({ spoke: z.string(), access: z.enum(['none', 'read', 'write']) }))
+        .optional(),
+      approval: z
+        .object({
+          required_for: z.array(z.string()).optional(),
+          auto_allow: z.array(z.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  memory: z
+    .object({
+      scope: z.enum(['none', 'read', 'read-write']),
+      vault: z.string().optional(),
+    })
+    .optional(),
+  output: z
+    .object({
+      conventions: z
+        .object({
+          commit_style: z.string().optional(),
+          response_format: z.string().nullable().optional(),
+        })
+        .optional(),
+      guides: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
 /** Clear the agent definition cache (for testing). */
 export function clearCache(): void {
   cache.clear();
@@ -189,19 +199,17 @@ async function loadFromLocal(
     if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
 
     const raw = await readFile(filePath, 'utf-8');
-    const parsed = parseYaml(raw) as Record<string, unknown>;
+    const yamlData = parseYaml(raw);
+    const parsed = LocalYamlSchema.safeParse(yamlData);
+    if (!parsed.success) {
+      log.warn('local YAML failed validation', {
+        agent: agentName,
+        errors: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+      });
+      return null;
+    }
 
-    if (!parsed || typeof parsed !== 'object') return null;
-
-    const identity = parsed.identity as AgentIdentity | undefined;
-    if (!identity?.name || !identity?.description) return null;
-
-    // Map the Centaur schema to our internal types
-    const provider = parsed.provider as AgentProvider | undefined;
-    const context = parsed.context as AgentContextConfig | undefined;
-    const governance = parsed.governance as AgentGovernance | undefined;
-    const memory = parsed.memory as AgentMemoryConfig | undefined;
-    const output = parsed.output as AgentOutput | undefined;
+    const { identity, provider, governance, memory, output, context } = parsed.data;
 
     return {
       definition: {
@@ -230,14 +238,16 @@ export async function loadAgentDef(
   cwd: string,
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
 ): Promise<LoadedAgentDefinition> {
-  // Validate agent name early — reject before any source attempt
-  if (!AGENT_NAME_RE.test(agentName)) {
-    log.warn('invalid agent name rejected', { agent: agentName });
+  // Normalize name from WS protocol format (uppercase, underscores) to loader format.
+  const normalized = normalizeAgentName(agentName);
+  if (!AGENT_NAME_RE.test(normalized)) {
+    log.warn('invalid agent name rejected', { agent: agentName, normalized });
     return {
       definition: DEFAULT_AGENT_DEFINITION,
       source: 'fallback',
     };
   }
+  agentName = normalized;
 
   // Check cache
   const cacheKey = `${agentName}:${cwd}:${contexginUrl}`;

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -134,6 +134,7 @@ async function loadFromContexGin(
     const provider = data.provider as AgentProvider | undefined;
     const governance = data.governance as AgentGovernance | undefined;
     const memory = data.memory as AgentMemoryConfig | undefined;
+    const output = data.output as AgentOutput | undefined;
 
     // Extract context config from boot response
     const boot = data.boot as Record<string, unknown> | undefined;
@@ -148,6 +149,7 @@ async function loadFromContexGin(
         context,
         governance,
         memory,
+        output,
       },
       source: 'contexgin',
     };

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -12,82 +12,36 @@
 import { readFile } from 'fs/promises';
 import path from 'path';
 import { load as parseYaml } from 'js-yaml';
+import { z } from 'zod';
 import { createLogger } from './logger.js';
 import { DEFAULT_AGENT_DEFINITION } from './constants.js';
+import type {
+  AgentDefinitionSource,
+  AgentDefinition,
+  AgentIdentity,
+  AgentProvider,
+  AgentContextConfig,
+  AgentGovernance,
+  AgentMemoryConfig,
+  AgentOutput,
+} from '@mitzo/protocol';
+
+// Re-export from @mitzo/protocol — single source of truth
+export type {
+  AgentDefinitionSource,
+  AgentDefinition,
+  AgentIdentity,
+  AgentProvider,
+  AgentContextConfig,
+  AgentGovernance,
+  AgentMemoryConfig,
+  AgentOutput,
+} from '@mitzo/protocol';
 
 const log = createLogger('agent-loader');
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
-export interface AgentIdentity {
-  name: string;
-  description: string;
-  mode?: 'narrow' | 'dynamic';
-  role?: string;
-}
-
-export interface AgentProviderTiering {
-  fast?: string | null;
-  standard?: string | null;
-  capable?: string | null;
-}
-
-export interface AgentProvider {
-  default: string;
-  tiering?: AgentProviderTiering;
-}
-
-export interface AgentContextConfig {
-  budget?: number;
-  sources?: {
-    hubs?: Array<{ path: string; spokes?: string[] }>;
-  };
-  priority?: string[];
-  exclude?: string[];
-  profile?: string;
-}
-
-export interface GovernanceBoundary {
-  spoke: string;
-  access: 'none' | 'read' | 'write';
-}
-
-export interface GovernanceApproval {
-  required_for?: string[];
-  auto_allow?: string[];
-}
-
-export interface AgentGovernance {
-  boundaries?: GovernanceBoundary[];
-  approval?: GovernanceApproval;
-}
-
-export interface AgentMemoryConfig {
-  scope: 'none' | 'read' | 'read-write';
-  vault?: string;
-}
-
-export interface AgentOutputConventions {
-  commit_style?: string;
-  response_format?: string | null;
-}
-
-export interface AgentOutput {
-  conventions?: AgentOutputConventions;
-  guides?: string[];
-}
-
-export interface AgentDefinition {
-  identity: AgentIdentity;
-  provider: AgentProvider;
-  context?: AgentContextConfig;
-  governance?: AgentGovernance;
-  memory?: AgentMemoryConfig;
-  output?: AgentOutput;
-}
-
-/** @see packages/harness/src/session-registry.ts for the canonical copy. */
-export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
+/** Validates agent names: lowercase alphanumeric + hyphens, no leading dash. */
+const AGENT_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 
 export interface LoadedAgentDefinition {
   definition: AgentDefinition;
@@ -102,7 +56,71 @@ interface CacheEntry {
 }
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const FALLBACK_CACHE_TTL_MS = 30 * 1000; // 30 seconds — allow faster recovery
 const cache = new Map<string, CacheEntry>();
+
+// ─── Zod schemas for ContexGin response validation ─────────────────────────
+
+const ContexGinIdentitySchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  mode: z.enum(['narrow', 'dynamic']).optional(),
+  role: z.string().optional(),
+});
+
+const ContexGinResponseSchema = z.object({
+  identity: ContexGinIdentitySchema,
+  provider: z
+    .object({
+      default: z.string(),
+      tiering: z
+        .object({
+          fast: z.string().nullable().optional(),
+          standard: z.string().nullable().optional(),
+          capable: z.string().nullable().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  governance: z
+    .object({
+      boundaries: z
+        .array(z.object({ spoke: z.string(), access: z.enum(['none', 'read', 'write']) }))
+        .optional(),
+      approval: z
+        .object({
+          required_for: z.array(z.string()).optional(),
+          auto_allow: z.array(z.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  memory: z
+    .object({
+      scope: z.enum(['none', 'read', 'read-write']),
+      vault: z.string().optional(),
+    })
+    .optional(),
+  output: z
+    .object({
+      conventions: z
+        .object({
+          commit_style: z.string().optional(),
+          response_format: z.string().nullable().optional(),
+        })
+        .optional(),
+      guides: z.array(z.string()).optional(),
+    })
+    .optional(),
+  boot: z
+    .object({
+      tokens: z.number().optional(),
+      content: z.string().optional(),
+      sources: z.array(z.string()).optional(),
+    })
+    .passthrough()
+    .optional(),
+});
 
 /** Clear the agent definition cache (for testing). */
 export function clearCache(): void {
@@ -125,21 +143,19 @@ async function loadFromContexGin(
 
     if (!res.ok) return null;
 
-    const data = (await res.json()) as Record<string, unknown>;
+    const raw = await res.json();
+    const parsed = ContexGinResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      log.warn('ContexGin response failed validation', {
+        agent: agentName,
+        errors: parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+      });
+      return null;
+    }
 
-    // ContexGin returns identity, provider, governance, memory at the top level
-    const identity = data.identity as AgentIdentity | undefined;
-    if (!identity?.name || !identity?.description) return null;
-
-    const provider = data.provider as AgentProvider | undefined;
-    const governance = data.governance as AgentGovernance | undefined;
-    const memory = data.memory as AgentMemoryConfig | undefined;
-    const output = data.output as AgentOutput | undefined;
-
-    // Extract context config from boot response
-    const boot = data.boot as Record<string, unknown> | undefined;
-    const context: AgentContextConfig | undefined = boot
-      ? { budget: typeof boot.tokens === 'number' ? boot.tokens : undefined }
+    const { identity, provider, governance, memory, output, boot } = parsed.data;
+    const context: AgentContextConfig | undefined = boot?.tokens
+      ? { budget: boot.tokens }
       : undefined;
 
     return {
@@ -167,9 +183,6 @@ async function loadFromLocal(
   cwd: string,
 ): Promise<LoadedAgentDefinition | null> {
   try {
-    // Validate agent name format (alphanumeric + hyphens only)
-    if (!/^[a-z0-9][a-z0-9-]*$/.test(agentName)) return null;
-
     const agentsDir = path.resolve(cwd, '.agents');
     const filePath = path.resolve(agentsDir, `${agentName}.yaml`);
     const rel = path.relative(agentsDir, filePath);
@@ -217,6 +230,15 @@ export async function loadAgentDef(
   cwd: string,
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
 ): Promise<LoadedAgentDefinition> {
+  // Validate agent name early — reject before any source attempt
+  if (!AGENT_NAME_RE.test(agentName)) {
+    log.warn('invalid agent name rejected', { agent: agentName });
+    return {
+      definition: DEFAULT_AGENT_DEFINITION,
+      source: 'fallback',
+    };
+  }
+
   // Check cache
   const cacheKey = `${agentName}:${cwd}:${contexginUrl}`;
   const cached = cache.get(cacheKey);
@@ -246,7 +268,7 @@ export async function loadAgentDef(
     return fromLocal;
   }
 
-  // 3. Bundled fallback
+  // 3. Bundled fallback — shorter TTL so we recover faster when ContexGin comes back
   log.info('using bundled agent definition fallback', { agent: agentName });
   const fallback: LoadedAgentDefinition = {
     definition: {
@@ -255,6 +277,6 @@ export async function loadAgentDef(
     },
     source: 'fallback',
   };
-  cache.set(cacheKey, { result: fallback, expiresAt: Date.now() + CACHE_TTL_MS });
+  cache.set(cacheKey, { result: fallback, expiresAt: Date.now() + FALLBACK_CACHE_TTL_MS });
   return fallback;
 }

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -9,9 +9,9 @@
  * Never blocks session start. All failures are graceful.
  */
 
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { parse as parseYaml } from 'yaml';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { load as parseYaml } from 'js-yaml';
 import { createLogger } from './logger.js';
 import { DEFAULT_AGENT_DEFINITION } from './constants.js';
 
@@ -159,10 +159,17 @@ async function loadFromContexGin(
  * Try to load agent definition from a local .agents/{name}.yaml file.
  * Returns null if file doesn't exist or is malformed.
  */
-function loadFromLocal(agentName: string, cwd: string): LoadedAgentDefinition | null {
+async function loadFromLocal(
+  agentName: string,
+  cwd: string,
+): Promise<LoadedAgentDefinition | null> {
   try {
-    const filePath = join(cwd, '.agents', `${agentName}.yaml`);
-    const raw = readFileSync(filePath, 'utf-8');
+    // Path traversal guard: ensure resolved path stays under .agents/
+    const agentsDir = resolve(cwd, '.agents');
+    const filePath = resolve(agentsDir, `${agentName}.yaml`);
+    if (!filePath.startsWith(agentsDir + '/')) return null;
+
+    const raw = await readFile(filePath, 'utf-8');
     const parsed = parseYaml(raw) as Record<string, unknown>;
 
     if (!parsed || typeof parsed !== 'object') return null;
@@ -205,7 +212,7 @@ export async function loadAgentDef(
   contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
 ): Promise<LoadedAgentDefinition> {
   // Check cache
-  const cacheKey = `${agentName}:${cwd}`;
+  const cacheKey = `${agentName}:${cwd}:${contexginUrl ?? 'default'}`;
   const cached = cache.get(cacheKey);
   if (cached && Date.now() < cached.expiresAt) {
     return cached.result;
@@ -223,7 +230,7 @@ export async function loadAgentDef(
   }
 
   // 2. Try local override
-  const fromLocal = loadFromLocal(agentName, cwd);
+  const fromLocal = await loadFromLocal(agentName, cwd);
   if (fromLocal) {
     log.info('agent definition loaded from local .agents/', {
       agent: agentName,
@@ -236,7 +243,10 @@ export async function loadAgentDef(
   // 3. Bundled fallback
   log.info('using bundled agent definition fallback', { agent: agentName });
   const fallback: LoadedAgentDefinition = {
-    definition: DEFAULT_AGENT_DEFINITION,
+    definition: {
+      ...DEFAULT_AGENT_DEFINITION,
+      identity: { ...DEFAULT_AGENT_DEFINITION.identity, name: agentName },
+    },
     source: 'fallback',
   };
   cache.set(cacheKey, { result: fallback, expiresAt: Date.now() + CACHE_TTL_MS });

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -86,8 +86,7 @@ export interface AgentDefinition {
   output?: AgentOutput;
 }
 
-// Re-export from harness to avoid duplicate definition
-export type { AgentDefinitionSource } from '@mitzo/harness';
+export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
 
 export interface LoadedAgentDefinition {
   definition: AgentDefinition;

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -241,10 +241,7 @@ export async function loadAgentDef(
   if (!AGENT_NAME_RE.test(name)) {
     log.warn('invalid agent name rejected', { agent: agentName, normalized: name });
     return {
-      definition: {
-        ...DEFAULT_AGENT_DEFINITION,
-        identity: { ...DEFAULT_AGENT_DEFINITION.identity },
-      },
+      definition: structuredClone(DEFAULT_AGENT_DEFINITION) as AgentDefinition,
       source: 'fallback',
     };
   }

--- a/server/agent-loader.ts
+++ b/server/agent-loader.ts
@@ -1,0 +1,244 @@
+/**
+ * Agent definition loader — discover, load, and cache agent recipes.
+ *
+ * Resolution order:
+ * 1. ContexGin API — GET /api/agents/:name/context (preferred)
+ * 2. Local override — .agents/{name}.yaml in workspace root (dev/testing)
+ * 3. Bundled fallback — DEFAULT_AGENT_DEFINITION from constants
+ *
+ * Never blocks session start. All failures are graceful.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+import { createLogger } from './logger.js';
+import { DEFAULT_AGENT_DEFINITION } from './constants.js';
+
+const log = createLogger('agent-loader');
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface AgentIdentity {
+  name: string;
+  description: string;
+  mode?: 'narrow' | 'dynamic';
+  role?: string;
+}
+
+export interface AgentProviderTiering {
+  fast?: string | null;
+  standard?: string | null;
+  capable?: string | null;
+}
+
+export interface AgentProvider {
+  default: string;
+  tiering?: AgentProviderTiering;
+}
+
+export interface AgentContextConfig {
+  budget?: number;
+  sources?: {
+    hubs?: Array<{ path: string; spokes?: string[] }>;
+  };
+  priority?: string[];
+  exclude?: string[];
+  profile?: string;
+}
+
+export interface GovernanceBoundary {
+  spoke: string;
+  access: 'none' | 'read' | 'write';
+}
+
+export interface GovernanceApproval {
+  required_for?: string[];
+  auto_allow?: string[];
+}
+
+export interface AgentGovernance {
+  boundaries?: GovernanceBoundary[];
+  approval?: GovernanceApproval;
+}
+
+export interface AgentMemoryConfig {
+  scope: 'none' | 'read' | 'read-write';
+  vault?: string;
+}
+
+export interface AgentOutputConventions {
+  commit_style?: string;
+  response_format?: string | null;
+}
+
+export interface AgentOutput {
+  conventions?: AgentOutputConventions;
+  guides?: string[];
+}
+
+export interface AgentDefinition {
+  identity: AgentIdentity;
+  provider: AgentProvider;
+  context?: AgentContextConfig;
+  governance?: AgentGovernance;
+  memory?: AgentMemoryConfig;
+  output?: AgentOutput;
+}
+
+export type AgentDefinitionSource = 'contexgin' | 'local' | 'fallback';
+
+export interface LoadedAgentDefinition {
+  definition: AgentDefinition;
+  source: AgentDefinitionSource;
+}
+
+// ─── Cache ──────────────────────────────────────────────────────────────────
+
+interface CacheEntry {
+  result: LoadedAgentDefinition;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const cache = new Map<string, CacheEntry>();
+
+/** Clear the agent definition cache (for testing). */
+export function clearCache(): void {
+  cache.clear();
+}
+
+// ─── Loaders ────────────────────────────────────────────────────────────────
+
+/**
+ * Try to load agent definition from ContexGin API.
+ * Returns null on any failure — never throws.
+ */
+async function loadFromContexGin(
+  agentName: string,
+  contexginUrl: string,
+): Promise<LoadedAgentDefinition | null> {
+  try {
+    const url = `${contexginUrl}/api/agents/${encodeURIComponent(agentName)}/context`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as Record<string, unknown>;
+
+    // ContexGin returns identity, provider, governance, memory at the top level
+    const identity = data.identity as AgentIdentity | undefined;
+    if (!identity?.name || !identity?.description) return null;
+
+    const provider = data.provider as AgentProvider | undefined;
+    const governance = data.governance as AgentGovernance | undefined;
+    const memory = data.memory as AgentMemoryConfig | undefined;
+
+    // Extract context config from boot response
+    const boot = data.boot as Record<string, unknown> | undefined;
+    const context: AgentContextConfig | undefined = boot
+      ? { budget: typeof boot.tokens === 'number' ? boot.tokens : undefined }
+      : undefined;
+
+    return {
+      definition: {
+        identity,
+        provider: provider ?? { default: 'claude-opus-4' },
+        context,
+        governance,
+        memory,
+      },
+      source: 'contexgin',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try to load agent definition from a local .agents/{name}.yaml file.
+ * Returns null if file doesn't exist or is malformed.
+ */
+function loadFromLocal(agentName: string, cwd: string): LoadedAgentDefinition | null {
+  try {
+    const filePath = join(cwd, '.agents', `${agentName}.yaml`);
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = parseYaml(raw) as Record<string, unknown>;
+
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const identity = parsed.identity as AgentIdentity | undefined;
+    if (!identity?.name || !identity?.description) return null;
+
+    // Map the Centaur schema to our internal types
+    const provider = parsed.provider as AgentProvider | undefined;
+    const context = parsed.context as AgentContextConfig | undefined;
+    const governance = parsed.governance as AgentGovernance | undefined;
+    const memory = parsed.memory as AgentMemoryConfig | undefined;
+    const output = parsed.output as AgentOutput | undefined;
+
+    return {
+      definition: {
+        identity,
+        provider: provider ?? { default: 'claude-opus-4' },
+        context,
+        governance,
+        memory,
+        output,
+      },
+      source: 'local',
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Load an agent definition, trying ContexGin → local override → bundled fallback.
+ * Results are cached for 5 minutes. Never throws.
+ */
+export async function loadAgentDef(
+  agentName: string,
+  cwd: string,
+  contexginUrl: string = process.env.CONTEXGIN_URL || 'http://localhost:8321',
+): Promise<LoadedAgentDefinition> {
+  // Check cache
+  const cacheKey = `${agentName}:${cwd}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAt) {
+    return cached.result;
+  }
+
+  // 1. Try ContexGin
+  const fromContexGin = await loadFromContexGin(agentName, contexginUrl);
+  if (fromContexGin) {
+    log.info('agent definition loaded from ContexGin', {
+      agent: agentName,
+      identity: fromContexGin.definition.identity.description,
+    });
+    cache.set(cacheKey, { result: fromContexGin, expiresAt: Date.now() + CACHE_TTL_MS });
+    return fromContexGin;
+  }
+
+  // 2. Try local override
+  const fromLocal = loadFromLocal(agentName, cwd);
+  if (fromLocal) {
+    log.info('agent definition loaded from local .agents/', {
+      agent: agentName,
+      identity: fromLocal.definition.identity.description,
+    });
+    cache.set(cacheKey, { result: fromLocal, expiresAt: Date.now() + CACHE_TTL_MS });
+    return fromLocal;
+  }
+
+  // 3. Bundled fallback
+  log.info('using bundled agent definition fallback', { agent: agentName });
+  const fallback: LoadedAgentDefinition = {
+    definition: DEFAULT_AGENT_DEFINITION,
+    source: 'fallback',
+  };
+  cache.set(cacheKey, { result: fallback, expiresAt: Date.now() + CACHE_TTL_MS });
+  return fallback;
+}

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -965,7 +965,7 @@ async function _startChatInner(
     .then((loaded) => {
       const s = registry.get(clientId);
       if (s) {
-        s.agentDefinition = loaded.definition as Record<string, unknown>;
+        s.agentDefinition = loaded.definition as unknown as Record<string, unknown>;
         s.agentDefinitionSource = loaded.source;
         log.info('agent definition stored', {
           agent: agentName,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -42,6 +42,7 @@ import {
 import { INTERNAL_TOKEN } from './internal-token.js';
 import { buildTaskSystemPrompt } from './task-context.js';
 import type { TaskStore } from './task-store.js';
+import { loadAgentDef } from './agent-loader.js';
 
 let _taskStore: TaskStore | null = null;
 export function setTaskStore(store: TaskStore): void {
@@ -959,6 +960,31 @@ async function _startChatInner(
     buildTaskPromptForSession(clientId) +
     bootContextAppend;
 
+  // Fire-and-forget: load agent definition and store in session registry.
+  loadAgentDef(agentName, cwd)
+    .then((loaded) => {
+      const s = registry.get(clientId);
+      if (s) {
+        s.agentDefinition = loaded.definition as unknown as Record<string, unknown>;
+        s.agentDefinitionSource = loaded.source;
+        log.info('agent definition stored', {
+          agent: agentName,
+          source: loaded.source,
+          identity: loaded.definition.identity.description,
+        });
+      } else {
+        log.warn('agent definition loaded but session already torn down', {
+          agent: agentName,
+          source: loaded.source,
+        });
+      }
+    })
+    .catch((err: unknown) => {
+      log.warn('agent definition load failed', {
+        agent: agentName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   capturePromptComparison(wtId, cwd, systemPromptAppend, repoWorktrees).catch(() => {});
 
   // Resolve SDK session UUID for resume — worktree IDs are not valid SDK session IDs

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -965,7 +965,7 @@ async function _startChatInner(
     .then((loaded) => {
       const s = registry.get(clientId);
       if (s) {
-        s.agentDefinition = loaded.definition as unknown as Record<string, unknown>;
+        s.agentDefinition = loaded.definition as Record<string, unknown>;
         s.agentDefinitionSource = loaded.source;
         log.info('agent definition stored', {
           agent: agentName,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -985,6 +985,7 @@ async function _startChatInner(
         error: err instanceof Error ? err.message : String(err),
       });
     });
+
   capturePromptComparison(wtId, cwd, systemPromptAppend, repoWorktrees).catch(() => {});
 
   // Resolve SDK session UUID for resume — worktree IDs are not valid SDK session IDs

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -965,7 +965,7 @@ async function _startChatInner(
     .then((loaded) => {
       const s = registry.get(clientId);
       if (s) {
-        s.agentDefinition = loaded.definition as unknown as Record<string, unknown>;
+        s.agentDefinition = loaded.definition;
         s.agentDefinitionSource = loaded.source;
         log.info('agent definition stored', {
           agent: agentName,

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -50,7 +50,7 @@ export const DEFAULT_AGENT_NAME = 'mitzo-conversational';
 /** Bundled fallback agent definition — used when ContexGin is unreachable and no local override. */
 export const DEFAULT_AGENT_DEFINITION = {
   identity: {
-    name: 'mitzo-conversational',
+    name: DEFAULT_AGENT_NAME,
     description: 'Primary conversational assistant via Mitzo iOS with full domain context',
     mode: 'dynamic' as const,
   },

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -46,6 +46,21 @@ export const WORKTREE_CLEANUP_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 // --- Agent Selection ---
 export const DEFAULT_AGENT_NAME = 'mitzo-conversational';
 
+/** Bundled fallback agent definition — used when ContexGin is unreachable and no local override. */
+export const DEFAULT_AGENT_DEFINITION = {
+  identity: {
+    name: 'mitzo-conversational' as const,
+    description: 'Primary conversational assistant via Mitzo iOS with full domain context',
+    mode: 'dynamic' as const,
+  },
+  provider: {
+    default: 'claude-opus-4',
+  },
+  context: {
+    budget: 12000,
+  },
+} as const;
+
 // --- Session List ---
 /** Grace period for zero-turn inactive sessions — recently created ones stay visible. */
 export const ZERO_TURN_GRACE_MS = 60 * 60 * 1000; // 1 hour

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -13,6 +13,7 @@ export {
   MAX_OBSERVERS_PER_SESSION,
   CONTEXT_CEILING_TOKENS,
 } from '@mitzo/protocol';
+import type { AgentDefinition } from '@mitzo/protocol';
 
 // --- Session & Permission ---
 // Re-export session lifecycle constants from harness (canonical source).
@@ -49,7 +50,7 @@ export const DEFAULT_AGENT_NAME = 'mitzo-conversational';
 /** Bundled fallback agent definition — used when ContexGin is unreachable and no local override. */
 export const DEFAULT_AGENT_DEFINITION = {
   identity: {
-    name: 'mitzo-conversational' as const,
+    name: 'mitzo-conversational',
     description: 'Primary conversational assistant via Mitzo iOS with full domain context',
     mode: 'dynamic' as const,
   },
@@ -59,7 +60,7 @@ export const DEFAULT_AGENT_DEFINITION = {
   context: {
     budget: 12000,
   },
-} as const;
+} as const satisfies AgentDefinition;
 
 // --- Session List ---
 /** Grace period for zero-turn inactive sessions — recently created ones stay visible. */


### PR DESCRIPTION
## Summary

- Add `server/agent-loader.ts` — three-tier recipe discovery (ContexGin API → local `.agents/` override → bundled fallback) with 5-minute TTL cache
- Store parsed `agentDefinition` + `agentDefinitionSource` in `ManagedSession` (session-registry)
- Wire `loadAgentDef()` fire-and-forget into session start in `chat.ts`
- Add `DEFAULT_AGENT_DEFINITION` bundled fallback to `constants.ts`

This is Phase 1 of the [agent-definition-loading spec](https://github.com/dimakis/mgmt/tree/main/local_features/agent-definition-loading/spec.md). Future phases will consume the stored recipe for governance enforcement, provider tiering, memory scoping, and output conventions.

## Test plan

- [x] 13 new tests in `agent-loader.test.ts` — all sources, caching, error handling
- [x] 45 existing tests (boot-context, session-registry) pass with no regressions
- [ ] Manual: verify session starts with ContexGin running (source=contexgin)
- [ ] Manual: verify session starts with ContexGin down (source=fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)