### PR TITLE
fix(worktree): prevent primary worktree deletion on cleanup

### DIFF
--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -211,6 +211,41 @@ describe('cleanupSessionWorktrees', () => {
 
     expect(session.worktreePaths.size).toBe(0);
   });
+
+  it('skips secondary whose path matches primary worktree', async () => {
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mgmt: '/repo', mitzo: '/tools/mitzo' },
+      isolation: true,
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10_000;
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    // "mgmt" secondary points to the same path as "primary" —
+    // simulates discoverSessionWorktrees adding both entries
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mgmt', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    // mgmt should NOT be removed (same path as primary), mitzo should be removed
+    expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
+
+    expect(session.worktreePaths.has('primary')).toBe(true);
+    expect(session.worktreePaths.size).toBe(1);
+
+    Date.now = realNow;
+    vi.restoreAllMocks();
+  });
 });
 
 describe('createSessionWorktrees — lazy secondary creation', () => {

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -613,6 +613,19 @@ describe('discoverSessionWorktrees', () => {
     expect(result.has('primary')).toBe(true);
     expect(result.has('mgmt')).toBe(false);
   });
+
+  it('deduplicates even with trailing slash differences', () => {
+    const wtId = '2026-04-20-abc123def456';
+    mkdirSync(join(primaryRepo, '.claude', 'worktrees', wtId), { recursive: true });
+
+    const result = discoverSessionWorktrees(wtId, primaryRepo, {
+      mgmt: primaryRepo + '/',
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.has('primary')).toBe(true);
+    expect(result.has('mgmt')).toBe(false);
+  });
 });
 
 describe('cleanupStaleWorktrees', () => {

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -598,6 +598,21 @@ describe('discoverSessionWorktrees', () => {
     expect(result.has('primary')).toBe(true);
     expect(result.has('secondary')).toBe(false);
   });
+
+  it('deduplicates secondary repos that match primaryRepo', () => {
+    const wtId = '2026-04-20-abc123def456';
+    mkdirSync(join(primaryRepo, '.claude', 'worktrees', wtId), { recursive: true });
+
+    // Pass primaryRepo as a secondary too (simulates mgmt in .mitzo.json repos)
+    const result = discoverSessionWorktrees(wtId, primaryRepo, {
+      mgmt: primaryRepo,
+    });
+
+    // Should only have "primary", not "mgmt" — dedup prevents double-mapping
+    expect(result.size).toBe(1);
+    expect(result.has('primary')).toBe(true);
+    expect(result.has('mgmt')).toBe(false);
+  });
 });
 
 describe('cleanupStaleWorktrees', () => {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1260,10 +1260,21 @@ export function cleanupSessionWorktrees(
   session: import('./session-registry.js').ManagedSession,
 ): void {
   const config = getRepoConfig();
-  for (const [repoName, { wtId }] of session.worktreePaths) {
+  const primaryPath = session.worktreePaths.get('primary')?.path;
+  for (const [repoName, { wtId, path }] of session.worktreePaths) {
     if (repoName === 'primary') continue;
     const repoPath = config.repos[repoName];
     if (!repoPath) continue;
+    // Guard: never remove a secondary whose path matches the primary worktree.
+    // This can happen when the base repo is also listed in .mitzo.json repos
+    // (e.g. "mgmt"), causing discoverSessionWorktrees to add both entries.
+    if (primaryPath && path === primaryPath) {
+      log.info('skipping secondary cleanup — path matches primary worktree', {
+        repoName,
+        path,
+      });
+      continue;
+    }
     try {
       removeWorktree(wtId, repoPath);
     } catch (err: unknown) {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1266,8 +1266,6 @@ export function cleanupSessionWorktrees(
     const repoPath = config.repos[repoName];
     if (!repoPath) continue;
     // Guard: never remove a secondary whose path matches the primary worktree.
-    // This can happen when the base repo is also listed in .mitzo.json repos
-    // (e.g. "mgmt"), causing discoverSessionWorktrees to add both entries.
     if (primaryPath && resolve(path) === resolve(primaryPath)) {
       log.info('skipping secondary cleanup — path matches primary worktree', {
         repoName,

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1268,7 +1268,7 @@ export function cleanupSessionWorktrees(
     // Guard: never remove a secondary whose path matches the primary worktree.
     // This can happen when the base repo is also listed in .mitzo.json repos
     // (e.g. "mgmt"), causing discoverSessionWorktrees to add both entries.
-    if (primaryPath && path === primaryPath) {
+    if (primaryPath && resolve(path) === resolve(primaryPath)) {
       log.info('skipping secondary cleanup — path matches primary worktree', {
         repoName,
         path,

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -237,6 +237,10 @@ export function discoverSessionWorktrees(
 
   const allRepos: Array<[string, string]> = [['primary', primaryRepo]];
   for (const [name, repoPath] of Object.entries(secondaryRepos)) {
+    // Skip secondary repos that resolve to the same path as the primary —
+    // otherwise both "primary" and "mgmt" map to the same worktree, and
+    // cleanupSessionWorktrees removes the primary thinking it's a secondary.
+    if (repoPath === primaryRepo) continue;
     allRepos.push([name, repoPath]);
   }
 

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -14,7 +14,7 @@ import {
   unlinkSync,
 } from 'fs';
 import { mkdir } from 'fs/promises';
-import { join, basename } from 'path';
+import { join, basename, resolve } from 'path';
 
 const execFileAsync = promisify(execFileCb);
 import {
@@ -240,7 +240,7 @@ export function discoverSessionWorktrees(
     // Skip secondary repos that resolve to the same path as the primary —
     // otherwise both "primary" and "mgmt" map to the same worktree, and
     // cleanupSessionWorktrees removes the primary thinking it's a secondary.
-    if (repoPath === primaryRepo) continue;
+    if (resolve(repoPath) === resolve(primaryRepo)) continue;
     allRepos.push([name, repoPath]);
   }
 


### PR DESCRIPTION
## Summary

- **Root cause:** When the base repo (mgmt) is also listed in `.mitzo.json` repos, `discoverSessionWorktrees` adds both `"primary"` and `"mgmt"` entries pointing to the same worktree directory. On session cleanup, `cleanupSessionWorktrees` skips `"primary"` but removes `"mgmt"` — destroying the primary worktree underneath the active SDK session.
- **Symptom:** `"Path does not exist"` errors mid-session, especially on iOS where frequent WS reconnects trigger zombie-abort → resume cycles that hit the cleanup path.
- **Fix (two layers):**
  - `discoverSessionWorktrees`: skip secondary repos whose path matches `primaryRepo`
  - `cleanupSessionWorktrees`: guard against removing any secondary whose worktree path matches the primary (defense in depth)

## Test plan

- [x] New test: `discoverSessionWorktrees` deduplicates secondary repos matching primaryRepo
- [x] New test: `cleanupSessionWorktrees` skips secondary whose path matches primary worktree
- [x] All 87 existing tests pass (worktree.test.ts + chat.test.ts)
- [ ] Deploy and verify no more "Path does not exist" errors on iOS sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)