### PR TITLE
fix(protocol): remove ambiguous .m language mapping

### DIFF
--- a/packages/protocol/__tests__/language.test.ts
+++ b/packages/protocol/__tests__/language.test.ts
@@ -75,8 +75,12 @@ describe('languageFromPath', () => {
   });
 
   // New language coverage
-  it('detects Objective-C from .m', () => {
-    expect(languageFromPath('AppDelegate.m')).toBe('objectivec');
+  it('returns undefined for ambiguous .m files', () => {
+    expect(languageFromPath('AppDelegate.m')).toBeUndefined();
+  });
+
+  it('detects Objective-C++ from .mm', () => {
+    expect(languageFromPath('AppDelegate.mm')).toBe('objectivec');
   });
 
   it('detects Dart from .dart', () => {

--- a/packages/protocol/src/language.ts
+++ b/packages/protocol/src/language.ts
@@ -56,7 +56,6 @@ const EXT_MAP: Record<string, string> = {
   kts: 'kotlin',
   swift: 'swift',
   cs: 'csharp',
-  m: 'objectivec',
   mm: 'objectivec',
   dart: 'dart',
   scala: 'scala',


### PR DESCRIPTION
## Summary

- Remove `.m → objectivec` mapping from `EXT_MAP` — `.m` is ambiguous (Objective-C vs MATLAB/Octave)
- Keep `.mm → objectivec` (unambiguous Objective-C++)
- Update tests: `.m` now returns `undefined`, add explicit `.mm` test

Addresses Centaur review finding on PR #357.

## Test plan

- [x] `vitest run packages/protocol/__tests__/language.test.ts` — 32/32 pass
- [ ] Centaur review

🤖 Generated with [Claude Code](https://claude.com/claude-code)