### PR TITLE
feat(telos): integrate Telos SQLite for reads and promote

### DIFF
--- a/server/__tests__/telos-store.test.ts
+++ b/server/__tests__/telos-store.test.ts
@@ -370,6 +370,21 @@ describe('TelosStore', () => {
       store.close();
     });
 
+    it('surfaces orphaned child as root when parent is filtered out', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'parent-done', status: 'completed' });
+      insertItem(db, { id: 'orphan-active', status: 'active', parent_id: 'parent-done' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      // Only active items — parent is completed so not fetched as root
+      const items = store.listItems(undefined, ['active']);
+      // The child should appear as a root since its parent isn't in the result set
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('orphan-active');
+      store.close();
+    });
+
     it('returns all items when statuses array is empty', () => {
       const db = createTelosDb();
       insertItem(db, { id: 'a-active', status: 'active' });
@@ -427,6 +442,16 @@ describe('TelosStore', () => {
 
       const store = new TelosStore(dbPath, profilesDir);
       expect(store.getItem('nonexistent')).toBeNull();
+      store.close();
+    });
+
+    it('returns null for empty string', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'some-item' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      expect(store.getItem('')).toBeNull();
       store.close();
     });
 

--- a/server/__tests__/telos-store.test.ts
+++ b/server/__tests__/telos-store.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { TelosStore } from '../telos-store.js';
+
+const TEST_DIR = join(tmpdir(), `mitzo-telos-test-${process.pid}`);
+
+// Telos schema matching store.py
+const TELOS_SCHEMA = `
+CREATE TABLE items (
+    id TEXT PRIMARY KEY,
+    summary TEXT NOT NULL,
+    profile TEXT NOT NULL,
+    cluster_id TEXT,
+    urgency REAL DEFAULT 0.0,
+    starred INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'active',
+    snoozed_until TEXT,
+    context_hints TEXT DEFAULT '{}',
+    first_seen TEXT NOT NULL,
+    last_seen TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    parent_id TEXT REFERENCES items(id) ON DELETE CASCADE,
+    goal_id TEXT
+);
+
+CREATE TABLE sources (
+    id TEXT PRIMARY KEY,
+    item_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    author TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    raw_snippet TEXT DEFAULT '',
+    FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE links (
+    id TEXT PRIMARY KEY,
+    item_id TEXT NOT NULL,
+    type TEXT NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id TEXT NOT NULL,
+    old_status TEXT,
+    new_status TEXT NOT NULL,
+    changed_at TEXT NOT NULL,
+    FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_items_profile ON items(profile);
+CREATE INDEX idx_items_status ON items(status);
+CREATE INDEX idx_items_parent ON items(parent_id);
+CREATE INDEX idx_sources_item ON sources(item_id);
+CREATE INDEX idx_links_item ON links(item_id);
+`;
+
+const NOW = new Date().toISOString();
+const WEEK_AGO = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+let dbPath: string;
+let profilesDir: string;
+
+function createTelosDb(): Database.Database {
+  dbPath = join(TEST_DIR, `telos-${Date.now()}.db`);
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(TELOS_SCHEMA);
+  return db;
+}
+
+function insertItem(
+  db: Database.Database,
+  overrides: Partial<{
+    id: string;
+    summary: string;
+    profile: string;
+    status: string;
+    urgency: number;
+    starred: number;
+    parent_id: string | null;
+    goal_id: string | null;
+    context_hints: string;
+    first_seen: string;
+  }> = {},
+) {
+  const id = overrides.id ?? `item-${Math.random().toString(36).slice(2, 10)}`;
+  db.prepare(
+    `INSERT INTO items (id, summary, profile, status, urgency, starred, parent_id, goal_id,
+     context_hints, first_seen, last_seen, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    overrides.summary ?? `Test item ${id}`,
+    overrides.profile ?? 'work',
+    overrides.status ?? 'active',
+    overrides.urgency ?? 0.5,
+    overrides.starred ?? 0,
+    overrides.parent_id ?? null,
+    overrides.goal_id ?? null,
+    overrides.context_hints ?? '{"repos":["mgmt"],"jira_keys":["RHAIENG-123"]}',
+    overrides.first_seen ?? WEEK_AGO,
+    NOW,
+    NOW,
+    NOW,
+  );
+  return id;
+}
+
+function insertSource(
+  db: Database.Database,
+  itemId: string,
+  overrides: Partial<{
+    id: string;
+    type: string;
+    source_id: string;
+    url: string;
+    title: string;
+    author: string;
+    raw_snippet: string;
+  }> = {},
+) {
+  const id = overrides.id ?? `src-${Math.random().toString(36).slice(2, 10)}`;
+  db.prepare(
+    `INSERT INTO sources (id, item_id, type, source_id, url, title, author, timestamp, raw_snippet)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    itemId,
+    overrides.type ?? 'manual',
+    overrides.source_id ?? `manual-${id}`,
+    overrides.url ?? '',
+    overrides.title ?? `Source for ${itemId}`,
+    overrides.author ?? 'test@example.com',
+    NOW,
+    overrides.raw_snippet ?? 'Test snippet content',
+  );
+}
+
+function insertLink(
+  db: Database.Database,
+  itemId: string,
+  overrides: Partial<{
+    id: string;
+    type: string;
+    url: string;
+    title: string;
+    description: string;
+  }> = {},
+) {
+  const id = overrides.id ?? `link-${Math.random().toString(36).slice(2, 10)}`;
+  db.prepare(
+    `INSERT INTO links (id, item_id, type, url, title, description, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    itemId,
+    overrides.type ?? 'design_doc',
+    overrides.url ?? 'https://example.com/doc',
+    overrides.title ?? 'Test doc',
+    overrides.description ?? '',
+    NOW,
+  );
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  profilesDir = join(TEST_DIR, 'profiles');
+  mkdirSync(profilesDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('TelosStore', () => {
+  describe('constructor', () => {
+    it('opens DB readonly', () => {
+      const db = createTelosDb();
+      db.close();
+      const store = new TelosStore(dbPath, profilesDir);
+      expect(store).toBeDefined();
+      store.close();
+    });
+
+    it('throws when DB does not exist', () => {
+      expect(
+        () => new TelosStore(join(TEST_DIR, 'nonexistent.db'), profilesDir),
+      ).toThrow('Telos DB not found');
+    });
+  });
+
+  describe('listItems', () => {
+    it('returns items with correct tree structure and completedChildCount', () => {
+      const db = createTelosDb();
+      const parentId = insertItem(db, { id: 'parent-001', summary: 'Parent task' });
+      insertSource(db, parentId);
+      insertItem(db, {
+        id: 'child-001',
+        summary: 'Child 1 (active)',
+        status: 'active',
+        parent_id: parentId,
+      });
+      insertItem(db, {
+        id: 'child-002',
+        summary: 'Child 2 (completed)',
+        status: 'completed',
+        parent_id: parentId,
+      });
+      insertItem(db, {
+        id: 'child-003',
+        summary: 'Child 3 (completed)',
+        status: 'completed',
+        parent_id: parentId,
+      });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems();
+
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('parent-001');
+      expect(items[0].childCount).toBe(3);
+      expect(items[0].completedChildCount).toBe(2);
+      expect(items[0].children).toHaveLength(3);
+      store.close();
+    });
+
+    it('filters by profile', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'work-1', profile: 'work' });
+      insertItem(db, { id: 'personal-1', profile: 'personal' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const workItems = store.listItems('work');
+      expect(workItems).toHaveLength(1);
+      expect(workItems[0].profile).toBe('work');
+      store.close();
+    });
+
+    it('filters by status', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'active-1', status: 'active' });
+      insertItem(db, { id: 'done-1', status: 'completed' });
+      insertItem(db, { id: 'snoozed-1', status: 'snoozed' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems(undefined, ['active']);
+      expect(items).toHaveLength(1);
+      expect(items[0].status).toBe('active');
+      store.close();
+    });
+
+    it('includes completed children even when filtering to active status', () => {
+      const db = createTelosDb();
+      const parentId = insertItem(db, { id: 'parent-a', status: 'active' });
+      insertItem(db, {
+        id: 'child-done',
+        status: 'completed',
+        parent_id: parentId,
+      });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      // Only active items, but completed children should still appear in the tree
+      const items = store.listItems(undefined, ['active']);
+      expect(items).toHaveLength(1);
+      expect(items[0].childCount).toBe(1);
+      expect(items[0].completedChildCount).toBe(1);
+      store.close();
+    });
+
+    it('maps context_hints snake_case to camelCase', () => {
+      const db = createTelosDb();
+      insertItem(db, {
+        id: 'hints-item',
+        context_hints: JSON.stringify({
+          repos: ['mgmt'],
+          doc_ids: ['doc-1'],
+          jira_keys: ['KEY-1'],
+          task_hint: 'do the thing',
+          session_ids: ['sess-1'],
+        }),
+      });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems();
+      const hints = items[0].contextHints;
+      expect(hints.repos).toEqual(['mgmt']);
+      expect(hints.docIds).toEqual(['doc-1']);
+      expect(hints.jiraKeys).toEqual(['KEY-1']);
+      expect(hints.taskHint).toBe('do the thing');
+      expect(hints.sessionIds).toEqual(['sess-1']);
+      store.close();
+    });
+
+    it('loads sources and links', () => {
+      const db = createTelosDb();
+      const id = insertItem(db, { id: 'sourced-item' });
+      insertSource(db, id, { type: 'jira', title: 'RHAIENG-42', url: 'https://jira/42' });
+      insertLink(db, id, { type: 'pr', url: 'https://github.com/pr/1', title: 'PR #1' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems();
+      expect(items[0].sources).toHaveLength(1);
+      expect(items[0].sources[0].type).toBe('jira');
+      expect(items[0].sources[0].title).toBe('RHAIENG-42');
+      expect(items[0].links).toHaveLength(1);
+      expect(items[0].links[0].type).toBe('pr');
+      store.close();
+    });
+
+    it('computes ageDays from first_seen', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'old-item', first_seen: WEEK_AGO });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems();
+      expect(items[0].ageDays).toBeGreaterThanOrEqual(6);
+      expect(items[0].ageDays).toBeLessThanOrEqual(8);
+      store.close();
+    });
+
+    it('includes goalId from DB', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'promoted-item', goal_id: 'task-uuid-123' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems();
+      expect(items[0].goalId).toBe('task-uuid-123');
+      store.close();
+    });
+  });
+
+  describe('getItem', () => {
+    it('finds item by exact ID', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'abc123def4567890', summary: 'Exact match' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const item = store.getItem('abc123def4567890');
+      expect(item).not.toBeNull();
+      expect(item!.summary).toBe('Exact match');
+      store.close();
+    });
+
+    it('finds item by prefix', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'abc123def4567890', summary: 'Prefix match' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const item = store.getItem('abc123');
+      expect(item).not.toBeNull();
+      expect(item!.summary).toBe('Prefix match');
+      store.close();
+    });
+
+    it('returns null for ambiguous prefix', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'abc123aaaa' });
+      insertItem(db, { id: 'abc123bbbb' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const item = store.getItem('abc123');
+      expect(item).toBeNull();
+      store.close();
+    });
+
+    it('returns null for nonexistent ID', () => {
+      const db = createTelosDb();
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      expect(store.getItem('nonexistent')).toBeNull();
+      store.close();
+    });
+
+    it('includes children in getItem result', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'parent-get', summary: 'Parent' });
+      insertItem(db, { id: 'child-get-1', parent_id: 'parent-get', status: 'completed' });
+      insertItem(db, { id: 'child-get-2', parent_id: 'parent-get', status: 'active' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const item = store.getItem('parent-get');
+      expect(item!.childCount).toBe(2);
+      expect(item!.completedChildCount).toBe(1);
+      store.close();
+    });
+  });
+
+  describe('listProfiles', () => {
+    it('returns profiles from YAML files', () => {
+      const db = createTelosDb();
+      db.close();
+
+      writeFileSync(join(profilesDir, 'work.yaml'), 'name: work');
+      writeFileSync(join(profilesDir, 'personal.yaml'), 'name: personal');
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const profiles = store.listProfiles();
+      expect(profiles).toContain('work');
+      expect(profiles).toContain('personal');
+      store.close();
+    });
+
+    it('includes DB-only profiles', () => {
+      const db = createTelosDb();
+      insertItem(db, { profile: 'db-only' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const profiles = store.listProfiles();
+      expect(profiles).toContain('db-only');
+      store.close();
+    });
+
+    it('deduplicates profiles from YAML and DB', () => {
+      const db = createTelosDb();
+      insertItem(db, { profile: 'work' });
+      db.close();
+
+      writeFileSync(join(profilesDir, 'work.yaml'), 'name: work');
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const profiles = store.listProfiles();
+      const workCount = profiles.filter((p) => p === 'work').length;
+      expect(workCount).toBe(1);
+      store.close();
+    });
+  });
+});

--- a/server/__tests__/telos-store.test.ts
+++ b/server/__tests__/telos-store.test.ts
@@ -201,9 +201,9 @@ describe('TelosStore', () => {
     });
 
     it('throws when DB does not exist', () => {
-      expect(
-        () => new TelosStore(join(TEST_DIR, 'nonexistent.db'), profilesDir),
-      ).toThrow('Telos DB not found');
+      expect(() => new TelosStore(join(TEST_DIR, 'nonexistent.db'), profilesDir)).toThrow(
+        'Telos DB not found',
+      );
     });
   });
 

--- a/server/__tests__/telos-store.test.ts
+++ b/server/__tests__/telos-store.test.ts
@@ -353,6 +353,35 @@ describe('TelosStore', () => {
       expect(items[0].goalId).toBe('task-uuid-123');
       store.close();
     });
+
+    it('nests active child under active parent without duplicating', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'parent-active', status: 'active' });
+      insertItem(db, { id: 'child-active', status: 'active', parent_id: 'parent-active' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems(undefined, ['active']);
+      // Child should be nested, not a separate root
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('parent-active');
+      expect(items[0].children).toHaveLength(1);
+      expect(items[0].children[0].id).toBe('child-active');
+      store.close();
+    });
+
+    it('returns all items when statuses array is empty', () => {
+      const db = createTelosDb();
+      insertItem(db, { id: 'a-active', status: 'active' });
+      insertItem(db, { id: 'b-completed', status: 'completed' });
+      insertItem(db, { id: 'c-snoozed', status: 'snoozed' });
+      db.close();
+
+      const store = new TelosStore(dbPath, profilesDir);
+      const items = store.listItems(undefined, []);
+      expect(items).toHaveLength(3);
+      store.close();
+    });
   });
 
   describe('getItem', () => {

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -65,6 +65,14 @@ const TodoContextHintsSchema = z.object({
   jiraKeys: z.array(z.string()).optional().default([]),
   keywords: z.array(z.string()).optional().default([]),
   taskHint: z.string().optional().default(''),
+  sessionIds: z.array(z.string()).optional().default([]),
+});
+
+const TodoLinkSchema = z.object({
+  type: z.string(),
+  url: z.string(),
+  title: z.string(),
+  description: z.string().optional().default(''),
 });
 
 const TodoItemSchema: z.ZodType<unknown> = z.lazy(() =>
@@ -84,6 +92,7 @@ const TodoItemSchema: z.ZodType<unknown> = z.lazy(() =>
     childCount: z.number().optional().default(0),
     completedChildCount: z.number().optional().default(0),
     sources: z.array(TodoSourceSchema),
+    links: z.array(TodoLinkSchema).optional().default([]),
     contextHints: TodoContextHintsSchema,
     goalId: z.string().nullable().optional().default(null),
   }),

--- a/server/app.ts
+++ b/server/app.ts
@@ -1977,9 +1977,7 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   if (body.data.description) descParts.push(body.data.description);
   if (telosItem.contextHints.taskHint) descParts.push(telosItem.contextHints.taskHint);
   const hintsWithValues = Object.entries(telosItem.contextHints)
-    .filter(
-      ([k, v]) => k !== 'taskHint' && k !== 'sessionIds' && Array.isArray(v) && v.length > 0,
-    )
+    .filter(([k, v]) => k !== 'taskHint' && k !== 'sessionIds' && Array.isArray(v) && v.length > 0)
     .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
   if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -1973,6 +1973,13 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     return;
   }
 
+  // Guard: if already promoted, return existing goal link instead of creating duplicate
+  if (telosItem.goalId) {
+    const existingTask = taskStore.get(telosItem.goalId);
+    res.status(200).json({ task: existingTask ?? { id: telosItem.goalId }, item: telosItem });
+    return;
+  }
+
   const descParts: string[] = [];
   if (body.data.description) descParts.push(body.data.description);
   if (telosItem.contextHints.taskHint) descParts.push(telosItem.contextHints.taskHint);
@@ -1999,15 +2006,14 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     });
   }
 
-  // Return the Telos item mapped to workload shape so frontend can update state
+  // Return Telos item with goalId so frontend can update state
   const mappedItem = {
-    id: telosItem.id,
-    title: telosItem.summary,
-    status: telosItem.status,
+    ...telosItem,
     goalId: task.id,
   };
   res.status(201).json({ task, item: mappedItem });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+  onWorkloadBroadcast?.({ type: 'workload_item_updated', item: mappedItem });
 });
 
 // --- Static files ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -1724,6 +1724,27 @@ app.get('/api/calendar', async (req, res) => {
 const TODO_SCRIPT = join(BASE_REPO, 'command_center', 'todo_api.py');
 const TODO_TIMEOUT_MS = 30_000;
 
+// In-flight promote guard: prevents duplicate task creation from rapid double-clicks
+const promotesInFlight = new Set<string>();
+
+/** Build a description from context hints and optional user description. */
+function buildPromoteDescription(
+  userDescription: string | undefined,
+  contextHints: Record<string, unknown>,
+): string | undefined {
+  const parts: string[] = [];
+  if (userDescription) parts.push(userDescription);
+  if (contextHints.taskHint) parts.push(contextHints.taskHint as string);
+  const hintsWithValues = Object.entries(contextHints)
+    .filter(
+      ([k, v]) =>
+        k !== 'taskHint' && k !== 'sessionIds' && Array.isArray(v) && (v as unknown[]).length > 0,
+    )
+    .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
+  if (hintsWithValues.length > 0) parts.push(hintsWithValues.join('\n'));
+  return parts.length > 0 ? parts.join('\n\n') : undefined;
+}
+
 app.get('/api/todos', async (req, res) => {
   const profile = req.query.profile as string | undefined;
   const refresh = req.query.refresh === 'true';
@@ -1766,7 +1787,8 @@ app.get('/api/todos', async (req, res) => {
   try {
     const items = telosStore.listItems(profile, ['active', 'acknowledged']);
     const profiles = telosStore.listProfiles();
-    res.json({ profiles, items });
+    const parsed = TodoListResponse.safeParse({ profiles, items });
+    res.json(parsed.success ? parsed.data : { profiles, items });
   } catch (err: unknown) {
     log.warn('telos read failed', { error: err instanceof Error ? err.message : 'unknown' });
     res.json({ profiles: [], items: [] });
@@ -1942,17 +1964,12 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   const workloadItem = workloadStore.get(req.params.id);
 
   if (workloadItem) {
-    const descParts: string[] = [];
-    if (body.data.description) descParts.push(body.data.description);
-    if (workloadItem.contextHints.taskHint) descParts.push(workloadItem.contextHints.taskHint);
-    const hintsWithValues = Object.entries(workloadItem.contextHints)
-      .filter(([k, v]) => k !== 'taskHint' && Array.isArray(v) && v.length > 0)
-      .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
-    if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
-
     const task = taskStore.create({
       title: workloadItem.title,
-      description: descParts.join('\n\n') || undefined,
+      description: buildPromoteDescription(
+        body.data.description,
+        workloadItem.contextHints as unknown as Record<string, unknown>,
+      ),
       annotations: workloadItem.sources.map(
         (s) => `Source: [${s.sourceType}] ${s.title} — ${s.url}`,
       ),
@@ -1973,46 +1990,52 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     return;
   }
 
-  // Guard: if already promoted, return existing goal link instead of creating duplicate
+  // Guard: if already promoted, return existing goal or 409 if task was deleted
   if (telosItem.goalId) {
     const existingTask = taskStore.get(telosItem.goalId);
-    res.status(200).json({ task: existingTask ?? { id: telosItem.goalId }, item: telosItem });
+    if (existingTask) {
+      res.status(200).json({ task: existingTask, item: telosItem });
+    } else {
+      res.status(409).json({ error: 'Item was previously promoted but the task was deleted' });
+    }
     return;
   }
 
-  const descParts: string[] = [];
-  if (body.data.description) descParts.push(body.data.description);
-  if (telosItem.contextHints.taskHint) descParts.push(telosItem.contextHints.taskHint);
-  const hintsWithValues = Object.entries(telosItem.contextHints)
-    .filter(([k, v]) => k !== 'taskHint' && k !== 'sessionIds' && Array.isArray(v) && v.length > 0)
-    .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
-  if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
-
-  const task = taskStore.create({
-    title: telosItem.summary,
-    description: descParts.join('\n\n') || undefined,
-    annotations: telosItem.sources.map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`),
-  });
-
-  // Bridge: set goal_id on the Telos item via Python (fire-and-forget, requires mgmt PR #202)
-  if (existsSync(TODO_SCRIPT)) {
-    execFileAsync('python3', [TODO_SCRIPT, '--set-goal', telosItem.id, task.id], {
-      timeout: TODO_TIMEOUT_MS,
-    }).catch((err) => {
-      log.warn('failed to set goal on telos item', {
-        itemId: telosItem.id,
-        error: err instanceof Error ? err.message : 'unknown',
-      });
-    });
+  // Race guard: prevent duplicate task creation from rapid double-clicks
+  if (promotesInFlight.has(telosItem.id)) {
+    res.status(409).json({ error: 'Promote already in progress' });
+    return;
   }
+  promotesInFlight.add(telosItem.id);
 
-  // Return Telos item with goalId so frontend can update state
-  const mappedItem = {
-    ...telosItem,
-    goalId: task.id,
-  };
-  res.status(201).json({ task, item: mappedItem });
-  onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+  try {
+    const task = taskStore.create({
+      title: telosItem.summary,
+      description: buildPromoteDescription(
+        body.data.description,
+        telosItem.contextHints as unknown as Record<string, unknown>,
+      ),
+      annotations: telosItem.sources.map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`),
+    });
+
+    // Bridge: set goal_id on the Telos item via Python (fire-and-forget, requires mgmt PR #202)
+    if (existsSync(TODO_SCRIPT)) {
+      execFileAsync('python3', [TODO_SCRIPT, '--set-goal', telosItem.id, task.id], {
+        timeout: TODO_TIMEOUT_MS,
+      }).catch((err) => {
+        log.warn('failed to set goal on telos item', {
+          itemId: telosItem.id,
+          error: err instanceof Error ? err.message : 'unknown',
+        });
+      });
+    }
+
+    const mappedItem = { ...telosItem, goalId: task.id };
+    res.status(201).json({ task, item: mappedItem });
+    onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+  } finally {
+    promotesInFlight.delete(telosItem.id);
+  }
 });
 
 // --- Static files ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -2013,7 +2013,6 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   };
   res.status(201).json({ task, item: mappedItem });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
-  onWorkloadBroadcast?.({ type: 'workload_item_updated', item: mappedItem });
 });
 
 // --- Static files ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -93,6 +93,7 @@ import { TaskStore, type TaskCreateInput, type TaskUpdateInput } from './task-st
 import { SseRegistry } from '@mitzo/harness';
 import { SessionSseRegistry } from './session-sse-registry.js';
 import { WorkloadStore, type WorkSignal, type TodoItemUpdateInput } from './workload-store.js';
+import { TelosStore } from './telos-store.js';
 
 const log = createLogger('server');
 
@@ -270,6 +271,14 @@ try {
 export const taskStore = new TaskStore(join(mitzoDir, 'tasks.db'));
 setTaskStore(taskStore);
 export const workloadStore = new WorkloadStore(taskStore.getDatabase());
+
+// Telos: read-only access to the strategic task DB (smart_todo.db)
+const TELOS_DB = join(BASE_REPO, 'command_center', 'data', 'smart_todo.db');
+const TELOS_PROFILES_DIR = join(BASE_REPO, 'command_center', 'config', 'todo_profiles');
+export const telosStore = existsSync(TELOS_DB)
+  ? new TelosStore(TELOS_DB, TELOS_PROFILES_DIR)
+  : null;
+
 setTokenStorePath(join(mitzoDir, 'device-tokens.json'));
 
 export const sseRegistry = new SseRegistry();
@@ -1719,34 +1728,47 @@ app.get('/api/todos', async (req, res) => {
   const profile = req.query.profile as string | undefined;
   const refresh = req.query.refresh === 'true';
 
-  if (!existsSync(TODO_SCRIPT)) {
-    log.warn('todo script not found', { path: TODO_SCRIPT });
-    res.json({ profiles: [], items: [] });
+  // Refresh delegates to Python (runs source fetchers: Jira, GitHub, Gmail, etc.)
+  if (refresh && profile && existsSync(TODO_SCRIPT)) {
+    try {
+      await execFileAsync('python3', [TODO_SCRIPT, '--refresh', '--profile', profile], {
+        timeout: TODO_TIMEOUT_MS,
+      });
+    } catch (err: unknown) {
+      log.warn('todo refresh failed', {
+        error: err instanceof Error ? err.message : 'unknown',
+      });
+    }
+    // Fall through to read from TelosStore after refresh
+  }
+
+  // Read directly from Telos SQLite (no Python subprocess for reads)
+  if (!telosStore) {
+    // Fallback: delegate to Python if TelosStore not available
+    if (!existsSync(TODO_SCRIPT)) {
+      res.json({ profiles: [], items: [] });
+      return;
+    }
+    try {
+      const args = [TODO_SCRIPT, '--list'];
+      if (profile) args.push('--profile', profile);
+      const { stdout } = await execFileAsync('python3', args, {
+        timeout: TODO_TIMEOUT_MS,
+      });
+      const parsed = TodoListResponse.safeParse(JSON.parse(stdout));
+      res.json(parsed.success ? parsed.data : { profiles: [], items: [] });
+    } catch {
+      res.json({ profiles: [], items: [] });
+    }
     return;
   }
 
   try {
-    const args = [TODO_SCRIPT];
-    if (refresh && profile) {
-      args.push('--refresh', '--profile', profile);
-    } else {
-      args.push('--list');
-      if (profile) args.push('--profile', profile);
-    }
-
-    const { stdout } = await execFileAsync('python3', args, {
-      timeout: TODO_TIMEOUT_MS,
-    });
-    const parsed = TodoListResponse.safeParse(JSON.parse(stdout));
-    if (!parsed.success) {
-      log.warn('todo API returned unexpected shape', { error: parsed.error.message });
-      res.json({ profiles: [], items: [] });
-      return;
-    }
-    res.json(parsed.data);
+    const items = telosStore.listItems(profile, ['active', 'acknowledged']);
+    const profiles = telosStore.listProfiles();
+    res.json({ profiles, items });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    log.warn('todo API failed', { error: message });
+    log.warn('telos read failed', { error: err instanceof Error ? err.message : 'unknown' });
     res.json({ profiles: [], items: [] });
   }
 });
@@ -1916,52 +1938,71 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     return;
   }
 
-  const item = workloadStore.get(req.params.id);
+  // Try WorkloadStore first (UUID items from work signals)
+  const workloadItem = workloadStore.get(req.params.id);
 
-  // Resolve title and context from workloadStore item or fallback body data (Telos items)
-  const title = item?.title ?? body.data.title;
-  if (!title) {
-    res.status(404).json({ error: 'Item not found and no title provided' });
-    return;
-  }
-
-  const hints = item?.contextHints ?? body.data.contextHints;
-  const taskHint = hints?.taskHint ?? undefined;
-
-  // Build description from item context
-  const descParts: string[] = [];
-  if (body.data.description) descParts.push(body.data.description);
-  if (taskHint) descParts.push(taskHint);
-  if (hints) {
-    const hintsWithValues = Object.entries(hints)
+  if (workloadItem) {
+    const descParts: string[] = [];
+    if (body.data.description) descParts.push(body.data.description);
+    if (workloadItem.contextHints.taskHint) descParts.push(workloadItem.contextHints.taskHint);
+    const hintsWithValues = Object.entries(workloadItem.contextHints)
       .filter(([k, v]) => k !== 'taskHint' && Array.isArray(v) && v.length > 0)
       .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
     if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
+
+    const task = taskStore.create({
+      title: workloadItem.title,
+      description: descParts.join('\n\n') || undefined,
+      annotations: workloadItem.sources.map(
+        (s) => `Source: [${s.sourceType}] ${s.title} — ${s.url}`,
+      ),
+    });
+
+    workloadStore.setGoalId(workloadItem.id, task.id);
+    const updatedItem = workloadStore.get(workloadItem.id);
+    res.status(201).json({ task, item: updatedItem });
+    onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
+    onWorkloadBroadcast?.({ type: 'workload_item_updated', item: updatedItem });
+    return;
   }
 
-  // Build annotations from sources
-  const annotations: string[] = item
-    ? item.sources.map((s) => `Source: [${s.sourceType}] ${s.title} — ${s.url}`)
-    : (body.data.sources ?? []).map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`);
+  // Fallback: try TelosStore (SHA256 items from strategic task tracker)
+  const telosItem = telosStore?.getItem(req.params.id);
+  if (!telosItem) {
+    res.status(404).json({ error: 'Item not found' });
+    return;
+  }
 
-  // Create root task (goal) from item
+  const descParts: string[] = [];
+  if (body.data.description) descParts.push(body.data.description);
+  if (telosItem.contextHints.taskHint) descParts.push(telosItem.contextHints.taskHint);
+  const hintsWithValues = Object.entries(telosItem.contextHints)
+    .filter(
+      ([k, v]) => k !== 'taskHint' && k !== 'sessionIds' && Array.isArray(v) && v.length > 0,
+    )
+    .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
+  if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
+
   const task = taskStore.create({
-    title,
+    title: telosItem.summary,
     description: descParts.join('\n\n') || undefined,
-    annotations,
+    annotations: telosItem.sources.map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`),
   });
 
-  // Link item to goal only if it exists in workloadStore
-  if (item) {
-    workloadStore.setGoalId(item.id, task.id);
+  // Bridge: set goal_id on the Telos item via Python (fire-and-forget)
+  if (existsSync(TODO_SCRIPT)) {
+    execFileAsync('python3', [TODO_SCRIPT, '--set-goal', telosItem.id, task.id], {
+      timeout: TODO_TIMEOUT_MS,
+    }).catch((err) => {
+      log.warn('failed to set goal on telos item', {
+        itemId: telosItem.id,
+        error: err instanceof Error ? err.message : 'unknown',
+      });
+    });
   }
 
-  const updatedItem = item ? workloadStore.get(item.id) : undefined;
-  res.status(201).json(updatedItem ? { task, item: updatedItem } : { task });
+  res.status(201).json({ task, item: null });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
-  if (updatedItem) {
-    onWorkloadBroadcast?.({ type: 'workload_item_updated', item: updatedItem });
-  }
 });
 
 // --- Static files ---

--- a/server/app.ts
+++ b/server/app.ts
@@ -1989,7 +1989,7 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     annotations: telosItem.sources.map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`),
   });
 
-  // Bridge: set goal_id on the Telos item via Python (fire-and-forget)
+  // Bridge: set goal_id on the Telos item via Python (fire-and-forget, requires mgmt PR #202)
   if (existsSync(TODO_SCRIPT)) {
     execFileAsync('python3', [TODO_SCRIPT, '--set-goal', telosItem.id, task.id], {
       timeout: TODO_TIMEOUT_MS,
@@ -2001,7 +2001,14 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     });
   }
 
-  res.status(201).json({ task, item: null });
+  // Return the Telos item mapped to workload shape so frontend can update state
+  const mappedItem = {
+    id: telosItem.id,
+    title: telosItem.summary,
+    status: telosItem.status,
+    goalId: task.id,
+  };
+  res.status(201).json({ task, item: mappedItem });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
 });
 

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -97,20 +97,22 @@ interface LinkRow {
 
 // --- Helpers ---
 
-const EMPTY_HINTS: TelosContextHints = Object.freeze({
-  repos: [],
-  paths: [],
-  issues: [],
-  docIds: [],
-  people: [],
-  jiraKeys: [],
-  keywords: [],
-  taskHint: '',
-  sessionIds: [],
-}) as TelosContextHints;
+function emptyHints(): TelosContextHints {
+  return {
+    repos: [],
+    paths: [],
+    issues: [],
+    docIds: [],
+    people: [],
+    jiraKeys: [],
+    keywords: [],
+    taskHint: '',
+    sessionIds: [],
+  };
+}
 
 function parseContextHints(raw: string | null): TelosContextHints {
-  if (!raw) return { ...EMPTY_HINTS };
+  if (!raw) return emptyHints();
   try {
     const d = JSON.parse(raw);
     return {
@@ -125,7 +127,7 @@ function parseContextHints(raw: string | null): TelosContextHints {
       sessionIds: d.session_ids ?? [],
     };
   } catch {
-    return { ...EMPTY_HINTS };
+    return emptyHints();
   }
 }
 

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -1,14 +1,4 @@
-/**
- * Read-only access to the Telos (smart_todo) SQLite database.
- *
- * Telos is the strategic task tracker owned by the mgmt Python codebase.
- * This store opens the same `smart_todo.db` file via better-sqlite3 in
- * readonly mode, eliminating the Python subprocess for reads while keeping
- * writes delegated to `todo_api.py`.
- *
- * Concurrency: Telos uses WAL journal mode, which permits unlimited
- * concurrent readers alongside a single writer.
- */
+/** Readonly better-sqlite3 reader for Telos smart_todo.db. Writes stay in todo_api.py. */
 
 import Database from 'better-sqlite3';
 import { existsSync, readdirSync } from 'fs';
@@ -120,7 +110,7 @@ const EMPTY_HINTS: TelosContextHints = Object.freeze({
 }) as TelosContextHints;
 
 function parseContextHints(raw: string | null): TelosContextHints {
-  if (!raw) return { ...EMPTY_HINTS, sessionIds: [] };
+  if (!raw) return { ...EMPTY_HINTS };
   try {
     const d = JSON.parse(raw);
     return {
@@ -135,7 +125,7 @@ function parseContextHints(raw: string | null): TelosContextHints {
       sessionIds: d.session_ids ?? [],
     };
   } catch {
-    return { ...EMPTY_HINTS, sessionIds: [] };
+    return { ...EMPTY_HINTS };
   }
 }
 
@@ -170,6 +160,7 @@ export class TelosStore {
   private db: Database.Database | null;
   private profilesDir: string;
   private hasGoalId: boolean;
+  private hasLinksTable: boolean;
 
   constructor(dbPath: string, profilesDir: string) {
     if (!existsSync(dbPath)) {
@@ -179,11 +170,17 @@ export class TelosStore {
     this.db = new Database(dbPath, { readonly: true });
     this.db.pragma('busy_timeout = 5000');
 
-    // Check if goal_id column exists (migration may not have run yet)
+    // Cache schema checks — DB is readonly so these won't change
     const cols = new Set(
       (this.db.pragma('table_info(items)') as { name: string }[]).map((c) => c.name),
     );
     this.hasGoalId = cols.has('goal_id');
+    this.hasLinksTable =
+      (
+        this.db
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='links'")
+          .all() as { name: string }[]
+      ).length > 0;
 
     log.info('TelosStore initialized (readonly)', { dbPath, hasGoalId: this.hasGoalId });
   }
@@ -354,14 +351,8 @@ export class TelosStore {
   }
 
   private loadLinksForItems(itemIds: string[]): Map<string, TelosLink[]> {
-    if (itemIds.length === 0) return new Map();
+    if (itemIds.length === 0 || !this.hasLinksTable) return new Map();
     const db = this.getDb();
-
-    // Check if links table exists (pre-migration DBs may not have it)
-    const tables = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='links'")
-      .all();
-    if (tables.length === 0) return new Map();
 
     const placeholders = itemIds.map(() => '?').join(',');
     const rows = db

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -1,0 +1,447 @@
+/**
+ * Read-only access to the Telos (smart_todo) SQLite database.
+ *
+ * Telos is the strategic task tracker owned by the mgmt Python codebase.
+ * This store opens the same `smart_todo.db` file via better-sqlite3 in
+ * readonly mode, eliminating the Python subprocess for reads while keeping
+ * writes delegated to `todo_api.py`.
+ *
+ * Concurrency: Telos uses WAL journal mode, which permits unlimited
+ * concurrent readers alongside a single writer.
+ */
+
+import Database from 'better-sqlite3';
+import { existsSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+import { createLogger } from './logger.js';
+
+const log = createLogger('telos-store');
+
+// --- Types ---
+
+export interface TelosSource {
+  type: string;
+  url: string;
+  title: string;
+  author: string;
+  snippet: string;
+}
+
+export interface TelosLink {
+  type: string;
+  url: string;
+  title: string;
+  description: string;
+}
+
+export interface TelosContextHints {
+  repos: string[];
+  paths: string[];
+  issues: string[];
+  docIds: string[];
+  people: string[];
+  jiraKeys: string[];
+  keywords: string[];
+  taskHint: string;
+  sessionIds: string[];
+}
+
+export interface TelosItem {
+  id: string;
+  summary: string;
+  profile: string;
+  urgency: number;
+  starred: boolean;
+  status: 'active' | 'acknowledged' | 'snoozed' | 'completed';
+  ageDays: number;
+  parentId: string | null;
+  children: TelosItem[];
+  childCount: number;
+  completedChildCount: number;
+  sources: TelosSource[];
+  links: TelosLink[];
+  contextHints: TelosContextHints;
+  goalId: string | null;
+}
+
+// --- DB row types ---
+
+interface ItemRow {
+  id: string;
+  summary: string;
+  profile: string;
+  cluster_id: string | null;
+  urgency: number;
+  starred: number;
+  status: string;
+  snoozed_until: string | null;
+  context_hints: string;
+  first_seen: string;
+  last_seen: string;
+  created_at: string;
+  updated_at: string;
+  parent_id: string | null;
+  goal_id: string | null;
+}
+
+interface SourceRow {
+  id: string;
+  item_id: string;
+  type: string;
+  source_id: string;
+  url: string;
+  title: string;
+  author: string;
+  timestamp: string;
+  raw_snippet: string | null;
+}
+
+interface LinkRow {
+  id: string;
+  item_id: string;
+  type: string;
+  url: string;
+  title: string;
+  description: string | null;
+}
+
+// --- Helpers ---
+
+const EMPTY_HINTS: TelosContextHints = Object.freeze({
+  repos: [],
+  paths: [],
+  issues: [],
+  docIds: [],
+  people: [],
+  jiraKeys: [],
+  keywords: [],
+  taskHint: '',
+  sessionIds: [],
+}) as TelosContextHints;
+
+function parseContextHints(raw: string | null): TelosContextHints {
+  if (!raw) return { ...EMPTY_HINTS, sessionIds: [] };
+  try {
+    const d = JSON.parse(raw);
+    return {
+      repos: d.repos ?? [],
+      paths: d.paths ?? [],
+      issues: d.issues ?? [],
+      docIds: d.doc_ids ?? [],
+      people: d.people ?? [],
+      jiraKeys: d.jira_keys ?? [],
+      keywords: d.keywords ?? [],
+      taskHint: d.task_hint ?? '',
+      sessionIds: d.session_ids ?? [],
+    };
+  } catch {
+    return { ...EMPTY_HINTS, sessionIds: [] };
+  }
+}
+
+function computeAgeDays(firstSeen: string): number {
+  const d = new Date(firstSeen);
+  if (isNaN(d.getTime())) return 0;
+  return Math.max(0, Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24)));
+}
+
+function rowToSource(row: SourceRow): TelosSource {
+  return {
+    type: row.type,
+    url: row.url,
+    title: row.title,
+    author: row.author,
+    snippet: (row.raw_snippet ?? '').slice(0, 200),
+  };
+}
+
+function rowToLink(row: LinkRow): TelosLink {
+  return {
+    type: row.type,
+    url: row.url,
+    title: row.title,
+    description: row.description ?? '',
+  };
+}
+
+// --- Store ---
+
+export class TelosStore {
+  private db: Database.Database | null;
+  private profilesDir: string;
+  private hasGoalId: boolean;
+
+  constructor(dbPath: string, profilesDir: string) {
+    if (!existsSync(dbPath)) {
+      throw new Error(`Telos DB not found: ${dbPath}`);
+    }
+    this.profilesDir = profilesDir;
+    this.db = new Database(dbPath, { readonly: true });
+    this.db.pragma('busy_timeout = 5000');
+
+    // Check if goal_id column exists (migration may not have run yet)
+    const cols = new Set(
+      (this.db.pragma('table_info(items)') as { name: string }[]).map((c) => c.name),
+    );
+    this.hasGoalId = cols.has('goal_id');
+
+    log.info('TelosStore initialized (readonly)', { dbPath, hasGoalId: this.hasGoalId });
+  }
+
+  close(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  private getDb(): Database.Database {
+    if (!this.db) throw new Error('TelosStore is closed');
+    return this.db;
+  }
+
+  /**
+   * List items with proper parent/child tree and accurate completedChildCount.
+   *
+   * Unlike the Python cmd_list which only fetches active/acknowledged items and
+   * then tries to backfill completed children, this method fetches ALL children
+   * of matched items regardless of status, ensuring correct counts.
+   */
+  listItems(
+    profile?: string,
+    statuses: string[] = ['active', 'acknowledged'],
+  ): TelosItem[] {
+    const db = this.getDb();
+
+    // Step 1: fetch root-eligible items (matching status filter)
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (statuses.length > 0) {
+      conditions.push(`status IN (${statuses.map(() => '?').join(',')})`);
+      params.push(...statuses);
+    }
+    if (profile) {
+      conditions.push('profile = ?');
+      params.push(profile);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const rootRows = db
+      .prepare(
+        `SELECT * FROM items ${where} ORDER BY starred DESC, urgency DESC, first_seen ASC`,
+      )
+      .all(...params) as ItemRow[];
+
+    if (rootRows.length === 0) {
+      return [];
+    }
+
+    // Step 2: fetch ALL children of these items (any status)
+    const rootIds = rootRows.map((r) => r.id);
+    const childRows = this.fetchAllChildren(rootIds);
+
+    // Step 3: batch-load sources and links for all items
+    const allIds = [...new Set([...rootIds, ...childRows.map((c) => c.id)])];
+    const sourceMap = this.loadSourcesForItems(allIds);
+    const linkMap = this.loadLinksForItems(allIds);
+
+    // Step 4: build tree
+    return this.buildTree(rootRows, childRows, sourceMap, linkMap);
+  }
+
+  /**
+   * Get a single item by full or partial ID (prefix match).
+   */
+  getItem(id: string): TelosItem | null {
+    const db = this.getDb();
+
+    // Try exact match
+    let row = db.prepare('SELECT * FROM items WHERE id = ?').get(id) as ItemRow | undefined;
+
+    if (!row) {
+      // Prefix match
+      const rows = db
+        .prepare('SELECT * FROM items WHERE substr(id, 1, ?) = ?')
+        .all(id.length, id) as ItemRow[];
+      if (rows.length === 1) {
+        row = rows[0];
+      } else {
+        return null;
+      }
+    }
+
+    const sourceMap = this.loadSourcesForItems([row.id]);
+    const linkMap = this.loadLinksForItems([row.id]);
+
+    // Also load children
+    const childRows = this.fetchAllChildren([row.id]);
+    const childIds = childRows.map((c) => c.id);
+    if (childIds.length > 0) {
+      const childSourceMap = this.loadSourcesForItems(childIds);
+      const childLinkMap = this.loadLinksForItems(childIds);
+      for (const [k, v] of childSourceMap) sourceMap.set(k, v);
+      for (const [k, v] of childLinkMap) linkMap.set(k, v);
+    }
+
+    const items = this.buildTree([row], childRows, sourceMap, linkMap);
+    return items[0] ?? null;
+  }
+
+  /**
+   * List available profiles from YAML config directory + DB.
+   */
+  listProfiles(): string[] {
+    const profiles = new Set<string>();
+
+    // Scan YAML profile directory
+    if (existsSync(this.profilesDir)) {
+      try {
+        for (const file of readdirSync(this.profilesDir)) {
+          if (file.endsWith('.yaml') || file.endsWith('.yml')) {
+            profiles.add(basename(file, file.endsWith('.yaml') ? '.yaml' : '.yml'));
+          }
+        }
+      } catch {
+        // Directory read failed — continue with DB profiles
+      }
+    }
+
+    // Also include profiles that exist in DB but not in YAML
+    const db = this.getDb();
+    const rows = db.prepare('SELECT DISTINCT profile FROM items').all() as {
+      profile: string;
+    }[];
+    for (const row of rows) {
+      profiles.add(row.profile);
+    }
+
+    return [...profiles].sort();
+  }
+
+  // --- Private helpers ---
+
+  /**
+   * Fetch all children (any status) whose parent_id is in the given set.
+   * Single level — items in this repo don't nest deeper than parent→child.
+   */
+  private fetchAllChildren(parentIds: string[]): ItemRow[] {
+    if (parentIds.length === 0) return [];
+    const db = this.getDb();
+    const placeholders = parentIds.map(() => '?').join(',');
+    return db
+      .prepare(`SELECT * FROM items WHERE parent_id IN (${placeholders})`)
+      .all(...parentIds) as ItemRow[];
+  }
+
+  private loadSourcesForItems(itemIds: string[]): Map<string, TelosSource[]> {
+    if (itemIds.length === 0) return new Map();
+    const db = this.getDb();
+    const placeholders = itemIds.map(() => '?').join(',');
+    const rows = db
+      .prepare(
+        `SELECT * FROM sources WHERE item_id IN (${placeholders}) ORDER BY timestamp DESC`,
+      )
+      .all(...itemIds) as SourceRow[];
+
+    const map = new Map<string, TelosSource[]>();
+    for (const row of rows) {
+      const sources = map.get(row.item_id) ?? [];
+      sources.push(rowToSource(row));
+      map.set(row.item_id, sources);
+    }
+    return map;
+  }
+
+  private loadLinksForItems(itemIds: string[]): Map<string, TelosLink[]> {
+    if (itemIds.length === 0) return new Map();
+    const db = this.getDb();
+
+    // Check if links table exists (pre-migration DBs may not have it)
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='links'")
+      .all();
+    if (tables.length === 0) return new Map();
+
+    const placeholders = itemIds.map(() => '?').join(',');
+    const rows = db
+      .prepare(`SELECT * FROM links WHERE item_id IN (${placeholders})`)
+      .all(...itemIds) as LinkRow[];
+
+    const map = new Map<string, TelosLink[]>();
+    for (const row of rows) {
+      const links = map.get(row.item_id) ?? [];
+      links.push(rowToLink(row));
+      map.set(row.item_id, links);
+    }
+    return map;
+  }
+
+  private rowToItem(
+    row: ItemRow,
+    sourceMap: Map<string, TelosSource[]>,
+    linkMap: Map<string, TelosLink[]>,
+  ): TelosItem {
+    return {
+      id: row.id,
+      summary: row.summary,
+      profile: row.profile,
+      urgency: row.urgency,
+      starred: row.starred === 1,
+      status: row.status as TelosItem['status'],
+      ageDays: computeAgeDays(row.first_seen),
+      parentId: row.parent_id,
+      children: [],
+      childCount: 0,
+      completedChildCount: 0,
+      sources: sourceMap.get(row.id) ?? [],
+      links: linkMap.get(row.id) ?? [],
+      contextHints: parseContextHints(row.context_hints),
+      goalId: this.hasGoalId ? (row.goal_id ?? null) : null,
+    };
+  }
+
+  private buildTree(
+    rootRows: ItemRow[],
+    childRows: ItemRow[],
+    sourceMap: Map<string, TelosSource[]>,
+    linkMap: Map<string, TelosLink[]>,
+  ): TelosItem[] {
+    const itemsById = new Map<string, TelosItem>();
+
+    // Convert all rows to TelosItem objects
+    for (const row of [...rootRows, ...childRows]) {
+      if (!itemsById.has(row.id)) {
+        itemsById.set(row.id, this.rowToItem(row, sourceMap, linkMap));
+      }
+    }
+
+    // Nest children under parents
+    for (const item of itemsById.values()) {
+      if (item.parentId && itemsById.has(item.parentId)) {
+        const parent = itemsById.get(item.parentId)!;
+        parent.children.push(item);
+      }
+    }
+
+    // Compute counts after all children are nested
+    for (const item of itemsById.values()) {
+      if (item.children.length > 0) {
+        item.childCount = item.children.length;
+        item.completedChildCount = item.children.filter(
+          (c) => c.status === 'completed',
+        ).length;
+      }
+    }
+
+    // Return only root-level items (not nested under another item in this set)
+    const result: TelosItem[] = [];
+    for (const row of rootRows) {
+      const item = itemsById.get(row.id);
+      if (item && (!item.parentId || !itemsById.has(item.parentId))) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+}

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -12,7 +12,7 @@
 
 import Database from 'better-sqlite3';
 import { existsSync, readdirSync } from 'fs';
-import { basename, join } from 'path';
+import { basename } from 'path';
 import { createLogger } from './logger.js';
 
 const log = createLogger('telos-store');

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -248,6 +248,7 @@ export class TelosStore {
    * Get a single item by full or partial ID (prefix match).
    */
   getItem(id: string): TelosItem | null {
+    if (!id) return null;
     const db = this.getDb();
 
     // Try exact match

--- a/server/telos-store.ts
+++ b/server/telos-store.ts
@@ -204,10 +204,7 @@ export class TelosStore {
    * then tries to backfill completed children, this method fetches ALL children
    * of matched items regardless of status, ensuring correct counts.
    */
-  listItems(
-    profile?: string,
-    statuses: string[] = ['active', 'acknowledged'],
-  ): TelosItem[] {
+  listItems(profile?: string, statuses: string[] = ['active', 'acknowledged']): TelosItem[] {
     const db = this.getDb();
 
     // Step 1: fetch root-eligible items (matching status filter)
@@ -225,9 +222,7 @@ export class TelosStore {
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
     const rootRows = db
-      .prepare(
-        `SELECT * FROM items ${where} ORDER BY starred DESC, urgency DESC, first_seen ASC`,
-      )
+      .prepare(`SELECT * FROM items ${where} ORDER BY starred DESC, urgency DESC, first_seen ASC`)
       .all(...params) as ItemRow[];
 
     if (rootRows.length === 0) {
@@ -336,9 +331,7 @@ export class TelosStore {
     const db = this.getDb();
     const placeholders = itemIds.map(() => '?').join(',');
     const rows = db
-      .prepare(
-        `SELECT * FROM sources WHERE item_id IN (${placeholders}) ORDER BY timestamp DESC`,
-      )
+      .prepare(`SELECT * FROM sources WHERE item_id IN (${placeholders}) ORDER BY timestamp DESC`)
       .all(...itemIds) as SourceRow[];
 
     const map = new Map<string, TelosSource[]>();
@@ -419,9 +412,7 @@ export class TelosStore {
     for (const item of itemsById.values()) {
       if (item.children.length > 0) {
         item.childCount = item.children.length;
-        item.completedChildCount = item.children.filter(
-          (c) => c.status === 'completed',
-        ).length;
+        item.completedChildCount = item.children.filter((c) => c.status === 'completed').length;
       }
     }
 


### PR DESCRIPTION
## Summary

- New `telos-store.ts`: readonly better-sqlite3 reader for `smart_todo.db` with proper parent/child tree building
- `GET /api/todos` now reads directly from Telos SQLite (eliminates Python subprocess for reads)
- `POST /api/workload/items/:id/promote` falls back to TelosStore when item not in WorkloadStore, bridging Telos SHA256 IDs to Task Board
- 18 new tests covering tree building, child counts, prefix matching, profile listing

### Bugs fixed

1. **"Item not found" on Promote** — Telos items (SHA256 IDs) were not found in WorkloadStore (UUID IDs). Now falls back to TelosStore.
2. **SUB-TASKS 0/9** — The old Python path fetched only active/acknowledged items then tried to backfill completed children. TelosStore fetches ALL children regardless of status before counting.

**Companion PR:** dimakis/mgmt#202 (goal_id column + --set-goal CLI)

## Test plan

- [x] 18/18 telos-store tests pass
- [x] 25/25 workload-store tests pass (no regressions)
- [x] TypeScript compiles cleanly (no new errors)
- [ ] Manual: verify Telos items load with correct child counts
- [ ] Manual: verify Promote creates task and sets goalId on Telos item

🤖 Generated with [Claude Code](https://claude.com/claude-code)