### PR TITLE
fix(client): await reconnect POST before flushing pending sends

### DIFF
--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -349,6 +349,67 @@ describe('SseConnection', () => {
     expect(newES.url).toBe('https://localhost:3100/api/chat/events');
   });
 
+  it('flushes pending sends only after reconnect POST completes', async () => {
+    let resolveReconnect!: () => void;
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/reconnect')) {
+        return new Promise<{ ok: boolean }>((resolve) => {
+          resolveReconnect = () => resolve({ ok: true });
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+    conn.trackSeq('sess-1', 10);
+
+    // Force reconnect — connection drops, then queue a send while disconnected
+    conn.checkAndReconnect(true);
+    conn.send({ type: 'send', text: 'hello' });
+    mockFetch.mockClear();
+
+    // Welcome arrives — reconnect POST fires but hasn't resolved
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-def' });
+
+    // Only the reconnect POST should have been called, not the queued send
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0][0]).toContain('/reconnect');
+
+    // Resolve the reconnect POST — flush should follow
+    resolveReconnect();
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+    expect(mockFetch.mock.calls[1][0]).toContain('/send');
+  });
+
+  it('flushes pending sends even if reconnect POST fails', async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/reconnect')) {
+        return Promise.reject(new Error('network error'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+    const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+    conn.connect();
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-abc' });
+    conn.trackSeq('sess-1', 10);
+
+    // Force reconnect, then queue a send while disconnected
+    conn.checkAndReconnect(true);
+    conn.send({ type: 'send', text: 'hello' });
+    mockFetch.mockClear();
+
+    lastES()._emit('welcome', { type: 'welcome', protocolVersion: 2, connectionId: 'conn-def' });
+
+    // Even though reconnect POST fails, pending sends should still flush
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+    expect(mockFetch.mock.calls[1][0]).toContain('/send');
+  });
+
   it('checkAndReconnect(false) is no-op when connected', () => {
     const conn = new SseConnection(createConfig());
     conn.connect();

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -217,6 +217,9 @@ export class SseConnection implements ChatConnection {
 
       // Send reconnect POST before flushing queued sends so the server
       // sets up watches/reattach before receiving client messages.
+      // Flush uses .finally() so queued sends still go out even if
+      // reconnect POST fails. _open fires after flush to match WS
+      // transport convention (ready = flushed + connected).
       if (this._isReconnect && this.seqBySession.size > 0) {
         this.doPost('reconnect', {
           type: 'reconnect',
@@ -224,13 +227,15 @@ export class SseConnection implements ChatConnection {
             sessionId,
             lastSeq,
           })),
-        }).then(() => this.flushPendingSends());
+        }).finally(() => {
+          this.flushPendingSends();
+          this.listener?.({ type: '_open' });
+        });
       } else {
         this.flushPendingSends();
+        this.listener?.({ type: '_open' });
       }
       this._isReconnect = true;
-
-      this.listener?.({ type: '_open' });
     });
 
     // Catch-all for session events. Server sends all non-welcome events as

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -215,12 +215,8 @@ export class SseConnection implements ChatConnection {
       this._connectionId = msg.connectionId as string;
       this._connected = true;
 
-      // Always send reconnect on welcome if we have tracked sessions.
-      // Native EventSource auto-reconnect reuses the original URL (without
-      // ?sessions= param), so the server never runs handleReconnect — no
-      // watch, no reattach, no event replay. This POST ensures every
-      // reconnect (auto or explicit) triggers the full server-side
-      // reconnect flow: watch + reattach + event replay.
+      // Send reconnect POST before flushing queued sends so the server
+      // sets up watches/reattach before receiving client messages.
       if (this._isReconnect && this.seqBySession.size > 0) {
         this.doPost('reconnect', {
           type: 'reconnect',
@@ -228,11 +224,12 @@ export class SseConnection implements ChatConnection {
             sessionId,
             lastSeq,
           })),
-        });
+        }).then(() => this.flushPendingSends());
+      } else {
+        this.flushPendingSends();
       }
       this._isReconnect = true;
 
-      this.flushPendingSends();
       this.listener?.({ type: '_open' });
     });
 


### PR DESCRIPTION
## Summary

- Reconnect POST was fire-and-forget — `flushPendingSends()` ran immediately after, so queued client messages could reach the server before it set up watches or reattached sessions
- Now `flushPendingSends()` is deferred until the reconnect POST resolves. On first connection (no reconnect needed), flush remains synchronous
- `doPost` catches internally, so flush always proceeds even if the POST fails

Found by Centaur review on #384.

## Test plan

- [x] New test: pending sends only flush after reconnect POST completes
- [x] New test: pending sends flush even if reconnect POST fails (network error)
- [x] All 22 existing SSE connection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)