### PR TITLE
fix(client): clear WS pending sends on session transition

### DIFF
--- a/packages/client/__tests__/connection.test.ts
+++ b/packages/client/__tests__/connection.test.ts
@@ -520,6 +520,44 @@ describe('MitzoConnection', () => {
     });
   });
 
+  describe('clearPendingSends', () => {
+    it('drains queued messages so they are not flushed on reconnect', () => {
+      vi.useFakeTimers();
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      const ws1 = openWithHandshake(conn);
+      ws1.simulateClose();
+
+      // Queue messages while disconnected
+      conn.send({ type: 'send', sessionId: 'old-sess', prompt: 'stale' });
+      conn.send({ type: 'send', sessionId: 'old-sess', prompt: 'also stale' });
+
+      // Clear the queue (simulating newSession)
+      conn.clearPendingSends();
+
+      // Reconnect
+      vi.advanceTimersByTime(100);
+      const ws2 = lastWs!;
+      ws2.simulateOpen();
+      ws2.simulateMessage({ type: 'welcome', protocolVersion: 2, connectionId: 'conn-2' });
+
+      // Only hello + reconnect should be on the wire — no stale messages
+      const calls = ws2.send.mock.calls.map((c: string[]) => JSON.parse(c[0]));
+      expect(calls.some((c: Record<string, unknown>) => c.prompt === 'stale')).toBe(false);
+      expect(calls.some((c: Record<string, unknown>) => c.prompt === 'also stale')).toBe(false);
+
+      vi.useRealTimers();
+    });
+
+    it('is safe to call when queue is already empty', () => {
+      const conn = createConnection();
+      conn.onMessage(() => {});
+      openWithHandshake(conn);
+
+      expect(() => conn.clearPendingSends()).not.toThrow();
+    });
+  });
+
   describe('sendSuspend', () => {
     it('sends session_suspend via WS with all tracked sessions', () => {
       const conn = createConnection();

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -254,6 +254,45 @@ describe('newSession', () => {
     expect(store.getState().progress.toolIndex).toEqual({});
   });
 
+  it('clears WS pending sends to prevent cross-session message leaks', () => {
+    vi.useFakeTimers();
+    try {
+      const store = createMitzoStore(makeOptions());
+      const ws1 = lastWs;
+      ws1.completeHandshake();
+
+      // Complete a turn so running=false
+      store.getState().sendMessage('hello');
+      lastWs.simulateMessage({ type: 'session_id', sessionId: 'sess-old' });
+      lastWs.simulateMessage({ type: 'session_end', sessionId: 'sess-old' });
+      expect(store.getState().messages.running).toBe(false);
+
+      // WS dies (iOS background)
+      ws1.simulateClose();
+
+      // User sends while WS is down and running=false → goes to connection.pendingSends
+      store.getState().sendMessage('stale message');
+      expect(store.getState().sendError).toBeNull(); // confirms message was queued, not dropped
+
+      // User starts a new session — should clear the WS queue
+      store.getState().newSession();
+
+      // WS reconnects (default reconnectDelayMs is 500ms)
+      vi.advanceTimersByTime(600);
+      const ws2 = lastWs;
+      expect(ws2).not.toBe(ws1); // verify a new WS was created
+      ws2.completeHandshake();
+
+      // The stale message should NOT have been flushed to the new session
+      const flushed = ws2
+        .parsedSent()
+        .filter((m) => m.type === 'send' && m.prompt === 'stale message');
+      expect(flushed).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('isolates new session from old session messages via sessionId filter', async () => {
     const store = createReadyStore();
     await store.getState().switchSession('old-session');

--- a/packages/client/src/connection.ts
+++ b/packages/client/src/connection.ts
@@ -110,6 +110,11 @@ export class MitzoConnection {
     this.seqBySession.delete(sessionId);
   }
 
+  /** Drain the pending-send queue (e.g. on session switch to avoid cross-session message leaks). */
+  clearPendingSends(): void {
+    this.pendingSends = [];
+  }
+
   getTrackedSessions(): string[] {
     return Array.from(this.seqBySession.keys());
   }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -250,6 +250,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         connection.clearSession(oldId);
       }
       parserState.currentSessionId = id;
+      // Drain stale pending sends from the previous session's WS queue.
+      connection.clearPendingSends();
 
       set((s) => ({
         sessions: { ...s.sessions, active: id },
@@ -281,6 +283,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = undefined;
       parserState.pendingSend = [];
       clearPendingSendTimer();
+      // Drain the WS pending-send queue to prevent stale messages from the
+      // old session leaking into the new one on reconnect (iOS background).
+      connection.clearPendingSends();
       connection.send({ type: 'switch_session', sessionId: null });
       set({
         sessions: { ...get().sessions, active: null },

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -250,7 +250,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         connection.clearSession(oldId);
       }
       parserState.currentSessionId = id;
-      // Drain stale pending sends from the previous session's WS queue.
+      parserState.pendingSend = [];
+      clearPendingSendTimer();
       connection.clearPendingSends();
 
       set((s) => ({
@@ -283,8 +284,6 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = undefined;
       parserState.pendingSend = [];
       clearPendingSendTimer();
-      // Drain the WS pending-send queue to prevent stale messages from the
-      // old session leaking into the new one on reconnect (iOS background).
       connection.clearPendingSends();
       connection.send({ type: 'switch_session', sessionId: null });
       set({


### PR DESCRIPTION
## Summary

- Messages queued in `connection.pendingSends` during WS downtime (iOS background) were flushed to the wrong session after reconnect
- Add `clearPendingSends()` to `MitzoConnection` and call it from `newSession()` and `switchSession()`
- Three new tests covering the drain, empty-queue safety, and end-to-end store-level leak prevention

Reopened from #371 (merged prematurely without reviews — reverted).

## Test plan

- [x] `npx vitest run packages/client/` — 309 tests pass
- [ ] Manual: send message on iOS → background app → start new session → verify old message doesn't appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)