### PR TITLE
fix(chat): use actual token count as boot budget fallback

### DIFF
--- a/server/__tests__/boot-context.test.ts
+++ b/server/__tests__/boot-context.test.ts
@@ -191,6 +191,32 @@ describe('fetchBootContext', () => {
     expect(result.tokenCount).toBe(100);
   });
 
+  it('falls back to bootTokens when tokenBudget is absent', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: { content: 'payload', tokens: 11297, sources: ['a.md'] },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.tokenBudget).toBe(11297);
+  });
+
+  it('uses tokenBudget from ContexGin when provided', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        boot: { content: 'payload', tokens: 11297, tokenBudget: 12000, sources: ['a.md'] },
+      }),
+    });
+
+    const result = await fetchBootContext('mitzo-conversational', CONTEXGIN_URL);
+
+    expect(result.tokenBudget).toBe(12000);
+  });
+
   it('filters non-string sources gracefully', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -196,7 +196,7 @@ export async function fetchBootContext(
     }
 
     const bootTokens = typeof boot.tokens === 'number' ? boot.tokens : 0;
-    const bootBudget = typeof boot.tokenBudget === 'number' ? boot.tokenBudget : 8000;
+    const bootBudget = typeof boot.tokenBudget === 'number' ? boot.tokenBudget : bootTokens;
     const rawSources = Array.isArray(boot.sources) ? boot.sources : [];
 
     const sources: Array<{ path: string; kind: string }> = rawSources


### PR DESCRIPTION
## Summary
- When ContexGin didn't return `tokenBudget` in its boot response, Mitzo fell back to a hardcoded `8000` — making the SessionBanner always show "8k"
- Changed fallback from `8000` to `bootTokens` (actual compiled token count), so the UI reflects reality even before ContexGin adds the field
- Paired with dimakis/contexgin#(pending) which adds the `tokenBudget` field to the ContexGin response

## Test plan
- [x] `tsc --noEmit` passes
- [x] No new test failures (37 pre-existing, all unrelated)
- [ ] Verify SessionBanner shows ~11k (or actual count) instead of 8k

🤖 Generated with [Claude Code](https://claude.com/claude-code)