### PR TITLE
feat(images): reference-based image rendering for tool results

### DIFF
--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -92,20 +92,37 @@ function ToolResult({
   block: StreamingBlock | FinishedBlock;
   onPopOut?: (path: string) => void;
 }) {
-  if (block.toolResult === undefined) return null;
+  const hasText = block.toolResult !== undefined && block.toolResult.length > 0;
+  const hasImages = block.toolResultImages && block.toolResultImages.length > 0;
+
+  if (!hasText && !hasImages) return null;
 
   const raw = block.rawInput;
   const isRead = raw?.type === 'read';
 
   return (
     <div className="tool-pill-section">
-      <CodeBlock
-        code={block.toolResult}
-        language={raw?.language}
-        label={isRead ? raw?.path : 'Result'}
-        maxHeight={400}
-        onPopOut={isRead && raw?.path && onPopOut ? () => onPopOut(raw.path!) : undefined}
-      />
+      {hasImages && (
+        <div className="tool-pill-images">
+          {block.toolResultImages!.map((img, i) => (
+            <img
+              key={i}
+              src={`data:${img.mediaType};base64,${img.data}`}
+              alt={`Result image ${i + 1}`}
+              className="tool-pill-result-img"
+            />
+          ))}
+        </div>
+      )}
+      {hasText && (
+        <CodeBlock
+          code={block.toolResult!}
+          language={raw?.language}
+          label={isRead ? raw?.path : 'Result'}
+          maxHeight={400}
+          onPopOut={isRead && raw?.path && onPopOut ? () => onPopOut(raw.path!) : undefined}
+        />
+      )}
     </div>
   );
 }
@@ -114,7 +131,7 @@ export function ToolPill({ block }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const [expanded, setExpanded] = useState(false);
-  const done = block.toolResult !== undefined;
+  const done = block.toolResult !== undefined || (block.toolResultImages && block.toolResultImages.length > 0);
   const hasError = (block as StreamingBlock).toolError === true;
   const input = block.toolInput || '';
 

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -107,7 +107,7 @@ function ToolResult({
           {block.toolResultImages!.map((img, i) => (
             <img
               key={i}
-              src={`data:${img.mediaType};base64,${img.data}`}
+              src={`/api/images/${img.id}`}
               alt={`Result image ${i + 1}`}
               className="tool-pill-result-img"
             />

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -131,7 +131,8 @@ export function ToolPill({ block }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
   const [expanded, setExpanded] = useState(false);
-  const done = block.toolResult !== undefined || (block.toolResultImages && block.toolResultImages.length > 0);
+  const done =
+    block.toolResult !== undefined || (block.toolResultImages && block.toolResultImages.length > 0);
   const hasError = (block as StreamingBlock).toolError === true;
   const input = block.toolInput || '';
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2344,6 +2344,20 @@ textarea:focus {
   margin: 0.15rem 0 0;
 }
 
+.tool-pill-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
+}
+
+.tool-pill-result-img {
+  max-width: 100%;
+  max-height: 400px;
+  border-radius: 6px;
+  object-fit: contain;
+}
+
 .tool-pill-code {
   color: var(--text);
   background: var(--code-bg);

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -15,6 +15,7 @@ import type {
   BlockType,
   ToolTier,
   RawToolInput,
+  ToolResultImage,
 } from '@mitzo/protocol';
 import type { MessagesAction } from './slices/messages.js';
 import type { WsMsg } from './server-messages.js';
@@ -337,6 +338,7 @@ export function parseServerMessage(
         toolId: msg.toolId as string,
         result: msg.result as string,
         isError: (msg.isError as boolean) ?? false,
+        images: msg.images as ToolResultImage[] | undefined,
       });
       break;
 
@@ -600,6 +602,7 @@ export function parseServerMessage(
         toolId: msg.toolId as string,
         result: msg.result as string,
         isError: (msg.isError as boolean) ?? false,
+        images: msg.images as ToolResultImage[] | undefined,
       });
       break;
 

--- a/packages/client/src/protocol-parser.ts
+++ b/packages/client/src/protocol-parser.ts
@@ -338,7 +338,7 @@ export function parseServerMessage(
         toolId: msg.toolId as string,
         result: msg.result as string,
         isError: (msg.isError as boolean) ?? false,
-        images: msg.images as ToolResultImage[] | undefined,
+        images: Array.isArray(msg.images) ? (msg.images as ToolResultImage[]) : undefined,
       });
       break;
 
@@ -602,7 +602,7 @@ export function parseServerMessage(
         toolId: msg.toolId as string,
         result: msg.result as string,
         isError: (msg.isError as boolean) ?? false,
-        images: msg.images as ToolResultImage[] | undefined,
+        images: Array.isArray(msg.images) ? (msg.images as ToolResultImage[]) : undefined,
       });
       break;
 

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -378,6 +378,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
           toolInput: b.toolInput,
           rawInput: b.rawInput,
           toolResult: b.toolResult,
+          toolResultImages: b.toolResultImages,
           toolError: b.toolError,
         });
         blockOrder.push(b.blockId);

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -238,7 +238,12 @@ export function patchToolResult(
     for (const block of current.blocks.values()) {
       if (block.toolId === toolId) {
         const newBlocks = new Map(current.blocks);
-        newBlocks.set(block.blockId, { ...block, toolResult: result, toolError: isError, ...imgPatch });
+        newBlocks.set(block.blockId, {
+          ...block,
+          toolResult: result,
+          toolError: isError,
+          ...imgPatch,
+        });
         return { messages, current: { ...current, blocks: newBlocks } };
       }
     }
@@ -703,7 +708,8 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
       if (!sub) return state;
 
       // Find the tool block with matching toolId
-      const imgPatch = action.images && action.images.length > 0 ? { toolResultImages: action.images } : {};
+      const imgPatch =
+        action.images && action.images.length > 0 ? { toolResultImages: action.images } : {};
       for (const [blockId, subBlock] of sub.blocks) {
         if (subBlock.toolId === action.toolId) {
           const newSubBlocks = new Map(sub.blocks);

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -15,6 +15,7 @@ import type {
   BlockType,
   StreamingSubagentState,
   FinishedSubagentState,
+  ToolResultImage,
 } from '@mitzo/protocol';
 
 // ─── State ───────────────────────────────────────────────────────────────────
@@ -101,6 +102,7 @@ export type MessagesAction =
       toolId: string;
       result: string;
       isError: boolean;
+      images?: ToolResultImage[];
     }
   | { type: 'MESSAGE_END'; messageId: string; sessionId?: string }
   | { type: 'SESSION_END'; sessionId?: string }
@@ -129,6 +131,7 @@ export type MessagesAction =
       toolId: string;
       result: string;
       isError: boolean;
+      images?: ToolResultImage[];
     }
   | {
       type: 'SUBAGENT_END';
@@ -195,6 +198,7 @@ function finishSubagent(
         toolInput: b.toolInput,
         rawInput: b.rawInput,
         toolResult: b.toolResult,
+        toolResultImages: b.toolResultImages,
         toolError: b.toolError,
       })),
   };
