### PR TITLE
fix(chat): resolve SSH agent socket fresh per session on macOS

### DIFF
--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -529,26 +529,67 @@ describe('validateResumable', () => {
 });
 
 describe('resolveSshAuthSock', () => {
-  it('returns a string on macOS when the agent is running', async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns trimmed socket path on macOS', async () => {
+    vi.resetModules();
+    vi.doMock('os', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return { ...actual, platform: () => 'darwin' };
+    });
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return {
+        ...actual,
+        execFileSync: vi.fn().mockReturnValue('  /private/tmp/com.apple.launchd.xxx/Listeners  \n'),
+      };
+    });
     const { resolveSshAuthSock } = await import('../chat.js');
-    const result = resolveSshAuthSock();
-    if (process.platform === 'darwin') {
-      // On macOS CI/dev, the agent should be running
-      expect(typeof result === 'string' || result === null).toBe(true);
-      if (result) {
-        expect(result).toContain('/');
-      }
-    } else {
-      expect(result).toBeNull();
-    }
+    expect(resolveSshAuthSock()).toBe('/private/tmp/com.apple.launchd.xxx/Listeners');
+  });
+
+  it('returns null when launchctl returns empty string', async () => {
+    vi.resetModules();
+    vi.doMock('os', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return { ...actual, platform: () => 'darwin' };
+    });
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return { ...actual, execFileSync: vi.fn().mockReturnValue('  \n') };
+    });
+    const { resolveSshAuthSock } = await import('../chat.js');
+    expect(resolveSshAuthSock()).toBeNull();
+  });
+
+  it('returns null when execFileSync throws', async () => {
+    vi.resetModules();
+    vi.doMock('os', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return { ...actual, platform: () => 'darwin' };
+    });
+    vi.doMock('child_process', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return {
+        ...actual,
+        execFileSync: vi.fn().mockImplementation(() => {
+          throw new Error('launchctl not found');
+        }),
+      };
+    });
+    const { resolveSshAuthSock } = await import('../chat.js');
+    expect(resolveSshAuthSock()).toBeNull();
   });
 
   it('returns null on non-macOS platforms', async () => {
-    // On macOS this test validates the shape; on Linux CI it validates the null path
+    vi.resetModules();
+    vi.doMock('os', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return { ...actual, platform: () => 'linux' };
+    });
     const { resolveSshAuthSock } = await import('../chat.js');
-    const result = resolveSshAuthSock();
-    if (process.platform !== 'darwin') {
-      expect(result).toBeNull();
-    }
+    expect(resolveSshAuthSock()).toBeNull();
   });
 });

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -527,3 +527,28 @@ describe('validateResumable', () => {
     expect(result).toEqual({ valid: false });
   });
 });
