### PR TITLE
fix(worktree): prevent cleanup from wiping worktrees with uncommitted work

### DIFF
--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -258,6 +258,9 @@ describe('cleanupSessionWorktrees', () => {
       isolation: true,
     });
 
+    // Advance fake clock to bust getRepoConfig TTL cache
+    vi.advanceTimersByTime(10_000);
+
     const worktreeMod = await import('../worktree.js');
     const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
     const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
@@ -297,6 +300,9 @@ describe('cleanupSessionWorktrees', () => {
       isolation: true,
     });
 
+    // Advance fake clock to bust getRepoConfig TTL cache
+    vi.advanceTimersByTime(10_000);
+
     const worktreeMod = await import('../worktree.js');
     const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
     const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
@@ -319,6 +325,45 @@ describe('cleanupSessionWorktrees', () => {
     // Dirty but rescue succeeded → worktree should be removed
     expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
     expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
+
+    hasUncommittedWorkMock.mockReturnValue(null);
+    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('preserves worktree when hasUncommittedWork returns git-failure sentinel', async () => {
+    vi.useFakeTimers();
+
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo' },
+      isolation: true,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    const worktreeMod = await import('../worktree.js');
+    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
+    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
+    // Sentinel from git status failure — treated as dirty
+    hasUncommittedWorkMock.mockReturnValue('[git status failed: timeout]');
+    rescueDirtyWorktreeMock.mockReturnValue({ success: false, error: 'broken worktree' });
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+    vi.runAllTimers();
+
+    // Git failure sentinel triggers rescue attempt; rescue fails → preserve worktree
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
 
     hasUncommittedWorkMock.mockReturnValue(null);
     rescueDirtyWorktreeMock.mockReturnValue({ success: true });

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -250,6 +250,8 @@ describe('cleanupSessionWorktrees', () => {
   });
 
   it('skips dirty secondary when rescue fails', async () => {
+    vi.useFakeTimers();
+
     const { loadRepoConfig } = await import('../repo-config.js');
     (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
       repos: { mitzo: '/tools/mitzo' },
@@ -262,9 +264,6 @@ describe('cleanupSessionWorktrees', () => {
     hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
     rescueDirtyWorktreeMock.mockReturnValue({ success: false, error: 'no remote' });
 
-    const realNow = Date.now;
-    Date.now = () => realNow() + 10_000;
-
     const { cleanupSessionWorktrees } = await import('../chat.js');
 
     const session = {
@@ -275,19 +274,23 @@ describe('cleanupSessionWorktrees', () => {
     } as unknown as ManagedSession;
 
     cleanupSessionWorktrees(session);
+    // Rescue is deferred via setTimeout(0) — flush it
+    vi.runAllTimers();
 
-    // Dirty + rescue failed → worktree must NOT be removed
+    // Dirty + rescue failed → worktree directory must NOT be removed from disk
     expect(removeWorktreeMock).not.toHaveBeenCalled();
-    // The mitzo entry should still be in the map (not cleared)
+    // Map is still cleared (only primary preserved) — the directory on disk is what matters
     expect(session.worktreePaths.has('primary')).toBe(true);
 
-    Date.now = realNow;
     hasUncommittedWorkMock.mockReturnValue(null);
     rescueDirtyWorktreeMock.mockReturnValue({ success: true });
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   it('removes dirty secondary after successful rescue', async () => {
+    vi.useFakeTimers();
+
     const { loadRepoConfig } = await import('../repo-config.js');
     (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
       repos: { mitzo: '/tools/mitzo' },
@@ -300,9 +303,6 @@ describe('cleanupSessionWorktrees', () => {
     hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
     rescueDirtyWorktreeMock.mockReturnValue({ success: true, prUrl: 'https://github.com/pr/1' });
 
-    const realNow = Date.now;
-    Date.now = () => realNow() + 10_000;
-
     const { cleanupSessionWorktrees } = await import('../chat.js');
 
     const session = {
@@ -313,14 +313,16 @@ describe('cleanupSessionWorktrees', () => {
     } as unknown as ManagedSession;
 
     cleanupSessionWorktrees(session);
+    // Rescue is deferred via setTimeout(0) — flush it
+    vi.runAllTimers();
 
     // Dirty but rescue succeeded → worktree should be removed
     expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
     expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
 
-    Date.now = realNow;
     hasUncommittedWorkMock.mockReturnValue(null);
     rescueDirtyWorktreeMock.mockReturnValue({ success: true });
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 });

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -131,11 +131,24 @@ describe('getMessages', () => {
 
 describe('cleanupSessionWorktrees', () => {
   let removeWorktreeMock: ReturnType<typeof vi.fn>;
+  let hasUncommittedWorkMock: ReturnType<typeof vi.fn>;
+  let rescueDirtyWorktreeMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     const worktreeMod = await import('../worktree.js');
     removeWorktreeMock = worktreeMod.removeWorktree as ReturnType<typeof vi.fn>;
+    hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
+    rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
     removeWorktreeMock.mockReset();
+    hasUncommittedWorkMock.mockReset();
+    hasUncommittedWorkMock.mockReturnValue(null);
+    rescueDirtyWorktreeMock.mockReset();
+    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('skips primary worktree and only removes secondaries', async () => {
@@ -258,12 +271,8 @@ describe('cleanupSessionWorktrees', () => {
       isolation: true,
     });
 
-    // Advance fake clock to bust getRepoConfig TTL cache
     vi.advanceTimersByTime(10_000);
 
-    const worktreeMod = await import('../worktree.js');
-    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
-    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
     hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
     rescueDirtyWorktreeMock.mockReturnValue({ success: false, error: 'no remote' });
 
@@ -277,18 +286,11 @@ describe('cleanupSessionWorktrees', () => {
     } as unknown as ManagedSession;
 
     cleanupSessionWorktrees(session);
-    // Rescue is deferred via setTimeout(0) — flush it
     vi.runAllTimers();
 
     // Dirty + rescue failed → worktree directory must NOT be removed from disk
     expect(removeWorktreeMock).not.toHaveBeenCalled();
-    // Map is still cleared (only primary preserved) — the directory on disk is what matters
     expect(session.worktreePaths.has('primary')).toBe(true);
-
-    hasUncommittedWorkMock.mockReturnValue(null);
-    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
-    vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 
   it('removes dirty secondary after successful rescue', async () => {
@@ -300,12 +302,8 @@ describe('cleanupSessionWorktrees', () => {
       isolation: true,
     });
 
-    // Advance fake clock to bust getRepoConfig TTL cache
     vi.advanceTimersByTime(10_000);
 
-    const worktreeMod = await import('../worktree.js');
-    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
-    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
     hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
     rescueDirtyWorktreeMock.mockReturnValue({ success: true, prUrl: 'https://github.com/pr/1' });
 
@@ -319,17 +317,10 @@ describe('cleanupSessionWorktrees', () => {
     } as unknown as ManagedSession;
 
     cleanupSessionWorktrees(session);
-    // Rescue is deferred via setTimeout(0) — flush it
     vi.runAllTimers();
 
-    // Dirty but rescue succeeded → worktree should be removed
     expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
     expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
-
-    hasUncommittedWorkMock.mockReturnValue(null);
-    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
-    vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 
   it('preserves worktree when hasUncommittedWork returns git-failure sentinel', async () => {
@@ -343,10 +334,6 @@ describe('cleanupSessionWorktrees', () => {
 
     vi.advanceTimersByTime(10_000);
 
-    const worktreeMod = await import('../worktree.js');
-    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
-    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
-    // Sentinel from git status failure — treated as dirty
     hasUncommittedWorkMock.mockReturnValue('[git status failed: timeout]');
     rescueDirtyWorktreeMock.mockReturnValue({ success: false, error: 'broken worktree' });
 
@@ -362,13 +349,7 @@ describe('cleanupSessionWorktrees', () => {
     cleanupSessionWorktrees(session);
     vi.runAllTimers();
 
-    // Git failure sentinel triggers rescue attempt; rescue fails → preserve worktree
     expect(removeWorktreeMock).not.toHaveBeenCalled();
-
-    hasUncommittedWorkMock.mockReturnValue(null);
-    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
-    vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 
   it('handles hasUncommittedWork throwing an exception gracefully', async () => {
@@ -382,9 +363,6 @@ describe('cleanupSessionWorktrees', () => {
 
     vi.advanceTimersByTime(10_000);
 
-    const worktreeMod = await import('../worktree.js');
-    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
-    // Simulate ENOENT or other JS exception (not a git-status sentinel)
     hasUncommittedWorkMock.mockImplementation(() => {
       throw new Error('ENOENT: no such file or directory');
     });
@@ -398,17 +376,47 @@ describe('cleanupSessionWorktrees', () => {
       ]),
     } as unknown as ManagedSession;
 
-    // Should not throw — caught by outer try/catch
     cleanupSessionWorktrees(session);
     vi.runAllTimers();
 
-    // Exception prevents both rescue and removal
     expect(removeWorktreeMock).not.toHaveBeenCalled();
     expect(session.worktreePaths.has('primary')).toBe(true);
+  });
 
-    hasUncommittedWorkMock.mockReturnValue(null);
-    vi.useRealTimers();
-    vi.restoreAllMocks();
+  it('handles multiple dirty secondaries — one rescue succeeds, one fails', async () => {
+    vi.useFakeTimers();
+
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo', centaur: '/projects/centaur' },
+      isolation: true,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    hasUncommittedWorkMock.mockReturnValue('M  file.ts');
+    // First call (mitzo) fails rescue, second call (centaur) succeeds
+    rescueDirtyWorktreeMock
+      .mockReturnValueOnce({ success: false, error: 'no remote' })
+      .mockReturnValueOnce({ success: true, prUrl: 'https://github.com/pr/2' });
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['centaur', { path: '/projects/centaur/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+    // Both deferred rescues fire after the loop
+    vi.runAllTimers();
+
+    // Only centaur (rescue succeeded) should be removed; mitzo preserved
+    expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/projects/centaur');
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -370,6 +370,46 @@ describe('cleanupSessionWorktrees', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
+
+  it('handles hasUncommittedWork throwing an exception gracefully', async () => {
+    vi.useFakeTimers();
+
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo' },
+      isolation: true,
+    });
+
+    vi.advanceTimersByTime(10_000);
+
+    const worktreeMod = await import('../worktree.js');
+    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
+    // Simulate ENOENT or other JS exception (not a git-status sentinel)
+    hasUncommittedWorkMock.mockImplementation(() => {
+      throw new Error('ENOENT: no such file or directory');
+    });
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    // Should not throw — caught by outer try/catch
+    cleanupSessionWorktrees(session);
+    vi.runAllTimers();
+
+    // Exception prevents both rescue and removal
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
+    expect(session.worktreePaths.has('primary')).toBe(true);
+
+    hasUncommittedWorkMock.mockReturnValue(null);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
 });
 
 describe('createSessionWorktrees — lazy secondary creation', () => {

--- a/server/__tests__/chat.test.ts
+++ b/server/__tests__/chat.test.ts
@@ -6,6 +6,8 @@ vi.mock('../worktree.js', async (importOriginal) => {
   return {
     ...actual,
     removeWorktree: vi.fn(),
+    hasUncommittedWork: vi.fn().mockReturnValue(null),
+    rescueDirtyWorktree: vi.fn().mockReturnValue({ success: true }),
     createWorktree: vi.fn(actual.createWorktree as (...args: unknown[]) => unknown),
   };
 });
@@ -244,6 +246,81 @@ describe('cleanupSessionWorktrees', () => {
     expect(session.worktreePaths.size).toBe(1);
 
     Date.now = realNow;
+    vi.restoreAllMocks();
+  });
+
+  it('skips dirty secondary when rescue fails', async () => {
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo' },
+      isolation: true,
+    });
+
+    const worktreeMod = await import('../worktree.js');
+    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
+    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
+    hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
+    rescueDirtyWorktreeMock.mockReturnValue({ success: false, error: 'no remote' });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10_000;
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    // Dirty + rescue failed → worktree must NOT be removed
+    expect(removeWorktreeMock).not.toHaveBeenCalled();
+    // The mitzo entry should still be in the map (not cleared)
+    expect(session.worktreePaths.has('primary')).toBe(true);
+
+    Date.now = realNow;
+    hasUncommittedWorkMock.mockReturnValue(null);
+    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
+    vi.restoreAllMocks();
+  });
+
+  it('removes dirty secondary after successful rescue', async () => {
+    const { loadRepoConfig } = await import('../repo-config.js');
+    (loadRepoConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      repos: { mitzo: '/tools/mitzo' },
+      isolation: true,
+    });
+
+    const worktreeMod = await import('../worktree.js');
+    const hasUncommittedWorkMock = worktreeMod.hasUncommittedWork as ReturnType<typeof vi.fn>;
+    const rescueDirtyWorktreeMock = worktreeMod.rescueDirtyWorktree as ReturnType<typeof vi.fn>;
+    hasUncommittedWorkMock.mockReturnValue('M  server/chat.ts');
+    rescueDirtyWorktreeMock.mockReturnValue({ success: true, prUrl: 'https://github.com/pr/1' });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 10_000;
+
+    const { cleanupSessionWorktrees } = await import('../chat.js');
+
+    const session = {
+      worktreePaths: new Map([
+        ['primary', { path: '/repo/.claude/worktrees/abc', wtId: 'abc' }],
+        ['mitzo', { path: '/tools/mitzo/.claude/worktrees/abc', wtId: 'abc' }],
+      ]),
+    } as unknown as ManagedSession;
+
+    cleanupSessionWorktrees(session);
+
+    // Dirty but rescue succeeded → worktree should be removed
+    expect(removeWorktreeMock).toHaveBeenCalledWith('abc', '/tools/mitzo');
+    expect(removeWorktreeMock).toHaveBeenCalledTimes(1);
+
+    Date.now = realNow;
+    hasUncommittedWorkMock.mockReturnValue(null);
+    rescueDirtyWorktreeMock.mockReturnValue({ success: true });
     vi.restoreAllMocks();
   });
 });

--- a/server/__tests__/rescue-worktree.test.ts
+++ b/server/__tests__/rescue-worktree.test.ts
@@ -119,10 +119,10 @@ describe('rescueDirtyWorktree', () => {
     expect(result.success).toBe(true);
     expect(result.prUrl).toBe('https://github.com/dimakis/mgmt/pull/42');
 
-    // Verify git add was called
+    // Verify git add -u was called (not -A, to avoid staging untracked secrets)
     expect(mockExecFileSync).toHaveBeenCalledWith(
       'git',
-      ['-C', '/tmp/worktree', 'add', '-A'],
+      ['-C', '/tmp/worktree', 'add', '-u'],
       expect.objectContaining({ timeout: 30_000 }),
     );
 
@@ -169,7 +169,7 @@ describe('rescueDirtyWorktree', () => {
   it('returns failure when git add fails', () => {
     // Step 0: getRepoRemote
     mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
-    // Step 1: git add -A fails
+    // Step 1: git add -u fails
     mockExecFileSync.mockImplementationOnce(() => {
       throw new Error('git add failed');
     });

--- a/server/__tests__/rescue-worktree.test.ts
+++ b/server/__tests__/rescue-worktree.test.ts
@@ -105,7 +105,7 @@ describe('rescueDirtyWorktree', () => {
   it('succeeds when all four steps work (add, commit, push, gh pr create)', () => {
     // Step 0: getRepoRemote — git remote get-url origin
     mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
-    // Step 1: git add -A
+    // Step 1: git add -u
     mockExecFileSync.mockReturnValueOnce('' as never);
     // Step 2: git commit
     mockExecFileSync.mockReturnValueOnce('' as never);
@@ -169,7 +169,7 @@ describe('rescueDirtyWorktree', () => {
   it('returns failure when git add fails', () => {
     // Step 0: getRepoRemote
     mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
-    // Step 1: git add -u fails
+    // Step 1: git add -u fails (staging tracked files)
     mockExecFileSync.mockImplementationOnce(() => {
       throw new Error('git add failed');
     });
@@ -184,7 +184,7 @@ describe('rescueDirtyWorktree', () => {
   it('returns failure when git commit fails', () => {
     // Step 0: getRepoRemote
     mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
-    // Step 1: git add -A succeeds
+    // Step 1: git add -u succeeds
     mockExecFileSync.mockReturnValueOnce('' as never);
     // Step 2: git commit fails
     mockExecFileSync.mockImplementationOnce(() => {
@@ -200,7 +200,7 @@ describe('rescueDirtyWorktree', () => {
   it('returns failure when git push fails', () => {
     // Step 0: getRepoRemote
     mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
-    // Step 1: git add -A
+    // Step 1: git add -u
     mockExecFileSync.mockReturnValueOnce('' as never);
     // Step 2: git commit
     mockExecFileSync.mockReturnValueOnce('' as never);

--- a/server/__tests__/rescue-worktree.test.ts
+++ b/server/__tests__/rescue-worktree.test.ts
@@ -246,4 +246,20 @@ describe('rescueDirtyWorktree', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('resolve GitHub remote');
   });
+
+  it('fails gracefully when only untracked files exist (git add -u stages nothing)', () => {
+    // Step 0: getRepoRemote
+    mockExecFileSync.mockReturnValueOnce('git@github.com:dimakis/mgmt.git\n' as never);
+    // Step 1: git add -u succeeds (but stages nothing — only untracked files)
+    mockExecFileSync.mockReturnValueOnce('' as never);
+    // Step 2: git commit fails — nothing staged
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('nothing to commit, working tree clean');
+    });
+
+    const result = rescueDirtyWorktree('/tmp/worktree', 'session/test-123', 'test-123');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('nothing to commit');
+  });
 });

--- a/server/__tests__/worktree.test.ts
+++ b/server/__tests__/worktree.test.ts
@@ -78,7 +78,31 @@ describe('parseWorktreeAge', () => {
     expect(parseWorktreeAge('2026-04-31-abc123')).toBeNull();
   });
 
-  it('returns null for names without 6-char hex suffix', () => {
+  it('parses age from 12-char hex IDs (generateWtId format)', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const age = parseWorktreeAge(`${today}-0f2e5bbfaeff`);
+    expect(age).not.toBeNull();
+    expect(age!).toBeLessThan(24 * 60 * 60 * 1000);
+    expect(age!).toBeGreaterThanOrEqual(0);
+  });
+
+  it('accepts hex suffixes between 6 and 12 chars', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    // 6 chars
+    expect(parseWorktreeAge(`${today}-abcdef`)).not.toBeNull();
+    // 8 chars
+    expect(parseWorktreeAge(`${today}-abcdef01`)).not.toBeNull();
+    // 12 chars
+    expect(parseWorktreeAge(`${today}-abcdef012345`)).not.toBeNull();
+  });
+
+  it('returns null for hex suffixes shorter than 6 or longer than 12', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    expect(parseWorktreeAge(`${today}-abcde`)).toBeNull();
+    expect(parseWorktreeAge(`${today}-abcdef0123456`)).toBeNull();
+  });
+
+  it('returns null for names without valid hex suffix', () => {
     expect(parseWorktreeAge('2026-04-20-ws-fix')).toBeNull();
     expect(parseWorktreeAge('2026-04-20-')).toBeNull();
     expect(parseWorktreeAge('2026-04-20')).toBeNull();

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -17,6 +17,8 @@ import {
   createWorktree,
   createWorktreeAsync,
   removeWorktree,
+  hasUncommittedWork,
+  rescueDirtyWorktree,
   symlinkRuntimeDirs,
   discoverSessionWorktrees,
 } from './worktree.js';
@@ -1283,6 +1285,9 @@ export async function interruptChat(
  * Primary worktree is preserved — the SDK encodes conversation data by CWD
  * path, so removing it breaks resume. Stale GC handles primary lifecycle.
  * Branches are always preserved for PRs.
+ *
+ * Dirty secondaries are auto-rescued (commit + push + draft PR) before removal.
+ * If rescue fails the worktree is kept on disk to avoid data loss.
  */
 export function cleanupSessionWorktrees(
   session: import('./session-registry.js').ManagedSession,
@@ -1302,6 +1307,24 @@ export function cleanupSessionWorktrees(
       continue;
     }
     try {
+      const dirty = hasUncommittedWork(path);
+      if (dirty) {
+        const branch = `session/${wtId}`;
+        const rescue = rescueDirtyWorktree(path, branch, wtId);
+        if (!rescue.success) {
+          log.warn('skipping dirty secondary worktree — rescue failed', {
+            repoName,
+            wtId,
+            error: rescue.error,
+          });
+          continue;
+        }
+        log.info('auto-rescued dirty secondary worktree', {
+          repoName,
+          wtId,
+          prUrl: rescue.prUrl,
+        });
+      }
       removeWorktree(wtId, repoPath);
     } catch (err: unknown) {
       log.warn('failed to clean up session worktree', {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1311,31 +1311,34 @@ export function cleanupSessionWorktrees(
       if (dirty) {
         // Defer rescue so the cleanup loop can finish first — rescueDirtyWorktree
         // makes up to 4 sync git/gh calls (~30s timeout each).
-        const capturedRepoName = repoName;
-        const capturedPath = path;
-        const capturedWtId = wtId;
-        const capturedRepoPath = repoPath;
+        // Note: for...of with const destructuring creates per-iteration bindings,
+        // so closing over repoName/path/wtId/repoPath directly is safe.
         setTimeout(() => {
           try {
-            const branch = `session/${capturedWtId}`;
-            const rescue = rescueDirtyWorktree(capturedPath, branch, capturedWtId);
+            const branch = `session/${wtId}`;
+            const rescue = rescueDirtyWorktree(path, branch, wtId);
             if (!rescue.success) {
-              log.warn('skipping dirty secondary worktree — rescue failed', {
-                repoName: capturedRepoName,
-                wtId: capturedWtId,
-                error: rescue.error,
-              });
+              // Worktree is orphaned from the session map (already cleared) but
+              // preserved on disk — stale GC will handle it after 96h.
+              log.warn(
+                'dirty secondary worktree rescue failed — preserved on disk for stale GC',
+                {
+                  repoName,
+                  wtId,
+                  error: rescue.error,
+                },
+              );
               return;
             }
             log.info('auto-rescued dirty secondary worktree', {
-              repoName: capturedRepoName,
-              wtId: capturedWtId,
+              repoName,
+              wtId,
               prUrl: rescue.prUrl,
             });
-            removeWorktree(capturedWtId, capturedRepoPath);
+            removeWorktree(wtId, repoPath);
           } catch (err: unknown) {
             log.warn('deferred rescue failed for secondary worktree', {
-              repoName: capturedRepoName,
+              repoName,
               error: err instanceof Error ? err.message : 'unknown',
             });
           }

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1309,7 +1309,7 @@ export function cleanupSessionWorktrees(
     try {
       const dirty = hasUncommittedWork(path);
       if (dirty) {
-        // Defer rescue to avoid blocking the event loop — rescueDirtyWorktree
+        // Defer rescue so the cleanup loop can finish first — rescueDirtyWorktree
         // makes up to 4 sync git/gh calls (~30s timeout each).
         const capturedRepoName = repoName;
         const capturedPath = path;

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1320,14 +1320,11 @@ export function cleanupSessionWorktrees(
             if (!rescue.success) {
               // Worktree is orphaned from the session map (already cleared) but
               // preserved on disk — stale GC will handle it after 96h.
-              log.warn(
-                'dirty secondary worktree rescue failed — preserved on disk for stale GC',
-                {
-                  repoName,
-                  wtId,
-                  error: rescue.error,
-                },
-              );
+              log.warn('dirty secondary worktree rescue failed — preserved on disk for stale GC', {
+                repoName,
+                wtId,
+                error: rescue.error,
+              });
               return;
             }
             log.info('auto-rescued dirty secondary worktree', {

--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1309,21 +1309,38 @@ export function cleanupSessionWorktrees(
     try {
       const dirty = hasUncommittedWork(path);
       if (dirty) {
-        const branch = `session/${wtId}`;
-        const rescue = rescueDirtyWorktree(path, branch, wtId);
-        if (!rescue.success) {
-          log.warn('skipping dirty secondary worktree — rescue failed', {
-            repoName,
-            wtId,
-            error: rescue.error,
-          });
-          continue;
-        }
-        log.info('auto-rescued dirty secondary worktree', {
-          repoName,
-          wtId,
-          prUrl: rescue.prUrl,
-        });
+        // Defer rescue to avoid blocking the event loop — rescueDirtyWorktree
+        // makes up to 4 sync git/gh calls (~30s timeout each).
+        const capturedRepoName = repoName;
+        const capturedPath = path;
+        const capturedWtId = wtId;
+        const capturedRepoPath = repoPath;
+        setTimeout(() => {
+          try {
+            const branch = `session/${capturedWtId}`;
+            const rescue = rescueDirtyWorktree(capturedPath, branch, capturedWtId);
+            if (!rescue.success) {
+              log.warn('skipping dirty secondary worktree — rescue failed', {
+                repoName: capturedRepoName,
+                wtId: capturedWtId,
+                error: rescue.error,
+              });
+              return;
+            }
+            log.info('auto-rescued dirty secondary worktree', {
+              repoName: capturedRepoName,
+              wtId: capturedWtId,
+              prUrl: rescue.prUrl,
+            });
+            removeWorktree(capturedWtId, capturedRepoPath);
+          } catch (err: unknown) {
+            log.warn('deferred rescue failed for secondary worktree', {
+              repoName: capturedRepoName,
+              error: err instanceof Error ? err.message : 'unknown',
+            });
+          }
+        }, 0);
+        continue;
       }
       removeWorktree(wtId, repoPath);
     } catch (err: unknown) {

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -440,7 +440,7 @@ export function getRepoRemote(worktreePath: string): string | null {
 export function rescueDirtyWorktree(
   worktreePath: string,
   branch: string,
-  sessionId: string,
+  wtId: string,
 ): RescueResult {
   const gitOpts = { stdio: ['pipe', 'pipe', 'pipe'] as 'pipe'[], timeout: WORKTREE_GIT_TIMEOUT_MS };
 
@@ -451,8 +451,9 @@ export function rescueDirtyWorktree(
   }
 
   try {
-    // 1. Stage all changes
-    execFileSync('git', ['-C', worktreePath, 'add', '-A'], gitOpts);
+    // 1. Stage tracked file changes only (-u avoids staging untracked files
+    //    that may contain secrets like .env or credentials)
+    execFileSync('git', ['-C', worktreePath, 'add', '-u'], gitOpts);
   } catch (err: unknown) {
     return { success: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -466,7 +467,7 @@ export function rescueDirtyWorktree(
         worktreePath,
         'commit',
         '-m',
-        `chore: rescue uncommitted work from session ${sessionId}`,
+        `chore: rescue uncommitted work from session ${wtId}`,
       ],
       gitOpts,
     );
@@ -483,7 +484,7 @@ export function rescueDirtyWorktree(
 
   try {
     // 4. Create draft PR
-    const prBody = `Auto-rescued uncommitted work from session \`${sessionId}\`.\n\nThis PR was created automatically by Mitzo's worktree cleanup.`;
+    const prBody = `Auto-rescued uncommitted work from session \`${wtId}\`.\n\nThis PR was created automatically by Mitzo's worktree cleanup.`;
     const prOutput = execFileSync(
       'gh',
       [
@@ -491,7 +492,7 @@ export function rescueDirtyWorktree(
         'create',
         '--draft',
         '--title',
-        `Rescued: ${sessionId}`,
+        `Rescued: ${wtId}`,
         '--body',
         prBody,
         '--repo',
@@ -506,7 +507,7 @@ export function rescueDirtyWorktree(
         timeout: WORKTREE_GIT_TIMEOUT_MS,
       },
     ).trim();
-    log.info('rescue PR created', { sessionId, prUrl: prOutput });
+    log.info('rescue PR created', { wtId, prUrl: prOutput });
     return { success: true, prUrl: prOutput };
   } catch (err: unknown) {
     return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -436,6 +436,11 @@ export function getRepoRemote(worktreePath: string): string | null {
  * Rescue a dirty worktree by committing, pushing, and creating a draft PR.
  * Each step is attempted in order; if any step fails the function returns
  * immediately with { success: false, error }.
+ *
+ * Note: uses `git add -u` (tracked files only) while `hasUncommittedWork`
+ * detects untracked files too. If a worktree is dirty only due to untracked
+ * files, the commit will fail with "nothing to commit" and the worktree is
+ * preserved on disk — this is intentional (safe, no data loss).
  */
 export function rescueDirtyWorktree(
   worktreePath: string,

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -71,11 +71,12 @@ function worktreesDir(baseRepo: string): string {
 }
 
 /**
- * Parse creation age from a worktree directory name (YYYY-MM-DD-XXXXXX format).
+ * Parse creation age from a worktree directory name (YYYY-MM-DD-<hex> format).
+ * Accepts 6–12 hex chars after the date (generateWtId produces 12).
  * Returns age in milliseconds, or null if the name doesn't match the convention.
  */
 export function parseWorktreeAge(entry: string): number | null {
-  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})-[a-f0-9]{6}$/);
+  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})-[a-f0-9]{6,12}$/);
   if (!match) return null;
   const [, year, month, day] = match;
   const created = new Date(`${year}-${month}-${day}T00:00:00Z`);

--- a/server/worktree.ts
+++ b/server/worktree.ts
@@ -462,13 +462,7 @@ export function rescueDirtyWorktree(
     // 2. Commit
     execFileSync(
       'git',
-      [
-        '-C',
-        worktreePath,
-        'commit',
-        '-m',
-        `chore: rescue uncommitted work from session ${wtId}`,
-      ],
+      ['-C', worktreePath, 'commit', '-m', `chore: rescue uncommitted work from session ${wtId}`],
       gitOpts,
     );
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- **Fix parseWorktreeAge regex**: was matching `[a-f0-9]{6}` but `generateWtId` produces 12 hex chars — name-based age safety check was dead code, all worktrees fell back to mtime-only staleness
- **Add dirty check to cleanupSessionWorktrees**: `stopChat()` removed secondary worktrees immediately without checking for uncommitted work. Now calls `hasUncommittedWork()` + `rescueDirtyWorktree()` before removal — if rescue fails, worktree is preserved on disk
- Tests for both fixes (4 new test cases)

## Root cause

Two bugs working together caused data loss:
1. Regex mismatch meant the name-based age guard never fired for real worktrees
2. Session close path (`cleanupSessionWorktrees`) bypassed the auto-rescue that the stale GC had

## Test plan

- [x] `parseWorktreeAge` accepts 6–12 hex char suffixes
- [x] `parseWorktreeAge` rejects <6 and >12 hex chars
- [x] `cleanupSessionWorktrees` skips dirty secondary when rescue fails
- [x] `cleanupSessionWorktrees` removes dirty secondary after successful rescue
- [x] All existing worktree + chat tests pass

## Follow-up

Telos `e28ee6e9`: persist full SessionRegistry to disk so startup cleanup never runs with empty registry (Bug 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)