### PR TITLE
feat(harness): schema loader for Centaur agent definitions

### DIFF
--- a/packages/harness/__tests__/schema-loader.test.ts
+++ b/packages/harness/__tests__/schema-loader.test.ts
@@ -80,7 +80,30 @@ describe('buildDeliberationConfig', () => {
     expect(config.challenger.temperature).toBe(0.9);
   });
 
-  it('uses defaults when protocol is not specified', () => {
+  it('uses defaults when neither agent specifies protocol', () => {
+    const proposerNoProtocol: AgentDefinitionInput = {
+      ...proposerDef,
+      deliberation: {
+        role: 'proposer',
+        counterpart: 'deliberation-challenger',
+      },
+    };
+
+    const challengerNoProtocol: AgentDefinitionInput = {
+      ...challengerDef,
+      deliberation: {
+        role: 'challenger',
+        counterpart: 'deliberation-architect',
+      },
+    };
+
+    const config = buildDeliberationConfig(proposerNoProtocol, challengerNoProtocol);
+
+    expect(config.maxRounds).toBe(2);
+    expect(config.convergence).toBe('fixed-rounds');
+  });
+
+  it('falls back to challenger protocol when proposer has none', () => {
     const proposerNoProtocol: AgentDefinitionInput = {
       ...proposerDef,
       deliberation: {
@@ -91,7 +114,8 @@ describe('buildDeliberationConfig', () => {
 
     const config = buildDeliberationConfig(proposerNoProtocol, challengerDef);
 
-    expect(config.maxRounds).toBe(2);
+    // Should use challenger's protocol settings
+    expect(config.maxRounds).toBe(3);
     expect(config.convergence).toBe('fixed-rounds');
   });
 
@@ -131,6 +155,29 @@ describe('buildDeliberationConfig', () => {
     };
 
     expect(() => buildDeliberationConfig(proposerDef, wrongRole)).toThrow('expected "challenger"');
+  });
+
+  it('warns but does not throw on counterpart name mismatch', () => {
+    const mismatchedProposer: AgentDefinitionInput = {
+      ...proposerDef,
+      deliberation: {
+        ...proposerDef.deliberation!,
+        counterpart: 'some-other-agent',
+      },
+    };
+
+    const mismatchedChallenger: AgentDefinitionInput = {
+      ...challengerDef,
+      deliberation: {
+        ...challengerDef.deliberation!,
+        counterpart: 'some-other-agent',
+      },
+    };
+
+    // Should not throw — mismatched counterparts are a warning, not an error
+    const config = buildDeliberationConfig(mismatchedProposer, mismatchedChallenger);
+    expect(config.proposer.name).toBe('deliberation-architect');
+    expect(config.challenger.name).toBe('deliberation-challenger');
   });
 });
 
@@ -182,6 +229,34 @@ describe('buildDeliberationConfigFromAgent', () => {
 
     expect(config.budgetUsd).toBe(10.0);
   });
+
+  it('propagates resolver rejection', async () => {
+    const resolve = async (): Promise<AgentDefinitionInput> => {
+      throw new Error('ContexGin unreachable');
+    };
+
+    await expect(buildDeliberationConfigFromAgent(proposerDef, resolve)).rejects.toThrow(
+      'ContexGin unreachable',
+    );
+  });
+
+  it('throws when resolved counterpart has wrong role', async () => {
+    // Resolver returns another proposer instead of a challenger
+    const anotherProposer: AgentDefinitionInput = {
+      identity: { name: 'another-proposer', description: 'Also proposes' },
+      provider: { default: 'claude-sonnet-4-6' },
+      deliberation: {
+        role: 'proposer',
+        counterpart: 'deliberation-architect',
+      },
+    };
+
+    const resolve = async () => anotherProposer;
+
+    await expect(buildDeliberationConfigFromAgent(proposerDef, resolve)).rejects.toThrow(
+      'expected "challenger"',
+    );
+  });
 });
 
 // ─── buildFusionConfig ──────────────────────────────────────────────────────
@@ -221,5 +296,16 @@ describe('buildFusionConfig', () => {
 
   it('throws on empty array', () => {
     expect(() => buildFusionConfig([])).toThrow('at least 2 panel models');
+  });
+
+  it('allows judge model that is not in the panel list', () => {
+    const config = buildFusionConfig(['claude-opus-4-6', 'gemini-2.5-pro'], {
+      judgeModel: 'claude-sonnet-4-6',
+    });
+
+    expect(config.judgeModel.model).toBe('claude-sonnet-4-6');
+    expect(config.panelModels).toHaveLength(2);
+    // Judge is not in panel — this is allowed behavior
+    expect(config.panelModels.map((p) => p.model)).not.toContain('claude-sonnet-4-6');
   });
 });

--- a/packages/harness/__tests__/schema-loader.test.ts
+++ b/packages/harness/__tests__/schema-loader.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDeliberationConfig,
+  buildDeliberationConfigFromAgent,
+  buildFusionConfig,
+} from '../src/reasoning/schema-loader.js';
+import type { AgentDefinitionInput } from '../src/reasoning/schema-loader.js';
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+const proposerDef: AgentDefinitionInput = {
+  identity: {
+    name: 'deliberation-architect',
+    description: 'Proposes architectural solutions',
+  },
+  provider: { default: 'claude-opus-4-6' },
+  deliberation: {
+    role: 'proposer',
+    counterpart: 'deliberation-challenger',
+    protocol: {
+      phases: ['propose', 'challenge', 'respond', 'converge'],
+      max_rounds: 3,
+      convergence: 'fixed-rounds',
+    },
+  },
+};
+
+const challengerDef: AgentDefinitionInput = {
+  identity: {
+    name: 'deliberation-challenger',
+    description: 'Critiques architectural proposals',
+  },
+  provider: { default: 'gemini-2.5-pro' },
+  deliberation: {
+    role: 'challenger',
+    counterpart: 'deliberation-architect',
+    protocol: {
+      phases: ['propose', 'challenge', 'respond', 'converge'],
+      max_rounds: 3,
+      convergence: 'fixed-rounds',
+    },
+  },
+};
+
+// ─── buildDeliberationConfig ────────────────────────────────────────────────
+
+describe('buildDeliberationConfig', () => {
+  it('builds config from proposer + challenger pair', () => {
+    const config = buildDeliberationConfig(proposerDef, challengerDef);
+
+    expect(config.proposer.name).toBe('deliberation-architect');
+    expect(config.proposer.model).toBe('claude-opus-4-6');
+    expect(config.challenger.name).toBe('deliberation-challenger');
+    expect(config.challenger.model).toBe('gemini-2.5-pro');
+    expect(config.maxRounds).toBe(3);
+    expect(config.convergence).toBe('fixed-rounds');
+    expect(config.budgetUsd).toBe(2.0);
+  });
+
+  it('uses default system prompts when not overridden', () => {
+    const config = buildDeliberationConfig(proposerDef, challengerDef);
+
+    expect(config.proposer.systemPrompt).toContain('architect');
+    expect(config.challenger.systemPrompt).toContain('adversarial');
+  });
+
+  it('applies option overrides', () => {
+    const config = buildDeliberationConfig(proposerDef, challengerDef, {
+      budgetUsd: 5.0,
+      proposerPrompt: 'Custom proposer prompt',
+      challengerPrompt: 'Custom challenger prompt',
+      proposerTemperature: 0.5,
+      challengerTemperature: 0.9,
+    });
+
+    expect(config.budgetUsd).toBe(5.0);
+    expect(config.proposer.systemPrompt).toBe('Custom proposer prompt');
+    expect(config.challenger.systemPrompt).toBe('Custom challenger prompt');
+    expect(config.proposer.temperature).toBe(0.5);
+    expect(config.challenger.temperature).toBe(0.9);
+  });
+
+  it('uses defaults when protocol is not specified', () => {
+    const proposerNoProtocol: AgentDefinitionInput = {
+      ...proposerDef,
+      deliberation: {
+        role: 'proposer',
+        counterpart: 'deliberation-challenger',
+      },
+    };
+
+    const config = buildDeliberationConfig(proposerNoProtocol, challengerDef);
+
+    expect(config.maxRounds).toBe(2);
+    expect(config.convergence).toBe('fixed-rounds');
+  });
+
+  it('throws if proposer has no deliberation block', () => {
+    const noDel: AgentDefinitionInput = {
+      identity: { name: 'plain-agent', description: 'No deliberation' },
+      provider: { default: 'claude-opus-4-6' },
+    };
+
+    expect(() => buildDeliberationConfig(noDel, challengerDef)).toThrow(
+      'has no deliberation block',
+    );
+  });
+
+  it('throws if challenger has no deliberation block', () => {
+    const noDel: AgentDefinitionInput = {
+      identity: { name: 'plain-agent', description: 'No deliberation' },
+      provider: { default: 'gemini-2.5-pro' },
+    };
+
+    expect(() => buildDeliberationConfig(proposerDef, noDel)).toThrow('has no deliberation block');
+  });
+
+  it('throws if proposer has wrong role', () => {
+    const wrongRole: AgentDefinitionInput = {
+      ...proposerDef,
+      deliberation: { ...proposerDef.deliberation!, role: 'challenger' },
+    };
+
+    expect(() => buildDeliberationConfig(wrongRole, challengerDef)).toThrow('expected "proposer"');
+  });
+
+  it('throws if challenger has wrong role', () => {
+    const wrongRole: AgentDefinitionInput = {
+      ...challengerDef,
+      deliberation: { ...challengerDef.deliberation!, role: 'proposer' },
+    };
+
+    expect(() => buildDeliberationConfig(proposerDef, wrongRole)).toThrow('expected "challenger"');
+  });
+});
+
+// ─── buildDeliberationConfigFromAgent ───────────────────────────────────────
+
+describe('buildDeliberationConfigFromAgent', () => {
+  it('resolves counterpart and builds config from proposer', async () => {
+    const resolve = async (name: string) => {
+      if (name === 'deliberation-challenger') return challengerDef;
+      throw new Error(`Unknown agent: ${name}`);
+    };
+
+    const config = await buildDeliberationConfigFromAgent(proposerDef, resolve);
+
+    expect(config.proposer.name).toBe('deliberation-architect');
+    expect(config.challenger.name).toBe('deliberation-challenger');
+  });
+
+  it('resolves counterpart and builds config from challenger', async () => {
+    const resolve = async (name: string) => {
+      if (name === 'deliberation-architect') return proposerDef;
+      throw new Error(`Unknown agent: ${name}`);
+    };
+
+    const config = await buildDeliberationConfigFromAgent(challengerDef, resolve);
+
+    // Should swap — proposer first regardless of input order
+    expect(config.proposer.name).toBe('deliberation-architect');
+    expect(config.challenger.name).toBe('deliberation-challenger');
+  });
+
+  it('throws if agent has no deliberation block', async () => {
+    const noDel: AgentDefinitionInput = {
+      identity: { name: 'plain-agent', description: 'No deliberation' },
+      provider: { default: 'claude-opus-4-6' },
+    };
+
+    await expect(buildDeliberationConfigFromAgent(noDel, async () => proposerDef)).rejects.toThrow(
+      'has no deliberation block',
+    );
+  });
+
+  it('passes options through to buildDeliberationConfig', async () => {
+    const resolve = async () => challengerDef;
+
+    const config = await buildDeliberationConfigFromAgent(proposerDef, resolve, {
+      budgetUsd: 10.0,
+    });
+
+    expect(config.budgetUsd).toBe(10.0);
+  });
+});
+
+// ─── buildFusionConfig ──────────────────────────────────────────────────────
+
+describe('buildFusionConfig', () => {
+  it('builds config from model name list', () => {
+    const config = buildFusionConfig(['claude-opus-4-6', 'gemini-2.5-pro', 'claude-sonnet-4-6']);
+
+    expect(config.panelModels).toHaveLength(3);
+    expect(config.panelModels[0].model).toBe('claude-opus-4-6');
+    expect(config.judgeModel.model).toBe('claude-opus-4-6'); // defaults to first
+    expect(config.budgetUsd).toBe(3.0);
+    expect(config.synthesizerModel).toBeUndefined();
+  });
+
+  it('allows custom judge and synthesizer', () => {
+    const config = buildFusionConfig(['claude-opus-4-6', 'gemini-2.5-pro'], {
+      judgeModel: 'gemini-2.5-pro',
+      synthesizerModel: 'claude-opus-4-6',
+    });
+
+    expect(config.judgeModel.model).toBe('gemini-2.5-pro');
+    expect(config.synthesizerModel?.model).toBe('claude-opus-4-6');
+  });
+
+  it('allows custom budget', () => {
+    const config = buildFusionConfig(['claude-opus-4-6', 'gemini-2.5-pro'], {
+      budgetUsd: 5.0,
+    });
+
+    expect(config.budgetUsd).toBe(5.0);
+  });
+
+  it('throws if fewer than 2 models', () => {
+    expect(() => buildFusionConfig(['claude-opus-4-6'])).toThrow('at least 2 panel models');
+  });
+
+  it('throws on empty array', () => {
+    expect(() => buildFusionConfig([])).toThrow('at least 2 panel models');
+  });
+});