+
+describe('resolveSshAuthSock', () => {
+  it('returns a string on macOS when the agent is running', async () => {
+    const { resolveSshAuthSock } = await import('../chat.js');
+    const result = resolveSshAuthSock();
+    if (process.platform === 'darwin') {
+      // On macOS CI/dev, the agent should be running
+      expect(typeof result === 'string' || result === null).toBe(true);
+      if (result) {
+        expect(result).toContain('/');
+      }
+    } else {
+      expect(result).toBeNull();
+    }
+  });
+
+  it('returns null on non-macOS platforms', async () => {
+    // On macOS this test validates the shape; on Linux CI it validates the null path
+    const { resolveSshAuthSock } = await import('../chat.js');
+    const result = resolveSshAuthSock();
+    if (process.platform !== 'darwin') {
+      expect(result).toBeNull();
+    }
+  });
+});

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -386,6 +386,25 @@ function send(transport: SessionTransport, data: Record<string, unknown> | BootC
 
 const IPV4_PRELOAD = join(dirname(fileURLToPath(import.meta.url)), 'ipv4-preload.cjs');
 
+/**
+ * Resolve the live SSH agent socket on macOS via launchctl.
+ * The server process may have started with a socket that became stale after
+ * sleep/wake — launchctl always returns the current one.
+ * Returns null on non-macOS or if the agent isn't running.
+ */
+export function resolveSshAuthSock(): string | null {
+  if (platform() !== 'darwin') return null;
+  try {
+    const sock = execFileSync('launchctl', ['getenv', 'SSH_AUTH_SOCK'], {
+      encoding: 'utf8',
+      timeout: 500,
+    }).trim();
+    return sock || null;
+  } catch {
+    return null;
+  }
+}
+
 function sdkEnv(): Record<string, string> {
   const env = { ...process.env } as Record<string, string>;
   env.CLAUDE_CODE_USE_VERTEX = process.env.CLAUDE_CODE_USE_VERTEX || '1';
@@ -406,20 +425,8 @@ function sdkEnv(): Record<string, string> {
   const venvPaths = getRepoConfig().resolvedVenvPaths;
   env.PATH = [...venvPaths, existingPath].join(':');
 
-  // Resolve the current SSH agent socket on macOS. The server process may have
-  // started with a socket that became stale after sleep/wake — launchctl always
-  // returns the live one.
-  if (platform() === 'darwin') {
-    try {
-      const sock = execFileSync('launchctl', ['getenv', 'SSH_AUTH_SOCK'], {
-        encoding: 'utf8',
-        timeout: 2000,
-      }).trim();
-      if (sock) env.SSH_AUTH_SOCK = sock;
-    } catch {
-      // launchctl unavailable or no agent — leave inherited value
-    }
-  }
+  const sock = resolveSshAuthSock();
+  if (sock) env.SSH_AUTH_SOCK = sock;
 
   delete env.AUTH_PASSPHRASE;
   delete env.AUTH_SECRET;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -12,7 +12,7 @@ import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { randomUUID } from 'crypto';
-import { homedir } from 'os';
+import { homedir, platform } from 'os';
 import {
   createWorktree,
   createWorktreeAsync,
@@ -405,6 +405,21 @@ function sdkEnv(): Record<string, string> {
   const existingPath = env.PATH || '/usr/bin:/bin:/usr/local/bin';
   const venvPaths = getRepoConfig().resolvedVenvPaths;
   env.PATH = [...venvPaths, existingPath].join(':');
+
+  // Resolve the current SSH agent socket on macOS. The server process may have
+  // started with a socket that became stale after sleep/wake — launchctl always
+  // returns the live one.
+  if (platform() === 'darwin') {
+    try {
+      const sock = execFileSync('launchctl', ['getenv', 'SSH_AUTH_SOCK'], {
+        encoding: 'utf8',
+        timeout: 2000,
+      }).trim();
+      if (sock) env.SSH_AUTH_SOCK = sock;
+    } catch {
+      // launchctl unavailable or no agent — leave inherited value
+    }
+  }
 
   delete env.AUTH_PASSPHRASE;
   delete env.AUTH_SECRET;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -386,12 +386,7 @@ function send(transport: SessionTransport, data: Record<string, unknown> | BootC
 
 const IPV4_PRELOAD = join(dirname(fileURLToPath(import.meta.url)), 'ipv4-preload.cjs');
 
-/**
- * Resolve the live SSH agent socket on macOS via launchctl.
- * The server process may have started with a socket that became stale after
- * sleep/wake — launchctl always returns the current one.
- * Returns null on non-macOS or if the agent isn't running.
- */
+// launchctl resolves the live socket — the inherited one goes stale after sleep/wake.
 export function resolveSshAuthSock(): string | null {
   if (platform() !== 'darwin') return null;
   try {


### PR DESCRIPTION
## Summary

- Mitzo's server process inherits `SSH_AUTH_SOCK` at launch, but macOS invalidates the socket path after sleep/wake
- SDK sessions spawned after wake get a stale socket → git push/fetch fails with "Permission denied (publickey)"
- Fix: resolve the live socket via `launchctl getenv SSH_AUTH_SOCK` in `sdkEnv()` at session spawn time
- No-op on non-macOS, graceful fallback if launchctl fails

## Test plan

- [x] Server tests pass (pre-existing failures unchanged)
- [ ] Deploy, sleep/wake Mac, verify git push works in a new Mitzo session

🤖 Generated with [Claude Code](https://claude.com/claude-code)