### PR TITLE
fix(infra): move Grafana to port 3002 + auto-start observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Auth via `ProtectedRoute` wrapper. Vite dev server proxies `/api` and `/ws` to b
 - **Tracing:** OpenTelemetry via `server/tracing.ts`, opt-in when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. BatchSpanProcessor with OTLP HTTP exporter to Jaeger. Currently instrumented: `ws.switch_session`, `ws.send`, `ws.reconnect`. Deep instrumentation roadmap in `docs/design/otel-deep-instrumentation.md`.
 - **Infrastructure:** Three containers via `docker-compose.yml` (podman). Start with `npm run tracing:up`, stop with `npm run tracing:down`.
   - Jaeger: http://localhost:16686 (trace viewer, OTLP receiver on :4318)
-  - Grafana: http://localhost:3001 (log viewer + dashboards, no login required)
+  - Grafana: http://localhost:3002 (log viewer + dashboards, no login required)
   - Loki: http://localhost:3200 (log aggregation backend)
 - **Env vars:** `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`, `LOKI_HOST=http://localhost:3200`, `LOG_LEVEL=info` (default).
 - **Log-to-trace correlation:** Grafana Loki datasource parses `trace_id` from log lines and links to Jaeger traces. In Grafana Explore, query `{app="mitzo"}` for all logs, `{app="mitzo", module="query-loop"}` to filter by module.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Jaeger only:  npm run tracing:up / tracing:down
 # Full stack:   npm run observability:up / observability:down
 # Jaeger UI: http://localhost:16686
-# Grafana:   http://localhost:3001 (no login required)
+# Grafana:   http://localhost:3002 (no login required)
 # Loki API:  http://localhost:3200
 services:
   jaeger:
@@ -34,7 +34,7 @@ services:
     image: grafana/grafana:12.4.1
     restart: always
     ports:
-      - '3001:3000'
+      - '3002:3000'
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: 'true'
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -542,7 +542,7 @@ Mitzo includes a local observability stack for debugging and performance analysi
 | Service | URL                    | Purpose                            |
 | ------- | ---------------------- | ---------------------------------- |
 | Jaeger  | http://localhost:16686 | Trace viewer                       |
-| Grafana | http://localhost:3001  | Log viewer + dashboards (no login) |
+| Grafana | http://localhost:3002  | Log viewer + dashboards (no login) |
 | Loki    | http://localhost:3200  | Log aggregation backend            |
 
 ### Quick start

--- a/scripts/ensure-observability.sh
+++ b/scripts/ensure-observability.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Ensure the observability stack (Jaeger + Loki + Grafana) is running.
+# Called by the com.mitzo.podman-machine launchd agent after machine start,
+# and can be run manually: ./scripts/ensure-observability.sh
+set -euo pipefail
+
+PODMAN="${PODMAN:-$(command -v podman 2>/dev/null || echo /opt/homebrew/bin/podman)}"
+COMPOSE_FILE="$(dirname "$0")/../docker-compose.yml"
+
+# 1. Ensure the podman machine is running
+if ! "$PODMAN" machine inspect --format '{{.State}}' 2>/dev/null | grep -q "running"; then
+  echo "[ensure-observability] Starting podman machine..."
+  "$PODMAN" machine start 2>&1 || true
+  # Wait for the API socket to appear
+  for i in $(seq 1 30); do
+    "$PODMAN" info >/dev/null 2>&1 && break
+    sleep 1
+  done
+fi
+
+# 2. Bring up the compose stack
+echo "[ensure-observability] Starting observability containers..."
+"$PODMAN" compose -f "$COMPOSE_FILE" up -d 2>&1
+
+# 3. Verify
+for svc in jaeger loki grafana; do
+  container="mitzo_${svc}_1"
+  if "$PODMAN" ps --filter "name=$container" --format '{{.Names}}' 2>/dev/null | grep -q "$container"; then
+    echo "[ensure-observability] $container: running"
+  else
+    echo "[ensure-observability] $container: FAILED TO START" >&2
+  fi
+done


### PR DESCRIPTION
## Summary
- Moved Grafana from port 3001 to 3002 — port 3001 had a persistent ghost reservation in podman's gvproxy networking layer that survived machine restarts and container pruning
- Added `scripts/ensure-observability.sh` that starts podman machine + all compose containers
- Updated `com.mitzo.podman-machine` launchd agent to call the new script — closes the gap where the machine could be running but containers were down for 7 weeks unnoticed
- Updated port references in CLAUDE.md and docs/onboarding.md

## Test plan
- [x] All three containers start and pass health checks
- [x] `curl http://localhost:3002/api/health` returns Grafana health
- [x] `curl http://localhost:3200/ready` returns Loki ready
- [x] `curl http://localhost:16686/api/services` returns Jaeger data
- [ ] Verify launchd agent runs on next reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)