### PR TITLE
feat(ui): improve Agent tool call visibility

### DIFF
--- a/frontend/src/components/SubagentCard.tsx
+++ b/frontend/src/components/SubagentCard.tsx
@@ -6,6 +6,7 @@ import { TextBubble } from './MessageBubble';
 
 interface SubagentCardProps {
   subagent: FinishedSubagentState | StreamingSubagentState;
+  description?: string;
 }
 
 function formatTokens(usage?: { inputTokens: number; outputTokens: number }): string {
@@ -14,11 +15,13 @@ function formatTokens(usage?: { inputTokens: number; outputTokens: number }): st
   return `${fmt(usage.inputTokens)}↓ ${fmt(usage.outputTokens)}↑`;
 }
 
-export function SubagentCard({ subagent }: SubagentCardProps) {
+export function SubagentCard({ subagent, description }: SubagentCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const isRunning = 'running' in subagent && subagent.running;
-  const summary = isRunning ? 'Working...' : subagent.summary || 'Complete';
+  const summary = isRunning
+    ? description || 'Working...'
+    : subagent.summary || description || 'Complete';
   const usage = 'usage' in subagent ? subagent.usage : undefined;
   const done = !isRunning;
 

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -77,7 +77,7 @@ function RawInputDetail({
     if (!raw.prompt) return null;
     return (
       <div className="tool-pill-section">
-        <p className="tool-pill-agent-prompt">{raw.prompt}</p>
+        <CodeBlock code={raw.prompt} label="Prompt" maxHeight={300} />
       </div>
     );
   }

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -73,6 +73,13 @@ function RawInputDetail({
       </div>
     );
   }
+  if (raw.type === 'agent') {
+    return (
+      <div className="tool-pill-section">
+        {raw.prompt && <p className="tool-pill-agent-prompt">{raw.prompt}</p>}
+      </div>
+    );
+  }
   return null;
 }
 
@@ -146,7 +153,12 @@ export function ToolPill({ block }: Props) {
           <ToolResult block={block} onPopOut={handlePopOut} />
         </div>
       )}
-      {block.subagent && <SubagentCard subagent={block.subagent} />}
+      {block.subagent && (
+        <SubagentCard
+          subagent={block.subagent}
+          description={block.rawInput?.type === 'agent' ? block.rawInput.description : undefined}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ToolPill.tsx
+++ b/frontend/src/components/ToolPill.tsx
@@ -74,9 +74,10 @@ function RawInputDetail({
     );
   }
   if (raw.type === 'agent') {
+    if (!raw.prompt) return null;
     return (
       <div className="tool-pill-section">
-        {raw.prompt && <p className="tool-pill-agent-prompt">{raw.prompt}</p>}
+        <p className="tool-pill-agent-prompt">{raw.prompt}</p>
       </div>
     );
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2369,6 +2369,18 @@ textarea:focus {
   border-left: 3px solid rgba(76, 175, 80, 0.4);
 }
 
+.tool-pill-agent-prompt {
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* ===== Thinking Block (now uses tool-pill pattern) ===== */
 
 .thinking-block-name {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2369,18 +2369,6 @@ textarea:focus {
   border-left: 3px solid rgba(76, 175, 80, 0.4);
 }
 
-.tool-pill-agent-prompt {
-  font-size: var(--text-xs);
-  line-height: 1.5;
-  color: var(--text-secondary);
-  white-space: pre-wrap;
-  word-break: break-word;
-  margin: 0;
-  max-height: 300px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
 /* ===== Thinking Block (now uses tool-pill pattern) ===== */
 
 .thinking-block-name {

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -77,6 +77,28 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Glob', {})).toBe(' in workspace');
   });
 
+  it('summarizes Agent tool with type and description', () => {
+    expect(
+      summarizeToolInput('Agent', {
+        subagent_type: 'Explore',
+        description: 'Find meeting transcript',
+        prompt: 'Search for...',
+      }),
+    ).toBe('Explore · Find meeting transcript');
+  });
+
+  it('summarizes Agent tool with only description', () => {
+    expect(summarizeToolInput('Agent', { description: 'Search codebase' })).toBe('Search codebase');
+  });
+
+  it('summarizes Agent tool with only subagent_type', () => {
+    expect(summarizeToolInput('Agent', { subagent_type: 'Plan' })).toBe('Plan');
+  });
+
+  it('summarizes Agent tool with no fields as "subagent"', () => {
+    expect(summarizeToolInput('Agent', {})).toBe('subagent');
+  });
+
   it('summarizes task MCP tools', () => {
     expect(summarizeToolInput('mcp__task-board__TaskSet', { tasks: [{}, {}, {}] })).toBe(
       '3 subtasks',
@@ -165,5 +187,31 @@ describe('getRawInput', () => {
     expect(
       (result?.old_string?.length || 0) + (result?.new_string?.length || 0),
     ).toBeLessThanOrEqual(100_000);
+  });
+
+  it('returns agent type for Agent tool', () => {
+    const result = getRawInput('Agent', {
+      description: 'Find transcript',
+      subagent_type: 'Explore',
+      prompt: 'Search for meeting notes',
+    });
+    expect(result).toEqual({
+      type: 'agent',
+      description: 'Find transcript',
+      subagent_type: 'Explore',
+      prompt: 'Search for meeting notes',
+    });
+  });
+
+  it('caps Agent prompt at RAW_INPUT_MAX_CHARS', () => {
+    const bigPrompt = 'z'.repeat(60_000);
+    const result = getRawInput('Agent', { prompt: bigPrompt });
+    expect(result?.prompt?.length).toBeLessThanOrEqual(50_000);
+  });
+
+  it('caps Agent description at TOOL_SUMMARY_MAX_CHARS', () => {
+    const bigDesc = 'a'.repeat(300);
+    const result = getRawInput('Agent', { description: bigDesc });
+    expect(result?.description?.length).toBeLessThanOrEqual(200);
   });
 });

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -99,18 +99,22 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Agent', {})).toBe('subagent');
   });
 
-  it('truncates long Agent type + description individually before combining', () => {
-    const longType = 'T'.repeat(150);
-    const longDesc = 'D'.repeat(150);
+  it('balances truncation so both type and description are visible', () => {
+    const longType = 'T'.repeat(200);
+    const longDesc = 'D'.repeat(200);
     const result = summarizeToolInput('Agent', {
       subagent_type: longType,
       description: longDesc,
     });
     expect(result.length).toBeLessThanOrEqual(200);
-    // Both fields should be present (not one entirely clipped by the other)
+    // Both fields must be present even when each exceeds the budget
     expect(result).toContain('T');
     expect(result).toContain('D');
     expect(result).toContain(' · ');
+    // Each half gets ~98 chars (floor((200-3)/2))
+    const [left, right] = result.split(' · ');
+    expect(left.length).toBeGreaterThan(0);
+    expect(right.length).toBeGreaterThan(0);
   });
 
   it('summarizes task MCP tools', () => {

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -214,4 +214,17 @@ describe('getRawInput', () => {
     const result = getRawInput('Agent', { description: bigDesc });
     expect(result?.description?.length).toBeLessThanOrEqual(200);
   });
+
+  it('caps Agent subagent_type at TOOL_SUMMARY_MAX_CHARS', () => {
+    const bigType = 'b'.repeat(300);
+    const result = getRawInput('Agent', { subagent_type: bigType });
+    expect(result?.subagent_type?.length).toBeLessThanOrEqual(200);
+  });
+
+  it('omits empty Agent fields', () => {
+    const result = getRawInput('Agent', { description: 'Search' });
+    expect(result).toEqual({ type: 'agent', description: 'Search' });
+    expect(result).not.toHaveProperty('subagent_type');
+    expect(result).not.toHaveProperty('prompt');
+  });
 });

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -107,14 +107,25 @@ describe('summarizeToolInput', () => {
       description: longDesc,
     });
     expect(result.length).toBeLessThanOrEqual(200);
-    // Both fields must be present even when each exceeds the budget
     expect(result).toContain('T');
     expect(result).toContain('D');
     expect(result).toContain(' · ');
-    // Each half gets ~98 chars (floor((200-3)/2))
     const [left, right] = result.split(' · ');
     expect(left.length).toBeGreaterThan(0);
     expect(right.length).toBeGreaterThan(0);
+  });
+
+  it('gives short field full length and allocates remainder to long field', () => {
+    const result = summarizeToolInput('Agent', {
+      subagent_type: 'Explore',
+      description: 'D'.repeat(200),
+    });
+    expect(result.length).toBeLessThanOrEqual(200);
+    // 'Explore' (7 chars) should appear untruncated
+    expect(result.startsWith('Explore · ')).toBe(true);
+    // Description gets the remaining budget (200 - 7 - 3 = 190 chars)
+    const desc = result.split(' · ')[1];
+    expect(desc.length).toBe(190);
   });
 
   it('summarizes task MCP tools', () => {

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -128,6 +128,19 @@ describe('summarizeToolInput', () => {
     expect(desc.length).toBe(190);
   });
 
+  it('gives short description full length and allocates remainder to long type', () => {
+    const result = summarizeToolInput('Agent', {
+      subagent_type: 'T'.repeat(200),
+      description: 'short',
+    });
+    expect(result.length).toBeLessThanOrEqual(200);
+    // 'short' (5 chars) should appear untruncated at end
+    expect(result.endsWith('short')).toBe(true);
+    // Type gets the remaining budget (200 - 5 - 3 = 192 chars)
+    const stype = result.split(' · ')[0];
+    expect(stype.length).toBe(192);
+  });
+
   it('summarizes task MCP tools', () => {
     expect(summarizeToolInput('mcp__task-board__TaskSet', { tasks: [{}, {}, {}] })).toBe(
       '3 subtasks',

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -99,6 +99,20 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Agent', {})).toBe('subagent');
   });
 
+  it('truncates long Agent type + description individually before combining', () => {
+    const longType = 'T'.repeat(150);
+    const longDesc = 'D'.repeat(150);
+    const result = summarizeToolInput('Agent', {
+      subagent_type: longType,
+      description: longDesc,
+    });
+    expect(result.length).toBeLessThanOrEqual(200);
+    // Both fields should be present (not one entirely clipped by the other)
+    expect(result).toContain('T');
+    expect(result).toContain('D');
+    expect(result).toContain(' · ');
+  });
+
   it('summarizes task MCP tools', () => {
     expect(summarizeToolInput('mcp__task-board__TaskSet', { tasks: [{}, {}, {}] })).toBe(
       '3 subtasks',

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -45,7 +45,7 @@ export function getRawInput(
     case 'Agent':
       return {
         type: 'agent',
-        description: String(input.description || ''),
+        description: String(input.description || '').slice(0, TOOL_SUMMARY_MAX_CHARS),
         subagent_type: String(input.subagent_type || ''),
         prompt: String(input.prompt || '').slice(0, RAW_INPUT_MAX_CHARS),
       };

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -47,7 +47,7 @@ export function getRawInput(
       const stype = String(input.subagent_type || '');
       const prompt = String(input.prompt || '');
       return {
-        type: 'agent' as const,
+        type: 'agent',
         ...(desc && { description: desc.slice(0, TOOL_SUMMARY_MAX_CHARS) }),
         ...(stype && { subagent_type: stype.slice(0, TOOL_SUMMARY_MAX_CHARS) }),
         ...(prompt && { prompt: prompt.slice(0, RAW_INPUT_MAX_CHARS) }),

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -42,6 +42,13 @@ export function getRawInput(
         command: String(input.command || ''),
         language: 'bash',
       };
+    case 'Agent':
+      return {
+        type: 'agent',
+        description: String(input.description || ''),
+        subagent_type: String(input.subagent_type || ''),
+        prompt: String(input.prompt || '').slice(0, RAW_INPUT_MAX_CHARS),
+      };
     default:
       return undefined;
   }
@@ -74,6 +81,12 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
       return 'get status';
     case 'mcp__task-board__TaskBlock':
       return `${String(input.reason || '').slice(0, 60)}`;
+    case 'Agent': {
+      const desc = String(input.description || '');
+      const type = String(input.subagent_type || '');
+      if (type && desc) return `${type} · ${desc}`.slice(0, TOOL_SUMMARY_MAX_CHARS);
+      return (desc || type || 'subagent').slice(0, TOOL_SUMMARY_MAX_CHARS);
+    }
     default:
       return JSON.stringify(input).slice(0, TOOL_SUMMARY_MAX_CHARS);
   }

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -89,9 +89,11 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
       const desc = String(input.description || '');
       const stype = String(input.subagent_type || '');
       if (stype && desc) {
-        // Split budget evenly so neither field is lost when both are long
-        const half = Math.floor((TOOL_SUMMARY_MAX_CHARS - 3) / 2);
-        return `${stype.slice(0, half)} · ${desc.slice(0, half)}`;
+        // Give the shorter field its full length, allocate the rest to the longer
+        const budget = TOOL_SUMMARY_MAX_CHARS - 3; // account for ' · '
+        const stypeLen = Math.min(stype.length, Math.max(Math.floor(budget / 2), budget - desc.length));
+        const descLen = budget - stypeLen;
+        return `${stype.slice(0, stypeLen)} · ${desc.slice(0, descLen)}`;
       }
       return (desc || stype || 'subagent').slice(0, TOOL_SUMMARY_MAX_CHARS);
     }

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -86,10 +86,10 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
     case 'mcp__task-board__TaskBlock':
       return `${String(input.reason || '').slice(0, 60)}`;
     case 'Agent': {
-      const desc = String(input.description || '');
-      const type = String(input.subagent_type || '');
-      if (type && desc) return `${type} · ${desc}`.slice(0, TOOL_SUMMARY_MAX_CHARS);
-      return (desc || type || 'subagent').slice(0, TOOL_SUMMARY_MAX_CHARS);
+      const desc = String(input.description || '').slice(0, TOOL_SUMMARY_MAX_CHARS);
+      const stype = String(input.subagent_type || '').slice(0, TOOL_SUMMARY_MAX_CHARS);
+      if (stype && desc) return `${stype} · ${desc}`.slice(0, TOOL_SUMMARY_MAX_CHARS);
+      return desc || stype || 'subagent';
     }
     default:
       return JSON.stringify(input).slice(0, TOOL_SUMMARY_MAX_CHARS);

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -86,10 +86,14 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
     case 'mcp__task-board__TaskBlock':
       return `${String(input.reason || '').slice(0, 60)}`;
     case 'Agent': {
-      const desc = String(input.description || '').slice(0, TOOL_SUMMARY_MAX_CHARS);
-      const stype = String(input.subagent_type || '').slice(0, TOOL_SUMMARY_MAX_CHARS);
-      if (stype && desc) return `${stype} · ${desc}`.slice(0, TOOL_SUMMARY_MAX_CHARS);
-      return desc || stype || 'subagent';
+      const desc = String(input.description || '');
+      const stype = String(input.subagent_type || '');
+      if (stype && desc) {
+        // Split budget evenly so neither field is lost when both are long
+        const half = Math.floor((TOOL_SUMMARY_MAX_CHARS - 3) / 2);
+        return `${stype.slice(0, half)} · ${desc.slice(0, half)}`;
+      }
+      return (desc || stype || 'subagent').slice(0, TOOL_SUMMARY_MAX_CHARS);
     }
     default:
       return JSON.stringify(input).slice(0, TOOL_SUMMARY_MAX_CHARS);

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -46,7 +46,7 @@ export function getRawInput(
       return {
         type: 'agent',
         description: String(input.description || '').slice(0, TOOL_SUMMARY_MAX_CHARS),
-        subagent_type: String(input.subagent_type || ''),
+        subagent_type: String(input.subagent_type || '').slice(0, TOOL_SUMMARY_MAX_CHARS),
         prompt: String(input.prompt || '').slice(0, RAW_INPUT_MAX_CHARS),
       };
     default:

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -42,13 +42,17 @@ export function getRawInput(
         command: String(input.command || ''),
         language: 'bash',
       };
-    case 'Agent':
+    case 'Agent': {
+      const desc = String(input.description || '');
+      const stype = String(input.subagent_type || '');
+      const prompt = String(input.prompt || '');
       return {
-        type: 'agent',
-        description: String(input.description || '').slice(0, TOOL_SUMMARY_MAX_CHARS),
-        subagent_type: String(input.subagent_type || '').slice(0, TOOL_SUMMARY_MAX_CHARS),
-        prompt: String(input.prompt || '').slice(0, RAW_INPUT_MAX_CHARS),
+        type: 'agent' as const,
+        ...(desc && { description: desc.slice(0, TOOL_SUMMARY_MAX_CHARS) }),
+        ...(stype && { subagent_type: stype.slice(0, TOOL_SUMMARY_MAX_CHARS) }),
+        ...(prompt && { prompt: prompt.slice(0, RAW_INPUT_MAX_CHARS) }),
       };
+    }
     default:
       return undefined;
   }

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -11,7 +11,7 @@ export type ToolTier = 'safe' | 'standard' | 'elevated' | 'unknown';
 // --- Tool input ---
 
 export interface RawToolInput {
-  type: 'write' | 'diff' | 'command' | 'read';
+  type: 'write' | 'diff' | 'command' | 'read' | 'agent';
   path?: string;
   contents?: string;
   old_string?: string;
@@ -19,6 +19,12 @@ export interface RawToolInput {
   command?: string;
   /** Language hint derived from file extension (e.g. 'typescript', 'python'). */
   language?: string;
+  /** Agent tool: description of what the subagent is doing. */
+  description?: string;
+  /** Agent tool: the type of subagent (e.g. 'Explore', 'Plan'). */
+  subagent_type?: string;
+  /** Agent tool: the full prompt sent to the subagent. */
+  prompt?: string;
 }
 
 // --- Snapshot (server-side current message state) ---


### PR DESCRIPTION
## Summary

- Parse Agent tool JSON input to show `subagent_type · description` in the header instead of raw JSON
- Show the full prompt as readable wrapped text when expanded, instead of dumping JSON in a `<pre>` tag
- Pass description to SubagentCard so it displays context while running ("Find today's meeting transcript") instead of generic "Working..."

**Before:** `● Agent {"subagent_type":"Explore","description":"Find today's...` 
**After:** `● Agent Explore · Find today's meeting transcript`

### Files changed

| File | Change |
|------|--------|
| `packages/protocol/src/types.ts` | Add `'agent'` to `RawToolInput` type union with `description`, `subagent_type`, `prompt` fields |
| `packages/protocol/src/tool-summary.ts` | Add `Agent` case to `getRawInput()` and `summarizeToolInput()` |
| `frontend/src/components/ToolPill.tsx` | Add `RawInputDetail` for agent type; pass description to SubagentCard |
| `frontend/src/components/SubagentCard.tsx` | Accept `description` prop, show it instead of "Working..." |
| `frontend/src/styles/global.css` | Add `.tool-pill-agent-prompt` class for readable prompt text |

## Test plan

- [ ] Trigger an Agent tool call (e.g. ask Claude to search the codebase) and verify header shows `Explore · <description>` instead of raw JSON
- [ ] Expand the Agent tool pill and verify prompt displays as readable text
- [ ] Verify SubagentCard shows the description while agent is running
- [ ] Verify completed agents still show summary text
- [ ] Verify non-Agent tool pills (Read, Write, Bash, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)