### PR TITLE
fix(client): SSE reconnect sends POST to restore session watch

### DIFF
--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -290,20 +290,63 @@ describe('SseConnection', () => {
     expect(conn.isConnected()).toBe(false);
   });
 
-  it('includes sessions in reconnect URL', () => {
-    const conn = new SseConnection(createConfig());
+  it('sends reconnect POST on welcome when has tracked sessions', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
     conn.connect();
     lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
 
     // Track a session
     conn.trackSeq('sess-1', 10);
 
+    // Force reconnect — creates new EventSource
+    conn.checkAndReconnect(true);
+    mockFetch.mockClear();
+
+    // New welcome arrives — should trigger reconnect POST
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-def' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://localhost:3100/api/chat/reconnect',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'reconnect',
+          sessions: [{ sessionId: 'sess-1', lastSeq: 10 }],
+        }),
+      }),
+    );
+  });
+
+  it('does not send reconnect POST on first connection', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+
+    // Track a session BEFORE welcome (simulating a pre-existing session)
+    conn.trackSeq('sess-1', 5);
+
+    // First welcome — _isReconnect is false, so no reconnect POST
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      'https://localhost:3100/api/chat/reconnect',
+      expect.any(Object),
+    );
+  });
+
+  it('reconnect URL never includes sessions query param', () => {
+    const conn = new SseConnection(createConfig());
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+    conn.trackSeq('sess-1', 10);
+
     // Force reconnect
     conn.checkAndReconnect(true);
 
+    // URL should be clean — reconnect is handled via POST, not query param
     const newES = lastES();
-    expect(newES.url).toContain('sessions=');
-    expect(newES.url).toContain('sess-1%7C10');
+    expect(newES.url).toBe('https://localhost:3100/api/chat/events');
   });
 
   it('checkAndReconnect(false) is no-op when connected', () => {

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -195,14 +195,11 @@ export class SseConnection implements ChatConnection {
       this.reconnectTimer = null;
     }
 
-    // Build URL with reconnect sessions if this is a reconnect
-    let url = `${this.config.baseUrl}/api/chat/events`;
-    if (this._isReconnect && this.seqBySession.size > 0) {
-      const sessionsParam = Array.from(this.seqBySession.entries())
-        .map(([sid, seq]) => `${sid}|${seq}`)
-        .join(',');
-      url += `?sessions=${encodeURIComponent(sessionsParam)}`;
-    }
+    // Always use the base URL — reconnect sessions are sent via POST in the
+    // welcome handler. This avoids the bug where EventSource auto-reconnect
+    // reuses the original URL (missing ?sessions=), and eliminates double
+    // handleReconnect when doConnect() AND welcome both trigger it.
+    const url = `${this.config.baseUrl}/api/chat/events`;
 
     const es = this.config.createEventSource(url);
     this.es = es;
@@ -217,6 +214,21 @@ export class SseConnection implements ChatConnection {
       }
       this._connectionId = msg.connectionId as string;
       this._connected = true;
+
+      // Always send reconnect on welcome if we have tracked sessions.
+      // Native EventSource auto-reconnect reuses the original URL (without
+      // ?sessions= param), so the server never runs handleReconnect — no
+      // watch, no reattach, no event replay. This POST ensures every
+      // reconnect (auto or explicit) triggers the full server-side
+      // reconnect flow: watch + reattach + event replay.
+      if (this._isReconnect && this.seqBySession.size > 0) {
+        this.doPost('reconnect', {
+          type: 'reconnect',
+          sessions: Array.from(this.seqBySession.entries()).map(
+            ([sessionId, lastSeq]) => ({ sessionId, lastSeq }),
+          ),
+        });
+      }
       this._isReconnect = true;
 
       this.flushPendingSends();


### PR DESCRIPTION
## Summary

- EventSource auto-reconnect reuses the original URL (without `?sessions=`), so the server never ran `handleReconnect` — no watch, no reattach, no event replay. Users had to send multiple messages before the session responded.
- Moved reconnect from URL query param to explicit POST in the welcome handler. Fires on every reconnect (auto or explicit), ensuring the server always runs the full flow: watch + reattach + event replay.

## Test plan

- [x] All 329 client tests pass (including 3 new tests for the reconnect behavior)
- [ ] Deploy to dev server and verify: background phone, return, send one message — should get response immediately
- [ ] Verify EventSource auto-reconnect (network drop) triggers reconnect POST
- [ ] Verify explicit `checkAndReconnect(true)` (Capacitor resume) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)