### PR TITLE
feat(server): SSE + HTTP POST chat transport — Phase 1

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -8,12 +8,30 @@
  */
 
 import { createMitzoStore } from '@mitzo/client';
+import type { SseConnectionConfig } from '@mitzo/client';
 import { apiFetch, getApiBaseUrl, getWsChatUrl } from './lib/api-fetch';
 import { registerCapacitorLifecycle } from './lib/capacitor';
 import { configureKeyboard } from './lib/keyboard';
 import { initPushNotifications } from './lib/push';
 import { eventBus } from './lib/event-bus-singleton';
 import { getPreferredModel } from './lib/model-preference';
+
+/**
+ * Transport selector — set localStorage 'mitzo:transport' to 'sse' to use
+ * SSE + HTTP POST instead of WebSocket. Default is 'ws'.
+ *
+ * Toggle from console: localStorage.setItem('mitzo:transport', 'sse'); location.reload();
+ * Revert:              localStorage.removeItem('mitzo:transport'); location.reload();
+ */
+const useSSE = typeof window !== 'undefined' && localStorage.getItem('mitzo:transport') === 'sse';
+
+const sseConfig: SseConnectionConfig | undefined = useSSE
+  ? {
+      baseUrl: getApiBaseUrl(),
+      fetch: (url, init) => apiFetch(url, init),
+      suspendUrl: `${getApiBaseUrl()}/api/sessions/suspend`,
+    }
+  : undefined;
 
 export const clientStore = createMitzoStore({
   transport: {
@@ -25,6 +43,7 @@ export const clientStore = createMitzoStore({
     reconnectDelayMs: 500,
     suspendUrl: `${getApiBaseUrl()}/api/sessions/suspend`,
   },
+  ...(sseConfig ? { sseConfig } : {}),
 });
 
 // Sync localStorage model preference into the store so sendMessage() includes it

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SseConnection } from '../sse-connection.js';
+import type { SseConnectionConfig } from '../sse-connection.js';
+
+// ─── Mock EventSource ──────────────────────────────────────────────────────
+
+type ESListener = (e: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  readyState = 0; // CONNECTING
+  private listeners = new Map<string, ESListener[]>();
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: ESListener): void {
+    const list = this.listeners.get(type) ?? [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+
+  removeEventListener(type: string, listener: ESListener): void {
+    const list = this.listeners.get(type) ?? [];
+    this.listeners.set(
+      type,
+      list.filter((l) => l !== listener),
+    );
+  }
+
+  close(): void {
+    this.readyState = 2; // CLOSED
+  }
+
+  // ─── Test helpers ────────────────────────────────────────────────────────
+
+  /** Simulate the server sending an SSE event */
+  _emit(type: string, data: Record<string, unknown>): void {
+    const event = new MessageEvent(type, { data: JSON.stringify(data) });
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  /** Simulate an error (triggers auto-reconnect in real EventSource) */
+  _triggerError(): void {
+    this.onerror?.();
+  }
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function createConfig(overrides?: Partial<SseConnectionConfig>): SseConnectionConfig {
+  return {
+    baseUrl: 'https://localhost:3100',
+    fetch: vi.fn().mockResolvedValue({ ok: true }),
+    createEventSource: (url: string) => new MockEventSource(url) as unknown as EventSource,
+    ...overrides,
+  };
+}
+
+function lastES(): MockEventSource {
+  return MockEventSource.instances[MockEventSource.instances.length - 1];
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('SseConnection', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ─── Connection lifecycle ────────────────────────────────────────────────
+
+  it('creates EventSource on connect()', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(lastES().url).toBe('https://localhost:3100/api/chat/events');
+  });
+
+  it('becomes connected after welcome event', () => {
+    const conn = new SseConnection(createConfig());
+    const listener = vi.fn();
+    conn.onMessage(listener);
+    conn.connect();
+
+    expect(conn.isConnected()).toBe(false);
+
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    expect(conn.isConnected()).toBe(true);
+    expect(conn.getConnectionId()).toBe('conn-abc');
+    expect(listener).toHaveBeenCalledWith({ type: '_open' });
+  });
+
+  it('disconnect() closes EventSource', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    conn.disconnect();
+
+    expect(conn.isConnected()).toBe(false);
+    expect(lastES().readyState).toBe(2); // CLOSED
+  });
+
+  // ─── Message receiving (server → client) ─────────────────────────────────
+
+  it('dispatches session events to listener', () => {
+    const conn = new SseConnection(createConfig());
+    const listener = vi.fn();
+    conn.onMessage(listener);
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    lastES()._emit('block_delta', {
+      type: 'block_delta',
+      sessionId: 'sess-1',
+      seq: 5,
+      delta: 'hello',
+    });
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'block_delta', delta: 'hello' }),
+    );
+  });
+
+  it('tracks seq numbers from incoming events', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    lastES()._emit('block_delta', {
+      type: 'block_delta',
+      sessionId: 'sess-1',
+      seq: 42,
+      delta: 'x',
+    });
+
+    expect(conn.getLastSeq('sess-1')).toBe(42);
+  });
+
+  // ─── Message sending (client → server) ─────────────────────────────────
+
+  it('sends messages via POST with X-Connection-ID', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    conn.send({ type: 'send', sessionId: 'sess-1', prompt: 'hello', clientMsgId: 'msg-1' });
+
+    expect(mockFetch).toHaveBeenCalledWith('https://localhost:3100/api/chat/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Connection-ID': 'conn-abc',
+      },
+      body: JSON.stringify({
+        type: 'send',
+        sessionId: 'sess-1',
+        prompt: 'hello',
+        clientMsgId: 'msg-1',
+      }),
+    });
+  });
+
+  it('maps message types to correct endpoints', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    const types: Array<[string, string]> = [
+      ['send', 'send'],
+      ['stop', 'stop'],
+      ['interrupt', 'interrupt'],
+      ['permission_response', 'permission'],
+      ['set_mode', 'mode'],
+      ['watch', 'watch'],
+      ['unwatch', 'unwatch'],
+      ['switch_session', 'switch'],
+      ['session_suspend', 'suspend'],
+      ['session_close', 'close'],
+      ['reconnect', 'reconnect'],
+    ];
+
+    for (const [msgType, endpoint] of types) {
+      mockFetch.mockClear();
+      conn.send({ type: msgType });
+      expect(mockFetch).toHaveBeenCalledWith(
+        `https://localhost:3100/api/chat/${endpoint}`,
+        expect.any(Object),
+      );
+    }
+  });
+
+  it('returns false for unknown message types', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    expect(conn.send({ type: 'unknown_garbage' })).toBe(false);
+  });
+
+  // ─── Pending send queue ──────────────────────────────────────────────────
+
+  it('queues sends before welcome and flushes after', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+
+    // Not yet connected — should queue
+    const queued = conn.send({ type: 'send', prompt: 'queued', clientMsgId: 'q-1' });
+    expect(queued).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Welcome arrives — should flush
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://localhost:3100/api/chat/send',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('drops oldest when queue exceeds MAX_PENDING_SENDS', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+
+    for (let i = 0; i < 101; i++) {
+      conn.send({ type: 'send', prompt: `msg-${i}`, clientMsgId: `id-${i}` });
+    }
+
+    // clearPendingSends exposes queue length indirectly
+    // After 101 sends with max 100, oldest should be dropped
+    // Flush and check
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    (conn as unknown as { config: { fetch: typeof mockFetch } }).config.fetch = mockFetch;
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    // Should have 100 sends, not 101
+    expect(mockFetch).toHaveBeenCalledTimes(100);
+  });
+
+  it('clearPendingSends() empties the queue', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+
+    conn.send({ type: 'send', prompt: 'will be cleared', clientMsgId: 'c-1' });
+    conn.clearPendingSends();
+
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    // Only the calls from flush — should be 0 since we cleared
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ─── Reconnect ────────────────────────────────────────────────────────────
+
+  it('notifies _close on error and recovers on next welcome', () => {
+    const conn = new SseConnection(createConfig());
+    const listener = vi.fn();
+    conn.onMessage(listener);
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    lastES()._triggerError();
+
+    expect(listener).toHaveBeenCalledWith({ type: '_close' });
+    expect(conn.isConnected()).toBe(false);
+  });
+
+  it('includes sessions in reconnect URL', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    // Track a session
+    conn.trackSeq('sess-1', 10);
+
+    // Force reconnect
+    conn.checkAndReconnect(true);
+
+    const newES = lastES();
+    expect(newES.url).toContain('sessions=');
+    expect(newES.url).toContain('sess-1%3A10');
+  });
+
+  it('checkAndReconnect(false) is no-op when connected', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    const count = MockEventSource.instances.length;
+    conn.checkAndReconnect(false);
+
+    // Should NOT create a new EventSource
+    expect(MockEventSource.instances.length).toBe(count);
+  });
+
+  // ─── Session tracking ──────────────────────────────────────────────────
+
+  it('trackSeq / getLastSeq / clearSession', () => {
+    const conn = new SseConnection(createConfig());
+
+    conn.trackSeq('sess-1', 5);
+    expect(conn.getLastSeq('sess-1')).toBe(5);
+    expect(conn.getLastSeq('nonexistent')).toBe(0);
+
+    conn.clearSession('sess-1');
+    expect(conn.getLastSeq('sess-1')).toBe(0);
+  });
+
+  it('getTrackedSessions returns all tracked session IDs', () => {
+    const conn = new SseConnection(createConfig());
+    conn.trackSeq('sess-1', 1);
+    conn.trackSeq('sess-2', 2);
+
+    expect(conn.getTrackedSessions()).toEqual(expect.arrayContaining(['sess-1', 'sess-2']));
+  });
+
+  // ─── Suspend ──────────────────────────────────────────────────────────────
+
+  it('sendSuspend posts to suspend endpoint when connected', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+    conn.trackSeq('sess-1', 42);
+
+    conn.sendSuspend();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://localhost:3100/api/chat/suspend',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('sess-1'),
+      }),
+    );
+  });
+
+  it('sendSuspend is no-op with no tracked sessions', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    conn.sendSuspend();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -13,6 +13,7 @@ class MockEventSource {
   readyState = 0; // CONNECTING
   private listeners = new Map<string, ESListener[]>();
   onerror: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
 
   constructor(url: string) {
     this.url = url;
@@ -39,15 +40,20 @@ class MockEventSource {
 
   // ─── Test helpers ────────────────────────────────────────────────────────
 
-  /** Simulate the server sending an SSE event */
+  /** Simulate the server sending an SSE event.
+   *  Named events (welcome) go to addEventListener listeners.
+   *  All others go to onmessage (matching server behavior). */
   _emit(type: string, data: Record<string, unknown>): void {
     const event = new MessageEvent(type, { data: JSON.stringify(data) });
-    for (const listener of this.listeners.get(type) ?? []) {
-      listener(event);
+    if (type === 'welcome') {
+      for (const listener of this.listeners.get(type) ?? []) {
+        listener(event);
+      }
+    } else {
+      this.onmessage?.(event);
     }
   }
 
-  /** Simulate an error (triggers auto-reconnect in real EventSource) */
   _triggerError(): void {
     this.onerror?.();
   }
@@ -297,7 +303,7 @@ describe('SseConnection', () => {
 
     const newES = lastES();
     expect(newES.url).toContain('sessions=');
-    expect(newES.url).toContain('sess-1%3A10');
+    expect(newES.url).toContain('sess-1%7C10');
   });
 
   it('checkAndReconnect(false) is no-op when connected', () => {

--- a/packages/client/src/chat-connection.ts
+++ b/packages/client/src/chat-connection.ts
@@ -1,13 +1,4 @@
-/**
- * ChatConnection — transport-agnostic interface for bidirectional chat.
- *
- * Both MitzoConnection (WebSocket) and SseConnection (SSE + HTTP POST)
- * implement this interface. The store and UI code depend only on this
- * contract, making the transport swappable via feature flag.
- *
- * Provider-agnostic: this interface carries protocol-level events
- * regardless of the inference provider behind them.
- */
+// Transport-agnostic chat connection interface (WS and SSE both implement this).
 
 import type { ConnectionListener } from './connection.js';
 

--- a/packages/client/src/chat-connection.ts
+++ b/packages/client/src/chat-connection.ts
@@ -1,0 +1,45 @@
+/**
+ * ChatConnection — transport-agnostic interface for bidirectional chat.
+ *
+ * Both MitzoConnection (WebSocket) and SseConnection (SSE + HTTP POST)
+ * implement this interface. The store and UI code depend only on this
+ * contract, making the transport swappable via feature flag.
+ *
+ * Provider-agnostic: this interface carries protocol-level events
+ * regardless of the inference provider behind them.
+ */
+
+import type { ConnectionListener } from './connection.js';
+
+export interface ChatConnection {
+  /** Open the transport (start WS connection or SSE EventSource). */
+  connect(): void;
+  /** Close the transport and clean up listeners. */
+  disconnect(): void;
+  /**
+   * Send a protocol message to the server.
+   * Returns true if sent or queued, false if the connection is down
+   * and not recovering.
+   */
+  send(msg: Record<string, unknown>): boolean;
+  /** Register the message listener (only one — last write wins). */
+  onMessage(listener: ConnectionListener): void;
+  /** Whether the transport is connected and ready to send. */
+  isConnected(): boolean;
+  /** Server-assigned connection ID (null before welcome). */
+  getConnectionId(): string | null;
+  /** Track the latest received seq for a session (for reconnect replay). */
+  trackSeq(sessionId: string, seq: number): void;
+  /** Get the last received seq for a session (0 if untracked). */
+  getLastSeq(sessionId: string): number;
+  /** Stop tracking a session (e.g. after close). */
+  clearSession(sessionId: string): void;
+  /** Drain the pending-send queue. */
+  clearPendingSends(): void;
+  /** List all session IDs currently being tracked. */
+  getTrackedSessions(): string[];
+  /** Signal the server that this client is about to be backgrounded. */
+  sendSuspend(): void;
+  /** Check connectivity and reconnect if needed. force=true tears down unconditionally. */
+  checkAndReconnect(force?: boolean): void;
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -67,6 +67,13 @@ export type { MitzoConnectionConfig, ConnectionListener } from './connection.js'
 export { WsPool } from './ws-connection.js';
 export type { WsPoolConfig, WebSocketLike, MsgListener } from './ws-connection.js';
 
+// Chat connection interface (transport-agnostic)
+export type { ChatConnection } from './chat-connection.js';
+
+// SSE chat connection (v2 — SSE + HTTP POST transport)
+export { SseConnection } from './sse-connection.js';
+export type { SseConnectionConfig } from './sse-connection.js';
+
 // SSE event bus (broadcast events)
 export { EventBus } from './event-bus.js';
 export type {

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -198,7 +198,7 @@ export class SseConnection {
     let url = `${this.config.baseUrl}/api/chat/events`;
     if (this._isReconnect && this.seqBySession.size > 0) {
       const sessionsParam = Array.from(this.seqBySession.entries())
-        .map(([sid, seq]) => `${sid}:${seq}`)
+        .map(([sid, seq]) => `${sid}|${seq}`)
         .join(',');
       url += `?sessions=${encodeURIComponent(sessionsParam)}`;
     }
@@ -222,49 +222,22 @@ export class SseConnection {
       this.listener?.({ type: '_open' });
     });
 
-    // All other session events — dispatch to listener
-    const eventTypes = [
-      'message_start',
-      'block_start',
-      'block_delta',
-      'block_stop',
-      'message_stop',
-      'session_end',
-      'session_start',
-      'session_state',
-      'session_list',
-      'permission_request',
-      'task_state',
-      'todo_state',
-      'tool_use',
-      'tool_result',
-      'tool_event',
-      'error',
-      'tokens',
-      'progress',
-      'boot_context_meta',
-      'config',
-      'calendar',
-      'inbox_state',
-    ];
+    // Catch-all for session events. Server sends all non-welcome events as
+    // `event: message`, so es.onmessage handles everything — no allowlist needed.
+    es.onmessage = (e: MessageEvent) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
 
-    for (const eventType of eventTypes) {
-      es.addEventListener(eventType, (e: MessageEvent) => {
-        let msg: Record<string, unknown>;
-        try {
-          msg = JSON.parse(e.data);
-        } catch {
-          return;
-        }
+      if (typeof msg.seq === 'number' && typeof msg.sessionId === 'string') {
+        this.seqBySession.set(msg.sessionId as string, msg.seq as number);
+      }
 
-        // Track seq for reconnect replay
-        if (typeof msg.seq === 'number' && typeof msg.sessionId === 'string') {
-          this.seqBySession.set(msg.sessionId as string, msg.seq as number);
-        }
-
-        this.listener?.(msg);
-      });
-    }
+      this.listener?.(msg);
+    };
 
     es.onerror = () => {
       // EventSource auto-reconnects on error. We only need to update

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ConnectionListener } from './connection.js';
+import type { ChatConnection } from './chat-connection.js';
 
 export interface SseConnectionConfig {
   /** Base URL for API endpoints (e.g. "https://host:3100"). No trailing slash. */
@@ -29,7 +30,7 @@ export interface SseConnectionConfig {
 
 const MAX_PENDING_SENDS = 100;
 
-export class SseConnection {
+export class SseConnection implements ChatConnection {
   private es: EventSource | null = null;
   private _connectionId: string | null = null;
   private _connected = false;

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -1,0 +1,382 @@
+/**
+ * SseConnection — SSE + HTTP POST transport for the v2 protocol.
+ *
+ * Drop-in replacement for MitzoConnection. Same public interface, different
+ * wire transport:
+ *   - Server→client: EventSource (SSE) on GET /api/chat/events
+ *   - Client→server: fetch POST to /api/chat/{send,stop,interrupt,...}
+ *
+ * Eliminates the iOS WebSocket reconnection bug class. EventSource auto-
+ * reconnects natively — no heartbeat hack, no readyState staleness, no
+ * silent kills without onclose firing.
+ *
+ * The server runs both transports in parallel during the migration period.
+ */
+
+import type { ConnectionListener } from './connection.js';
+
+export interface SseConnectionConfig {
+  /** Base URL for API endpoints (e.g. "https://host:3100"). No trailing slash. */
+  baseUrl: string;
+  /** fetch implementation — allows the store to inject apiFetch with auth headers. */
+  fetch: (url: string, init?: RequestInit) => Promise<Response>;
+  /** Factory for EventSource — allows injection for testing. */
+  createEventSource?: (url: string) => EventSource;
+  reconnectDelayMs?: number;
+  /** URL for the sendBeacon suspend fallback. */
+  suspendUrl?: string;
+}
+
+const MAX_PENDING_SENDS = 100;
+
+export class SseConnection {
+  private es: EventSource | null = null;
+  private _connectionId: string | null = null;
+  private _connected = false;
+  private _isReconnect = false;
+  private listener: ConnectionListener | null = null;
+  private seqBySession = new Map<string, number>();
+  private pendingSends: Array<{ endpoint: string; body: Record<string, unknown> }> = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private boundOnVisibility: (() => void) | null = null;
+  private boundOnPageShow: ((e: PageTransitionEvent) => void) | null = null;
+  private boundOnPageHide: (() => void) | null = null;
+  private config: Required<SseConnectionConfig>;
+
+  constructor(config: SseConnectionConfig) {
+    this.config = {
+      createEventSource: (url: string) => new EventSource(url),
+      reconnectDelayMs: 500,
+      suspendUrl: '',
+      ...config,
+    };
+  }
+
+  connect(): void {
+    this.doConnect();
+    this.addBrowserListeners();
+  }
+
+  disconnect(): void {
+    this.removeBrowserListeners();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.es) {
+      this.es.close();
+      this.es = null;
+    }
+    this._connected = false;
+  }
+
+  /**
+   * Send a message to the server via HTTP POST.
+   *
+   * Maps message types to REST endpoints:
+   *   { type: 'send', ... }      → POST /api/chat/send
+   *   { type: 'stop', ... }      → POST /api/chat/stop
+   *   { type: 'interrupt', ... } → POST /api/chat/interrupt
+   *   etc.
+   *
+   * Returns true if the message was sent or queued, false if not connected
+   * and not reconnecting.
+   */
+  send(msg: Record<string, unknown>): boolean {
+    const endpoint = this.messageTypeToEndpoint(msg.type as string);
+    if (!endpoint) return false;
+
+    if (this._connected && this._connectionId) {
+      this.doPost(endpoint, msg);
+      return true;
+    }
+
+    // Queue if reconnecting
+    if (this.reconnectTimer || this.es) {
+      if (this.pendingSends.length >= MAX_PENDING_SENDS) {
+        this.pendingSends.shift();
+      }
+      this.pendingSends.push({ endpoint, body: msg });
+      return true;
+    }
+
+    return false;
+  }
+
+  onMessage(listener: ConnectionListener): void {
+    this.listener = listener;
+  }
+
+  isConnected(): boolean {
+    return this._connected;
+  }
+
+  getConnectionId(): string | null {
+    return this._connectionId;
+  }
+
+  trackSeq(sessionId: string, seq: number): void {
+    this.seqBySession.set(sessionId, seq);
+  }
+
+  getLastSeq(sessionId: string): number {
+    return this.seqBySession.get(sessionId) ?? 0;
+  }
+
+  clearSession(sessionId: string): void {
+    this.seqBySession.delete(sessionId);
+  }
+
+  clearPendingSends(): void {
+    this.pendingSends = [];
+  }
+
+  getTrackedSessions(): string[] {
+    return Array.from(this.seqBySession.keys());
+  }
+
+  /**
+   * Signal the server that this client is about to be backgrounded.
+   * Uses fetch POST first; falls back to sendBeacon.
+   */
+  sendSuspend(): void {
+    if (this.seqBySession.size === 0) return;
+
+    const sessions = Array.from(this.seqBySession.entries()).map(([sessionId, lastSeq]) => ({
+      sessionId,
+      lastSeq,
+    }));
+
+    // Try POST first
+    if (this._connected && this._connectionId) {
+      this.doPost('suspend', { type: 'session_suspend', sessions });
+      return;
+    }
+
+    // sendBeacon fallback
+    if (
+      this.config.suspendUrl &&
+      this._connectionId &&
+      typeof globalThis.navigator?.sendBeacon === 'function'
+    ) {
+      const payload = JSON.stringify({ connectionId: this._connectionId, sessions });
+      globalThis.navigator.sendBeacon(
+        this.config.suspendUrl,
+        new Blob([payload], { type: 'application/json' }),
+      );
+    }
+  }
+
+  /**
+   * Force reconnect — close existing EventSource and reconnect.
+   * Unlike WS, EventSource reconnects automatically, but force=true
+   * tears down and rebuilds for iOS Capacitor lifecycle hooks.
+   */
+  checkAndReconnect(force = false): void {
+    if (!force && this._connected) return;
+    if (this.reconnectTimer) return;
+    if (this.es) {
+      this.es.close();
+      this.es = null;
+    }
+    this._connected = false;
+    this.listener?.({ type: '_close' });
+    this.doConnect();
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private doConnect(): void {
+    if (this.es) return;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    // Build URL with reconnect sessions if this is a reconnect
+    let url = `${this.config.baseUrl}/api/chat/events`;
+    if (this._isReconnect && this.seqBySession.size > 0) {
+      const sessionsParam = Array.from(this.seqBySession.entries())
+        .map(([sid, seq]) => `${sid}:${seq}`)
+        .join(',');
+      url += `?sessions=${encodeURIComponent(sessionsParam)}`;
+    }
+
+    const es = this.config.createEventSource(url);
+    this.es = es;
+
+    // Welcome event — server sends connectionId
+    es.addEventListener('welcome', (e: MessageEvent) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(e.data);
+      } catch {
+        return;
+      }
+      this._connectionId = msg.connectionId as string;
+      this._connected = true;
+      this._isReconnect = true;
+
+      this.flushPendingSends();
+      this.listener?.({ type: '_open' });
+    });
+
+    // All other session events — dispatch to listener
+    const eventTypes = [
+      'message_start',
+      'block_start',
+      'block_delta',
+      'block_stop',
+      'message_stop',
+      'session_end',
+      'session_start',
+      'session_state',
+      'session_list',
+      'permission_request',
+      'task_state',
+      'todo_state',
+      'tool_use',
+      'tool_result',
+      'tool_event',
+      'error',
+      'tokens',
+      'progress',
+      'boot_context_meta',
+      'config',
+      'calendar',
+      'inbox_state',
+    ];
+
+    for (const eventType of eventTypes) {
+      es.addEventListener(eventType, (e: MessageEvent) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+
+        // Track seq for reconnect replay
+        if (typeof msg.seq === 'number' && typeof msg.sessionId === 'string') {
+          this.seqBySession.set(msg.sessionId as string, msg.seq as number);
+        }
+
+        this.listener?.(msg);
+      });
+    }
+
+    es.onerror = () => {
+      // EventSource auto-reconnects on error. We only need to update
+      // our state and notify the listener.
+      if (this._connected) {
+        this._connected = false;
+        this.listener?.({ type: '_close' });
+      }
+    };
+
+    // EventSource fires 'open' when the connection is established,
+    // but we wait for the 'welcome' event before marking as connected.
+  }
+
+  private async doPost(endpoint: string, body: Record<string, unknown>): Promise<void> {
+    if (!this._connectionId) return;
+    try {
+      await this.config.fetch(`${this.config.baseUrl}/api/chat/${endpoint}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Connection-ID': this._connectionId,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // POST failures are non-fatal — the server may be temporarily
+      // unreachable. The SSE stream will reconnect and replay missed events.
+    }
+  }
+
+  private flushPendingSends(): void {
+    if (this.pendingSends.length === 0) return;
+    const toFlush = this.pendingSends;
+    this.pendingSends = [];
+    for (const { endpoint, body } of toFlush) {
+      this.doPost(endpoint, body);
+    }
+  }
+
+  /**
+   * Map v2 message types to REST endpoint names.
+   * Returns null for unknown types.
+   */
+  private messageTypeToEndpoint(type: string): string | null {
+    switch (type) {
+      case 'send':
+        return 'send';
+      case 'stop':
+        return 'stop';
+      case 'interrupt':
+        return 'interrupt';
+      case 'permission_response':
+        return 'permission';
+      case 'set_mode':
+        return 'mode';
+      case 'watch':
+        return 'watch';
+      case 'unwatch':
+        return 'unwatch';
+      case 'switch_session':
+        return 'switch';
+      case 'session_suspend':
+        return 'suspend';
+      case 'session_close':
+        return 'close';
+      case 'reconnect':
+        return 'reconnect';
+      default:
+        return null;
+    }
+  }
+
+  // ─── Browser lifecycle ─────────────────────────────────────────────────────
+
+  private addBrowserListeners(): void {
+    if (typeof globalThis.document === 'undefined') return;
+
+    this.boundOnVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        this.checkAndReconnect();
+        this.listener?.({ type: '_foreground' });
+      } else if (document.visibilityState === 'hidden') {
+        this.sendSuspend();
+      }
+    };
+
+    this.boundOnPageShow = (e: PageTransitionEvent) => {
+      if (e.persisted) this.checkAndReconnect();
+    };
+
+    this.boundOnPageHide = () => {
+      this.sendSuspend();
+    };
+
+    document.addEventListener('visibilitychange', this.boundOnVisibility);
+    globalThis.addEventListener('pageshow', this.boundOnPageShow);
+    globalThis.addEventListener('pagehide', this.boundOnPageHide);
+  }
+
+  private removeBrowserListeners(): void {
+    if (this.boundOnVisibility) {
+      document.removeEventListener('visibilitychange', this.boundOnVisibility);
+      this.boundOnVisibility = null;
+    }
+    if (this.boundOnPageShow) {
+      globalThis.removeEventListener('pageshow', this.boundOnPageShow);
+      this.boundOnPageShow = null;
+    }
+    if (this.boundOnPageHide) {
+      globalThis.removeEventListener('pagehide', this.boundOnPageHide);
+      this.boundOnPageHide = null;
+    }
+  }
+}

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -44,6 +44,9 @@ import type { WsMsg } from './server-messages.js';
 import { MitzoApiClient } from './api-client.js';
 import { MitzoConnection } from './connection.js';
 import type { MitzoConnectionConfig } from './connection.js';
+import { SseConnection } from './sse-connection.js';
+import type { SseConnectionConfig } from './sse-connection.js';
+import type { ChatConnection } from './chat-connection.js';
 
 // ─── Store state ─────────────────────────────────────────────────────────────
 
@@ -138,6 +141,8 @@ export interface MitzoStoreState {
 export interface MitzoStoreOptions {
   transport: TransportAdapter;
   wsConfig: MitzoConnectionConfig;
+  /** When provided, the store uses SSE + HTTP POST instead of WebSocket. */
+  sseConfig?: SseConnectionConfig;
 }
 
 // ─── Tree helpers ───────────────────────────────────────────────────────────
@@ -173,7 +178,9 @@ const PENDING_SEND_TIMEOUT_MS = 5_000;
 
 export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStoreState> {
   const api = new MitzoApiClient(options.transport.fetch.bind(options.transport));
-  const connection = new MitzoConnection(options.wsConfig);
+  const connection: ChatConnection = options.sseConfig
+    ? new SseConnection(options.sseConfig)
+    : new MitzoConnection(options.wsConfig);
 
   const parserState: ProtocolParserState & {
     pendingSendTimer?: ReturnType<typeof setTimeout>;

--- a/server/__tests__/chat-rest-handler.test.ts
+++ b/server/__tests__/chat-rest-handler.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { SessionSseRegistry } from '../session-sse-registry.js';
+import { SseTransport } from '../sse-transport.js';
+import { createChatRestRouter } from '../chat-rest-handler.js';
+import { ConnectionRegistry } from '@mitzo/harness';
+import type { V2HandlerContext } from '../ws-handler-v2.js';
+
+// ─── Mock the handler functions ──────────────────────────────────────────────
+
+vi.mock('../ws-handler-v2.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    handleSendV2: vi.fn(),
+    handleStopV2: vi.fn(),
+    handleInterruptV2: vi.fn(),
+    handlePermissionResponseV2: vi.fn(),
+    handleSetModeV2: vi.fn(),
+    handleWatch: vi.fn(),
+    handleUnwatch: vi.fn(),
+    handleSwitchSession: vi.fn().mockResolvedValue(undefined),
+    handleSessionSuspend: vi.fn(),
+    handleSessionClose: vi.fn(),
+    handleReconnect: vi.fn(),
+  };
+});
+
+import {
+  handleSendV2,
+  handleStopV2,
+  handleInterruptV2,
+  handlePermissionResponseV2,
+  handleSetModeV2,
+  handleWatch,
+  handleUnwatch,
+  handleSwitchSession,
+  handleSessionSuspend,
+  handleSessionClose,
+  handleReconnect,
+} from '../ws-handler-v2.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockResponse() {
+  return {
+    write: vi.fn(() => true),
+    end: vi.fn(),
+    writableEnded: false,
+  } as unknown as import('express').Response;
+}
+
+function buildApp(sseRegistry: SessionSseRegistry, connRegistry: ConnectionRegistry) {
+  const ctx: V2HandlerContext = {
+    connRegistry,
+    sessionRegistry: {} as V2HandlerContext['sessionRegistry'],
+    eventStore: {} as V2HandlerContext['eventStore'],
+    nativeCommands: {} as V2HandlerContext['nativeCommands'],
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.use('/api/chat', createChatRestRouter(sseRegistry, ctx));
+  return { app, ctx };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('chat-rest-handler', () => {
+  let sseRegistry: SessionSseRegistry;
+  let connRegistry: ConnectionRegistry;
+  let testApp: express.Express;
+  const CONNECTION_ID = 'conn-test-123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sseRegistry = new SessionSseRegistry();
+    connRegistry = new ConnectionRegistry();
+
+    // Register an SSE stream + connection
+    const res = mockResponse();
+    sseRegistry.add(CONNECTION_ID, res);
+    const transport = new SseTransport(CONNECTION_ID, sseRegistry);
+    connRegistry.register(CONNECTION_ID, transport);
+
+    const { app } = buildApp(sseRegistry, connRegistry);
+    testApp = app;
+  });
+
+  afterEach(() => {
+    sseRegistry.destroy();
+    connRegistry.dispose();
+  });
+
+  // ─── Header validation ──────────────────────────────────────────────────
+
+  it('rejects requests without X-Connection-ID', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/send')
+      .send({ prompt: 'hello', clientMsgId: 'msg-1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('X-Connection-ID');
+  });
+
+  it('rejects requests with unknown connection', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/send')
+      .set('X-Connection-ID', 'conn-nonexistent')
+      .send({ prompt: 'hello', clientMsgId: 'msg-1' });
+
+    expect(res.status).toBe(404);
+  });
+
+  // ─── POST /api/chat/send ────────────────────────────────────────────────
+
+  it('POST /send calls handleSendV2 and returns 202', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/send')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        type: 'send',
+        sessionId: null,
+        prompt: 'hello world',
+        clientMsgId: 'msg-1',
+      });
+
+    expect(res.status).toBe(202);
+    expect(res.body.ok).toBe(true);
+    expect(handleSendV2).toHaveBeenCalledOnce();
+    expect(handleSendV2).toHaveBeenCalledWith(
+      CONNECTION_ID,
+      expect.any(SseTransport),
+      expect.objectContaining({ prompt: 'hello world' }),
+      expect.any(Object),
+    );
+  });
+
+  // ─── POST /api/chat/stop ────────────────────────────────────────────────
+
+  it('POST /stop calls handleStopV2', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/stop')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'stop', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(handleStopV2).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/interrupt ───────────────────────────────────────────
+
+  it('POST /interrupt calls handleInterruptV2', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/interrupt')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        type: 'interrupt',
+        sessionId: 'sess-1',
+        prompt: 'stop that',
+        clientMsgId: 'msg-int-1',
+      });
+
+    expect(res.status).toBe(202);
+    expect(res.body.ok).toBe(true);
+    expect(handleInterruptV2).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/permission ──────────────────────────────────────────
+
+  it('POST /permission calls handlePermissionResponseV2', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/permission')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        type: 'permission_response',
+        permId: 'perm-1',
+        decision: 'once',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(handlePermissionResponseV2).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/mode ───────────────────────────────────────────────
+
+  it('POST /mode calls handleSetModeV2', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/mode')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        type: 'set_mode',
+        sessionId: 'sess-1',
+        mode: 'agent',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(handleSetModeV2).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/watch + unwatch ─────────────────────────────────────
+
+  it('POST /watch calls handleWatch', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/watch')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'watch', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(handleWatch).toHaveBeenCalledOnce();
+  });
+
+  it('POST /unwatch calls handleUnwatch', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/unwatch')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'unwatch', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(handleUnwatch).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/switch ──────────────────────────────────────────────
+
+  it('POST /switch calls handleSwitchSession', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/switch')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'switch_session', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(handleSwitchSession).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/suspend ─────────────────────────────────────────────
+
+  it('POST /suspend calls handleSessionSuspend', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/suspend')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        type: 'session_suspend',
+        sessions: [{ sessionId: 'sess-1', lastSeq: 42 }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(handleSessionSuspend).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/close ──────────────────────────────────────────────
+
+  it('POST /close calls handleSessionClose', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/close')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'session_close', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(handleSessionClose).toHaveBeenCalledOnce();
+  });
+
+  // ─── POST /api/chat/reconnect ──────────────────────────────────────────
+
+  it('POST /reconnect calls handleReconnect', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/reconnect')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({
+        sessions: [
+          { sessionId: 'sess-1', lastSeq: 10 },
+          { sessionId: 'sess-2', lastSeq: 20 },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(handleReconnect).toHaveBeenCalledOnce();
+    expect(handleReconnect).toHaveBeenCalledWith(
+      CONNECTION_ID,
+      expect.objectContaining({
+        type: 'reconnect',
+        sessions: expect.arrayContaining([
+          expect.objectContaining({ sessionId: 'sess-1', lastSeq: 10 }),
+        ]),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('POST /reconnect rejects missing sessions array', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/reconnect')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('sessions');
+  });
+
+  // ─── Error handling ─────────────────────────────────────────────────────
+
+  it('returns 500 when handler throws', async () => {
+    (handleStopV2 as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('SDK crashed');
+    });
+
+    const res = await request(testApp)
+      .post('/api/chat/stop')
+      .set('X-Connection-ID', CONNECTION_ID)
+      .send({ type: 'stop', sessionId: 'sess-1' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+});

--- a/server/__tests__/chat-rest-handler.test.ts
+++ b/server/__tests__/chat-rest-handler.test.ts
@@ -104,11 +104,20 @@ describe('chat-rest-handler', () => {
     expect(res.body.error).toContain('X-Connection-ID');
   });
 
-  it('rejects requests with unknown connection', async () => {
+  it('rejects requests with unknown connection (getTransport path)', async () => {
     const res = await request(testApp)
       .post('/api/chat/send')
       .set('X-Connection-ID', 'conn-nonexistent')
       .send({ prompt: 'hello', clientMsgId: 'msg-1' });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects requests with unknown connection (requireConnection path)', async () => {
+    const res = await request(testApp)
+      .post('/api/chat/stop')
+      .set('X-Connection-ID', 'conn-nonexistent')
+      .send({ type: 'stop', sessionId: 'sess-1' });
 
     expect(res.status).toBe(404);
   });
@@ -270,6 +279,7 @@ describe('chat-rest-handler', () => {
       .post('/api/chat/reconnect')
       .set('X-Connection-ID', CONNECTION_ID)
       .send({
+        type: 'reconnect',
         sessions: [
           { sessionId: 'sess-1', lastSeq: 10 },
           { sessionId: 'sess-2', lastSeq: 20 },
@@ -297,7 +307,7 @@ describe('chat-rest-handler', () => {
       .send({});
 
     expect(res.status).toBe(400);
-    expect(res.body.error).toContain('sessions');
+    expect(res.body.error).toContain('Invalid request body');
   });
 
   // ─── Error handling ─────────────────────────────────────────────────────

--- a/server/__tests__/sse-transport.test.ts
+++ b/server/__tests__/sse-transport.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Response } from 'express';
+import { SessionSseRegistry } from '../session-sse-registry.js';
+import { SseTransport } from '../sse-transport.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mockResponse(): Response {
+  const chunks: string[] = [];
+  return {
+    write: vi.fn((data: string) => {
+      chunks.push(data);
+      return true;
+    }),
+    writeHead: vi.fn(),
+    end: vi.fn(),
+    writableEnded: false,
+    // Access captured output for assertions
+    _chunks: chunks,
+  } as unknown as Response & { _chunks: string[] };
+}
+
+// ─── SessionSseRegistry ─────────────────────────────────────────────────────
+
+describe('SessionSseRegistry', () => {
+  let registry: SessionSseRegistry;
+
+  beforeEach(() => {
+    registry = new SessionSseRegistry();
+  });
+
+  it('registers and tracks connections', () => {
+    const res = mockResponse();
+    registry.add('conn-1', res);
+    expect(registry.size).toBe(1);
+    expect(registry.isOpen('conn-1')).toBe(true);
+  });
+
+  it('removes connections', () => {
+    const res = mockResponse();
+    registry.add('conn-1', res);
+    registry.remove('conn-1');
+    expect(registry.size).toBe(0);
+    expect(registry.isOpen('conn-1')).toBe(false);
+  });
+
+  it('closes existing stream when same connectionId re-registers', () => {
+    const res1 = mockResponse();
+    const res2 = mockResponse();
+    registry.add('conn-1', res1);
+    registry.add('conn-1', res2);
+    expect(registry.size).toBe(1);
+    expect(res1.end).toHaveBeenCalled();
+  });
+
+  it('sends SSE event with correct format', () => {
+    const res = mockResponse() as Response & { _chunks: string[] };
+    registry.add('conn-1', res);
+
+    const sent = registry.sendTo('conn-1', { type: 'welcome', protocolVersion: 2 });
+
+    expect(sent).toBe(true);
+    expect(res._chunks).toHaveLength(1);
+    const frame = res._chunks[0];
+    expect(frame).toContain('event: welcome');
+    expect(frame).toContain('data: {"type":"welcome","protocolVersion":2}');
+    expect(frame.endsWith('\n\n')).toBe(true);
+  });
+
+  it('includes SSE id field when seq provided', () => {
+    const res = mockResponse() as Response & { _chunks: string[] };
+    registry.add('conn-1', res);
+
+    registry.sendTo('conn-1', { type: 'block_delta', delta: 'hello' }, 42);
+
+    const frame = res._chunks[0];
+    expect(frame).toContain('id: 42');
+    expect(frame).toContain('event: block_delta');
+  });
+
+  it('omits id field when no seq', () => {
+    const res = mockResponse() as Response & { _chunks: string[] };
+    registry.add('conn-1', res);
+
+    registry.sendTo('conn-1', { type: 'welcome' });
+
+    const frame = res._chunks[0];
+    expect(frame).not.toContain('id:');
+  });
+
+  it('returns false for unknown connection', () => {
+    expect(registry.sendTo('unknown', { type: 'test' })).toBe(false);
+  });
+
+  it('removes connection on write failure', () => {
+    const res = mockResponse();
+    (res.write as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('socket closed');
+    });
+    registry.add('conn-1', res);
+
+    const sent = registry.sendTo('conn-1', { type: 'test' });
+
+    expect(sent).toBe(false);
+    expect(registry.size).toBe(0);
+  });
+
+  it('reports closed when writableEnded', () => {
+    const res = mockResponse();
+    registry.add('conn-1', res);
+    expect(registry.isOpen('conn-1')).toBe(true);
+
+    (res as unknown as { writableEnded: boolean }).writableEnded = true;
+    expect(registry.isOpen('conn-1')).toBe(false);
+  });
+
+  it('destroy closes all streams', () => {
+    const res1 = mockResponse();
+    const res2 = mockResponse();
+    registry.add('conn-1', res1);
+    registry.add('conn-2', res2);
+
+    registry.destroy();
+
+    expect(res1.end).toHaveBeenCalled();
+    expect(res2.end).toHaveBeenCalled();
+    expect(registry.size).toBe(0);
+  });
+});
+
+// ─── SseTransport ────────────────────────────────────────────────────────────
+
+describe('SseTransport', () => {
+  let sseRegistry: SessionSseRegistry;
+  let transport: SseTransport;
+  let res: Response & { _chunks: string[] };
+
+  beforeEach(() => {
+    sseRegistry = new SessionSseRegistry();
+    res = mockResponse() as Response & { _chunks: string[] };
+    sseRegistry.add('conn-1', res);
+    transport = new SseTransport('conn-1', sseRegistry);
+  });
+
+  it('implements SessionTransport.send()', () => {
+    transport.send({ type: 'message_start', messageId: 'msg-1' });
+
+    expect(res._chunks).toHaveLength(1);
+    expect(res._chunks[0]).toContain('event: message_start');
+  });
+
+  it('passes seq as SSE id field', () => {
+    transport.send({ type: 'block_delta', seq: 7, delta: 'hi' });
+
+    expect(res._chunks[0]).toContain('id: 7');
+  });
+
+  it('implements SessionTransport.isOpen()', () => {
+    expect(transport.isOpen()).toBe(true);
+
+    sseRegistry.remove('conn-1');
+    expect(transport.isOpen()).toBe(false);
+  });
+
+  it('send without seq omits id field', () => {
+    transport.send({ type: 'session_end', sessionId: 's-1' });
+
+    expect(res._chunks[0]).not.toContain('id:');
+  });
+});

--- a/server/__tests__/sse-transport.test.ts
+++ b/server/__tests__/sse-transport.test.ts
@@ -67,6 +67,17 @@ describe('SessionSseRegistry', () => {
     expect(frame.endsWith('\n\n')).toBe(true);
   });
 
+  it('sends non-welcome events as event: message', () => {
+    const res = mockResponse() as Response & { _chunks: string[] };
+    registry.add('conn-1', res);
+
+    registry.sendTo('conn-1', { type: 'block_delta', delta: 'hello' });
+
+    const frame = res._chunks[0];
+    expect(frame).toContain('event: message');
+    expect(frame).not.toContain('event: block_delta');
+  });
+
   it('includes SSE id field when seq provided', () => {
     const res = mockResponse() as Response & { _chunks: string[] };
     registry.add('conn-1', res);
@@ -75,7 +86,7 @@ describe('SessionSseRegistry', () => {
 
     const frame = res._chunks[0];
     expect(frame).toContain('id: 42');
-    expect(frame).toContain('event: block_delta');
+    expect(frame).toContain('event: message');
   });
 
   it('omits id field when no seq', () => {
@@ -146,7 +157,7 @@ describe('SseTransport', () => {
     transport.send({ type: 'message_start', messageId: 'msg-1' });
 
     expect(res._chunks).toHaveLength(1);
-    expect(res._chunks[0]).toContain('event: message_start');
+    expect(res._chunks[0]).toContain('event: message');
   });
 
   it('passes seq as SSE id field', () => {

--- a/server/__tests__/sse-transport.test.ts
+++ b/server/__tests__/sse-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Response } from 'express';
 import { SessionSseRegistry } from '../session-sse-registry.js';
 import { SseTransport } from '../sse-transport.js';
@@ -26,7 +26,13 @@ describe('SessionSseRegistry', () => {
   let registry: SessionSseRegistry;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     registry = new SessionSseRegistry();
+  });
+
+  afterEach(() => {
+    registry.destroy();
+    vi.useRealTimers();
   });
 
   it('registers and tracks connections', () => {
@@ -137,6 +143,26 @@ describe('SessionSseRegistry', () => {
     expect(res2.end).toHaveBeenCalled();
     expect(registry.size).toBe(0);
   });
+
+  it('heartbeat writes comment frames and cleans dead connections', () => {
+    const alive = mockResponse();
+    const dead = mockResponse();
+    (dead.write as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('broken pipe');
+    });
+
+    registry.add('conn-alive', alive);
+    registry.add('conn-dead', dead);
+    expect(registry.size).toBe(2);
+
+    // Advance past heartbeat interval (30s)
+    vi.advanceTimersByTime(30_000);
+
+    expect(alive.write).toHaveBeenCalledWith(':heartbeat\n\n');
+    expect(registry.size).toBe(1);
+    expect(registry.isOpen('conn-alive')).toBe(true);
+    expect(registry.isOpen('conn-dead')).toBe(false);
+  });
 });
 
 // ─── SseTransport ────────────────────────────────────────────────────────────
@@ -151,6 +177,10 @@ describe('SseTransport', () => {
     res = mockResponse() as Response & { _chunks: string[] };
     sseRegistry.add('conn-1', res);
     transport = new SseTransport('conn-1', sseRegistry);
+  });
+
+  afterEach(() => {
+    sseRegistry.destroy();
   });
 
   it('implements SessionTransport.send()', () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -88,6 +88,7 @@ import { mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { TaskStore, type TaskCreateInput, type TaskUpdateInput } from './task-store.js';
 import { SseRegistry } from '@mitzo/harness';
+import { SessionSseRegistry } from './session-sse-registry.js';
 import { WorkloadStore, type WorkSignal, type TodoItemUpdateInput } from './workload-store.js';
 
 const log = createLogger('server');
@@ -254,6 +255,7 @@ export const workloadStore = new WorkloadStore(taskStore.getDatabase());
 setTokenStorePath(join(mitzoDir, 'device-tokens.json'));
 
 export const sseRegistry = new SseRegistry();
+export const chatSseRegistry = new SessionSseRegistry();
 
 export function setUpdateBroadcast(fn: () => void) {
   onUpdateAvailable = fn;

--- a/server/chat-rest-handler.ts
+++ b/server/chat-rest-handler.ts
@@ -1,16 +1,4 @@
-/**
- * chat-rest-handler.ts — HTTP POST endpoints for chat operations.
- *
- * Each endpoint is a thin wrapper around the existing handler functions
- * in ws-handler-v2.ts. The handlers are transport-agnostic — they take
- * (connectionId, transport, msg, ctx) and work identically whether the
- * transport is WsTransport or SseTransport.
- *
- * Client→server sends become stateless HTTP POST requests.
- * Server→client responses stream back via the SSE connection.
- *
- * The X-Connection-ID header binds each POST to the correct SSE stream.
- */
+// HTTP POST endpoints for chat operations — thin wrappers around ws-handler-v2.
 
 import { Router } from 'express';
 import type { Request, Response } from 'express';
@@ -25,8 +13,8 @@ import {
   SwitchSessionMessage,
   SessionSuspendMessage,
   SessionCloseMessage,
+  ReconnectMessage,
 } from '@mitzo/protocol';
-import type { ConnectionRegistry } from '@mitzo/harness';
 import type { V2HandlerContext } from './ws-handler-v2.js';
 import {
   handleSendV2,
@@ -47,10 +35,6 @@ import { createLogger } from './logger.js';
 
 const log = createLogger('chat-rest');
 
-/**
- * Extract and validate the X-Connection-ID header.
- * Returns the connectionId or sends a 400 error.
- */
 function getConnectionId(req: Request, res: Response): string | null {
   const connectionId = req.headers['x-connection-id'] as string | undefined;
   if (!connectionId) {
@@ -60,14 +44,10 @@ function getConnectionId(req: Request, res: Response): string | null {
   return connectionId;
 }
 
-/**
- * Look up the SseTransport for a connection.
- * Returns the transport or sends a 404 error.
- */
 function getTransport(
   connectionId: string,
   sseRegistry: SessionSseRegistry,
-  connRegistry: ConnectionRegistry,
+  connRegistry: V2HandlerContext['connRegistry'],
   res: Response,
 ): SseTransport | null {
   if (!sseRegistry.isOpen(connectionId)) {
@@ -82,10 +62,19 @@ function getTransport(
   return conn.transport as SseTransport;
 }
 
-/**
- * Validate request body against a Zod schema.
- * Returns the parsed value or sends a 400 error.
- */
+/** Verify the connection exists in the registry. */
+function requireConnection(
+  connectionId: string,
+  connRegistry: V2HandlerContext['connRegistry'],
+  res: Response,
+): boolean {
+  if (!connRegistry.get(connectionId)) {
+    res.status(404).json({ ok: false, error: 'Connection not registered' });
+    return false;
+  }
+  return true;
+}
+
 function validateBody<T>(
   schema: { safeParse: (data: unknown) => { success: boolean; data?: T; error?: unknown } },
   body: unknown,
@@ -105,17 +94,13 @@ export function createChatRestRouter(
 ): Router {
   const router = Router();
 
-  // POST /api/chat/send
   router.post('/send', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
     const transport = getTransport(connectionId, sseRegistry, ctx.connRegistry, res);
     if (!transport) return;
-
     const msg = validateBody(V2SendMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleSendV2(connectionId, transport, msg, ctx);
       res.status(202).json({ ok: true });
@@ -125,17 +110,13 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/interrupt
   router.post('/interrupt', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
     const transport = getTransport(connectionId, sseRegistry, ctx.connRegistry, res);
     if (!transport) return;
-
     const msg = validateBody(V2InterruptMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleInterruptV2(connectionId, transport, msg, ctx);
       res.status(202).json({ ok: true });
@@ -145,14 +126,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/stop
   router.post('/stop', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(V2StopMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleStopV2(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -162,14 +141,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/permission
   router.post('/permission', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(V2PermissionResponseMessage, req.body, res);
     if (!msg) return;
-
     try {
       handlePermissionResponseV2(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -179,14 +156,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/mode
   router.post('/mode', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(V2SetModeMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleSetModeV2(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -196,14 +171,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/watch
   router.post('/watch', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(WatchMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleWatch(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -213,14 +186,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/unwatch
   router.post('/unwatch', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(UnwatchMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleUnwatch(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -230,14 +201,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/switch
   router.post('/switch', async (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(SwitchSessionMessage, req.body, res);
     if (!msg) return;
-
     try {
       await handleSwitchSession(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -247,14 +216,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/suspend
   router.post('/suspend', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(SessionSuspendMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleSessionSuspend(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -264,14 +231,12 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/close
   router.post('/close', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
     const msg = validateBody(SessionCloseMessage, req.body, res);
     if (!msg) return;
-
     try {
       handleSessionClose(connectionId, msg, ctx);
       res.json({ ok: true });
@@ -281,19 +246,14 @@ export function createChatRestRouter(
     }
   });
 
-  // POST /api/chat/reconnect
   router.post('/reconnect', (req, res) => {
     const connectionId = getConnectionId(req, res);
     if (!connectionId) return;
-
-    const body = req.body as { sessions?: Array<{ sessionId: string; lastSeq: number }> };
-    if (!body.sessions || !Array.isArray(body.sessions)) {
-      res.status(400).json({ ok: false, error: 'Missing sessions array' });
-      return;
-    }
-
+    if (!requireConnection(connectionId, ctx.connRegistry, res)) return;
+    const msg = validateBody(ReconnectMessage, req.body, res);
+    if (!msg) return;
     try {
-      handleReconnect(connectionId, { type: 'reconnect', sessions: body.sessions }, ctx);
+      handleReconnect(connectionId, msg, ctx);
       res.json({ ok: true });
     } catch (err) {
       log.error('POST /chat/reconnect failed', { connectionId, error: String(err) });

--- a/server/chat-rest-handler.ts
+++ b/server/chat-rest-handler.ts
@@ -1,0 +1,305 @@
+/**
+ * chat-rest-handler.ts — HTTP POST endpoints for chat operations.
+ *
+ * Each endpoint is a thin wrapper around the existing handler functions
+ * in ws-handler-v2.ts. The handlers are transport-agnostic — they take
+ * (connectionId, transport, msg, ctx) and work identically whether the
+ * transport is WsTransport or SseTransport.
+ *
+ * Client→server sends become stateless HTTP POST requests.
+ * Server→client responses stream back via the SSE connection.
+ *
+ * The X-Connection-ID header binds each POST to the correct SSE stream.
+ */
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import {
+  V2SendMessage,
+  V2StopMessage,
+  V2InterruptMessage,
+  V2PermissionResponseMessage,
+  V2SetModeMessage,
+  WatchMessage,
+  UnwatchMessage,
+  SwitchSessionMessage,
+  SessionSuspendMessage,
+  SessionCloseMessage,
+} from '@mitzo/protocol';
+import type { ConnectionRegistry } from '@mitzo/harness';
+import type { V2HandlerContext } from './ws-handler-v2.js';
+import {
+  handleSendV2,
+  handleStopV2,
+  handleInterruptV2,
+  handlePermissionResponseV2,
+  handleSetModeV2,
+  handleWatch,
+  handleUnwatch,
+  handleSwitchSession,
+  handleSessionSuspend,
+  handleSessionClose,
+  handleReconnect,
+} from './ws-handler-v2.js';
+import type { SessionSseRegistry } from './session-sse-registry.js';
+import { SseTransport } from './sse-transport.js';
+import { createLogger } from './logger.js';
+
+const log = createLogger('chat-rest');
+
+/**
+ * Extract and validate the X-Connection-ID header.
+ * Returns the connectionId or sends a 400 error.
+ */
+function getConnectionId(req: Request, res: Response): string | null {
+  const connectionId = req.headers['x-connection-id'] as string | undefined;
+  if (!connectionId) {
+    res.status(400).json({ ok: false, error: 'Missing X-Connection-ID header' });
+    return null;
+  }
+  return connectionId;
+}
+
+/**
+ * Look up the SseTransport for a connection.
+ * Returns the transport or sends a 404 error.
+ */
+function getTransport(
+  connectionId: string,
+  sseRegistry: SessionSseRegistry,
+  connRegistry: ConnectionRegistry,
+  res: Response,
+): SseTransport | null {
+  if (!sseRegistry.isOpen(connectionId)) {
+    res.status(404).json({ ok: false, error: 'No SSE stream for this connection' });
+    return null;
+  }
+  const conn = connRegistry.get(connectionId);
+  if (!conn) {
+    res.status(404).json({ ok: false, error: 'Connection not registered' });
+    return null;
+  }
+  return conn.transport as SseTransport;
+}
+
+/**
+ * Validate request body against a Zod schema.
+ * Returns the parsed value or sends a 400 error.
+ */
+function validateBody<T>(
+  schema: { safeParse: (data: unknown) => { success: boolean; data?: T; error?: unknown } },
+  body: unknown,
+  res: Response,
+): T | null {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    res.status(400).json({ ok: false, error: 'Invalid request body', details: result.error });
+    return null;
+  }
+  return result.data!;
+}
+
+export function createChatRestRouter(
+  sseRegistry: SessionSseRegistry,
+  ctx: V2HandlerContext,
+): Router {
+  const router = Router();
+
+  // POST /api/chat/send
+  router.post('/send', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const transport = getTransport(connectionId, sseRegistry, ctx.connRegistry, res);
+    if (!transport) return;
+
+    const msg = validateBody(V2SendMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleSendV2(connectionId, transport, msg, ctx);
+      res.status(202).json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/send failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/interrupt
+  router.post('/interrupt', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const transport = getTransport(connectionId, sseRegistry, ctx.connRegistry, res);
+    if (!transport) return;
+
+    const msg = validateBody(V2InterruptMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleInterruptV2(connectionId, transport, msg, ctx);
+      res.status(202).json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/interrupt failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/stop
+  router.post('/stop', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(V2StopMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleStopV2(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/stop failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/permission
+  router.post('/permission', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(V2PermissionResponseMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handlePermissionResponseV2(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/permission failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/mode
+  router.post('/mode', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(V2SetModeMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleSetModeV2(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/mode failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/watch
+  router.post('/watch', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(WatchMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleWatch(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/watch failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/unwatch
+  router.post('/unwatch', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(UnwatchMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleUnwatch(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/unwatch failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/switch
+  router.post('/switch', async (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(SwitchSessionMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      await handleSwitchSession(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/switch failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/suspend
+  router.post('/suspend', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(SessionSuspendMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleSessionSuspend(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/suspend failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/close
+  router.post('/close', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const msg = validateBody(SessionCloseMessage, req.body, res);
+    if (!msg) return;
+
+    try {
+      handleSessionClose(connectionId, msg, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/close failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  // POST /api/chat/reconnect
+  router.post('/reconnect', (req, res) => {
+    const connectionId = getConnectionId(req, res);
+    if (!connectionId) return;
+
+    const body = req.body as { sessions?: Array<{ sessionId: string; lastSeq: number }> };
+    if (!body.sessions || !Array.isArray(body.sessions)) {
+      res.status(400).json({ ok: false, error: 'Missing sessions array' });
+      return;
+    }
+
+    try {
+      handleReconnect(connectionId, { type: 'reconnect', sessions: body.sessions }, ctx);
+      res.json({ ok: true });
+    } catch (err) {
+      log.error('POST /chat/reconnect failed', { connectionId, error: String(err) });
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,6 +45,7 @@ import { createLogger } from './logger.js';
 import {
   app,
   sseRegistry,
+  chatSseRegistry,
   setUpdateBroadcast,
   setInboxBroadcast,
   setTaskBroadcast,
@@ -76,11 +77,14 @@ import { ConnectionRegistry } from '@mitzo/harness';
 import {
   isHelloHandshake,
   handleHello,
+  handleReconnect,
   dispatchV2Message,
   type V2HandlerContext,
 } from './ws-handler-v2.js';
 import { withSpan, withSpanAsync } from './tracing.js';
 import { contextFromTraceparent } from './trace-context.js';
+import { SseTransport } from './sse-transport.js';
+import { createChatRestRouter } from './chat-rest-handler.js';
 
 const log = createLogger('server');
 
@@ -353,6 +357,84 @@ const v2Ctx: V2HandlerContext = {
   eventStore,
   nativeCommands,
 };
+
+// ─── SSE Chat Transport ──────────────────────────────────────────────────────
+// SSE (server→client) + HTTP POST (client→server) transport for chat events.
+// Runs alongside WS during migration. Feature-flagged on the client side.
+
+app.get('/api/chat/events', (req, res) => {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+
+  const connectionId = `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const transport = new SseTransport(connectionId, chatSseRegistry);
+
+  chatSseRegistry.add(connectionId, res);
+  connRegistry.register(connectionId, transport);
+
+  // Send welcome with connectionId — client uses this in X-Connection-ID header on POSTs
+  chatSseRegistry.sendTo(connectionId, {
+    type: 'welcome',
+    protocolVersion: 2,
+    connectionId,
+  });
+
+  // Handle reconnect if sessions provided as query param
+  const sessionsParam = req.query.sessions as string | undefined;
+  if (sessionsParam) {
+    try {
+      const sessions = sessionsParam.split(',').map((entry) => {
+        const [sessionId, seqStr] = entry.split(':');
+        return { sessionId, lastSeq: parseInt(seqStr, 10) || 0 };
+      });
+      handleReconnect(connectionId, { type: 'reconnect', sessions }, v2Ctx);
+    } catch (err) {
+      log.warn('SSE chat reconnect parse error', { connectionId, error: String(err) });
+    }
+  }
+
+  log.info('SSE chat stream connected', { connectionId });
+
+  req.on('close', () => {
+    chatSseRegistry.remove(connectionId);
+
+    // Detach owned sessions — same logic as WS close handler
+    withSpan(
+      'sse.disconnect',
+      { 'sse.connectionId': connectionId },
+      (span) => {
+        // Find all sessions owned by this connection and detach them
+        for (const sessionId of [...(connRegistry.get(connectionId)?.watchedSessions ?? [])]) {
+          const found = registry.findBySessionId(sessionId);
+          if (!found) continue;
+          const ownerConnection = found.clientId.split(':')[0];
+          if (ownerConnection === connectionId && isActive(found.clientId)) {
+            detachChat(found.clientId);
+            overviewEmitter.touch(found.clientId);
+            span.setAttribute('sse.disconnect.detached', true);
+            log.info('SSE session detached (surviving)', {
+              connectionId,
+              sessionId,
+              clientId: found.clientId,
+            });
+          }
+        }
+        overviewEmitter.scheduleBroadcast();
+      },
+    );
+
+    connRegistry.remove(connectionId);
+    log.info('SSE chat stream disconnected', { connectionId });
+  });
+});
+
+// Mount HTTP POST chat endpoints (authenticated)
+const chatRestRouter = createChatRestRouter(chatSseRegistry, v2Ctx);
+app.use('/api/chat', chatRestRouter);
 
 /**
  * Handle a v2 WebSocket connection (after hello handshake detected).
@@ -857,6 +939,7 @@ function shutdown(signal: string) {
   healthMonitor.destroy();
   overviewEmitter.destroy();
   sseRegistry.destroy();
+  chatSseRegistry.destroy();
   connRegistry.dispose(); // Stop periodic sync + clear state
   registry.dispose();
   for (const client of wss.clients) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -402,32 +402,32 @@ app.get('/api/chat/events', (req, res) => {
   req.on('close', () => {
     chatSseRegistry.remove(connectionId);
 
-    // Detach owned sessions — same logic as WS close handler
-    withSpan(
-      'sse.disconnect',
-      { 'sse.connectionId': connectionId },
-      (span) => {
-        // Find all sessions owned by this connection and detach them
-        for (const sessionId of [...(connRegistry.get(connectionId)?.watchedSessions ?? [])]) {
-          const found = registry.findBySessionId(sessionId);
-          if (!found) continue;
-          const ownerConnection = found.clientId.split(':')[0];
-          if (ownerConnection === connectionId && isActive(found.clientId)) {
-            detachChat(found.clientId);
-            overviewEmitter.touch(found.clientId);
-            span.setAttribute('sse.disconnect.detached', true);
-            log.info('SSE session detached (surviving)', {
-              connectionId,
-              sessionId,
-              clientId: found.clientId,
-            });
-          }
-        }
-        overviewEmitter.scheduleBroadcast();
-      },
-    );
+    const conn = connRegistry.get(connectionId);
+    const watchedSessions = conn ? [...conn.watchedSessions] : [];
 
     connRegistry.remove(connectionId);
+    registry.removeObserver(transport);
+
+    withSpan('sse.disconnect', { 'sse.connectionId': connectionId }, () => {
+      for (const sessionId of watchedSessions) {
+        const found = registry.findBySessionId(sessionId);
+        if (!found) continue;
+
+        if (registry.isSuspended(found.clientId)) {
+          log.info('SSE closed for suspended session (expected)', { connectionId, sessionId });
+          continue;
+        }
+
+        const session = registry.get(found.clientId);
+        if (session && session.transport === transport && registry.isAttached(found.clientId)) {
+          detachChat(found.clientId);
+          overviewEmitter.touch(found.clientId);
+          overviewEmitter.scheduleBroadcast();
+          log.info('SSE session detached (surviving)', { connectionId, sessionId });
+        }
+      }
+    });
+
     log.info('SSE chat stream disconnected', { connectionId });
   });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -388,7 +388,9 @@ app.get('/api/chat/events', (req, res) => {
   if (sessionsParam) {
     try {
       const sessions = sessionsParam.split(',').map((entry) => {
-        const [sessionId, seqStr] = entry.split(':');
+        const sep = entry.lastIndexOf('|');
+        const sessionId = sep > 0 ? entry.slice(0, sep) : entry;
+        const seqStr = sep > 0 ? entry.slice(sep + 1) : '0';
         return { sessionId, lastSeq: parseInt(seqStr, 10) || 0 };
       });
       handleReconnect(connectionId, { type: 'reconnect', sessions }, v2Ctx);

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -1,0 +1,139 @@
+/**
+ * SessionSseRegistry — manages per-connection SSE streams for chat events.
+ *
+ * Distinct from the global SseRegistry (packages/harness/src/sse-registry.ts)
+ * which handles broadcast events (session_activity, health, task_state).
+ * This registry manages the SSE streams that carry session-scoped chat events
+ * (message_start, block_delta, session_end, etc.) as part of the
+ * SSE + HTTP POST transport migration replacing WebSocket chat transport.
+ */
+
+import type { Response } from 'express';
+import { createLogger } from './logger.js';
+
+const log = createLogger('session-sse');
+
+const HEARTBEAT_INTERVAL_MS = 30_000; // 30s — keeps connection alive through proxies
+
+export class SessionSseRegistry {
+  private streams = new Map<string, Response>();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  /**
+   * Register an SSE response stream for a connection.
+   */
+  add(connectionId: string, res: Response): void {
+    // Close any existing stream for this connection (e.g. stale reconnect)
+    const existing = this.streams.get(connectionId);
+    if (existing) {
+      try {
+        existing.end();
+      } catch {
+        // best effort
+      }
+    }
+
+    this.streams.set(connectionId, res);
+    log.info('SSE chat stream connected', { connectionId, total: this.streams.size });
+
+    if (this.streams.size === 1) {
+      this.startHeartbeat();
+    }
+  }
+
+  /**
+   * Remove and clean up an SSE stream.
+   */
+  remove(connectionId: string): void {
+    if (!this.streams.has(connectionId)) return;
+    this.streams.delete(connectionId);
+    log.info('SSE chat stream disconnected', { connectionId, total: this.streams.size });
+
+    if (this.streams.size === 0) {
+      this.stopHeartbeat();
+    }
+  }
+
+  /**
+   * Send an SSE event to a specific connection.
+   * Returns false if the connection doesn't exist or the write fails.
+   *
+   * @param connectionId - The connection to send to
+   * @param data - Event payload (JSON-serialized)
+   * @param id - Optional SSE `id:` field (EventStore seq number for replay)
+   */
+  sendTo(connectionId: string, data: Record<string, unknown>, id?: string | number): boolean {
+    const res = this.streams.get(connectionId);
+    if (!res) return false;
+
+    try {
+      const eventType = (data.type as string) || 'message';
+      let frame = '';
+      if (id !== undefined) {
+        frame += `id: ${id}\n`;
+      }
+      frame += `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`;
+      res.write(frame);
+      return true;
+    } catch (err) {
+      log.warn('SSE chat sendTo failed', { connectionId, error: String(err) });
+      this.remove(connectionId);
+      return false;
+    }
+  }
+
+  /**
+   * Check if a connection has an open SSE stream.
+   */
+  isOpen(connectionId: string): boolean {
+    const res = this.streams.get(connectionId);
+    if (!res) return false;
+    return !res.writableEnded;
+  }
+
+  get size(): number {
+    return this.streams.size;
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+
+    log.info('Starting SSE chat heartbeat', { intervalMs: HEARTBEAT_INTERVAL_MS });
+    this.heartbeatTimer = setInterval(() => {
+      const failures: string[] = [];
+      for (const [connectionId, res] of this.streams) {
+        try {
+          res.write(':heartbeat\n\n');
+        } catch {
+          failures.push(connectionId);
+        }
+      }
+      for (const id of failures) {
+        this.remove(id);
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    log.info('Stopping SSE chat heartbeat');
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  destroy(): void {
+    log.info('Destroying SessionSseRegistry', { streams: this.streams.size });
+    this.stopHeartbeat();
+
+    for (const [, res] of this.streams) {
+      try {
+        res.end();
+      } catch {
+        // best effort
+      }
+    }
+    this.streams.clear();
+  }
+}

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -38,7 +38,6 @@ export class SessionSseRegistry {
   remove(connectionId: string): void {
     if (!this.streams.has(connectionId)) return;
     this.streams.delete(connectionId);
-    log.info('SSE chat stream disconnected', { connectionId, total: this.streams.size });
 
     if (this.streams.size === 0) {
       this.stopHeartbeat();

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -1,12 +1,4 @@
-/**
- * SessionSseRegistry — manages per-connection SSE streams for chat events.
- *
- * Distinct from the global SseRegistry (packages/harness/src/sse-registry.ts)
- * which handles broadcast events (session_activity, health, task_state).
- * This registry manages the SSE streams that carry session-scoped chat events
- * (message_start, block_delta, session_end, etc.) as part of the
- * SSE + HTTP POST transport migration replacing WebSocket chat transport.
- */
+// Per-connection SSE stream registry for chat events (distinct from broadcast SseRegistry).
 
 import type { Response } from 'express';
 import { createLogger } from './logger.js';

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -26,7 +26,6 @@ export class SessionSseRegistry {
     }
 
     this.streams.set(connectionId, res);
-    log.info('SSE chat stream connected', { connectionId, total: this.streams.size });
 
     if (this.streams.size === 1) {
       this.startHeartbeat();
@@ -59,7 +58,10 @@ export class SessionSseRegistry {
     if (!res) return false;
 
     try {
-      const eventType = (data.type as string) || 'message';
+      // Use named event only for 'welcome' (handshake). All other events
+      // go as default 'message' — the client uses es.onmessage as a catch-all,
+      // eliminating any event type allowlist maintenance.
+      const eventType = (data.type as string) === 'welcome' ? 'welcome' : 'message';
       let frame = '';
       if (id !== undefined) {
         frame += `id: ${id}\n`;

--- a/server/sse-transport.ts
+++ b/server/sse-transport.ts
@@ -1,14 +1,4 @@
-/**
- * SseTransport — adapts the SessionSseRegistry to the SessionTransport interface.
- *
- * This is the SSE equivalent of WsTransport. The SessionTransport interface
- * (send + isOpen) is the seam between chat logic and wire transport — chat.ts,
- * query-loop.ts, and session-registry.ts are completely decoupled from the
- * underlying transport mechanism.
- *
- * Provider-agnostic: this transport carries protocol-level events (message_start,
- * block_delta, session_end) regardless of the inference provider behind them.
- */
+// SseTransport — adapts SessionSseRegistry to the SessionTransport interface.
 
 import type { SessionTransport } from '@mitzo/harness';
 import type { SessionSseRegistry } from './session-sse-registry.js';

--- a/server/sse-transport.ts
+++ b/server/sse-transport.ts
@@ -1,0 +1,30 @@
+/**
+ * SseTransport — adapts the SessionSseRegistry to the SessionTransport interface.
+ *
+ * This is the SSE equivalent of WsTransport. The SessionTransport interface
+ * (send + isOpen) is the seam between chat logic and wire transport — chat.ts,
+ * query-loop.ts, and session-registry.ts are completely decoupled from the
+ * underlying transport mechanism.
+ *
+ * Provider-agnostic: this transport carries protocol-level events (message_start,
+ * block_delta, session_end) regardless of the inference provider behind them.
+ */
+
+import type { SessionTransport } from '@mitzo/harness';
+import type { SessionSseRegistry } from './session-sse-registry.js';
+
+export class SseTransport implements SessionTransport {
+  constructor(
+    private readonly connectionId: string,
+    private readonly sseRegistry: SessionSseRegistry,
+  ) {}
+
+  send(data: Record<string, unknown>): void {
+    const seq = data.seq as number | undefined;
+    this.sseRegistry.sendTo(this.connectionId, data, seq);
+  }
+
+  isOpen(): boolean {
+    return this.sseRegistry.isOpen(this.connectionId);
+  }
+}


### PR DESCRIPTION
## Summary

SSE + HTTP POST transport migration (Phases 1-3 of 4):

### Phase 1 — Server-side SSE endpoints
- **SessionSseRegistry**: Per-connection SSE stream manager with 30s heartbeat, auto-cleanup, seq-based event IDs for replay
- **SseTransport**: SessionTransport adapter (same interface as WsTransport)
- **chat-rest-handler**: 11 HTTP POST endpoints wrapping ws-handler-v2 handlers with Zod validation and X-Connection-ID binding
- **GET /api/chat/events**: SSE stream endpoint with welcome handshake and reconnect-via-query-param

### Phase 2 — Client-side SseConnection
- **SseConnection**: Drop-in replacement for MitzoConnection using EventSource (server→client) + fetch POST (client→server)
- **ChatConnection**: Transport-agnostic interface both MitzoConnection and SseConnection implement
- EventSource auto-reconnects natively — no heartbeat hack needed
- Reconnect URL includes session:seq params for server-side replay

### Phase 3 — Feature flag wiring
- Store accepts optional `sseConfig` — when provided, creates SseConnection instead of MitzoConnection
- localStorage feature flag: `localStorage.setItem('mitzo:transport', 'sse')` + reload
- Default remains WebSocket — enables side-by-side testing

## Motivation

Eliminates the entire class of iOS WebSocket reconnection bugs by replacing WS chat transport with SSE (server→client) + HTTP POST (client→server). SSE connections survive iOS background/foreground transitions that kill WebSocket connections.

## Test plan

- [x] 29 server-side tests passing (SessionSseRegistry, SseTransport, chat-rest-handler)
- [x] 18 client-side tests passing (SseConnection lifecycle, send/receive, queueing, reconnect)
- [x] Type-checks clean
- [ ] Centaur review
- [ ] Manual smoke test: toggle localStorage flag, verify chat works end-to-end over SSE

## Remaining

- Phase 4: Remove WS chat transport (separate PR after SSE transport is validated in production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)