@@ -212,6 +216,7 @@ export function finishCurrent(current: StreamingMessage): FinishedMessage {
       toolInput: b.toolInput,
       rawInput: b.rawInput,
       toolResult: b.toolResult,
+      toolResultImages: b.toolResultImages,
       toolError: b.toolError,
       subagent: b.subagent ? finishSubagent(b.subagent) : undefined,
     };
@@ -225,13 +230,15 @@ export function patchToolResult(
   toolId: string,
   result: string,
   isError: boolean,
+  images?: ToolResultImage[],
 ): { messages: FinishedMessage[]; current: StreamingMessage | null } {
+  const imgPatch = images && images.length > 0 ? { toolResultImages: images } : {};
   // Check current first (tool result may arrive before message_end in edge cases).
   if (current) {
     for (const block of current.blocks.values()) {
       if (block.toolId === toolId) {
         const newBlocks = new Map(current.blocks);
-        newBlocks.set(block.blockId, { ...block, toolResult: result, toolError: isError });
+        newBlocks.set(block.blockId, { ...block, toolResult: result, toolError: isError, ...imgPatch });
         return { messages, current: { ...current, blocks: newBlocks } };
       }
     }
@@ -241,7 +248,7 @@ export function patchToolResult(
     const idx = msg.blocks.findIndex((b) => b.toolId === toolId);
     if (idx === -1) return msg;
     const newBlocks = [...msg.blocks];
-    newBlocks[idx] = { ...newBlocks[idx], toolResult: result, toolError: isError };
+    newBlocks[idx] = { ...newBlocks[idx], toolResult: result, toolError: isError, ...imgPatch };
     return { ...msg, blocks: newBlocks };
   });
   return { messages: newMessages, current };
@@ -322,6 +329,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
         action.toolId,
         action.result,
         action.isError,
+        action.images,
       );
       return { ...state, messages, current };
     }
@@ -695,6 +703,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
       if (!sub) return state;
 
       // Find the tool block with matching toolId
