### PR TITLE
fix(client): always force WS reconnect on iOS foreground return

### DIFF
--- a/packages/client/__tests__/connection.test.ts
+++ b/packages/client/__tests__/connection.test.ts
@@ -412,6 +412,114 @@ describe('MitzoConnection', () => {
     });
   });
 
+  describe('checkAndReconnect', () => {
+    it('forces reconnect even when WS appears OPEN (iOS stale socket)', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws1 = openWithHandshake(conn);
+      expect(ws1.readyState).toBe(1); // OPEN
+
+      // Force reconnect — simulates iOS foreground return
+      conn.checkAndReconnect(true);
+
+      // Old socket should be closed and defused
+      expect(ws1.close).toHaveBeenCalled();
+      expect(ws1.onclose).toBeNull();
+
+      // New socket should be created
+      const ws2 = lastWs!;
+      expect(ws2).not.toBe(ws1);
+      expect(conn.isConnected()).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('preserves healthy socket when force=false (default)', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      conn.checkAndReconnect(); // default: force=false
+
+      // Same socket, still connected
+      expect(lastWs).toBe(ws);
+      expect(conn.isConnected()).toBe(true);
+    });
+
+    it('reconnects when WS is dead and force=false', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws1 = openWithHandshake(conn);
+
+      // Simulate dead socket (readyState updated)
+      ws1.readyState = 3;
+      conn.checkAndReconnect(false);
+
+      expect(lastWs).not.toBe(ws1);
+      expect(conn.isConnected()).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('is a no-op when reconnectTimer is already set', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws1 = openWithHandshake(conn);
+
+      // Trigger a close to start the reconnect timer
+      ws1.simulateClose();
+      const wsAfterClose = lastWs;
+
+      // Force check — should be a no-op because timer is pending
+      conn.checkAndReconnect(true);
+      expect(lastWs).toBe(wsAfterClose);
+
+      vi.useRealTimers();
+    });
+
+    it('queues sends during forced reconnect and flushes after welcome', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      openWithHandshake(conn);
+
+      // Force reconnect (iOS resume)
+      conn.checkAndReconnect(true);
+
+      // Send while reconnecting — should queue
+      const sent = conn.send({ type: 'send', prompt: 'first message' });
+      expect(sent).toBe(true);
+
+      // Complete handshake on new socket
+      const ws2 = lastWs!;
+      ws2.simulateOpen();
+      ws2.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+
+      // Queued message should have been flushed
+      const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      expect(calls).toContainEqual({ type: 'send', prompt: 'first message' });
+
+      vi.useRealTimers();
+    });
+
+    it('closes the old socket to prevent server-side connection leak', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws = openWithHandshake(conn);
+
+      conn.checkAndReconnect(true);
+
+      // ws.close() must have been called — not just handler-nulled
+      expect(ws.close).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+
   describe('sendSuspend', () => {
     it('sends session_suspend via WS with all tracked sessions', () => {
       const conn = createConnection();

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -324,14 +324,21 @@ export class MitzoConnection {
     }
   }
 
-  /** Force a reconnect check — call from native lifecycle hooks (e.g. Capacitor appStateChange). */
+  /**
+   * Force a reconnect — call from native lifecycle hooks (e.g. Capacitor
+   * appStateChange) and browser visibility events.
+   *
+   * iOS kills WebSocket connections during background without updating
+   * readyState, so we NEVER trust the old socket after a foreground
+   * transition. Always tear down and create a fresh connection. Any
+   * sends that arrive during the reconnect window queue in pendingSends
+   * and flush after the welcome handshake completes.
+   */
   checkAndReconnect(): void {
-    if (!this.ws || this.ws.readyState !== WS_READY_STATE.OPEN) {
-      if (this.reconnectTimer) return;
-      this.defuseOldWs();
-      this._connected = false;
-      this.listener?.({ type: '_close' });
-      this.doConnect();
-    }
+    if (this.reconnectTimer) return;
+    this.defuseOldWs();
+    this._connected = false;
+    this.listener?.({ type: '_close' });
+    this.doConnect();
   }
 }

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -170,6 +170,14 @@ export class MitzoConnection {
       this.ws.onclose = null;
       this.ws.onmessage = null;
       this.ws.onerror = null;
+      // Explicitly close the socket to avoid orphaning a live connection
+      // on the server side (e.g. desktop tab switch where the socket is
+      // still healthy). No-op if the socket is already dead.
+      try {
+        this.ws.close();
+      } catch {
+        // Socket may already be in a broken state — ignore.
+      }
       this.ws = null;
     }
   }
@@ -325,16 +333,19 @@ export class MitzoConnection {
   }
 
   /**
-   * Force a reconnect — call from native lifecycle hooks (e.g. Capacitor
-   * appStateChange) and browser visibility events.
+   * Check connectivity and reconnect if needed.
    *
-   * iOS kills WebSocket connections during background without updating
-   * readyState, so we NEVER trust the old socket after a foreground
-   * transition. Always tear down and create a fresh connection. Any
-   * sends that arrive during the reconnect window queue in pendingSends
-   * and flush after the welcome handshake completes.
+   * @param force — when true, always tear down and reconnect regardless of
+   *   readyState. Required for iOS where the OS kills WebSocket connections
+   *   during background without updating readyState. Capacitor lifecycle
+   *   hooks pass force=true; browser visibility events use the default
+   *   (false) which only reconnects when the socket is visibly dead.
+   *
+   *   Sends arriving during the reconnect window queue in pendingSends
+   *   and flush after the welcome handshake completes.
    */
-  checkAndReconnect(): void {
+  checkAndReconnect(force = false): void {
+    if (!force && this.ws?.readyState === WS_READY_STATE.OPEN) return;
     if (this.reconnectTimer) return;
     this.defuseOldWs();
     this._connected = false;

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -614,7 +614,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     },
 
     forceReconnect() {
-      connection.checkAndReconnect();
+      connection.checkAndReconnect(true);
     },
 
     sendSuspend() {


### PR DESCRIPTION
## Summary

- iOS kills WebSocket connections during background without updating `readyState`
- `checkAndReconnect()` trusted `readyState` — if the socket appeared OPEN, it did nothing
- First message sent on the dead socket was silently lost (regression)
- Fix: always tear down the old socket and force a fresh connection on foreground return
- Sends during the reconnect window queue in `pendingSends` and flush after the welcome handshake

## Root cause

`connection.ts:328-336` — the `readyState !== OPEN` guard:

```typescript
// BEFORE (broken)
checkAndReconnect(): void {
    if (!this.ws || this.ws.readyState !== WS_READY_STATE.OPEN) {
        // only reconnects if socket is visibly dead
    }
    // if readyState appears OPEN → does NOTHING
}
```

iOS kills the TCP connection during background but the JS `readyState` property stays `OPEN` until a send/recv actually fails. The first user message fires into the void.

## Test plan

- [ ] Background Mitzo on iOS, wait 30+ seconds, return to foreground
- [ ] Send a message — verify it reaches the agent on the first try
- [ ] Verify rapid foreground/background cycling doesn't cause double connections (reconnectTimer guard)
- [ ] Verify desktop browser tab switching still works (visibilitychange path)

> Re-opened from #367 which was merged without Centaur reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)