### PR TITLE
fix: persist boot context in system prompt and sticky banner

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -5,6 +5,7 @@ import { ToolPill } from './ToolPill';
 import { ToolGroup } from './ToolGroup';
 import { PermissionBanner } from './PermissionBanner';
 import { ProgressWidget } from './ProgressWidget';
+import { SessionBanner } from './SessionBanner';
 import { groupBlocks } from '../lib/groupMessages';
 import { SCROLL_NEAR_BOTTOM_PX } from '../lib/constants';
 import type {
@@ -13,6 +14,7 @@ import type {
   StreamingMessage,
   PermissionRequest,
 } from '../types/chat';
+import type { BootContextMeta } from '@mitzo/client';
 import type { ProgressBlock } from '@mitzo/protocol';
 import type { UseVoiceReturn } from '../hooks/useVoice';
 
@@ -37,6 +39,10 @@ export interface ChatAreaProps {
   progressByToolId?: Record<string, ProgressBlock>;
   /** Voice capabilities for per-block read-aloud */
   voice?: ChatAreaVoice;
+  /** Boot context metadata for sticky banner */
+  bootContext?: BootContextMeta | null;
+  /** Session context string for sticky banner */
+  sessionContext?: string | null;
 }
 
 export function ChatArea({
@@ -48,6 +54,8 @@ export function ChatArea({
   scrollRef: externalScrollRef,
   progressByToolId,
   voice,
+  bootContext,
+  sessionContext,
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
@@ -143,6 +151,8 @@ export function ChatArea({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
+        <SessionBanner bootContext={bootContext} sessionContext={sessionContext} />
+
         {messages.length === 0 && !current && !running && (
           <p className="chat-empty">Send a message to start</p>
         )}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
-import { SessionBanner } from '../components/SessionBanner';
+
 import { VoiceSettings } from '../components/VoiceSettings';
 import { MitzoLogo } from '../components/MitzoLogo';
 import { useMessages, useConnection, useTokens, useMitzoStore } from '@mitzo/client/hooks';
@@ -272,8 +272,6 @@ export function ChatView() {
         )}
       </header>
 
-      <SessionBanner bootContext={bootContext} sessionContext={sessionContext} />
-
       <ChatArea
         messages={messages.messages}
         current={messages.current}
@@ -283,6 +281,8 @@ export function ChatView() {
         scrollRef={scrollRef}
         progressByToolId={progressByToolId}
         voice={voice}
+        bootContext={bootContext}
+        sessionContext={sessionContext}
       />
 
       <ChatInput

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams, useNavigate } from 'react-router-dom';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
-
 import { VoiceSettings } from '../components/VoiceSettings';
 import { MitzoLogo } from '../components/MitzoLogo';
 import { useMessages, useConnection, useTokens, useMitzoStore } from '@mitzo/client/hooks';

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -5,7 +5,7 @@ import { SessionPanel } from '../components/SessionPanel';
 import { CommandCenter } from '../components/CommandCenter';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
-import { SessionBanner } from '../components/SessionBanner';
+
 import { ScrollFab } from '../components/ScrollFab';
 import { StatusBar } from '../components/StatusBar';
 import { VoiceSettings } from '../components/VoiceSettings';
@@ -242,7 +242,6 @@ export function DesktopChatView() {
               onVoiceChange={voice.setVoice}
             />
           </header>
-          <SessionBanner bootContext={bootContext} sessionContext={sessionContext} />
           <ChatArea
             messages={messages.messages}
             current={messages.current}
@@ -252,6 +251,8 @@ export function DesktopChatView() {
             scrollRef={scrollRef}
             progressByToolId={progressByToolId}
             voice={voice}
+            bootContext={bootContext}
+            sessionContext={sessionContext}
           />
           <ScrollFab scrollRef={scrollRef} />
           <ChatInput

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -5,7 +5,6 @@ import { SessionPanel } from '../components/SessionPanel';
 import { CommandCenter } from '../components/CommandCenter';
 import { ChatArea } from '../components/ChatArea';
 import { ChatInput } from '../components/ChatInput';
-
 import { ScrollFab } from '../components/ScrollFab';
 import { StatusBar } from '../components/StatusBar';
 import { VoiceSettings } from '../components/VoiceSettings';

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2410,10 +2410,11 @@ textarea:focus {
 /* ===== Session Banner (persistent boot + session context) ===== */
 
 .session-banner {
-  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
   border-bottom: 1px solid var(--border);
   background: var(--bg-primary);
-  z-index: 10;
 }
 
 .session-banner-header {

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -91,7 +91,10 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
       if (stype && desc) {
         // Give the shorter field its full length, allocate the rest to the longer
         const budget = TOOL_SUMMARY_MAX_CHARS - 3; // account for ' · '
-        const stypeLen = Math.min(stype.length, Math.max(Math.floor(budget / 2), budget - desc.length));
+        const stypeLen = Math.min(
+          stype.length,
+          Math.max(Math.floor(budget / 2), budget - desc.length),
+        );
         const descLen = budget - stypeLen;
         return `${stype.slice(0, stypeLen)} · ${desc.slice(0, descLen)}`;
       }

--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -255,6 +255,46 @@ describe('fetchBootContext', () => {
     expect(result.fullMarkdown).toBe('json fallback');
   });
 
+  it('returns fullMarkdown suitable for system prompt append', async () => {
+    const markdown = '# Identity\nYou are a helpful assistant.\n\n# Preferences\nBe concise.';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: {
+          content: markdown,
+          tokens: 200,
+          tokenBudget: 8000,
+          sources: ['profile.md'],
+        },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.fullMarkdown).toBe(markdown);
+    // Verify the append pattern matches what chat.ts does:
+    // `\n\n# Boot Context\n${fullMarkdown}`
+    const append = result.fullMarkdown ? `\n\n# Boot Context\n${result.fullMarkdown}` : '';
+    expect(append).toContain('# Boot Context');
+    expect(append).toContain('# Identity');
+    expect(append).toContain('Be concise.');
+  });
+
+  it('returns empty string for append when fullMarkdown is missing', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: { tokens: 0, sources: [] },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.fullMarkdown).toBeUndefined();
+    const append = result.fullMarkdown ? `\n\n# Boot Context\n${result.fullMarkdown}` : '';
+    expect(append).toBe('');
+  });
+
   it('uses default URL from env when not provided', async () => {
     const origUrl = process.env.CONTEXGIN_URL;
     process.env.CONTEXGIN_URL = 'http://test-host:9999';

--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -271,16 +271,13 @@ describe('fetchBootContext', () => {
 
     const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
 
+    // fullMarkdown must be the exact content string — chat.ts appends it to the system prompt
     expect(result.fullMarkdown).toBe(markdown);
-    // Verify the append pattern matches what chat.ts does:
-    // `\n\n# Boot Context\n${fullMarkdown}`
-    const append = result.fullMarkdown ? `\n\n# Boot Context\n${result.fullMarkdown}` : '';
-    expect(append).toContain('# Boot Context');
-    expect(append).toContain('# Identity');
-    expect(append).toContain('Be concise.');
+    expect(typeof result.fullMarkdown).toBe('string');
+    expect(result.fullMarkdown!.length).toBeGreaterThan(0);
   });
 
-  it('returns empty string for append when fullMarkdown is missing', async () => {
+  it('returns undefined fullMarkdown when boot.content is missing', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -290,9 +287,8 @@ describe('fetchBootContext', () => {
 
     const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
 
+    // chat.ts checks `bootContextMsg.fullMarkdown` — undefined means no append
     expect(result.fullMarkdown).toBeUndefined();
-    const append = result.fullMarkdown ? `\n\n# Boot Context\n${result.fullMarkdown}` : '';
-    expect(append).toBe('');
   });
 
   it('uses default URL from env when not provided', async () => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -919,17 +919,25 @@ async function _startChatInner(
 
   // Fetch boot context BEFORE building system prompt so it's part of the
   // system prompt append and survives SDK context compaction.
-  const bootContextMsg = await fetchBootContext(agentName);
+  // fetchBootContext never throws and has a 5s AbortSignal timeout internally.
+  // Race with a 2s deadline so session startup isn't blocked when ContexGin is slow.
+  const bootContextMsg = await Promise.race([
+    fetchBootContext(agentName),
+    new Promise<Awaited<ReturnType<typeof fetchBootContext>>>((resolve) =>
+      setTimeout(() => resolve({ ...FALLBACK_BOOT_CONTEXT }), 2000),
+    ),
+  ]);
   const bootContextAppend = bootContextMsg.fullMarkdown
     ? `\n\n# Boot Context\n${bootContextMsg.fullMarkdown}`
     : '';
 
-  // Send boot context to UI for display (separate from system prompt injection).
-  // stateSessionId is the worktree-level session ID, already computed above.
+  // Send boot context to UI immediately (sessionId may be undefined for new sessions — OK,
+  // it's a display-only hint; the client doesn't key on it for boot context).
   send(transport, { ...bootContextMsg, ...(stateSessionId ? { sessionId: stateSessionId } : {}) });
   // Cache in ManagedSession for replay on reconnect/switch
   session.bootContext = bootContextMsg as unknown as Record<string, unknown>;
-  // Persist to EventStore for cold-path recovery
+  // For resumed sessions, persist immediately (sessionId is known).
+  // For new sessions, persist in onSessionResolved once SDK assigns the ID.
   if (stateSessionId) {
     eventStore.upsertSession({
       sessionId: stateSessionId,
@@ -1020,7 +1028,14 @@ async function _startChatInner(
       options.resume ? undefined : fullPrompt,
       {
         connRegistry: _connRegistry ?? undefined,
-        onSessionResolved: options.onSessionResolved,
+        onSessionResolved: (sessionId: string) => {
+          // Persist boot context to EventStore now that we have a real session ID
+          eventStore.upsertSession({
+            sessionId,
+            bootContext: JSON.stringify(bootContextMsg),
+          });
+          options.onSessionResolved?.(sessionId);
+        },
         onInitialPrompt: (sessionId: string) => {
           tryAutoRename(sessionId, clientId).catch(() => {
             /* errors logged internally */

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -924,15 +924,17 @@ async function _startChatInner(
     ? `\n\n# Boot Context\n${bootContextMsg.fullMarkdown}`
     : '';
 
-  // Send boot context to UI for display (separate from system prompt injection)
-  const bootSid = options.resume ?? registry.get(clientId)?.sessionId;
-  send(transport, { ...bootContextMsg, ...(bootSid ? { sessionId: bootSid } : {}) });
+  // Send boot context to UI for display (separate from system prompt injection).
+  // stateSessionId is the worktree-level session ID, already computed above.
+  send(transport, { ...bootContextMsg, ...(stateSessionId ? { sessionId: stateSessionId } : {}) });
   // Cache in ManagedSession for replay on reconnect/switch
-  const bootSession = registry.get(clientId);
-  if (bootSession) bootSession.bootContext = bootContextMsg as unknown as Record<string, unknown>;
+  session.bootContext = bootContextMsg as unknown as Record<string, unknown>;
   // Persist to EventStore for cold-path recovery
-  if (bootSid) {
-    eventStore.upsertSession({ sessionId: bootSid, bootContext: JSON.stringify(bootContextMsg) });
+  if (stateSessionId) {
+    eventStore.upsertSession({
+      sessionId: stateSessionId,
+      bootContext: JSON.stringify(bootContextMsg),
+    });
   }
 
   // Build the system prompt append string (used by both query and comparison)

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -921,12 +921,14 @@ async function _startChatInner(
   // system prompt append and survives SDK context compaction.
   // fetchBootContext never throws and has a 5s AbortSignal timeout internally.
   // Race with a 2s deadline so session startup isn't blocked when ContexGin is slow.
+  let raceTimer: ReturnType<typeof setTimeout> | undefined;
   const bootContextMsg = await Promise.race([
     fetchBootContext(agentName),
-    new Promise<Awaited<ReturnType<typeof fetchBootContext>>>((resolve) =>
-      setTimeout(() => resolve({ ...FALLBACK_BOOT_CONTEXT }), 2000),
-    ),
+    new Promise<Awaited<ReturnType<typeof fetchBootContext>>>((resolve) => {
+      raceTimer = setTimeout(() => resolve({ ...FALLBACK_BOOT_CONTEXT }), 2000);
+    }),
   ]);
+  clearTimeout(raceTimer);
   const bootContextAppend = bootContextMsg.fullMarkdown
     ? `\n\n# Boot Context\n${bootContextMsg.fullMarkdown}`
     : '';
@@ -1029,11 +1031,13 @@ async function _startChatInner(
       {
         connRegistry: _connRegistry ?? undefined,
         onSessionResolved: (sessionId: string) => {
-          // Persist boot context to EventStore now that we have a real session ID
-          eventStore.upsertSession({
-            sessionId,
-            bootContext: JSON.stringify(bootContextMsg),
-          });
+          // Persist boot context for new sessions (resume sessions already persisted above)
+          if (!options.resume) {
+            eventStore.upsertSession({
+              sessionId,
+              bootContext: JSON.stringify(bootContextMsg),
+            });
+          }
           options.onSessionResolved?.(sessionId);
         },
         onInitialPrompt: (sessionId: string) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -917,6 +917,24 @@ async function _startChatInner(
   // Load project hooks from .claude/settings.json (e.g. SessionStart boot context)
   const hooks = loadProjectHooks(cwd);
 
+  // Fetch boot context BEFORE building system prompt so it's part of the
+  // system prompt append and survives SDK context compaction.
+  const bootContextMsg = await fetchBootContext(agentName);
+  const bootContextAppend = bootContextMsg.fullMarkdown
+    ? `\n\n# Boot Context\n${bootContextMsg.fullMarkdown}`
+    : '';
+
+  // Send boot context to UI for display (separate from system prompt injection)
+  const bootSid = options.resume ?? registry.get(clientId)?.sessionId;
+  send(transport, { ...bootContextMsg, ...(bootSid ? { sessionId: bootSid } : {}) });
+  // Cache in ManagedSession for replay on reconnect/switch
+  const bootSession = registry.get(clientId);
+  if (bootSession) bootSession.bootContext = bootContextMsg as unknown as Record<string, unknown>;
+  // Persist to EventStore for cold-path recovery
+  if (bootSid) {
+    eventStore.upsertSession({ sessionId: bootSid, bootContext: JSON.stringify(bootContextMsg) });
+  }
+
   // Build the system prompt append string (used by both query and comparison)
   const systemPromptAppend =
     'This is Mitzo, a mobile chat interface. The user is on their phone.\n' +
@@ -925,36 +943,9 @@ async function _startChatInner(
     '- Keep responses concise — small screen.\n' +
     '- Read CLAUDE.md and .cursor/rules/ for project context before doing substantive work.' +
     buildWorktreeSystemPrompt(repoWorktrees) +
-    buildTaskPromptForSession(clientId);
+    buildTaskPromptForSession(clientId) +
+    bootContextAppend;
 
-  // Fire-and-forget: fetch boot context from running ContexGin server.
-  // The callback may fire after the session ends (registry cleaned up) or
-  // before the SDK assigns a sessionId (new sessions). We include agentName
-  // in the upsert as a safety net so it's never null in the DB.
-  fetchBootContext(agentName)
-    .then((msg) => {
-      const session = registry.get(clientId);
-      const sid = options.resume ?? session?.sessionId;
-      // Send to client if transport still connected
-      if (session) {
-        send(transport, { ...msg, ...(sid ? { sessionId: sid } : {}) });
-        session.bootContext = msg as unknown as Record<string, unknown>;
-      }
-      // Persist to EventStore — include agentName as safety net since
-      // this upsert may be the last write for short-lived sessions.
-      if (sid) {
-        eventStore.upsertSession({
-          sessionId: sid,
-          bootContext: JSON.stringify(msg),
-          agentName,
-        });
-      }
-    })
-    .catch((err: unknown) => {
-      log.warn('boot context fetch unexpected error', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
   capturePromptComparison(wtId, cwd, systemPromptAppend, repoWorktrees).catch(() => {});
 
   // Resolve SDK session UUID for resume — worktree IDs are not valid SDK session IDs


### PR DESCRIPTION
## Summary

- **Server:** Boot context was fire-and-forget — sent as a UI event but never included in the system prompt. On SDK context compaction the model lost it entirely. Now `fetchBootContext()` is awaited and `fullMarkdown` is appended to `systemPromptAppend` so it survives compaction.
- **Frontend:** SessionBanner sat outside the scroll container as a flex sibling, causing it to be pushed offscreen on mobile Safari as messages accumulated. Moved inside `ChatArea`'s scroll container with `position: sticky; top: 0` so it pins to the top regardless of scroll position.

## Test plan

- [ ] Start a new session on mobile — verify boot context banner appears
- [ ] Send 3-4 messages — verify banner stays pinned at top of scroll area
- [ ] Scroll through long conversation — banner stays visible
- [ ] Verify boot context still displays on desktop
- [ ] Verify model retains boot context behavior after extended conversation (compaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)