### PR TITLE
feat(auth): accept internal token in authMiddleware

### DIFF
--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { validateConfig, authMiddleware, verifyToken } from '../auth.js';
+import { validateConfig, authMiddleware } from '../auth.js';
 import { INTERNAL_TOKEN } from '../internal-token.js';
 
 describe('validateConfig', () => {

--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { validateConfig, authMiddleware } from '../auth.js';
+import { validateConfig, authMiddleware, verifyToken } from '../auth.js';
 import { INTERNAL_TOKEN } from '../internal-token.js';
 
 describe('validateConfig', () => {
@@ -158,5 +158,18 @@ describe('authMiddleware — internal token', () => {
     authMiddleware(req, res, next);
 
     expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('falls through to JWT auth when no internal token', async () => {
+    const { login } = await import('../auth.js');
+    const jwt = await login(process.env.AUTH_PASSPHRASE!);
+    const req = mockReq({ authorization: `Bearer ${jwt}` });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    // verifyToken is async — wait for it to resolve
+    await vi.waitFor(() => expect(next).toHaveBeenCalledOnce());
   });
 });

--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { validateConfig } from '../auth.js';
+import { describe, it, expect, vi } from 'vitest';
+import { validateConfig, authMiddleware } from '../auth.js';
+import { INTERNAL_TOKEN } from '../internal-token.js';
 
 describe('validateConfig', () => {
   it('rejects missing passphrase', () => {
@@ -85,5 +86,64 @@ describe('verifyWsAuth', () => {
     const { login, verifyWsAuth } = await import('../auth.js');
     const token = await login(process.env.AUTH_PASSPHRASE!);
     expect(await verifyWsAuth(`other=foo; cc_auth=${token}; bar=baz`)).toBe(true);
+  });
+});
+
+describe('authMiddleware — internal token', () => {
+  function mockReq(headers: Record<string, string> = {}, path = '/tasks') {
+    return { headers, path, cookies: {} } as any;
+  }
+
+  function mockRes() {
+    const res: any = { statusCode: 0 };
+    res.status = (code: number) => {
+      res.statusCode = code;
+      return res;
+    };
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+  }
+
+  it('bypasses JWT auth with valid internal token', () => {
+    const req = mockReq({ 'x-internal-token': INTERNAL_TOKEN });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid internal token', () => {
+    const req = mockReq({ 'x-internal-token': 'wrong-token' });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects request with no auth at all', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows /auth/login without any auth', () => {
+    const req = mockReq({}, '/auth/login');
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
   });
 });

--- a/server/__tests__/auth.test.ts
+++ b/server/__tests__/auth.test.ts
@@ -115,8 +115,21 @@ describe('authMiddleware — internal token', () => {
     expect(res.json).not.toHaveBeenCalled();
   });
 
-  it('rejects invalid internal token', () => {
+  it('rejects invalid internal token (wrong length)', () => {
     const req = mockReq({ 'x-internal-token': 'wrong-token' });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authMiddleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects invalid internal token (same length, wrong value)', () => {
+    // INTERNAL_TOKEN is 64 hex chars — use a same-length string to exercise timingSafeEqual
+    const fakeToken = '0'.repeat(INTERNAL_TOKEN.length);
+    const req = mockReq({ 'x-internal-token': fakeToken });
     const res = mockRes();
     const next = vi.fn();
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { join, dirname, resolve, extname, basename } from 'path';
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { createHash, randomUUID } from 'crypto';
+import { createHash, randomUUID, timingSafeEqual } from 'crypto';
 import { fileURLToPath } from 'url';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { login, authMiddleware, verifyToken, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
@@ -342,7 +342,9 @@ app.post('/api/permission/:permId/respond', (req, res) => {
 // --- Repo registry API (internal-token auth, no cookie needed) ---
 
 function verifyInternalToken(req: express.Request): boolean {
-  return req.headers['x-internal-token'] === INTERNAL_TOKEN;
+  const token = req.headers['x-internal-token'] as string | undefined;
+  if (!token || token.length !== INTERNAL_TOKEN.length) return false;
+  return timingSafeEqual(Buffer.from(token), Buffer.from(INTERNAL_TOKEN));
 }
 
 app.get('/api/repos', (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -342,7 +342,7 @@ app.post('/api/permission/:permId/respond', (req, res) => {
 // --- Repo registry API (internal-token auth, no cookie needed) ---
 
 function verifyInternalToken(req: express.Request): boolean {
-  return isValidInternalToken(req.headers['x-internal-token'] as string | undefined);
+  return isValidInternalToken(req.headers['x-internal-token']);
 }
 
 app.get('/api/repos', (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from '
 import { join, dirname, resolve, extname, basename } from 'path';
 import { execFileSync, execFile } from 'child_process';
 import { promisify } from 'util';
-import { createHash, randomUUID, timingSafeEqual } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { fileURLToPath } from 'url';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { login, authMiddleware, verifyToken, COOKIE_NAME, MAX_AGE_HOURS } from './auth.js';
@@ -37,7 +37,7 @@ import {
   listWorktrees,
 } from './worktree.js';
 import { DEFAULT_AGENT_NAME, GIT_BRANCH_TIMEOUT_MS } from './constants.js';
-import { INTERNAL_TOKEN } from './internal-token.js';
+import { isValidInternalToken } from './internal-token.js';
 import { getLocalCommit, isUpdateAvailable } from './git-version.js';
 import { resolvePending } from './permissions.js';
 import { createLogger } from './logger.js';
@@ -342,9 +342,7 @@ app.post('/api/permission/:permId/respond', (req, res) => {
 // --- Repo registry API (internal-token auth, no cookie needed) ---
 
 function verifyInternalToken(req: express.Request): boolean {
-  const token = req.headers['x-internal-token'] as string | undefined;
-  if (!token || token.length !== INTERNAL_TOKEN.length) return false;
-  return timingSafeEqual(Buffer.from(token), Buffer.from(INTERNAL_TOKEN));
+  return isValidInternalToken(req.headers['x-internal-token'] as string | undefined);
 }
 
 app.get('/api/repos', (req, res) => {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,5 +1,6 @@
 import { SignJWT, jwtVerify } from 'jose';
 import type { Request, Response, NextFunction } from 'express';
+import { INTERNAL_TOKEN } from './internal-token.js';
 
 const INSECURE_PASSPHRASES = ['change-me', 'change-me-to-something-secure'];
 const INSECURE_SECRETS = [
@@ -59,6 +60,9 @@ function extractBearerToken(req: Request): string | undefined {
 
 export function authMiddleware(req: Request, res: Response, next: NextFunction) {
   if (req.path === '/auth/login') return next();
+
+  // Allow internal-token auth for programmatic access (agents, CLI)
+  if (req.headers['x-internal-token'] === INTERNAL_TOKEN) return next();
 
   const token = req.cookies?.[COOKIE_NAME] || extractBearerToken(req);
   if (!token) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,7 +1,6 @@
-import { timingSafeEqual } from 'crypto';
 import { SignJWT, jwtVerify } from 'jose';
 import type { Request, Response, NextFunction } from 'express';
-import { INTERNAL_TOKEN } from './internal-token.js';
+import { isValidInternalToken } from './internal-token.js';
 
 const INSECURE_PASSPHRASES = ['change-me', 'change-me-to-something-secure'];
 const INSECURE_SECRETS = [
@@ -65,12 +64,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction) 
   // Allow internal-token auth for programmatic access (agents, CLI).
   // All /api/* routes are accessible with the internal token — this is
   // intentional to support task board, template, and loop endpoints.
-  const internalToken = req.headers['x-internal-token'] as string | undefined;
-  if (
-    internalToken &&
-    internalToken.length === INTERNAL_TOKEN.length &&
-    timingSafeEqual(Buffer.from(internalToken), Buffer.from(INTERNAL_TOKEN))
-  ) {
+  if (isValidInternalToken(req.headers['x-internal-token'] as string | undefined)) {
     return next();
   }
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -64,7 +64,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction) 
   // Allow internal-token auth for programmatic access (agents, CLI).
   // All /api/* routes are accessible with the internal token — this is
   // intentional to support task board, template, and loop endpoints.
-  if (isValidInternalToken(req.headers['x-internal-token'] as string | undefined)) {
+  if (isValidInternalToken(req.headers['x-internal-token'])) {
     return next();
   }
 

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'crypto';
 import { SignJWT, jwtVerify } from 'jose';
 import type { Request, Response, NextFunction } from 'express';
 import { INTERNAL_TOKEN } from './internal-token.js';
@@ -61,8 +62,17 @@ function extractBearerToken(req: Request): string | undefined {
 export function authMiddleware(req: Request, res: Response, next: NextFunction) {
   if (req.path === '/auth/login') return next();
 
-  // Allow internal-token auth for programmatic access (agents, CLI)
-  if (req.headers['x-internal-token'] === INTERNAL_TOKEN) return next();
+  // Allow internal-token auth for programmatic access (agents, CLI).
+  // All /api/* routes are accessible with the internal token — this is
+  // intentional to support task board, template, and loop endpoints.
+  const internalToken = req.headers['x-internal-token'] as string | undefined;
+  if (
+    internalToken &&
+    internalToken.length === INTERNAL_TOKEN.length &&
+    timingSafeEqual(Buffer.from(internalToken), Buffer.from(INTERNAL_TOKEN))
+  ) {
+    return next();
+  }
 
   const token = req.cookies?.[COOKIE_NAME] || extractBearerToken(req);
   if (!token) {

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -16,7 +16,8 @@ try {
 }
 
 /** Constant-time check for internal token validity. */
-export function isValidInternalToken(candidate: string | undefined): boolean {
-  if (!candidate || candidate.length !== INTERNAL_TOKEN.length) return false;
+export function isValidInternalToken(candidate: string | string[] | undefined): boolean {
+  if (!candidate || Array.isArray(candidate)) return false;
+  if (candidate.length !== INTERNAL_TOKEN.length) return false;
   return timingSafeEqual(Buffer.from(candidate), Buffer.from(INTERNAL_TOKEN));
 }

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -13,4 +13,10 @@ try {
   writeFileSync(join(dir, 'internal-token'), INTERNAL_TOKEN, { mode: 0o600 });
 } catch {
   // Non-fatal — hooks will fall back gracefully
+}
+
+/** Constant-time check for internal token validity. */
+export function isValidInternalToken(candidate: string | undefined): boolean {
+  if (!candidate || candidate.length !== INTERNAL_TOKEN.length) return false;
+  return timingSafeEqual(Buffer.from(candidate), Buffer.from(INTERNAL_TOKEN));
 }


### PR DESCRIPTION
## Summary

- Add `X-Internal-Token` check to `authMiddleware` so agents and CLI tools can access task board, template, and loop endpoints programmatically
- Previously only cookie/bearer auth was accepted, blocking internal API callers

Prerequisite for PR Shepherd -> Task Board goal tree integration (Phase 3 multi-agent orchestration, dimakis/mgmt#TBD).

## Test plan

- [ ] Existing auth tests still pass (cookie/bearer flows unchanged)
- [ ] Internal token callers can now access `POST /api/tasks`, `POST /api/loop/start`, etc.
- [ ] Requests without any auth still get 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)