### PR TITLE
feat(orchestrator): multi-agent goal execution via session_policy spawn

### DIFF
--- a/server/__tests__/signal-processor.test.ts
+++ b/server/__tests__/signal-processor.test.ts
@@ -217,6 +217,167 @@ describe('SignalProcessor', () => {
       const results = store.findActiveSignalTasks('centaur_review');
       expect(results).toHaveLength(0);
     });
+
+    it('finds human_approval tasks', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Human approval gate',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'human_approval' },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const results = store.findActiveSignalTasks('human_approval');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(t1.id);
+    });
+
+    it('does not cross-match gate types', () => {
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'CI gate',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      });
+
+      const results = store.findActiveSignalTasks('human_approval');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('gate matching (mirrors /api/signals/resolve logic)', () => {
+    it('centaur_review matches by pr_url', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Centaur review',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: {
+          type: 'centaur_review',
+          pr_url: 'https://github.com/dimakis/mitzo/pull/360',
+        },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const candidates = store.findActiveSignalTasks('centaur_review');
+      expect(candidates).toHaveLength(1);
+
+      // Simulate the matching logic from the endpoint
+      const gc = candidates[0].gateConfig as Record<string, unknown>;
+      const incomingPrUrl = 'https://github.com/dimakis/mitzo/pull/360';
+      expect(gc.pr_url).toBe(incomingPrUrl);
+    });
+
+    it('centaur_review matches by repo + pr number', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Centaur review',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'centaur_review', repo: 'dimakis/mitzo', pr: 360 },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const candidates = store.findActiveSignalTasks('centaur_review');
+      const gc = candidates[0].gateConfig as Record<string, unknown>;
+      expect(gc.repo).toBe('dimakis/mitzo');
+      expect(gc.pr).toBe(360);
+    });
+
+    it('gh_ci matches by repo + pr', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'CI check',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'dimakis/mitzo', pr: 377 },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const candidates = store.findActiveSignalTasks('gh_ci');
+      expect(candidates).toHaveLength(1);
+      const gc = candidates[0].gateConfig as Record<string, unknown>;
+      expect(gc.repo).toBe('dimakis/mitzo');
+      expect(gc.pr).toBe(377);
+    });
+
+    it('human_approval matches any active task of that type', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Approval gate',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'human_approval' },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const candidates = store.findActiveSignalTasks('human_approval');
+      expect(candidates).toHaveLength(1);
+      // human_approval: isMatch = true for any candidate (no repo/pr filtering)
+    });
+
+    it('does not match across gate types', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'CI check',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'org/repo', pr: 1 },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      expect(store.findActiveSignalTasks('centaur_review')).toHaveLength(0);
+      expect(store.findActiveSignalTasks('human_approval')).toHaveLength(0);
+    });
+
+    it('matches multiple tasks of same gate type', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Review 1',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'centaur_review', repo: 'dimakis/mitzo', pr: 360 },
+      });
+      const t2 = store.create({
+        title: 'Review 2',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'centaur_review', repo: 'dimakis/mitzo', pr: 361 },
+      });
+      store.update(t1.id, { status: 'active' });
+      store.update(t2.id, { status: 'active' });
+
+      const candidates = store.findActiveSignalTasks('centaur_review');
+      expect(candidates).toHaveLength(2);
+    });
+
+    it('resolves matching task via processor', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'CI gate',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'dimakis/mitzo', pr: 377 },
+      });
+      store.update(t1.id, { status: 'active' });
+      processor.watch(t1.id, t1.gateConfig!);
+
+      // Simulate what the endpoint does: find + match + resolve
+      const candidates = store.findActiveSignalTasks('gh_ci');
+      for (const task of candidates) {
+        const gc = task.gateConfig as Record<string, unknown>;
+        if (gc.repo === 'dimakis/mitzo' && gc.pr === 377) {
+          processor.resolveSignal(task.id, { status: 'pass', artifacts: { ci: 'green' } });
+        }
+      }
+
+      const updated = store.get(t1.id);
+      expect(updated!.status).toBe('done');
+      expect(updated!.artifacts).toEqual({ ci: 'green' });
+      expect(onResolved).toHaveBeenCalledWith(t1.id);
+    });
   });
 
   it('stores failure artifacts in annotations on retry', () => {

--- a/server/__tests__/signal-processor.test.ts
+++ b/server/__tests__/signal-processor.test.ts
@@ -170,6 +170,55 @@ describe('SignalProcessor', () => {
     expect(processor.isWatching(t2.id)).toBe(false);
   });
 
+  describe('findActiveSignalTasks', () => {
+    it('finds active wait_for_signal tasks by gate type', () => {
+      const goal = store.create({ title: 'Goal' });
+      const t1 = store.create({
+        title: 'Centaur review',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'centaur_review', repo: 'dimakis/mitzo', pr: 360 },
+      });
+      store.update(t1.id, { status: 'active' });
+
+      const t2 = store.create({
+        title: 'CI check',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'gh_ci', repo: 'dimakis/mitzo', pr: 360 },
+      });
+      store.update(t2.id, { status: 'active' });
+
+      const centaurTasks = store.findActiveSignalTasks('centaur_review');
+      expect(centaurTasks).toHaveLength(1);
+      expect(centaurTasks[0].id).toBe(t1.id);
+
+      const ciTasks = store.findActiveSignalTasks('gh_ci');
+      expect(ciTasks).toHaveLength(1);
+      expect(ciTasks[0].id).toBe(t2.id);
+    });
+
+    it('ignores non-active or non-signal tasks', () => {
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Pending signal',
+        parentId: goal.id,
+        stageType: 'wait_for_signal',
+        gateConfig: { type: 'centaur_review', repo: 'dimakis/mitzo', pr: 1 },
+      });
+
+      const t2 = store.create({
+        title: 'Agent task',
+        parentId: goal.id,
+        stageType: 'agent_work',
+      });
+      store.update(t2.id, { status: 'active' });
+
+      const results = store.findActiveSignalTasks('centaur_review');
+      expect(results).toHaveLength(0);
+    });
+  });
+
   it('stores failure artifacts in annotations on retry', () => {
     const goal = store.create({ title: 'Goal' });
     const agent = store.create({

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -550,4 +550,103 @@ describe('TaskOrchestrator', () => {
       expect(orch.getStatus().state).toBe('idle');
     });
   });
+
+  describe('session_policy: spawn', () => {
+    it('calls spawnSession for tasks with session_policy spawn', async () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      await vi.waitFor(() => {
+        expect(spawnSession).toHaveBeenCalled();
+      });
+
+      const [, prompt, goalArg] = spawnSession.mock.calls[0];
+      expect(goalArg).toBe(goal.id);
+      expect(prompt).toContain('Spawn task');
+    });
+
+    it('does not set activeTaskId for spawned tasks', () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      expect(orch.getStatus().activeTaskId).toBeNull();
+    });
+
+    it('falls back to pinned session when spawnSession is not provided', () => {
+      const deps = createTestDeps(store);
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      const task = store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      expect(orch.getStatus().activeTaskId).toBe(task.id);
+      expect(deps.setTaskContext).toHaveBeenCalledWith(task.id, goal.id);
+    });
+
+    it('marks task active before spawning', () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      const task = store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      expect(store.get(task.id)!.status).toBe('active');
+    });
+
+    it('reuse policy tasks use pinned session as before', () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      const task = store.create({
+        title: 'Reuse task',
+        parentId: goal.id,
+        sessionPolicy: 'reuse',
+      });
+
+      orch.start(goal.id);
+
+      expect(spawnSession).not.toHaveBeenCalled();
+      expect(orch.getStatus().activeTaskId).toBe(task.id);
+      expect(deps.setTaskContext).toHaveBeenCalledWith(task.id, goal.id);
+    });
+  });
 });

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -629,6 +629,194 @@ describe('TaskOrchestrator', () => {
       expect(store.get(task.id)!.status).toBe('active');
     });
 
