### PR TITLE
fix(client): always force WS reconnect on iOS foreground return

### DIFF
--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -324,14 +324,21 @@ export class MitzoConnection {
     }
   }
 
-  /** Force a reconnect check — call from native lifecycle hooks (e.g. Capacitor appStateChange). */
+  /**
+   * Force a reconnect — call from native lifecycle hooks (e.g. Capacitor
+   * appStateChange) and browser visibility events.
+   *
+   * iOS kills WebSocket connections during background without updating
+   * readyState, so we NEVER trust the old socket after a foreground
+   * transition. Always tear down and create a fresh connection. Any
+   * sends that arrive during the reconnect window queue in pendingSends
+   * and flush after the welcome handshake completes.
+   */
   checkAndReconnect(): void {
-    if (!this.ws || this.ws.readyState !== WS_READY_STATE.OPEN) {
-      if (this.reconnectTimer) return;
-      this.defuseOldWs();
-      this._connected = false;
-      this.listener?.({ type: '_close' });
-      this.doConnect();
-    }
+    if (this.reconnectTimer) return;
+    this.defuseOldWs();
+    this._connected = false;
+    this.listener?.({ type: '_close' });
+    this.doConnect();
   }
 }


### PR DESCRIPTION
## Summary

- iOS kills WebSocket connections during background without updating `readyState`
- `checkAndReconnect()` trusted `readyState` — if the socket appeared OPEN, it did nothing
- First message sent on the dead socket was silently lost (regression from prior reconnect work)
- Fix: always tear down the old socket and force a fresh connection on foreground return
- Sends during the reconnect window queue in `pendingSends` and flush after the welcome handshake

This is a regression — previously both messages reached the agent (even if a double-send was needed to wake it up). Now the first message is silently dropped into a dead socket.

## Root cause

`connection.ts:328-336` — the `readyState !== OPEN` guard:

```typescript
// BEFORE (broken)
checkAndReconnect(): void {
    if (!this.ws || this.ws.readyState !== WS_READY_STATE.OPEN) {
        // only reconnects if socket is visibly dead
    }
    // if readyState appears OPEN → does NOTHING
}
```

iOS kills the TCP connection during background but the JS `readyState` property stays `OPEN` until a send/recv actually fails. The heartbeat (5s interval) also checks `readyState !== OPEN`, so it has the same blind spot. The first user message fires into the void.

## Test plan

- [ ] Background Mitzo on iOS, wait 30+ seconds, return to foreground
- [ ] Send a message — verify it reaches the agent on the first try
- [ ] Verify rapid foreground/background cycling doesn't cause double connections (reconnectTimer guard)
- [ ] Verify desktop browser tab switching still works (visibilitychange path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)