### PR TITLE
fix(chat): prevent duplicate user messages via idempotency guard

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -144,12 +144,12 @@ export function ChatInput({
       clearDraft();
       setImages([]);
       if (!useExternal) setContextBlocks([]);
+      autoResize();
+      textareaRef.current?.focus();
     }
     requestAnimationFrame(() => {
       sendGuard.current = false;
     });
-    autoResize();
-    textareaRef.current?.focus();
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -70,6 +70,7 @@ export function ChatInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const initialApplied = useRef(false);
   const prevRunning = useRef(running);
+  const sendGuard = useRef(false);
 
   const autoResize = useCallback(() => {
     const el = textareaRef.current;
@@ -129,8 +130,10 @@ export function ChatInput({
   }
 
   function handleSend() {
+    if (sendGuard.current) return;
     const trimmed = text.trim();
     if (!trimmed && images.length === 0) return;
+    sendGuard.current = true;
     const sent = onSend(
       trimmed || 'What do you see in this image?',
       images.length > 0 ? images : undefined,
@@ -141,11 +144,12 @@ export function ChatInput({
       clearDraft();
       setImages([]);
       if (!useExternal) setContextBlocks([]);
-      requestAnimationFrame(() => {
-        autoResize();
-        textareaRef.current?.focus();
-      });
     }
+    requestAnimationFrame(() => {
+      sendGuard.current = false;
+      autoResize();
+      textareaRef.current?.focus();
+    });
   }
 
   function handleKeyDown(e: KeyboardEvent) {

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -147,9 +147,9 @@ export function ChatInput({
     }
     requestAnimationFrame(() => {
       sendGuard.current = false;
-      autoResize();
-      textareaRef.current?.focus();
     });
+    autoResize();
+    textareaRef.current?.focus();
   }
 
   function handleKeyDown(e: KeyboardEvent) {
@@ -270,9 +270,11 @@ export function ChatInput({
   }
 
   function handleInterrupt() {
+    if (sendGuard.current) return;
     if (!onInterrupt) return;
     const trimmed = text.trim();
     if (!trimmed && images.length === 0) return;
+    sendGuard.current = true;
     onInterrupt(
       trimmed || 'What do you see in this image?',
       images.length > 0 ? images : undefined,
@@ -282,9 +284,10 @@ export function ChatInput({
     setImages([]);
     if (!useExternal) setContextBlocks([]);
     requestAnimationFrame(() => {
-      autoResize();
-      textareaRef.current?.focus();
+      sendGuard.current = false;
     });
+    autoResize();
+    textareaRef.current?.focus();
   }
 
   return (

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -126,6 +126,7 @@ export class EventStore {
     this.migrateAttentionTracking(db);
     this.migrateSessionState(db);
     this.migrateBootContext(db);
+    this.migrateUserMessageIndex(db);
 
     this.log.info('EventStore initialized', { dbPath });
 
@@ -302,6 +303,13 @@ export class EventStore {
       db.exec('ALTER TABLE sessions ADD COLUMN boot_context TEXT');
       this.log.info('migrated sessions table: added boot_context');
     }
+  }
+
+  private migrateUserMessageIndex(db: Database.Database): void {
+    db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_events_user_msg_dedup
+       ON events (session_id, type, json_extract(payload, '$.messageId'))`,
+    );
   }
 
   close(): void {

--- a/packages/protocol/src/event-store.ts
+++ b/packages/protocol/src/event-store.ts
@@ -95,6 +95,7 @@ export class EventStore {
   private log: EventStoreLogger;
   private stmts: {
     append: Database.Statement;
+    hasUserMessage: Database.Statement;
     eventsAfter: Database.Statement;
     eventsAfterLimited: Database.Statement;
     sessionEvents: Database.Statement;
@@ -130,6 +131,12 @@ export class EventStore {
 
     this.stmts = {
       append: db.prepare('INSERT INTO events (session_id, type, payload) VALUES (?, ?, ?)'),
+      hasUserMessage: db.prepare(
+        `SELECT 1 FROM events
+         WHERE session_id = ? AND type = 'user_message'
+           AND json_extract(payload, '$.messageId') = ?
+         LIMIT 1`,
+      ),
       eventsAfter: db.prepare(
         'SELECT seq, session_id, type, payload, created_at FROM events WHERE session_id = ? AND seq > ? ORDER BY seq',
       ),
@@ -307,6 +314,11 @@ export class EventStore {
   append(sessionId: string, type: string, payload: Record<string, unknown>): number {
     const result = this.stmts.append.run(sessionId, type, JSON.stringify(payload));
     return Number(result.lastInsertRowid);
+  }
+
+  /** Check if a user_message with the given messageId already exists for this session. */
+  hasUserMessage(sessionId: string, messageId: string): boolean {
+    return this.stmts.hasUserMessage.get(sessionId, messageId) != null;
   }
 
   getEventsAfter(sessionId: string, afterSeq: number, limit?: number): StoredEvent[] {

--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -52,6 +52,39 @@ describe('EventStore', () => {
     });
   });
 
+  describe('hasUserMessage', () => {
+    it('returns false when no matching event exists', () => {
+      expect(store.hasUserMessage('sess-1', 'umsg-123')).toBe(false);
+    });
+
+    it('returns true when a user_message with the given messageId exists', () => {
+      store.append('sess-1', 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId: 'user-abc-123',
+        text: 'Hello',
+      });
+      expect(store.hasUserMessage('sess-1', 'user-abc-123')).toBe(true);
+    });
+
+    it('does not match across different sessions', () => {
+      store.append('sess-1', 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId: 'user-abc-123',
+        text: 'Hello',
+      });
+      expect(store.hasUserMessage('sess-2', 'user-abc-123')).toBe(false);
+    });
+
+    it('does not match non-user_message events', () => {
+      store.append('sess-1', 'message_start', { messageId: 'msg-1' });
+      expect(store.hasUserMessage('sess-1', 'msg-1')).toBe(false);
+    });
+  });
+
   describe('getEventsAfter', () => {
     it('returns all events for a session when afterSeq is 0', () => {
       store.append('sess-1', 'message_start', { messageId: 'm1' });

--- a/server/__tests__/event-store.test.ts
+++ b/server/__tests__/event-store.test.ts
@@ -83,6 +83,23 @@ describe('EventStore', () => {
       store.append('sess-1', 'message_start', { messageId: 'msg-1' });
       expect(store.hasUserMessage('sess-1', 'msg-1')).toBe(false);
     });
+
+    it('prevents duplicate resume-path user messages', () => {
+      const resumeId = 'umsg-1234567890-resume';
+      store.append('sess-resume', 'user_message', {
+        v: 2,
+        type: 'user_message',
+        ts: Date.now(),
+        messageId: resumeId,
+        text: 'Resumed prompt',
+      });
+      // First check — exists
+      expect(store.hasUserMessage('sess-resume', resumeId)).toBe(true);
+      // A retried POST with the same messageId should be caught
+      expect(store.hasUserMessage('sess-resume', resumeId)).toBe(true);
+      // Different messageId on same session — not a duplicate
+      expect(store.hasUserMessage('sess-resume', 'umsg-9999-resume')).toBe(false);
+    });
   });
 
   describe('getEventsAfter', () => {

--- a/server/__tests__/send-to-chat.test.ts
+++ b/server/__tests__/send-to-chat.test.ts
@@ -145,6 +145,32 @@ describe('sendToChat emits user_message via transport', () => {
     sendToChat(CLIENT_ID, 'Follow-up');
     expect(pushSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('sends echo without sessionId when session.sessionId is falsy', () => {
+    const transport = mockTransport();
+    const pushSpy = vi.fn();
+
+    registry.register(CLIENT_ID, {
+      transport,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+    });
+
+    const session = registry.get(CLIENT_ID)!;
+    // Deliberately leave sessionId unset (falsy)
+    session.inputQueue = { push: pushSpy, close: vi.fn() };
+
+    const result = sendToChat(CLIENT_ID, 'Before session resolved');
+    expect(result).toBe(true);
+
+    const userMsgs = transport._sent.filter(
+      (m: Record<string, unknown>) => m.type === 'user_message',
+    );
+    expect(userMsgs).toHaveLength(1);
+    expect(userMsgs[0]).not.toHaveProperty('sessionId');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('interruptChat emits user_message via transport', () => {
@@ -218,7 +244,7 @@ describe('interruptChat emits user_message via transport', () => {
     expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe(clientMsgId);
   });
 
-  it('skips duplicate when same clientMsgId is sent twice', async () => {
+  it('deduplicates echo but still interrupts on retried clientMsgId', async () => {
     const transport = mockTransport();
     const pushSpy = vi.fn();
     const interruptSpy = vi.fn().mockResolvedValue(undefined);
@@ -243,12 +269,12 @@ describe('interruptChat emits user_message via transport', () => {
     expect(await interruptChat(CLIENT_ID, 'First', undefined, undefined, clientMsgId)).toBe(true);
     expect(interruptSpy).toHaveBeenCalledTimes(1);
 
-    // Second interrupt with same clientMsgId — should be silently deduplicated
+    // Second interrupt with same clientMsgId — echo is deduplicated but
+    // the interrupt side-effect still fires (a retried interrupt must stop the agent)
     const result = await interruptChat(CLIENT_ID, 'First', undefined, undefined, clientMsgId);
     expect(result).toBe(true);
-    // interrupt() should NOT be called again
-    expect(interruptSpy).toHaveBeenCalledTimes(1);
-    // transport should only have ONE user_message echo
+    expect(interruptSpy).toHaveBeenCalledTimes(2);
+    // transport should only have ONE user_message echo (deduped)
     const userMsgs = transport._sent.filter(
       (m: Record<string, unknown>) => m.type === 'user_message',
     );

--- a/server/__tests__/send-to-chat.test.ts
+++ b/server/__tests__/send-to-chat.test.ts
@@ -279,6 +279,8 @@ describe('interruptChat emits user_message via transport', () => {
       (m: Record<string, unknown>) => m.type === 'user_message',
     );
     expect(userMsgs).toHaveLength(1);
+    // inputQueue should only get ONE push (no double-queue on retry)
+    expect(pushSpy).toHaveBeenCalledTimes(1);
   });
 
   it('calls stopTask for active subagent tasks before interrupt', async () => {

--- a/server/__tests__/send-to-chat.test.ts
+++ b/server/__tests__/send-to-chat.test.ts
@@ -218,6 +218,43 @@ describe('interruptChat emits user_message via transport', () => {
     expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe(clientMsgId);
   });
 
+  it('skips duplicate when same clientMsgId is sent twice', async () => {
+    const transport = mockTransport();
+    const pushSpy = vi.fn();
+    const interruptSpy = vi.fn().mockResolvedValue(undefined);
+
+    registry.register(CLIENT_ID, {
+      transport,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+    });
+
+    const session = registry.get(CLIENT_ID)!;
+    session.sessionId = `sess-int-dedup-${Date.now()}`;
+    session.inputQueue = { push: pushSpy, close: vi.fn() };
+    session.queryInstance = {
+      interrupt: interruptSpy,
+      close: vi.fn(),
+      stopTask: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const clientMsgId = `user-int-dedup-${Date.now()}`;
+    expect(await interruptChat(CLIENT_ID, 'First', undefined, undefined, clientMsgId)).toBe(true);
+    expect(interruptSpy).toHaveBeenCalledTimes(1);
+
+    // Second interrupt with same clientMsgId — should be silently deduplicated
+    const result = await interruptChat(CLIENT_ID, 'First', undefined, undefined, clientMsgId);
+    expect(result).toBe(true);
+    // interrupt() should NOT be called again
+    expect(interruptSpy).toHaveBeenCalledTimes(1);
+    // transport should only have ONE user_message echo
+    const userMsgs = transport._sent.filter(
+      (m: Record<string, unknown>) => m.type === 'user_message',
+    );
+    expect(userMsgs).toHaveLength(1);
+  });
+
   it('calls stopTask for active subagent tasks before interrupt', async () => {
     const transport = mockTransport();
     const pushSpy = vi.fn();

--- a/server/__tests__/send-to-chat.test.ts
+++ b/server/__tests__/send-to-chat.test.ts
@@ -61,17 +61,18 @@ describe('sendToChat emits user_message via transport', () => {
     });
 
     const session = registry.get(CLIENT_ID)!;
-    session.sessionId = 'sess-client-id';
+    session.sessionId = `sess-client-id-${Date.now()}`;
     session.inputQueue = { push: pushSpy, close: vi.fn() };
 
-    const result = sendToChat(CLIENT_ID, 'Hello', undefined, undefined, 'user-1234-abc');
+    const clientMsgId = `user-${Date.now()}-abc`;
+    const result = sendToChat(CLIENT_ID, 'Hello', undefined, undefined, clientMsgId);
     expect(result).toBe(true);
 
     const userMsgEvents = transport._sent.filter(
       (m: Record<string, unknown>) => m.type === 'user_message',
     );
     expect(userMsgEvents).toHaveLength(1);
-    expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe('user-1234-abc');
+    expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe(clientMsgId);
   });
 
   it('does not crash when transport is not open', () => {
@@ -93,6 +94,37 @@ describe('sendToChat emits user_message via transport', () => {
     expect(result).toBe(true);
     // send() guards on isOpen(), so no message should be sent
     expect(transport.send).not.toHaveBeenCalled();
+  });
+
+  it('skips duplicate when same clientMsgId is sent twice', () => {
+    const transport = mockTransport();
+    const pushSpy = vi.fn();
+
+    registry.register(CLIENT_ID, {
+      transport,
+      abortController: new AbortController(),
+      mode: 'agent',
+      sessionAllowList: new Set(),
+    });
+
+    const session = registry.get(CLIENT_ID)!;
+    session.sessionId = `sess-dedup-${Date.now()}`;
+    session.inputQueue = { push: pushSpy, close: vi.fn() };
+
+    // First send — should succeed
+    expect(sendToChat(CLIENT_ID, 'Hello', undefined, undefined, 'user-dedup-1')).toBe(true);
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+
+    // Second send with same clientMsgId — should be silently deduplicated
+    const result = sendToChat(CLIENT_ID, 'Hello', undefined, undefined, 'user-dedup-1');
+    expect(result).toBe(true);
+    // inputQueue should NOT get a second push
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    // transport should only have ONE user_message echo
+    const userMsgs = transport._sent.filter(
+      (m: Record<string, unknown>) => m.type === 'user_message',
+    );
+    expect(userMsgs).toHaveLength(1);
   });
 
   it('still pushes to inputQueue even when transport send happens', () => {
@@ -167,7 +199,7 @@ describe('interruptChat emits user_message via transport', () => {
     });
 
     const session = registry.get(CLIENT_ID)!;
-    session.sessionId = 'sess-int-2';
+    session.sessionId = `sess-int-${Date.now()}`;
     session.inputQueue = { push: pushSpy, close: vi.fn() };
     session.queryInstance = {
       interrupt: vi.fn().mockResolvedValue(undefined),
@@ -175,14 +207,15 @@ describe('interruptChat emits user_message via transport', () => {
       stopTask: vi.fn().mockResolvedValue(undefined),
     };
 
-    const result = await interruptChat(CLIENT_ID, 'Urgent', undefined, undefined, 'user-5678-def');
+    const clientMsgId = `user-${Date.now()}-def`;
+    const result = await interruptChat(CLIENT_ID, 'Urgent', undefined, undefined, clientMsgId);
     expect(result).toBe(true);
 
     const userMsgEvents = transport._sent.filter(
       (m: Record<string, unknown>) => m.type === 'user_message',
     );
     expect(userMsgEvents).toHaveLength(1);
-    expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe('user-5678-def');
+    expect((userMsgEvents[0] as Record<string, unknown>).messageId).toBe(clientMsgId);
   });
 
   it('calls stopTask for active subagent tasks before interrupt', async () => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1007,24 +1007,27 @@ async function _startChatInner(
     // Store and echo it here so the frontend can replay it.
     if (options.resume) {
       const messageId = options.clientMsgId || `umsg-${Date.now()}-resume`;
-      eventStore.append(options.resume, 'user_message', {
-        v: 2,
-        type: 'user_message',
-        ts: Date.now(),
-        messageId,
-        text: fullPrompt,
-      });
-      eventStore.updateLastSpeaker(options.resume, 'user');
-      _onSessionChange?.(clientId, 'user_message');
-      const echo = {
-        type: 'user_message',
-        v: 2,
-        messageId,
-        text: fullPrompt,
-        sessionId: options.resume,
-      };
-      send(transport, echo);
-      broadcastToObservers(session.observers, echo);
+      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
+      if (!eventStore.hasUserMessage(options.resume, messageId)) {
+        eventStore.append(options.resume, 'user_message', {
+          v: 2,
+          type: 'user_message',
+          ts: Date.now(),
+          messageId,
+          text: fullPrompt,
+        });
+        eventStore.updateLastSpeaker(options.resume, 'user');
+        _onSessionChange?.(clientId, 'user_message');
+        const echo = {
+          type: 'user_message',
+          v: 2,
+          messageId,
+          text: fullPrompt,
+          sessionId: options.resume,
+        };
+        send(transport, echo);
+        broadcastToObservers(session.observers, echo);
+      }
     }
 
     await runQueryLoop(
@@ -1136,6 +1139,10 @@ export function sendToChat(
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
     const messageId = clientMsgId || `umsg-${Date.now()}-send`;
     if (session.sessionId) {
+      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
+      if (eventStore.hasUserMessage(session.sessionId, messageId)) {
+        return true;
+      }
       eventStore.append(session.sessionId, 'user_message', {
         v: 2,
         type: 'user_message',
@@ -1179,6 +1186,10 @@ export async function interruptChat(
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
     const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
     if (session.sessionId) {
+      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
+      if (eventStore.hasUserMessage(session.sessionId, messageId)) {
+        return true;
+      }
       eventStore.append(session.sessionId, 'user_message', {
         v: 2,
         type: 'user_message',

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1123,7 +1123,7 @@ function storeAndEchoIfNew(
   text: string,
   clientId: string,
   transport: SessionTransport,
-  observers?: Set<SessionTransport>,
+  observers: Set<SessionTransport>,
 ): boolean {
   if (eventStore.hasUserMessage(sessionId, messageId)) {
     return true;
@@ -1139,7 +1139,7 @@ function storeAndEchoIfNew(
   _onSessionChange?.(clientId, 'user_message');
   const echo = { type: 'user_message', v: 2, messageId, text, sessionId };
   send(transport, echo);
-  if (observers) broadcastToObservers(observers, echo);
+  broadcastToObservers(observers, echo);
   return false;
 }
 
@@ -1170,6 +1170,9 @@ export function sendToChat(
         /* errors logged internally */
       });
     } else {
+      // Pre-session-resolve: no eventStore to dedup against.
+      // The frontend deduplicates echoes by messageId, and server-generated
+      // fallback IDs include randomUUID, so duplicates are not possible in practice.
       const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt };
       send(session.transport, echo);
       broadcastToObservers(session.observers, echo);
@@ -1194,11 +1197,11 @@ export async function interruptChat(
     if (model) session.model = model;
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
     const messageId = clientMsgId || `umsg-${Date.now()}-${randomUUID().slice(0, 8)}-interrupt`;
-    // Store and echo the user message, but always proceed with the interrupt
-    // even if the message is a duplicate — a retried interrupt must still stop
-    // the agent, just without re-storing the echo.
+    // Store and echo the user message. A retried interrupt must still stop
+    // the agent — only the echo/store is skipped on duplicate.
+    let isDup = false;
     if (session.sessionId) {
-      storeAndEchoIfNew(
+      isDup = storeAndEchoIfNew(
         session.sessionId,
         messageId,
         fullPrompt,
@@ -1207,6 +1210,7 @@ export async function interruptChat(
         session.observers,
       );
     } else {
+      // Pre-session-resolve: no eventStore to dedup against (see sendToChat).
       const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt };
       send(session.transport, echo);
       broadcastToObservers(session.observers, echo);
@@ -1223,7 +1227,11 @@ export async function interruptChat(
       await Promise.allSettled(stops);
     }
     await session.queryInstance.interrupt();
-    session.inputQueue.push(makeUserMessage(fullPrompt, 'now'));
+    // Only push to inputQueue on first delivery — a retried interrupt should
+    // still call interrupt() (to halt the agent) but not double-queue the prompt.
+    if (!isDup) {
+      session.inputQueue.push(makeUserMessage(fullPrompt, 'now'));
+    }
     return true;
   });
 }

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1006,8 +1006,9 @@ async function _startChatInner(
     // in the event store — making user messages invisible after WS reconnect.
     // Store and echo it here so the frontend can replay it.
     if (options.resume) {
-      const messageId = options.clientMsgId || `umsg-${Date.now()}-resume`;
-      storeAndEchoUserMessage(
+      const messageId =
+        options.clientMsgId || `umsg-${Date.now()}-${randomUUID().slice(0, 8)}-resume`;
+      storeAndEchoIfNew(
         options.resume,
         messageId,
         fullPrompt,
@@ -1113,10 +1114,10 @@ async function tryAutoRename(sessionId: string, clientId: string): Promise<void>
 }
 
 /**
- * Deduplicated store-and-echo for user messages.
+ * Store and echo a user message only if it hasn't been stored before.
  * Returns true if the message was a duplicate (already stored), false if newly stored.
  */
-function storeAndEchoUserMessage(
+function storeAndEchoIfNew(
   sessionId: string,
   messageId: string,
   text: string,
@@ -1154,9 +1155,9 @@ export function sendToChat(
     const session = registry.get(clientId);
     if (!session?.inputQueue) return false;
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-    const messageId = clientMsgId || `umsg-${Date.now()}-send`;
+    const messageId = clientMsgId || `umsg-${Date.now()}-${randomUUID().slice(0, 8)}-send`;
     if (session.sessionId) {
-      const isDup = storeAndEchoUserMessage(
+      const isDup = storeAndEchoIfNew(
         session.sessionId,
         messageId,
         fullPrompt,
@@ -1192,9 +1193,12 @@ export async function interruptChat(
     if (!session?.queryInstance || !session?.inputQueue) return false;
     if (model) session.model = model;
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
-    const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
+    const messageId = clientMsgId || `umsg-${Date.now()}-${randomUUID().slice(0, 8)}-interrupt`;
+    // Store and echo the user message, but always proceed with the interrupt
+    // even if the message is a duplicate — a retried interrupt must still stop
+    // the agent, just without re-storing the echo.
     if (session.sessionId) {
-      const isDup = storeAndEchoUserMessage(
+      storeAndEchoIfNew(
         session.sessionId,
         messageId,
         fullPrompt,
@@ -1202,7 +1206,6 @@ export async function interruptChat(
         session.transport,
         session.observers,
       );
-      if (isDup) return true;
     } else {
       const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt };
       send(session.transport, echo);

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1007,27 +1007,14 @@ async function _startChatInner(
     // Store and echo it here so the frontend can replay it.
     if (options.resume) {
       const messageId = options.clientMsgId || `umsg-${Date.now()}-resume`;
-      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
-      if (!eventStore.hasUserMessage(options.resume, messageId)) {
-        eventStore.append(options.resume, 'user_message', {
-          v: 2,
-          type: 'user_message',
-          ts: Date.now(),
-          messageId,
-          text: fullPrompt,
-        });
-        eventStore.updateLastSpeaker(options.resume, 'user');
-        _onSessionChange?.(clientId, 'user_message');
-        const echo = {
-          type: 'user_message',
-          v: 2,
-          messageId,
-          text: fullPrompt,
-          sessionId: options.resume,
-        };
-        send(transport, echo);
-        broadcastToObservers(session.observers, echo);
-      }
+      storeAndEchoUserMessage(
+        options.resume,
+        messageId,
+        fullPrompt,
+        clientId,
+        transport,
+        session.observers,
+      );
     }
 
     await runQueryLoop(
@@ -1125,6 +1112,36 @@ async function tryAutoRename(sessionId: string, clientId: string): Promise<void>
   }
 }
 
+/**
+ * Deduplicated store-and-echo for user messages.
+ * Returns true if the message was a duplicate (already stored), false if newly stored.
+ */
+function storeAndEchoUserMessage(
+  sessionId: string,
+  messageId: string,
+  text: string,
+  clientId: string,
+  transport: SessionTransport,
+  observers?: Set<SessionTransport>,
+): boolean {
+  if (eventStore.hasUserMessage(sessionId, messageId)) {
+    return true;
+  }
+  eventStore.append(sessionId, 'user_message', {
+    v: 2,
+    type: 'user_message',
+    ts: Date.now(),
+    messageId,
+    text,
+  });
+  eventStore.updateLastSpeaker(sessionId, 'user');
+  _onSessionChange?.(clientId, 'user_message');
+  const echo = { type: 'user_message', v: 2, messageId, text, sessionId };
+  send(transport, echo);
+  if (observers) broadcastToObservers(observers, echo);
+  return false;
+}
+
 /** Push a follow-up message into a running session. */
 export function sendToChat(
   clientId: string,
@@ -1139,32 +1156,23 @@ export function sendToChat(
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
     const messageId = clientMsgId || `umsg-${Date.now()}-send`;
     if (session.sessionId) {
-      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
-      if (eventStore.hasUserMessage(session.sessionId, messageId)) {
-        return true;
-      }
-      eventStore.append(session.sessionId, 'user_message', {
-        v: 2,
-        type: 'user_message',
-        ts: Date.now(),
+      const isDup = storeAndEchoUserMessage(
+        session.sessionId,
         messageId,
-        text: fullPrompt,
-      });
-      eventStore.updateLastSpeaker(session.sessionId, 'user');
-      _onSessionChange?.(clientId, 'user_message');
+        fullPrompt,
+        clientId,
+        session.transport,
+        session.observers,
+      );
+      if (isDup) return true;
       tryAutoRename(session.sessionId, clientId).catch(() => {
         /* errors logged internally */
       });
+    } else {
+      const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt };
+      send(session.transport, echo);
+      broadcastToObservers(session.observers, echo);
     }
-    const echo = {
-      type: 'user_message',
-      v: 2,
-      messageId,
-      text: fullPrompt,
-      ...(session.sessionId ? { sessionId: session.sessionId } : {}),
-    };
-    send(session.transport, echo);
-    broadcastToObservers(session.observers, echo);
     session.inputQueue.push(makeUserMessage(fullPrompt, 'next'));
     return true;
   });
@@ -1186,29 +1194,20 @@ export async function interruptChat(
     const fullPrompt = assemblePrompt(prompt, session.cwd ?? '.', images, contextBlocks);
     const messageId = clientMsgId || `umsg-${Date.now()}-interrupt`;
     if (session.sessionId) {
-      // Idempotency guard: skip if this user_message was already stored (e.g. retried POST)
-      if (eventStore.hasUserMessage(session.sessionId, messageId)) {
-        return true;
-      }
-      eventStore.append(session.sessionId, 'user_message', {
-        v: 2,
-        type: 'user_message',
-        ts: Date.now(),
+      const isDup = storeAndEchoUserMessage(
+        session.sessionId,
         messageId,
-        text: fullPrompt,
-      });
-      eventStore.updateLastSpeaker(session.sessionId, 'user');
-      _onSessionChange?.(clientId, 'user_message');
+        fullPrompt,
+        clientId,
+        session.transport,
+        session.observers,
+      );
+      if (isDup) return true;
+    } else {
+      const echo = { type: 'user_message', v: 2, messageId, text: fullPrompt };
+      send(session.transport, echo);
+      broadcastToObservers(session.observers, echo);
     }
-    const echo = {
-      type: 'user_message',
-      v: 2,
-      messageId,
-      text: fullPrompt,
-      ...(session.sessionId ? { sessionId: session.sessionId } : {}),
-    };
-    send(session.transport, echo);
-    broadcastToObservers(session.observers, echo);
     // Stop all active subagent tasks before interrupting the parent query.
     // Without this, interrupt() only halts the parent — which is blocked
     // waiting for the subagent, so the session hangs.


### PR DESCRIPTION
## Summary

- Adds `EventStore.hasUserMessage(sessionId, messageId)` — efficient SQLite check before storing user_message events
- Guards `sendToChat`, `interruptChat`, and the `startChat` resume path with the idempotency check — if a POST is retried (network retry, iOS lifecycle, SSE reconnect), the duplicate is silently dropped (no double echo, no double inputQueue push)
- Adds ref-based send guard in `ChatInput.handleSend` to prevent double-tap from firing two sends before React re-renders
- Fixes test isolation: existing tests used static session IDs that collided across test files sharing the file-based event store

## Test plan
- [x] `hasUserMessage` unit tests (4 cases: miss, hit, cross-session, non-user_message)
- [x] `sendToChat` dedup integration test (same clientMsgId sent twice → only one echo + one inputQueue push)
- [x] All existing event-store, send-to-chat, and chat tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)