### PR TITLE
fix(chat): deferred boot context persist for new sessions

### DIFF
--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -277,6 +277,46 @@ describe('EventStore', () => {
       expect(session!.bootContext).toBe(bootPayload);
     });
 
+    it('deferred persist fills bootContext when query-loop missed it', () => {
+      // Simulates the deferred persist pattern: query-loop creates the session
+      // without bootContext (it wasn't cached yet), then the deferred timer
+      // fires and persists it.
+      store.upsertSession({
+        sessionId: 'sess-deferred',
+        agentName: 'mitzo-conversational',
+        // bootContext not included — simulates query-loop upsert before fetch completed
+      });
+
+      const before = store.getSession('sess-deferred');
+      expect(before!.bootContext).toBeNull();
+
+      // Deferred persist fills in bootContext
+      const bootPayload = JSON.stringify({ type: 'boot_context', source: 'contexgin' });
+      store.upsertSession({
+        sessionId: 'sess-deferred',
+        bootContext: bootPayload,
+        agentName: 'mitzo-conversational',
+      });
+
+      const after = store.getSession('sess-deferred');
+      expect(after!.bootContext).toBe(bootPayload);
+      expect(after!.agentName).toBe('mitzo-conversational');
+    });
+
+    it('deferred persist skips when query-loop already persisted bootContext', () => {
+      // Query-loop persisted boot context successfully — deferred should not overwrite
+      const bootPayload = JSON.stringify({ type: 'boot_context', source: 'contexgin', tokens: 11429 });
+      store.upsertSession({
+        sessionId: 'sess-already',
+        agentName: 'mitzo-conversational',
+        bootContext: bootPayload,
+      });
+
+      const session = store.getSession('sess-already');
+      expect(session!.bootContext).toBe(bootPayload);
+      // Deferred persist would check this and skip
+    });
+
     it('preserves agentName when updating only bootContext', () => {
       store.upsertSession({
         sessionId: 'sess-preserve',

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -931,6 +931,13 @@ async function _startChatInner(
   // The callback may fire after the session ends (registry cleaned up) or
   // before the SDK assigns a sessionId (new sessions). We include agentName
   // in the upsert as a safety net so it's never null in the DB.
+  //
+  // For new sessions the SDK session ID typically arrives 1–5s after query()
+  // starts, while ContexGin responds in ~100ms. The in-memory cache
+  // (session.bootContext) bridges the gap — the query-loop upsert reads it
+  // when the session ID is resolved. But if the SDK is faster (cache hit) or
+  // ContexGin is slow, the cache may not be set yet. We handle that by
+  // polling once after a short delay when sid is initially unavailable.
   fetchBootContext(agentName)
     .then((msg) => {
       const session = registry.get(clientId);
@@ -948,6 +955,26 @@ async function _startChatInner(
           bootContext: JSON.stringify(msg),
           agentName,
         });
+      } else {
+        // Session ID not yet available (new session, SDK hasn't responded).
+        // The in-memory cache is set above; the query-loop upsert will read
+        // it when the ID arrives. As a belt-and-suspenders fallback, poll
+        // once after a short delay in case the query-loop upsert missed it.
+        setTimeout(() => {
+          const s = registry.get(clientId);
+          const deferredSid = s?.sessionId;
+          if (deferredSid) {
+            // Only persist if the query-loop hasn't already done it
+            const existing = eventStore.getSession(deferredSid);
+            if (!existing?.bootContext) {
+              eventStore.upsertSession({
+                sessionId: deferredSid,
+                bootContext: JSON.stringify(msg),
+                agentName,
+              });
+            }
+          }
+        }, 5000);
       }
     })
     .catch((err: unknown) => {

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -497,7 +497,9 @@ async function _runQueryLoopInner(
                 ...(currentSession.worktreePath ? { wtId: currentSession.wtId } : {}),
                 ...(initialPrompt ? { initialPrompt } : {}),
                 ...(currentSession.telosTaskId ? { telosTaskId: currentSession.telosTaskId } : {}),
-                ...(currentSession.agentName ? { agentName: currentSession.agentName } : {}),
+                // Always persist agentName — truthiness guard previously caused
+                // sessions to end up with null agent_name in the DB.
+                agentName: currentSession.agentName ?? null,
                 ...(currentSession.bootContext
                   ? { bootContext: JSON.stringify(currentSession.bootContext) }
                   : {}),


### PR DESCRIPTION
## Summary

- Boot context was silently lost for most sessions due to a race between the ~100ms ContexGin fetch and the 1-5s SDK session ID assignment. Only **12 of 1117 sessions** had `boot_context` persisted in the EventStore.
- Adds a 5-second deferred retry in the boot context callback — if the session ID becomes available after the initial attempt, persists to EventStore (skips if the query-loop already handled it).
- Makes `agentName` unconditional in the query-loop session-ID upsert — the previous truthiness guard let reconciliation-created rows keep `null` agent_name.

Builds on #378 which fixed the `agentName` gaps in interrupt_resume and headless paths.

## Test plan

- [ ] New `event-store.test.ts` tests pass: deferred persist fills bootContext when query-loop missed it
- [ ] Existing boot-context and event-store tests still pass
- [ ] Manual: start a new Mitzo session, verify `boot_context` column is populated in EventStore within 10s
- [ ] Manual: verify reconnect/switch replays boot context from EventStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)