### PR TITLE
fix(chat): ensure agentName persists across all session paths

### DIFF
--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -235,6 +235,63 @@ describe('EventStore', () => {
       expect(session).not.toBeNull();
       expect(session!.cwd).toBeNull();
     });
+
+    it('persists agentName on insert', () => {
+      store.upsertSession({
+        sessionId: 'sess-agent',
+        agentName: 'mitzo-conversational',
+      });
+
+      const session = store.getSession('sess-agent');
+      expect(session).not.toBeNull();
+      expect(session!.agentName).toBe('mitzo-conversational');
+    });
+
+    it('updates agentName on existing session', () => {
+      store.upsertSession({ sessionId: 'sess-1', summary: 'Test' });
+      expect(store.getSession('sess-1')!.agentName).toBeNull();
+
+      store.upsertSession({ sessionId: 'sess-1', agentName: 'mitzo-conversational' });
+      expect(store.getSession('sess-1')!.agentName).toBe('mitzo-conversational');
+    });
+
+    it('persists bootContext and agentName together (fire-and-forget safety net)', () => {
+      // Simulates the pattern from chat.ts: boot context callback stores
+      // both bootContext and agentName in a single upsert to ensure
+      // agentName is never null even for short-lived sessions.
+      store.upsertSession({ sessionId: 'sess-boot', summary: 'Boot test' });
+
+      const bootPayload = JSON.stringify({
+        type: 'boot_context',
+        source: 'contexgin',
+        sourceCount: 7,
+      });
+      store.upsertSession({
+        sessionId: 'sess-boot',
+        bootContext: bootPayload,
+        agentName: 'mitzo-conversational',
+      });
+
+      const session = store.getSession('sess-boot');
+      expect(session!.agentName).toBe('mitzo-conversational');
+      expect(session!.bootContext).toBe(bootPayload);
+    });
+
+    it('preserves agentName when updating only bootContext', () => {
+      store.upsertSession({
+        sessionId: 'sess-preserve',
+        agentName: 'mitzo-conversational',
+      });
+
+      store.upsertSession({
+        sessionId: 'sess-preserve',
+        bootContext: '{"type":"boot_context"}',
+      });
+
+      const session = store.getSession('sess-preserve');
+      expect(session!.agentName).toBe('mitzo-conversational');
+      expect(session!.bootContext).toBe('{"type":"boot_context"}');
+    });
   });
 
   describe('getSession', () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -35,7 +35,7 @@ import {
   createSessionWorktrees as createAllWorktrees,
   listWorktrees,
 } from './worktree.js';
-import { GIT_BRANCH_TIMEOUT_MS } from './constants.js';
+import { DEFAULT_AGENT_NAME, GIT_BRANCH_TIMEOUT_MS } from './constants.js';
 import { INTERNAL_TOKEN } from './internal-token.js';
 import { getLocalCommit, isUpdateAvailable } from './git-version.js';
 import { resolvePending } from './permissions.js';
@@ -472,6 +472,7 @@ async function handleSessionCreate(
         initialPrompt,
         isActive: true,
         mode: mode ?? 'agent',
+        agentName: DEFAULT_AGENT_NAME,
       });
 
       // Start the session headlessly — NullTransport discards WS messages
@@ -487,6 +488,7 @@ async function handleSessionCreate(
         mode: mode ?? 'agent',
         model,
         isolation: true,
+        agentName: DEFAULT_AGENT_NAME,
       });
 
       log.info('headless session started', { sessionId: wtId, prompt: initialPrompt });

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -927,19 +927,27 @@ async function _startChatInner(
     buildWorktreeSystemPrompt(repoWorktrees) +
     buildTaskPromptForSession(clientId);
 
-  // Fire-and-forget: fetch boot context from running ContexGin server
+  // Fire-and-forget: fetch boot context from running ContexGin server.
+  // The callback may fire after the session ends (registry cleaned up) or
+  // before the SDK assigns a sessionId (new sessions). We include agentName
+  // in the upsert as a safety net so it's never null in the DB.
   fetchBootContext(agentName)
     .then((msg) => {
-      // Include sessionId for consistency with reconnect/switch replay paths
-      const sid = options.resume ?? registry.get(clientId)?.sessionId;
-      send(transport, { ...msg, ...(sid ? { sessionId: sid } : {}) });
-      // Cache in ManagedSession for replay on reconnect/switch
-      const s = registry.get(clientId);
-      if (s) s.bootContext = msg as unknown as Record<string, unknown>;
-      // Persist to EventStore for cold-path recovery (resumed sessions
-      // may not run the query loop long enough for it to upsert).
+      const session = registry.get(clientId);
+      const sid = options.resume ?? session?.sessionId;
+      // Send to client if transport still connected
+      if (session) {
+        send(transport, { ...msg, ...(sid ? { sessionId: sid } : {}) });
+        session.bootContext = msg as unknown as Record<string, unknown>;
+      }
+      // Persist to EventStore — include agentName as safety net since
+      // this upsert may be the last write for short-lived sessions.
       if (sid) {
-        eventStore.upsertSession({ sessionId: sid, bootContext: JSON.stringify(msg) });
+        eventStore.upsertSession({
+          sessionId: sid,
+          bootContext: JSON.stringify(msg),
+          agentName,
+        });
       }
     })
     .catch((err: unknown) => {

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -751,6 +751,8 @@ export function handleInterruptV2(
         images: msg.images,
         contextBlocks: msg.contextBlocks,
         clientMsgId: msg.clientMsgId,
+        agentName: found.session?.agentName,
+        telosTaskId: found.session?.telosTaskId,
       });
       log.info('interrupt_resume', { connectionId, sessionId: msg.sessionId });
     },


### PR DESCRIPTION
## Summary

- **interrupt_resume** path in `ws-handler-v2.ts` now forwards `agentName` and `telosTaskId` from the existing session
- **REST headless session creation** in `app.ts` now includes `DEFAULT_AGENT_NAME` in both the DB upsert and `startChat` call
- **Boot context persistence** in `chat.ts` now includes `agentName` as a safety net in the fire-and-forget upsert, preventing null agent_name when sessions end before the callback fires

Fixes 6 sessions/day running without boot context due to null `agent_name` in the DB.

## Test plan
- [x] `boot-context.test.ts` — 10/10 passing
- [x] `ws-handler-v2.test.ts` — 135/135 passing
- [ ] Manual: create new session, verify `agent_name` is set in DB
- [ ] Manual: interrupt a session, verify `agent_name` persists
- [ ] Manual: verify boot context pill shows sources on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)