+      const imgPatch = action.images && action.images.length > 0 ? { toolResultImages: action.images } : {};
       for (const [blockId, subBlock] of sub.blocks) {
         if (subBlock.toolId === action.toolId) {
           const newSubBlocks = new Map(sub.blocks);
@@ -702,6 +711,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
             ...subBlock,
             toolResult: action.result,
             toolError: action.isError,
+            ...imgPatch,
           });
 
           const newBlocks = new Map(state.current.blocks);
@@ -739,6 +749,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
             toolInput: b.toolInput,
             rawInput: b.rawInput,
             toolResult: b.toolResult,
+            toolResultImages: b.toolResultImages,
             toolError: b.toolError,
           })),
         summary: action.summary,

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -259,7 +259,6 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = id;
       parserState.pendingSend = [];
       clearPendingSendTimer();
-      // Drain stale pending sends from the previous session's WS queue.
       connection.clearPendingSends();
 
       set((s) => ({
@@ -292,8 +291,6 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = undefined;
       parserState.pendingSend = [];
       clearPendingSendTimer();
-      // Drain the WS pending-send queue to prevent stale messages from the
-      // old session leaking into the new one on reconnect (iOS background).
       connection.clearPendingSends();
       connection.send({ type: 'switch_session', sessionId: null });
       set({

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -259,6 +259,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = id;
       parserState.pendingSend = [];
       clearPendingSendTimer();
+      // Drain stale pending sends from the previous session's WS queue.
       connection.clearPendingSends();
 
       set((s) => ({
@@ -291,6 +292,8 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       parserState.currentSessionId = undefined;
       parserState.pendingSend = [];
       clearPendingSendTimer();
+      // Drain the WS pending-send queue to prevent stale messages from the
+      // old session leaking into the new one on reconnect (iOS background).
       connection.clearPendingSends();
       connection.send({ type: 'switch_session', sessionId: null });
       set({

--- a/packages/protocol/__tests__/content-blocks.test.ts
+++ b/packages/protocol/__tests__/content-blocks.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { parseContentBlocks, extractToolResultText } from '../src/content-blocks.js';
+import {
+  parseContentBlocks,
+  extractToolResultText,
+  extractToolResultImages,
+} from '../src/content-blocks.js';
 
 describe('extractToolResultText', () => {
   it('returns string content directly', () => {
@@ -73,5 +77,67 @@ describe('parseContentBlocks', () => {
     expect(result.text).toBe('prefix');
     expect(result.toolCalls).toHaveLength(1);
     expect(result.toolResults).toHaveLength(1);
+  });
+});
+
+describe('extractToolResultImages', () => {
+  it('returns empty array for string content', () => {
+    expect(extractToolResultImages('hello')).toEqual([]);
+  });
+
+  it('returns empty array for undefined content', () => {
+    expect(extractToolResultImages(undefined)).toEqual([]);
+  });
+
+  it('extracts image blocks with base64 source', () => {
+    const content = [
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'iVBOR...' },
+      },
+    ];
+    const result = extractToolResultImages(content);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ data: 'iVBOR...', mediaType: 'image/png' });
+  });
+
+  it('ignores non-image blocks', () => {
+    const content = [
+      { type: 'text', text: 'hello' },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/jpeg', data: '/9j/4...' },
+      },
+    ];
+    const result = extractToolResultImages(content);
+    expect(result).toHaveLength(1);
+    expect(result[0].mediaType).toBe('image/jpeg');
+  });
+
+  it('skips image blocks missing source fields', () => {
+    const content = [
+      { type: 'image' },
+      { type: 'image', source: { type: 'url', url: 'https://example.com/img.png' } },
+      { type: 'image', source: { type: 'base64' } },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png' } },
+    ];
+    expect(extractToolResultImages(content)).toEqual([]);
+  });
+
+  it('extracts multiple images', () => {
+    const content = [
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/png', data: 'aaa' },
+      },
+      {
+        type: 'image',
+        source: { type: 'base64', media_type: 'image/webp', data: 'bbb' },
+      },
+    ];
+    const result = extractToolResultImages(content);
+    expect(result).toHaveLength(2);
+    expect(result[0].mediaType).toBe('image/png');
+    expect(result[1].mediaType).toBe('image/webp');
   });
 });

--- a/packages/protocol/src/content-blocks.ts
+++ b/packages/protocol/src/content-blocks.ts
@@ -1,5 +1,6 @@
 import { summarizeToolInput } from './tool-summary.js';
 import { TOOL_RESULT_MAX_CHARS } from './constants.js';
+import type { ToolResultImage } from './types.js';
 
 interface ContentBlock {
   type: string;
@@ -7,8 +8,14 @@ interface ContentBlock {
   name?: string;
   id?: string;
   input?: Record<string, unknown>;
-  content?: string | Array<{ type: string; text?: string }>;
+  content?: string | Array<ContentItem>;
   tool_use_id?: string;
+}
+
+interface ContentItem {
+  type: string;
+  text?: string;
+  source?: { type: string; media_type?: string; data?: string };
 }
 
 interface ParsedToolCall {
@@ -29,7 +36,7 @@ interface ParsedContent {
 }
 
 export function extractToolResultText(
-  content: string | Array<{ type: string; text?: string }> | undefined,
+  content: string | ContentItem[] | undefined,
 ): string {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
@@ -38,6 +45,19 @@ export function extractToolResultText(
     if (c.type === 'text' && c.text) text += c.text;
   }
   return text;
+}
+
+export function extractToolResultImages(
+  content: string | ContentItem[] | undefined,
+): ToolResultImage[] {
+  if (typeof content === 'string' || !Array.isArray(content)) return [];
+  const images: ToolResultImage[] = [];
+  for (const c of content) {
+    if (c.type === 'image' && c.source?.type === 'base64' && c.source.data && c.source.media_type) {
+      images.push({ data: c.source.data, mediaType: c.source.media_type });
+    }
+  }
+  return images;
 }
 
 export function parseContentBlocks(blocks: ContentBlock[]): ParsedContent {

--- a/packages/protocol/src/content-blocks.ts
+++ b/packages/protocol/src/content-blocks.ts
@@ -35,9 +35,7 @@ interface ParsedContent {
   toolResults: ParsedToolResult[];
 }
 
-export function extractToolResultText(
-  content: string | ContentItem[] | undefined,
-): string {
+export function extractToolResultText(content: string | ContentItem[] | undefined): string {
   if (typeof content === 'string') return content;
   if (!Array.isArray(content)) return '';
   let text = '';

--- a/packages/protocol/src/content-blocks.ts
+++ b/packages/protocol/src/content-blocks.ts
@@ -1,6 +1,6 @@
 import { summarizeToolInput } from './tool-summary.js';
 import { TOOL_RESULT_MAX_CHARS } from './constants.js';
-import type { ToolResultImage } from './types.js';
+import type { RawToolResultImage } from './types.js';
 
 interface ContentBlock {
   type: string;
@@ -47,9 +47,9 @@ export function extractToolResultText(content: string | ContentItem[] | undefine
 
 export function extractToolResultImages(
   content: string | ContentItem[] | undefined,
-): ToolResultImage[] {
+): RawToolResultImage[] {
   if (typeof content === 'string' || !Array.isArray(content)) return [];
-  const images: ToolResultImage[] = [];
+  const images: RawToolResultImage[] = [];
   for (const c of content) {
     if (c.type === 'image' && c.source?.type === 'base64' && c.source.data && c.source.media_type) {
       images.push({ data: c.source.data, mediaType: c.source.media_type });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export type {
   FinishedMessage,
   PermissionRequest,
   ImageAttachment,
+  RawToolResultImage,
   ToolResultImage,
   Session,
   SessionClosedBy,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export type {
   FinishedMessage,
   PermissionRequest,
   ImageAttachment,
+  ToolResultImage,
   Session,
   SessionClosedBy,
   SessionState,
@@ -55,7 +56,7 @@ export { getRawInput, summarizeToolInput } from './tool-summary.js';
 export { languageFromPath } from './language.js';
 
 // Content blocks
-export { extractToolResultText, parseContentBlocks } from './content-blocks.js';
+export { extractToolResultText, extractToolResultImages, parseContentBlocks } from './content-blocks.js';
 
 // Async queue
 export { AsyncQueue } from './async-queue.js';

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -56,7 +56,11 @@ export { getRawInput, summarizeToolInput } from './tool-summary.js';
 export { languageFromPath } from './language.js';
 
 // Content blocks
-export { extractToolResultText, extractToolResultImages, parseContentBlocks } from './content-blocks.js';
+export {
+  extractToolResultText,
+  extractToolResultImages,
+  parseContentBlocks,
+} from './content-blocks.js';
 
 // Async queue
 export { AsyncQueue } from './async-queue.js';

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -113,8 +113,15 @@ export interface ImageAttachment {
   preview: string;
 }
 
-// --- Tool result image (reference to server-stored image) ---
+// --- Tool result image ---
 
+/** Raw image extracted from SDK tool result content blocks (base64 data). */
+export interface RawToolResultImage {
+  data: string;
+  mediaType: string;
+}
+
+/** Reference to a server-stored image (sent over WS / persisted in blocks). */
 export interface ToolResultImage {
   id: string;
   mediaType: string;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -57,6 +57,7 @@ export interface StreamingBlock {
   toolInput?: string;
   rawInput?: RawToolInput;
   toolResult?: string;
+  toolResultImages?: ToolResultImage[];
   toolError?: boolean;
   subagent?: StreamingSubagentState | FinishedSubagentState;
 }
@@ -78,6 +79,7 @@ export interface FinishedBlock {
   toolInput?: string;
   rawInput?: RawToolInput;
   toolResult?: string;
+  toolResultImages?: ToolResultImage[];
   toolError?: boolean;
   subagent?: FinishedSubagentState;
 }
@@ -109,6 +111,13 @@ export interface ImageAttachment {
   data: string;
   mediaType: string;
   preview: string;
+}
+
+// --- Tool result image (from SDK image content blocks) ---
+
+export interface ToolResultImage {
+  data: string;
+  mediaType: string;
 }
 
 // --- Session (client-facing) ---

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -113,10 +113,10 @@ export interface ImageAttachment {
   preview: string;
 }
 
-// --- Tool result image (from SDK image content blocks) ---
+// --- Tool result image (reference to server-stored image) ---
 
 export interface ToolResultImage {
-  data: string;
+  id: string;
   mediaType: string;
 }
 

--- a/server/__tests__/image-store.test.ts
+++ b/server/__tests__/image-store.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { storeImage, getImage, clearSessionImages } from '../image-store.js';
+import { storeImage, getImage, clearSessionImages, _resetForTest } from '../image-store.js';
 
 describe('image-store', () => {
   const SESSION = 'test-session';
+
+  beforeEach(() => {
+    _resetForTest();
+  });
 
   it('stores and retrieves an image', () => {
     const id = storeImage(SESSION, 'aGVsbG8=', 'image/png');
@@ -42,5 +46,11 @@ describe('image-store', () => {
     expect(cleared).toBe(1);
     expect(getImage(id1)).toBeNull();
     expect(getImage(id2)).not.toBeNull();
+  });
+
+  it('rejects images exceeding 10 MB', () => {
+    // Create base64 string that decodes to >10 MB
+    const bigData = Buffer.alloc(10 * 1024 * 1024 + 1).toString('base64');
+    expect(storeImage(SESSION, bigData, 'image/png')).toBeNull();
   });
 });

--- a/server/__tests__/image-store.test.ts
+++ b/server/__tests__/image-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { storeImage, getImage, clearSessionImages } from '../image-store.js';
+
+describe('image-store', () => {
+  const SESSION = 'test-session';
+
+  it('stores and retrieves an image', () => {
+    const id = storeImage(SESSION, 'aGVsbG8=', 'image/png');
+    expect(id).toBeTruthy();
+    const img = getImage(id!);
+    expect(img).not.toBeNull();
+    expect(img!.mediaType).toBe('image/png');
+    expect(img!.sessionId).toBe(SESSION);
+    expect(img!.data).toBeInstanceOf(Buffer);
+  });
+
+  it('rejects non-image media types', () => {
+    expect(storeImage(SESSION, 'data', 'text/html')).toBeNull();
+    expect(storeImage(SESSION, 'data', 'application/json')).toBeNull();
+    expect(storeImage(SESSION, 'data', 'video/mp4')).toBeNull();
+  });
+
+  it('accepts all supported image types', () => {
+    for (const type of ['image/jpeg', 'image/png', 'image/gif', 'image/webp']) {
+      const id = storeImage(SESSION, 'dGVzdA==', type);
+      expect(id).toBeTruthy();
+      expect(getImage(id!)!.mediaType).toBe(type);
+    }
+  });
+
+  it('returns null for unknown image ID', () => {
+    expect(getImage('nonexistent-id')).toBeNull();
+  });
+
+  it('clears images by session', () => {
+    const s1 = 'session-1';
+    const s2 = 'session-2';
+    const id1 = storeImage(s1, 'YQ==', 'image/png')!;
+    const id2 = storeImage(s2, 'Yg==', 'image/png')!;
+
+    const cleared = clearSessionImages(s1);
+    expect(cleared).toBe(1);
+    expect(getImage(id1)).toBeNull();
+    expect(getImage(id2)).not.toBeNull();
+  });
+});

--- a/server/__tests__/image-store.test.ts
+++ b/server/__tests__/image-store.test.ts
@@ -53,4 +53,15 @@ describe('image-store', () => {
     const bigData = Buffer.alloc(10 * 1024 * 1024 + 1).toString('base64');
     expect(storeImage(SESSION, bigData, 'image/png')).toBeNull();
   });
+
+  it('enforces per-session image limit of 50', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(storeImage(SESSION, 'dGVzdA==', 'image/png')).toBeTruthy();
+    }
+    // 51st should be rejected
+    expect(storeImage(SESSION, 'dGVzdA==', 'image/png')).toBeNull();
+
+    // Different session should still work
+    expect(storeImage('other-session', 'dGVzdA==', 'image/png')).toBeTruthy();
+  });
 });

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,6 +30,7 @@ import {
   generateWtId,
 } from './chat.js';
 import { NullTransport } from './null-transport.js';
+import { getImage } from './image-store.js';
 import {
   createWorktree,
   createSessionWorktrees as createAllWorktrees,
@@ -1357,6 +1358,19 @@ app.get('/api/files/read', (req, res) => {
     });
     res.status(500).json({ error: 'Failed to read file' });
   }
+});
+
+// ── Tool result images (served from in-memory store) ──────────────────────
+app.get('/api/images/:imageId', (req, res) => {
+  const img = getImage(req.params.imageId);
+  if (!img) {
+    res.status(404).json({ error: 'Image not found' });
+    return;
+  }
+  res.setHeader('Content-Type', img.mediaType);
+  res.setHeader('Content-Length', img.data.length);
+  res.setHeader('Cache-Control', 'private, max-age=3600');
+  res.send(img.data);
 });
 
 app.get('/api/files/download', (req, res) => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -29,6 +29,7 @@ import { loadRepoConfig } from './repo-config.js';
 import { loadProjectHooks } from './hook-bridge.js';
 import { buildPermissionHandler } from './permission-handler.js';
 import { runQueryLoop, broadcastToObservers } from './query-loop.js';
+import { clearSessionImages } from './image-store.js';
 import { AsyncQueue } from './async-queue.js';
 import {
   GIT_BRANCH_TIMEOUT_MS,
@@ -1399,6 +1400,7 @@ export function closeSessionByUser(clientId: string): void {
 
     if (!session.inputQueue) {
       // No active agent — finalize immediately
+      if (session.sessionId) clearSessionImages(session.sessionId);
       if (session.wtId) {
         try {
           finalizeCloseout(BASE_REPO, session.wtId, {
@@ -1465,6 +1467,7 @@ export function stopChat(clientId: string) {
     const session = registry.get(clientId);
     if (session) {
       cleanupSessionWorktrees(session);
+      if (session.sessionId) clearSessionImages(session.sessionId);
       session.inputQueue?.close();
       session.queryInstance?.close();
     }

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1318,6 +1318,7 @@ function _closeoutSessionInner(clientId: string): void {
   const session = registry.get(clientId);
   if (!session?.inputQueue) {
     // No active session or input queue — just finalize as abandoned
+    if (session?.sessionId) clearSessionImages(session.sessionId);
     if (session?.wtId) {
       try {
         finalizeCloseout(BASE_REPO, session.wtId, {
@@ -1353,6 +1354,7 @@ function _closeoutSessionInner(clientId: string): void {
   if (session.wtId) {
     const wtId = session.wtId;
     const onAbort = () => {
+      if (session.sessionId) clearSessionImages(session.sessionId);
       const status = registry.isClosingOut(clientId) ? 'abandoned' : 'closed';
       const closedBy = registry.isUserClose(clientId)
         ? 'user'
@@ -1433,6 +1435,7 @@ export function closeSessionByUser(clientId: string): void {
     if (session.wtId) {
       const wtId = session.wtId;
       const onAbort = () => {
+        if (session.sessionId) clearSessionImages(session.sessionId);
         try {
           finalizeCloseout(BASE_REPO, wtId, {
             status: 'closed',

--- a/server/content-blocks.ts
+++ b/server/content-blocks.ts
@@ -1,1 +1,1 @@
-export { extractToolResultText, parseContentBlocks } from '@mitzo/protocol';
+export { extractToolResultText, extractToolResultImages, parseContentBlocks } from '@mitzo/protocol';

--- a/server/content-blocks.ts
+++ b/server/content-blocks.ts
@@ -1,1 +1,5 @@
-export { extractToolResultText, extractToolResultImages, parseContentBlocks } from '@mitzo/protocol';
+export {
+  extractToolResultText,
+  extractToolResultImages,
+  parseContentBlocks,
+} from '@mitzo/protocol';

--- a/server/image-store.ts
+++ b/server/image-store.ts
@@ -12,6 +12,9 @@ const ALLOWED_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'im
 /** Max decoded image size: 10 MB. */
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 
+/** Max images per session to prevent unbounded accumulation. */
+const MAX_IMAGES_PER_SESSION = 50;
+
 interface StoredImage {
   data: Buffer;
   mediaType: string;
@@ -28,6 +31,14 @@ export function storeImage(
   mediaType: string,
 ): string | null {
   if (!ALLOWED_MEDIA_TYPES.has(mediaType)) return null;
+
+  // Enforce per-session image count limit
+  let sessionCount = 0;
+  for (const img of images.values()) {
+    if (img.sessionId === sessionId) sessionCount++;
+  }
+  if (sessionCount >= MAX_IMAGES_PER_SESSION) return null;
+
   const buf = Buffer.from(base64Data, 'base64');
   if (buf.length > MAX_IMAGE_BYTES) return null;
   const id = randomUUID();

--- a/server/image-store.ts
+++ b/server/image-store.ts
@@ -1,0 +1,53 @@
+/**
+ * In-memory store for tool result images.
+ *
+ * Images are stored server-side and served via REST endpoint.
+ * WS events carry only image IDs — no base64 over the wire.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const ALLOWED_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+interface StoredImage {
+  data: Buffer;
+  mediaType: string;
+  sessionId: string;
+  createdAt: number;
+}
+
+const images = new Map<string, StoredImage>();
+
+/** Store an image and return its ID. Returns null if mediaType is not allowed. */
+export function storeImage(
+  sessionId: string,
+  base64Data: string,
+  mediaType: string,
+): string | null {
+  if (!ALLOWED_MEDIA_TYPES.has(mediaType)) return null;
+  const id = randomUUID();
+  images.set(id, {
+    data: Buffer.from(base64Data, 'base64'),
+    mediaType,
+    sessionId,
+    createdAt: Date.now(),
+  });
+  return id;
+}
+
+/** Retrieve an image by ID. Returns null if not found. */
+export function getImage(imageId: string): StoredImage | null {
+  return images.get(imageId) ?? null;
+}
+
+/** Remove all images for a session. Called on session cleanup. */
+export function clearSessionImages(sessionId: string): number {
+  let count = 0;
+  for (const [id, img] of images) {
+    if (img.sessionId === sessionId) {
+      images.delete(id);
+      count++;
+    }
+  }
+  return count;
+}

--- a/server/image-store.ts
+++ b/server/image-store.ts
@@ -9,6 +9,9 @@ import { randomUUID } from 'node:crypto';
 
 const ALLOWED_MEDIA_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
+/** Max decoded image size: 10 MB. */
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
 interface StoredImage {
   data: Buffer;
   mediaType: string;
@@ -25,9 +28,11 @@ export function storeImage(
   mediaType: string,
 ): string | null {
   if (!ALLOWED_MEDIA_TYPES.has(mediaType)) return null;
+  const buf = Buffer.from(base64Data, 'base64');
+  if (buf.length > MAX_IMAGE_BYTES) return null;
   const id = randomUUID();
   images.set(id, {
-    data: Buffer.from(base64Data, 'base64'),
+    data: buf,
     mediaType,
     sessionId,
     createdAt: Date.now(),
@@ -50,4 +55,9 @@ export function clearSessionImages(sessionId: string): number {
     }
   }
   return count;
+}
+
+/** Reset the entire store. Test-only. */
+export function _resetForTest(): void {
+  images.clear();
 }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1,6 +1,6 @@
 import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { summarizeToolInput, getRawInput } from './tool-summary.js';
-import { extractToolResultText } from './content-blocks.js';
+import { extractToolResultText, extractToolResultImages } from './content-blocks.js';
 import {
   TOOL_RESULT_MAX_CHARS,
   CONTEXT_CEILING_TOKENS,
@@ -1258,6 +1258,7 @@ async function _runQueryLoopInner(
             for (const block of content) {
               if (block.type === 'tool_result') {
                 const resultText = extractToolResultText(block.content);
+                const resultImages = extractToolResultImages(block.content);
                 const trResult = truncateForTrace(resultText);
 
                 // Check if this is a subagent tool result
@@ -1269,6 +1270,7 @@ async function _runQueryLoopInner(
                       toolId: block.tool_use_id || '',
                       result: resultText.slice(0, TOOL_RESULT_MAX_CHARS),
                       isError: block.is_error === true,
+                      ...(resultImages.length > 0 ? { images: resultImages } : {}),
                     }),
                   );
                   log.info('subagent tool result', {
@@ -1305,6 +1307,7 @@ async function _runQueryLoopInner(
                     toolId: block.tool_use_id || '',
                     result: resultText.slice(0, TOOL_RESULT_MAX_CHARS),
                     isError: block.is_error === true,
+                    ...(resultImages.length > 0 ? { images: resultImages } : {}),
                   }),
                 );
               }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1,6 +1,7 @@
 import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
 import { summarizeToolInput, getRawInput } from './tool-summary.js';
 import { extractToolResultText, extractToolResultImages } from './content-blocks.js';
+import { storeImage } from './image-store.js';
 import {
   TOOL_RESULT_MAX_CHARS,
   CONTEXT_CEILING_TOKENS,
@@ -1261,6 +1262,18 @@ async function _runQueryLoopInner(
                 const resultImages = extractToolResultImages(block.content);
                 const trResult = truncateForTrace(resultText);
 
+                // Store images server-side and build reference array
+                const sid = resolvedSessionId || registry.get(clientId)?.sessionId;
+                let imageRefs: { id: string; mediaType: string }[] | undefined;
+                if (resultImages.length > 0 && sid) {
+                  imageRefs = [];
+                  for (const img of resultImages) {
+                    const imgId = storeImage(sid, img.data, img.mediaType);
+                    if (imgId) imageRefs.push({ id: imgId, mediaType: img.mediaType });
+                  }
+                  if (imageRefs.length === 0) imageRefs = undefined;
+                }
+
                 // Check if this is a subagent tool result
                 if (subagent) {
                   emit(
@@ -1270,7 +1283,7 @@ async function _runQueryLoopInner(
                       toolId: block.tool_use_id || '',
                       result: resultText.slice(0, TOOL_RESULT_MAX_CHARS),
                       isError: block.is_error === true,
-                      ...(resultImages.length > 0 ? { images: resultImages } : {}),
+                      ...(imageRefs ? { images: imageRefs } : {}),
                     }),
                   );
                   log.info('subagent tool result', {
@@ -1294,6 +1307,7 @@ async function _runQueryLoopInner(
                   toolId: block.tool_use_id || '',
                   isError: block.is_error === true,
                   resultLength: resultText.length,
+                  imageCount: imageRefs?.length ?? 0,
                 });
                 log.debug('tool result content', {
                   clientId,
@@ -1307,7 +1321,7 @@ async function _runQueryLoopInner(
                     toolId: block.tool_use_id || '',
                     result: resultText.slice(0, TOOL_RESULT_MAX_CHARS),
                     isError: block.is_error === true,
-                    ...(resultImages.length > 0 ? { images: resultImages } : {}),
+                    ...(imageRefs ? { images: imageRefs } : {}),
                   }),
                 );
               }

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1265,6 +1265,9 @@ async function _runQueryLoopInner(
                 // Store images server-side and build reference array
                 const sid = resolvedSessionId || registry.get(clientId)?.sessionId;
                 let imageRefs: { id: string; mediaType: string }[] | undefined;
+                if (resultImages.length > 0 && !sid) {
+                  log.warn('dropping tool result images — no sessionId', { clientId });
+                }
                 if (resultImages.length > 0 && sid) {
                   imageRefs = [];
                   for (const img of resultImages) {


### PR DESCRIPTION
## Summary
- Adds image rendering for tool results (screenshots, photos, matplotlib plots, etc.)
- **Reference-based architecture**: images are stored server-side in memory, WS carries lightweight `{id, mediaType}` refs, frontend fetches via `GET /api/images/:id` with browser caching
- Supports JPEG, PNG, GIF, and WebP via MIME allowlist validation
- Extracts `type: 'image'` content blocks from Claude SDK tool results (previously discarded by `extractToolResultText`)

## Changes
- `server/image-store.ts` — in-memory image store with session-scoped cleanup
- `server/app.ts` — REST endpoint `GET /api/images/:imageId`
- `server/query-loop.ts` — extract images from tool results, store server-side, emit refs
- `packages/protocol/` — `ToolResultImage` type, `extractToolResultImages()` function, updated block types
- `packages/client/` — protocol parser + messages slice handle image refs
- `frontend/src/components/ToolPill.tsx` — renders images via REST URL
- 20 tests (6 protocol + 5 image-store + 9 existing)

## Test plan
- [x] Unit tests for `extractToolResultImages` (6 cases)
- [x] Unit tests for `image-store` (5 cases: store/retrieve, MIME validation, session cleanup)
- [ ] E2E: ask Claude to read a screenshot → image renders in chat
- [ ] E2E: ask Claude to generate a matplotlib plot → chart renders
- [ ] Verify no regression on text-only tool results

🤖 Generated with [Claude Code](https://claude.com/claude-code)