+    it('blocks task when spawnSession rejects', async () => {
+      const spawnSession = vi.fn().mockRejectedValue(new Error('worktree failure'));
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      const task = store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      await vi.waitFor(() => {
+        expect(store.get(task.id)!.status).toBe('blocked');
+      });
+
+      const updated = store.get(task.id)!;
+      expect(updated.annotations.some((a) => a.includes('spawn_error'))).toBe(true);
+      expect(deps.broadcastTasks).toHaveBeenCalled();
+    });
+
+    it('falls back to pinned session when spawnSession returns null', async () => {
+      const spawnSession = vi.fn().mockResolvedValue(null);
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      const task = store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      await vi.waitFor(() => {
+        expect(deps.setTaskContext).toHaveBeenCalledWith(task.id, goal.id);
+      });
+
+      expect(orch.getStatus().activeTaskId).toBe(task.id);
+    });
+
+    it('ignores spawn callback if stop() was called during spawn', async () => {
+      let resolveSpawn: (v: string | null) => void;
+      const spawnSession = vi.fn().mockImplementation(
+        () =>
+          new Promise<string | null>((r) => {
+            resolveSpawn = r;
+          }),
+      );
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Spawn task',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+      orch.stop();
+
+      // Resolve after stop — callback should be a no-op
+      resolveSpawn!(null);
+      await vi.waitFor(() => {
+        expect(spawnSession).toHaveBeenCalled();
+      });
+
+      expect(orch.getStatus().state).toBe('idle');
+      expect(deps.setTaskContext).not.toHaveBeenCalled();
+    });
+
+    it('ignores spawn callback if orchestrator restarted with different goal', async () => {
+      let resolveSpawn: (v: string | null) => void;
+      const spawnSession = vi.fn().mockImplementation(
+        () =>
+          new Promise<string | null>((r) => {
+            resolveSpawn = r;
+          }),
+      );
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal1 = store.create({ title: 'Goal 1' });
+      store.create({
+        title: 'Spawn task',
+        parentId: goal1.id,
+        sessionPolicy: 'spawn',
+      });
+
+      const goal2 = store.create({ title: 'Goal 2' });
+      const reuse = store.create({ title: 'Reuse task', parentId: goal2.id });
+
+      // Start goal1 (spawns), stop, start goal2
+      orch.start(goal1.id);
+      orch.stop();
+      orch.start(goal2.id);
+
+      expect(orch.getStatus().goalId).toBe(goal2.id);
+      expect(orch.getStatus().activeTaskId).toBe(reuse.id);
+
+      // Resolve old spawn — should be ignored (goalId changed)
+      resolveSpawn!(null);
+      await vi.waitFor(() => {
+        expect(spawnSession).toHaveBeenCalled();
+      });
+
+      // activeTaskId should still be the goal2 task, not clobbered
+      expect(orch.getStatus().activeTaskId).toBe(reuse.id);
+    });
+
+    it('blocks spawn-failed task when pinned session is busy', async () => {
+      const calls: Array<(v: string | null) => void> = [];
+      const spawnSession = vi.fn().mockImplementation(
+        () =>
+          new Promise<string | null>((r) => {
+            calls.push(r);
+          }),
+      );
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Spawn task 1',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+      store.create({
+        title: 'Spawn task 2',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      await vi.waitFor(() => {
+        expect(calls).toHaveLength(2);
+      });
+
+      // First spawn fails — claims pinned session
+      calls[0](null);
+      await vi.waitFor(() => {
+        expect(orch.getStatus().activeTaskId).not.toBeNull();
+      });
+
+      // Second spawn also fails — pinned session busy, should block
+      calls[1](null);
+      await vi.waitFor(() => {
+        const tasks = store.getChildren(goal.id);
+        const blocked = tasks.filter((t) => t.status === 'blocked');
+        expect(blocked).toHaveLength(1);
+      });
+    });
+
+    it('dispatches multiple spawn tasks via queueMicrotask', async () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      store.create({
+        title: 'Spawn task 1',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+      store.create({
+        title: 'Spawn task 2',
+        parentId: goal.id,
+        sessionPolicy: 'spawn',
+      });
+
+      orch.start(goal.id);
+
+      await vi.waitFor(() => {
+        expect(spawnSession).toHaveBeenCalledTimes(2);
+      });
+    });
+
     it('reuse policy tasks use pinned session as before', () => {
       const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
       const deps = createTestDeps(store);

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -184,6 +184,15 @@ export const SignalBody = z.object({
   artifacts: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const SignalResolveBody = z.object({
+  type: z.enum(['gh_ci', 'gh_review', 'centaur_review', 'human_approval']),
+  repo: z.string().optional(),
+  pr: z.number().optional(),
+  pr_url: z.string().optional(),
+  status: z.enum(['pass', 'fail']),
+  artifacts: z.record(z.string(), z.unknown()).optional(),
+});
+
 // -- Workload schemas --
 
 const WorkSignalContextHints = z.object({

--- a/server/app.ts
+++ b/server/app.ts
@@ -1023,21 +1023,22 @@ app.post('/api/signals/resolve', (req, res) => {
     const gc = task.gateConfig;
     if (!gc) continue;
 
+    const { repo: taskRepo, pr: taskPr, pr_url: taskPrUrl } = gc as Record<string, unknown>;
     let isMatch = false;
     switch (type) {
       case 'centaur_review': {
-        const taskPrUrl = (gc as Record<string, unknown>).pr_url as string | undefined;
-        const taskRepo = (gc as Record<string, unknown>).repo as string | undefined;
-        const taskPr = (gc as Record<string, unknown>).pr as number | undefined;
         if (pr_url && taskPrUrl && taskPrUrl === pr_url) isMatch = true;
         if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
         break;
       }
       case 'gh_ci':
       case 'gh_review': {
-        const taskRepo = (gc as Record<string, unknown>).repo as string | undefined;
-        const taskPr = (gc as Record<string, unknown>).pr as number | undefined;
         if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
+        break;
+      }
+      case 'human_approval': {
+        // human_approval signals match any active task of this gate type
+        isMatch = true;
         break;
       }
     }

--- a/server/app.ts
+++ b/server/app.ts
@@ -64,6 +64,7 @@ import {
   WorkflowInstantiateBody,
   TemplateCreateBody,
   SignalBody,
+  SignalResolveBody,
   WorkSignalBody,
   WorkSignalBatchBody,
   WorkloadItemUpdateBody,
@@ -990,6 +991,67 @@ app.post('/api/tasks/:id/signal', (req, res) => {
   });
   res.json({ ok: true });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+});
+
+/**
+ * Resolve a signal by gate metadata (type + repo/PR).
+ * External agents (e.g. Centaur) POST here after completing work —
+ * they don't need to know task IDs, just the gate parameters.
+ */
+app.post('/api/signals/resolve', (req, res) => {
+  if (!verifyInternalToken(req)) {
+    res.status(401).json({ error: 'Internal token required' });
+    return;
+  }
+  if (!signalProcessor) {
+    res.status(503).json({ error: 'Signal processor not initialized' });
+    return;
+  }
+  const body = SignalResolveBody.safeParse(req.body);
+  if (!body.success) {
+    res.status(400).json({ error: body.error.issues[0]?.message ?? 'Invalid input' });
+    return;
+  }
+
+  const { type, repo, pr, pr_url, status, artifacts } = body.data;
+
+  // Find active wait_for_signal tasks matching this gate type
+  const candidates = taskStore.findActiveSignalTasks(type);
+  const matched: string[] = [];
+
+  for (const task of candidates) {
+    const gc = task.gateConfig;
+    if (!gc) continue;
+
+    let isMatch = false;
+    switch (type) {
+      case 'centaur_review': {
+        const taskPrUrl = (gc as Record<string, unknown>).pr_url as string | undefined;
+        const taskRepo = (gc as Record<string, unknown>).repo as string | undefined;
+        const taskPr = (gc as Record<string, unknown>).pr as number | undefined;
+        if (pr_url && taskPrUrl && taskPrUrl === pr_url) isMatch = true;
+        if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
+        break;
+      }
+      case 'gh_ci':
+      case 'gh_review': {
+        const taskRepo = (gc as Record<string, unknown>).repo as string | undefined;
+        const taskPr = (gc as Record<string, unknown>).pr as number | undefined;
+        if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
+        break;
+      }
+    }
+
+    if (isMatch) {
+      signalProcessor.resolveSignal(task.id, { status, artifacts });
+      matched.push(task.id);
+    }
+  }
+
+  res.json({ ok: true, matched });
+  if (matched.length > 0) {
+    onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+  }
 });
 
 app.post('/api/auth/login', loginLimiter, async (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -1024,16 +1024,19 @@ app.post('/api/signals/resolve', (req, res) => {
     if (!gc) continue;
 
     const { repo: taskRepo, pr: taskPr, pr_url: taskPrUrl } = gc as Record<string, unknown>;
+    // taskPr is parsed from JSON (could be string or number); pr is Zod-validated (number).
+    // Coerce both to Number for safe comparison.
+    const prMatch = pr != null && taskPr != null && Number(taskPr) === Number(pr);
     let isMatch = false;
     switch (type) {
       case 'centaur_review': {
         if (pr_url && taskPrUrl && taskPrUrl === pr_url) isMatch = true;
-        if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
+        if (repo && taskRepo === repo && prMatch) isMatch = true;
         break;
       }
       case 'gh_ci':
       case 'gh_review': {
-        if (repo && pr && taskRepo === repo && taskPr === pr) isMatch = true;
+        if (repo && taskRepo === repo && prMatch) isMatch = true;
         break;
       }
       case 'human_approval': {

--- a/server/app.ts
+++ b/server/app.ts
@@ -1037,7 +1037,10 @@ app.post('/api/signals/resolve', (req, res) => {
         break;
       }
       case 'human_approval': {
-        // human_approval signals match any active task of this gate type
+        // human_approval signals match any active task of this gate type.
+        // Intentionally broad: for MVP, only one pending human_approval at
+        // a time is expected. If multiple concurrent approvals are needed,
+        // add a discriminator field (e.g. gate_id) to gateConfig.
         isMatch = true;
         break;
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,7 @@ import {
   setSessionsChangedCallback,
   reconcileSessionsBackground,
 } from './chat.js';
-import { cleanupStaleWorktrees, countWorktrees, createSessionWorktrees } from './worktree.js';
+import { cleanupStaleWorktrees, countWorktrees } from './worktree.js';
 import { NullTransport } from './null-transport.js';
 import { getWorktreeGuardStats, resetWorktreeGuardStats } from '@mitzo/harness';
 import {
@@ -241,30 +241,30 @@ const orchestrator = new TaskOrchestrator({
     return ids;
   },
   spawnSession: async (taskId: string, prompt: string, goalId: string) => {
-    const wtId = generateWtId();
-    const clientId = `headless:${wtId}`;
-    const config = getRepoConfig();
+    const clientId = `headless:${generateWtId()}`;
 
     try {
-      createSessionWorktrees(wtId, BASE_REPO, config.repos);
-
-      eventStore.upsertSession({
-        sessionId: wtId,
-        summary: `Task: ${taskId.slice(0, 8)}`,
-        initialPrompt: prompt,
-        isActive: true,
-        mode: 'agent',
-        telosTaskId: goalId,
-      });
-
       const transport = new NullTransport();
-      await startChat(transport, clientId, prompt, {
+      // Fire-and-forget — startChat handles worktree creation, EventStore
+      // registration, and the full session lifecycle internally. We must NOT
+      // await it: startChat blocks until the agent session completes (via
+      // runQueryLoop), so awaiting would block the orchestrator tick chain.
+      startChat(transport, clientId, prompt, {
         mode: 'agent',
         isolation: true,
+        telosTaskId: goalId,
+        onSessionResolved: (sessionId) => {
+          log.info('spawned headless session resolved', { taskId, sessionId, clientId });
+          sseRegistry.broadcast('sessions_changed', {});
+        },
+      }).catch((err) => {
+        log.error('spawned session failed', {
+          taskId,
+          clientId,
+          error: (err as Error).message,
+        });
       });
 
-      log.info('spawned headless session for task', { taskId, sessionId: wtId, clientId });
-      sseRegistry.broadcast('sessions_changed', {});
       return clientId;
     } catch (err) {
       log.error('failed to spawn session for task', {

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,12 +27,14 @@ import {
   registry,
   eventStore,
   getRepoConfig,
+  generateWtId,
   setConnectionRegistry,
   setSessionChangeCallback,
   setSessionsChangedCallback,
   reconcileSessionsBackground,
 } from './chat.js';
-import { cleanupStaleWorktrees, countWorktrees } from './worktree.js';
+import { cleanupStaleWorktrees, countWorktrees, createSessionWorktrees } from './worktree.js';
+import { NullTransport } from './null-transport.js';
 import { getWorktreeGuardStats, resetWorktreeGuardStats } from '@mitzo/harness';
 import {
   HEARTBEAT_INTERVAL_MS,
@@ -237,6 +239,40 @@ const orchestrator = new TaskOrchestrator({
       if (session?.sessionId) ids.add(session.sessionId);
     }
     return ids;
+  },
+  spawnSession: async (taskId: string, prompt: string, goalId: string) => {
+    const wtId = generateWtId();
+    const clientId = `headless:${wtId}`;
+    const config = getRepoConfig();
+
+    try {
+      createSessionWorktrees(wtId, BASE_REPO, config.repos);
+
+      eventStore.upsertSession({
+        sessionId: wtId,
+        summary: `Task: ${taskId.slice(0, 8)}`,
+        initialPrompt: prompt,
+        isActive: true,
+        mode: 'agent',
+        telosTaskId: goalId,
+      });
+
+      const transport = new NullTransport();
+      await startChat(transport, clientId, prompt, {
+        mode: 'agent',
+        isolation: true,
+      });
+
+      log.info('spawned headless session for task', { taskId, sessionId: wtId, clientId });
+      sseRegistry.broadcast('sessions_changed', {});
+      return clientId;
+    } catch (err) {
+      log.error('failed to spawn session for task', {
+        taskId,
+        error: (err as Error).message,
+      });
+      return null;
+    }
   },
 });
 orchestratorRef = orchestrator;

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -37,6 +37,8 @@ export interface OrchestratorDeps {
   getActiveSessionIds?: () => Set<string>;
   /** Register a signal watch for a wait_for_signal task */
   watchSignal?: (taskId: string, gateConfig: GateConfig) => void;
+  /** Spawn a new headless session for a task. Returns clientId or null on failure. */
+  spawnSession?: (taskId: string, prompt: string, goalId: string) => Promise<string | null>;
 }
 
 export class TaskOrchestrator {
@@ -333,17 +335,50 @@ export class TaskOrchestrator {
 
       case 'agent_work':
       default: {
-        // Original behavior: assign to session, send prompt
-        this.activeTaskId = next.id;
-        this.deps.store.update(next.id, { status: 'active' });
-        this.deps.store.cascadeStatus(next.id);
-        this.deps.setTaskContext(next.id, this.goalId);
-        this.deps.broadcastTasks();
-        this.deps.broadcastStatus(this.getStatus());
+        const policy = next.sessionPolicy ?? 'reuse';
 
-        if (this.pinnedClientId) {
+        if (policy === 'spawn' && this.deps.spawnSession) {
+          // Spawn a dedicated headless session for this task
+          this.deps.store.update(next.id, { status: 'active' });
+          this.deps.store.cascadeStatus(next.id);
+          this.deps.broadcastTasks();
+          this.deps.broadcastStatus(this.getStatus());
+
           const prompt = this.buildTaskPrompt(next);
-          sendToChat(this.pinnedClientId, prompt);
+          this.deps.spawnSession(next.id, prompt, this.goalId).then(
+            (clientId) => {
+              if (clientId) {
+                this.deps.store.setSessionId(next.id, clientId);
+                log.info('spawned session for task', { taskId: next.id, clientId });
+              } else {
+                log.error('failed to spawn session, falling back to pinned', { taskId: next.id });
+                this.deps.setTaskContext(next.id, this.goalId!);
+                if (this.pinnedClientId) sendToChat(this.pinnedClientId, prompt);
+              }
+            },
+            (err) => {
+              log.error('spawnSession threw', { taskId: next.id, error: (err as Error).message });
+              this.deps.store.update(next.id, { status: 'pending' });
+              this.deps.store.cascadeStatus(next.id);
+            },
+          );
+
+          // Don't set activeTaskId — spawned tasks run independently.
+          // Continue ticking to find more parallel work.
+          this.tick();
+        } else {
+          // Reuse pinned session (original behavior)
+          this.activeTaskId = next.id;
+          this.deps.store.update(next.id, { status: 'active' });
+          this.deps.store.cascadeStatus(next.id);
+          this.deps.setTaskContext(next.id, this.goalId);
+          this.deps.broadcastTasks();
+          this.deps.broadcastStatus(this.getStatus());
+
+          if (this.pinnedClientId) {
+            const prompt = this.buildTaskPrompt(next);
+            sendToChat(this.pinnedClientId, prompt);
+          }
         }
         break;
       }

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -42,12 +42,16 @@ export interface OrchestratorDeps {
 }
 
 export class TaskOrchestrator {
+  /** Maximum concurrent spawn dispatches per tick chain to prevent runaway loops. */
+  private static readonly MAX_SPAWN_DEPTH = 50;
+
   private state: LoopState = 'idle';
   private goalId: string | null = null;
   private activeTaskId: string | null = null;
   private specMode = false;
   private awaitingApproval = false;
   private pinnedClientId: string | null = null;
+  private spawnDepth = 0;
   private deps: OrchestratorDeps;
 
   constructor(deps: OrchestratorDeps) {
@@ -143,6 +147,7 @@ export class TaskOrchestrator {
     this.specMode = false;
     this.awaitingApproval = false;
     this.pinnedClientId = null;
+    this.spawnDepth = 0;
     this.deps.clearTaskContext();
     log.info('orchestrator stopped');
     this.deps.broadcastStatus(this.getStatus());
@@ -189,6 +194,7 @@ export class TaskOrchestrator {
   onTaskCompleted(taskId: string): void {
     if (this.state !== 'running') return;
     log.info('task completed, triggering tick', { taskId });
+    this.spawnDepth = 0;
     this.tick();
   }
 
@@ -196,6 +202,7 @@ export class TaskOrchestrator {
   onTaskBlocked(taskId: string): void {
     if (this.state !== 'running') return;
     log.info('task blocked, triggering tick', { taskId });
+    this.spawnDepth = 0;
     this.tick();
   }
 
@@ -344,28 +351,64 @@ export class TaskOrchestrator {
           this.deps.broadcastTasks();
           this.deps.broadcastStatus(this.getStatus());
 
+          // Capture state before async boundary — stop()+start() could change
+          // goalId/pinnedClientId to a different goal while spawn is in-flight.
+          const capturedGoalId = this.goalId;
+          const capturedPinnedClientId = this.pinnedClientId;
+
           const prompt = this.buildTaskPrompt(next);
-          this.deps.spawnSession(next.id, prompt, this.goalId).then(
+          this.deps.spawnSession(next.id, prompt, capturedGoalId).then(
             (clientId) => {
+              // Guard: orchestrator moved on (stop or new goal)
+              if (this.goalId !== capturedGoalId) return;
+
               if (clientId) {
                 this.deps.store.setSessionId(next.id, clientId);
                 log.info('spawned session for task', { taskId: next.id, clientId });
               } else {
+                // Spawn returned null (e.g. worktree failure) — fall back to pinned session
                 log.error('failed to spawn session, falling back to pinned', { taskId: next.id });
-                this.deps.setTaskContext(next.id, this.goalId!);
-                if (this.pinnedClientId) sendToChat(this.pinnedClientId, prompt);
+                // Only claim pinned session if no other task has it
+                if (!this.activeTaskId) {
+                  this.activeTaskId = next.id;
+                  this.deps.setTaskContext(next.id, capturedGoalId);
+                  this.deps.broadcastStatus(this.getStatus());
+                  if (capturedPinnedClientId) sendToChat(capturedPinnedClientId, prompt);
+                } else {
+                  // Pinned session busy — mark blocked so it's retried later
+                  log.warn('pinned session busy, blocking spawn-failed task', { taskId: next.id });
+                  this.deps.store.update(next.id, { status: 'blocked' });
+                  this.deps.store.cascadeStatus(next.id);
+                  this.deps.broadcastTasks();
+                }
               }
             },
             (err) => {
+              // Guard: orchestrator moved on (stop or new goal)
+              if (this.goalId !== capturedGoalId) return;
+
               log.error('spawnSession threw', { taskId: next.id, error: (err as Error).message });
-              this.deps.store.update(next.id, { status: 'pending' });
+              // Mark as blocked (not pending) to prevent infinite retry via tick loop
+              const annotations = [
+                ...(this.deps.store.get(next.id)?.annotations ?? []),
+                `spawn_error: ${(err as Error).message}`,
+              ];
+              this.deps.store.update(next.id, { status: 'blocked', annotations });
               this.deps.store.cascadeStatus(next.id);
+              this.deps.broadcastTasks();
             },
           );
 
           // Don't set activeTaskId — spawned tasks run independently.
-          // Continue ticking to find more parallel work.
-          this.tick();
+          // Continue ticking to find more parallel work, with depth guard.
+          this.spawnDepth++;
+          if (this.spawnDepth < TaskOrchestrator.MAX_SPAWN_DEPTH) {
+            queueMicrotask(() => this.tick());
+          } else {
+            log.warn('spawn depth limit reached, deferring further dispatch', {
+              depth: this.spawnDepth,
+            });
+          }
         } else {
           // Reuse pinned session (original behavior)
           this.activeTaskId = next.id;
@@ -386,6 +429,7 @@ export class TaskOrchestrator {
   }
 
   private broadcastAndTick(): void {
+    this.spawnDepth = 0;
     this.deps.broadcastStatus(this.getStatus());
     this.tick();
   }

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -503,6 +503,16 @@ export class TaskStore {
     return null;
   }
 
+  /** Find active wait_for_signal tasks matching a gate type. */
+  findActiveSignalTasks(gateType: string): Task[] {
+    const rows = this.getDb()
+      .prepare(
+        "SELECT * FROM tasks WHERE status = 'active' AND stage_type = 'wait_for_signal' AND gate_config IS NOT NULL",
+      )
+      .all() as TaskRow[];
+    return rows.map(rowToTask).filter((t) => t.gateConfig?.type === gateType);
+  }
+
   /** Find active tasks whose session_id is not in the set of active sessions. */
   getOrphaned(activeSessionIds: Set<string>): Task[] {
     const rows = this.getDb()

--- a/server/task-store.ts
+++ b/server/task-store.ts
@@ -507,10 +507,10 @@ export class TaskStore {
   findActiveSignalTasks(gateType: string): Task[] {
     const rows = this.getDb()
       .prepare(
-        "SELECT * FROM tasks WHERE status = 'active' AND stage_type = 'wait_for_signal' AND gate_config IS NOT NULL",
+        "SELECT * FROM tasks WHERE status = 'active' AND stage_type = 'wait_for_signal' AND json_extract(gate_config, '$.type') = ?",
       )
-      .all() as TaskRow[];
-    return rows.map(rowToTask).filter((t) => t.gateConfig?.type === gateType);
+      .all(gateType) as TaskRow[];
+    return rows.map(rowToTask);
   }
 
   /** Find active tasks whose session_id is not in the set of active sessions. */


### PR DESCRIPTION
## Summary

Enable the TaskOrchestrator to spawn dedicated headless sessions for individual tasks, unlocking multi-agent goal coordination. This is **Phase 1 of 4** in the multi-agent orchestration initiative.

### What changed

- **task-orchestrator.ts**: Implement `session_policy: 'spawn'` path in `tick()`. When a task has `sessionPolicy: 'spawn'`, the orchestrator creates a dedicated headless session instead of routing to the pinned session. Spawned tasks don't set `activeTaskId`, enabling parallel execution. Falls back to pinned session on failure.

- **index.ts**: Wire `spawnSession` dependency — creates worktrees, registers in EventStore, starts headless session with `NullTransport`.

- **app.ts**: Add `POST /api/signals/resolve` endpoint. External agents (e.g. Centaur) can resolve `wait_for_signal` tasks by gate metadata (`type` + `repo` + `PR`) without knowing task IDs. Authenticated via internal token.

- **api-schemas.ts**: Add `SignalResolveBody` zod schema for the new endpoint.

- **task-store.ts**: Add `findActiveSignalTasks(gateType)` query method for gate-metadata-based task lookup.

### Context: Multi-Agent Orchestration Roadmap

The `session_policy` column and `wait_for_signal` stage type already existed in the schema but were unused. This PR activates them.

**Phase 1 (this PR):** Multi-session `tick()` + signal resolve endpoint
**Phase 2:** Centaur signal bridge — Centaur POSTs `ReviewCompleted` to `/api/signals/resolve`
**Phase 3:** PR Shepherd creates Task Board goals instead of ad-hoc sessions
**Phase 4:** Scheduled PR discovery trigger

A PR lifecycle would look like:
```
Goal: "Shepherd PR #360"
  ├── [agent_work, spawn]         Request Centaur review
  ├── [wait_for_signal]           Wait for review completion
  ├── [agent_work, spawn]         Address findings
  ├── [wait_for_signal, gh_ci]    Wait for CI
  └── [human_review]              Approve merge
```

### Key files
- `server/task-orchestrator.ts` — spawn path in tick()
- `server/index.ts` — spawnSession wiring
- `server/app.ts` — POST /api/signals/resolve
- `server/task-store.ts` — findActiveSignalTasks()

## Test plan

- [x] 7 new tests: spawn dispatch, activeTaskId semantics, fallback, signal lookup
- [x] All 48 existing tests pass
- [x] TypeScript compilation clean
- [ ] E2E: create goal with spawn tasks, verify sessions are created
- [ ] E2E: POST to /api/signals/resolve, verify matching tasks resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)