--- a/packages/harness/__tests__/schema-loader.test.ts
+++ b/packages/harness/__tests__/schema-loader.test.ts
@@ -257,6 +257,24 @@ describe('buildDeliberationConfigFromAgent', () => {
       'expected "challenger"',
     );
   });
+
+  it('throws when challenger input resolves another challenger (symmetric)', async () => {
+    // Challenger input whose resolver returns another challenger instead of a proposer
+    const anotherChallenger: AgentDefinitionInput = {
+      identity: { name: 'another-challenger', description: 'Also challenges' },
+      provider: { default: 'claude-sonnet-4-6' },
+      deliberation: {
+        role: 'challenger',
+        counterpart: 'deliberation-challenger',
+      },
+    };
+
+    const resolve = async () => anotherChallenger;
+
+    await expect(buildDeliberationConfigFromAgent(challengerDef, resolve)).rejects.toThrow(
+      'expected "proposer"',
+    );
+  });
 });
 
 // ─── buildFusionConfig ──────────────────────────────────────────────────────

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -102,7 +102,16 @@ export {
   DEFAULT_FUSION_CONFIG,
   SELF_FUSION_CONFIG,
 } from './reasoning/index.js';
+export {
+  buildDeliberationConfig,
+  buildDeliberationConfigFromAgent,
+  buildFusionConfig,
+} from './reasoning/index.js';
 export type {
+  AgentDeliberationBlock,
+  AgentDefinitionInput,
+  BuildDeliberationConfigOptions,
+  BuildFusionConfigOptions,
   DeliberationConfig,
   DeliberationResult,
   FusionConfig,

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -96,13 +96,12 @@ export type {
 export { MODEL_COSTS, calculateCost } from './providers/index.js';
 
 // Reasoning — deliberation + fusion orchestrators
-export { DeliberationOrchestrator, DEFAULT_DELIBERATION_CONFIG } from './reasoning/index.js';
 export {
+  DeliberationOrchestrator,
+  DEFAULT_DELIBERATION_CONFIG,
   FusionOrchestrator,
   DEFAULT_FUSION_CONFIG,
   SELF_FUSION_CONFIG,
-} from './reasoning/index.js';
-export {
   buildDeliberationConfig,
   buildDeliberationConfigFromAgent,
   buildFusionConfig,

--- a/packages/harness/src/reasoning/index.ts
+++ b/packages/harness/src/reasoning/index.ts
@@ -8,6 +8,17 @@
 
 export { DeliberationOrchestrator, DEFAULT_DELIBERATION_CONFIG } from './deliberation.js';
 export { FusionOrchestrator, DEFAULT_FUSION_CONFIG, SELF_FUSION_CONFIG } from './fusion.js';
+export {
+  buildDeliberationConfig,
+  buildDeliberationConfigFromAgent,
+  buildFusionConfig,
+} from './schema-loader.js';
+export type {
+  AgentDeliberationBlock,
+  AgentDefinitionInput,
+  BuildDeliberationConfigOptions,
+  BuildFusionConfigOptions,
+} from './schema-loader.js';
 export type {
   // Shared
   TranscriptEntry,

--- a/packages/harness/src/reasoning/schema-loader.ts
+++ b/packages/harness/src/reasoning/schema-loader.ts
@@ -118,7 +118,7 @@ export function buildDeliberationConfig(
   }
 
   // Extract protocol settings (proposer's take precedence)
-  const protocol = proposerDef.deliberation.protocol ?? {};
+  const protocol = proposerDef.deliberation.protocol ?? challengerDef.deliberation.protocol ?? {};
   const maxRounds = protocol.max_rounds ?? 2;
   const convergence = protocol.convergence ?? 'fixed-rounds';
 
@@ -188,7 +188,7 @@ export interface BuildFusionConfigOptions {
   budgetUsd?: number;
   /** Override judge model (defaults to first panel model). */
   judgeModel?: string;
-  /** Override synthesizer model (defaults to judge model). */
+  /** Optional synthesizer model. If omitted, no separate synthesis step is performed. */
   synthesizerModel?: string;
 }
 

--- a/packages/harness/src/reasoning/schema-loader.ts
+++ b/packages/harness/src/reasoning/schema-loader.ts
@@ -29,6 +29,11 @@ export interface AgentDeliberationBlock {
   role: 'proposer' | 'challenger';
   counterpart: string;
   protocol?: {
+    /**
+     * Declared for schema fidelity with Centaur agent definitions.
+     * Not consumed by the orchestrator yet — the deliberation protocol
+     * is fixed at 4 phases (propose, challenge, respond, converge).
+     */
     phases?: string[];
     max_rounds?: number;
     convergence?: 'fixed-rounds' | 'explicit-agreement';

--- a/packages/harness/src/reasoning/schema-loader.ts
+++ b/packages/harness/src/reasoning/schema-loader.ts
@@ -1,0 +1,229 @@
+/**
+ * Schema loader — converts Centaur agent definition YAML into
+ * DeliberationConfig and FusionConfig for the reasoning orchestrators.
+ *
+ * Centaur agent definitions describe deliberation participants declaratively:
+ *
+ *   deliberation:
+ *     role: proposer | challenger
+ *     counterpart: deliberation-challenger
+ *     protocol:
+ *       phases: [propose, challenge, respond, converge]
+ *       max_rounds: 2
+ *       convergence: fixed-rounds
+ *
+ * This module resolves a proposer + challenger pair into a ready-to-run
+ * DeliberationConfig, pulling model names from each agent's provider block
+ * and applying sensible defaults for system prompts and budget.
+ */
+
+import { createLogger } from '../logger.js';
+import type { AgentRole, DeliberationConfig, FusionConfig, PanelMember } from './types.js';
+
+const log = createLogger('schema-loader');
+
+// ─── Centaur agent definition types (subset we consume) ───────────────────
+
+/** The deliberation block from a Centaur agent definition. */
+export interface AgentDeliberationBlock {
+  role: 'proposer' | 'challenger';
+  counterpart: string;
+  protocol?: {
+    phases?: string[];
+    max_rounds?: number;
+    convergence?: 'fixed-rounds' | 'explicit-agreement';
+  };
+}
+
+/** Minimal agent definition shape we need for config resolution. */
+export interface AgentDefinitionInput {
+  identity: {
+    name: string;
+    description: string;
+  };
+  provider: {
+    default: string;
+  };
+  deliberation?: AgentDeliberationBlock;
+}
+
+// ─── Deliberation config builder ──────────────────────────────────────────
+
+/** Default system prompts when the agent definition doesn't specify one. */
+const DEFAULT_PROPOSER_PROMPT =
+  'You are a senior software architect. You design robust, well-reasoned solutions. When challenged, you evaluate critique honestly and commit to changes when warranted.';
+
+const DEFAULT_CHALLENGER_PROMPT =
+  'You are a critical technical reviewer. Your role is adversarial — find flaws, edge cases, missing considerations, and better alternatives. Be specific and evidence-based.';
+
+/** Default budget when not specified. */
+const DEFAULT_BUDGET_USD = 2.0;
+
+export interface BuildDeliberationConfigOptions {
+  /** Override budget (USD). */
+  budgetUsd?: number;
+  /** Override proposer system prompt. */
+  proposerPrompt?: string;
+  /** Override challenger system prompt. */
+  challengerPrompt?: string;
+  /** Override proposer temperature. */
+  proposerTemperature?: number;
+  /** Override challenger temperature. */
+  challengerTemperature?: number;
+}
+
+/**
+ * Build a DeliberationConfig from a proposer + challenger agent definition pair.
+ *
+ * Both definitions must have a `deliberation` block. The proposer's protocol
+ * settings take precedence when they differ.
+ *
+ * @throws if either definition is missing the deliberation block or has the wrong role.
+ */
+export function buildDeliberationConfig(
+  proposerDef: AgentDefinitionInput,
+  challengerDef: AgentDefinitionInput,
+  options: BuildDeliberationConfigOptions = {},
+): Omit<DeliberationConfig, 'onEvent'> {
+  // Validate deliberation blocks
+  if (!proposerDef.deliberation) {
+    throw new Error(`Agent "${proposerDef.identity.name}" has no deliberation block`);
+  }
+  if (!challengerDef.deliberation) {
+    throw new Error(`Agent "${challengerDef.identity.name}" has no deliberation block`);
+  }
+  if (proposerDef.deliberation.role !== 'proposer') {
+    throw new Error(
+      `Agent "${proposerDef.identity.name}" has role "${proposerDef.deliberation.role}", expected "proposer"`,
+    );
+  }
+  if (challengerDef.deliberation.role !== 'challenger') {
+    throw new Error(
+      `Agent "${challengerDef.identity.name}" has role "${challengerDef.deliberation.role}", expected "challenger"`,
+    );
+  }
+
+  // Validate counterpart references
+  if (proposerDef.deliberation.counterpart !== challengerDef.identity.name) {
+    log.warn('Proposer counterpart mismatch', {
+      expected: proposerDef.deliberation.counterpart,
+      actual: challengerDef.identity.name,
+    });
+  }
+  if (challengerDef.deliberation.counterpart !== proposerDef.identity.name) {
+    log.warn('Challenger counterpart mismatch', {
+      expected: challengerDef.deliberation.counterpart,
+      actual: proposerDef.identity.name,
+    });
+  }
+
+  // Extract protocol settings (proposer's take precedence)
+  const protocol = proposerDef.deliberation.protocol ?? {};
+  const maxRounds = protocol.max_rounds ?? 2;
+  const convergence = protocol.convergence ?? 'fixed-rounds';
+
+  const proposer: AgentRole = {
+    name: proposerDef.identity.name,
+    model: proposerDef.provider.default,
+    systemPrompt: options.proposerPrompt ?? DEFAULT_PROPOSER_PROMPT,
+    temperature: options.proposerTemperature ?? 0.7,
+  };
+
+  const challenger: AgentRole = {
+    name: challengerDef.identity.name,
+    model: challengerDef.provider.default,
+    systemPrompt: options.challengerPrompt ?? DEFAULT_CHALLENGER_PROMPT,
+    temperature: options.challengerTemperature ?? 0.8,
+  };
+
+  log.info('Built deliberation config from agent definitions', {
+    proposer: `${proposer.name} (${proposer.model})`,
+    challenger: `${challenger.name} (${challenger.model})`,
+    maxRounds,
+    convergence,
+  });
+
+  return {
+    proposer,
+    challenger,
+    maxRounds,
+    convergence,
+    budgetUsd: options.budgetUsd ?? DEFAULT_BUDGET_USD,
+  };
+}
+
+// ─── Single-definition convenience ────────────────────────────────────────
+
+/**
+ * Build a DeliberationConfig from a single agent definition.
+ *
+ * Resolves the counterpart by name using the provided resolver function.
+ * This is the typical path — the caller has one definition and needs to
+ * look up its counterpart from the same source (ContexGin, local files, etc).
+ */
+export async function buildDeliberationConfigFromAgent(
+  agentDef: AgentDefinitionInput,
+  resolveCounterpart: (name: string) => Promise<AgentDefinitionInput>,
+  options: BuildDeliberationConfigOptions = {},
+): Promise<Omit<DeliberationConfig, 'onEvent'>> {
+  if (!agentDef.deliberation) {
+    throw new Error(`Agent "${agentDef.identity.name}" has no deliberation block`);
+  }
+
+  const counterpartName = agentDef.deliberation.counterpart;
+  const counterpartDef = await resolveCounterpart(counterpartName);
+
+  // Determine which is proposer and which is challenger
+  if (agentDef.deliberation.role === 'proposer') {
+    return buildDeliberationConfig(agentDef, counterpartDef, options);
+  } else {
+    return buildDeliberationConfig(counterpartDef, agentDef, options);
+  }
+}
+
+// ─── Fusion config builder ────────────────────────────────────────────────
+
+export interface BuildFusionConfigOptions {
+  /** Override budget (USD). */
+  budgetUsd?: number;
+  /** Override judge model (defaults to first panel model). */
+  judgeModel?: string;
+  /** Override synthesizer model (defaults to judge model). */
+  synthesizerModel?: string;
+}
+
+/**
+ * Build a FusionConfig from a list of model names.
+ *
+ * Fusion doesn't use Centaur agent definitions (it's model-level, not
+ * agent-level), but this helper provides consistent config construction.
+ */
+export function buildFusionConfig(
+  panelModels: string[],
+  options: BuildFusionConfigOptions = {},
+): Omit<FusionConfig, 'onEvent'> {
+  if (panelModels.length < 2) {
+    throw new Error('Fusion requires at least 2 panel models');
+  }
+
+  const panel: PanelMember[] = panelModels.map((model) => ({ model }));
+  const judgeModel = options.judgeModel ?? panelModels[0];
+
+  const config: Omit<FusionConfig, 'onEvent'> = {
+    panelModels: panel,
+    judgeModel: { model: judgeModel },
+    budgetUsd: options.budgetUsd ?? 3.0,
+  };
+
+  if (options.synthesizerModel) {
+    config.synthesizerModel = { model: options.synthesizerModel };
+  }
+
+  log.info('Built fusion config', {
+    panelSize: panel.length,
+    panelModels,
+    judgeModel,
+  });
+
+  return config;
+}

--- a/packages/harness/src/reasoning/schema-loader.ts
+++ b/packages/harness/src/reasoning/schema-loader.ts
@@ -1,21 +1,4 @@
-/**
- * Schema loader — converts Centaur agent definition YAML into
- * DeliberationConfig and FusionConfig for the reasoning orchestrators.
- *
- * Centaur agent definitions describe deliberation participants declaratively:
- *
- *   deliberation:
- *     role: proposer | challenger
- *     counterpart: deliberation-challenger
- *     protocol:
- *       phases: [propose, challenge, respond, converge]
- *       max_rounds: 2
- *       convergence: fixed-rounds
- *
- * This module resolves a proposer + challenger pair into a ready-to-run
- * DeliberationConfig, pulling model names from each agent's provider block
- * and applying sensible defaults for system prompts and budget.
- */
+/** Schema loader — converts Centaur agent definition YAML into DeliberationConfig / FusionConfig. */
 
 import { createLogger } from '../logger.js';
 import type { AgentRole, DeliberationConfig, FusionConfig, PanelMember } from './types.js';

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -91,7 +91,10 @@ export function summarizeToolInput(toolName: string, input: Record<string, unkno
       if (stype && desc) {
         // Give the shorter field its full length, allocate the rest to the longer
         const budget = TOOL_SUMMARY_MAX_CHARS - 3; // account for ' · '
-        const stypeLen = Math.min(stype.length, Math.max(Math.floor(budget / 2), budget - desc.length));
+        const stypeLen = Math.min(
+          stype.length,
+          Math.max(Math.floor(budget / 2), budget - desc.length),
+        );
         const descLen = budget - stypeLen;
         return `${stype.slice(0, stypeLen)} · ${desc.slice(0, descLen)}`;
       }


### PR DESCRIPTION
## Summary

- Adds schema loader that bridges Centaur YAML agent definitions to Mitzo's `DeliberationConfig` / `FusionConfig` types
- `buildDeliberationConfig()` — takes proposer + challenger pair, validates roles/counterparts, applies defaults
- `buildDeliberationConfigFromAgent()` — async resolver-based: pass one agent, it looks up the counterpart
- `buildFusionConfig()` — model name list → panel/judge/synthesizer config
- 17 tests covering happy paths, defaults, overrides, and all error cases

Follows up on #387 (reasoning engine). Prerequisite for wiring ContexGin agent definitions into deliberation sessions.

## Test plan

- [x] 17 unit tests passing (`vitest run packages/harness/__tests__/schema-loader.test.ts`)
- [x] `tsc -b` clean
- [x] Lint + prettier passing (pre-commit hooks)
- [ ] CI green
- [ ] Centaur review

🤖 Generated with [Claude Code](https://claude.com/claude-code)