### PR TITLE
feat: add MLflow to observability stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ logs/
 .jaeger-data/
 .loki-data/
 .grafana-data/
+.mlflow-data/
 .DS_Store
 .claude/worktrees/
 .cursor/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,11 +245,12 @@ Auth via `ProtectedRoute` wrapper. Vite dev server proxies `/api` and `/ws` to b
 
 - **Logging:** Pino structured JSON logger (`server/logger.ts`). Three transport targets: pino-roll (daily-rotated JSON files in `logs/`), stdout (JSON, or `pino-pretty` when `NODE_ENV=development`), and pino-loki (pushes to Grafana Loki when `LOKI_HOST` is set). Every log line includes `module`, `msg`, `level`, `time`. When an OTel span is active, `trace_id` and `span_id` are injected via the Pino mixin.
 - **Tracing:** OpenTelemetry via `server/tracing.ts`, opt-in when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. BatchSpanProcessor with OTLP HTTP exporter to Jaeger. Currently instrumented: `ws.switch_session`, `ws.send`, `ws.reconnect`. Deep instrumentation roadmap in `docs/design/otel-deep-instrumentation.md`.
-- **Infrastructure:** Three containers via `docker-compose.yml` (podman). Start with `npm run tracing:up`, stop with `npm run tracing:down`.
+- **Infrastructure:** Four containers via `docker-compose.yml` (podman). Start with `npm run tracing:up`, stop with `npm run tracing:down`.
   - Jaeger: http://localhost:16686 (trace viewer, OTLP receiver on :4318)
   - Grafana: http://localhost:3002 (log viewer + dashboards, no login required)
   - Loki: http://localhost:3200 (log aggregation backend)
-- **Env vars:** `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`, `LOKI_HOST=http://localhost:3200`, `LOG_LEVEL=info` (default).
+  - MLflow: http://localhost:5050 (experiment tracking for V-learning and prompt tuning)
+- **Env vars:** `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318`, `LOKI_HOST=http://localhost:3200`, `MLFLOW_TRACKING_URI=http://localhost:5050` (optional), `LOG_LEVEL=info` (default).
 - **Log-to-trace correlation:** Grafana Loki datasource parses `trace_id` from log lines and links to Jaeger traces. In Grafana Explore, query `{app="mitzo"}` for all logs, `{app="mitzo", module="query-loop"}` to filter by module.
 
 **MCP integration:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,6 @@ services:
     restart: always
     ports:
       - '5050:5000' # 5050 externally — 5000 conflicts with macOS AirPlay
-    environment:
-      MLFLOW_BACKEND_STORE_URI: 'sqlite:///mlflow/mlflow.db'
-      MLFLOW_ARTIFACTS_DESTINATION: '/mlflow/artifacts'
     command: mlflow server --host 0.0.0.0 --backend-store-uri sqlite:///mlflow/mlflow.db --default-artifact-root /mlflow/artifacts
     volumes:
       - ./.mlflow-data:/mlflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - loki
       - jaeger
 
+  # Experiment tracking for knowledge space V-learning and prompt tuning
   mlflow:
     image: ghcr.io/mlflow/mlflow:v2.22.0
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
-# Local observability stack: Jaeger (traces) + Loki (logs) + Grafana (UI).
+# Local observability stack: Jaeger (traces) + Loki (logs) + Grafana (UI) + MLflow (experiments).
 # Jaeger only:  npm run tracing:up / tracing:down
 # Full stack:   npm run observability:up / observability:down
 # Jaeger UI: http://localhost:16686
 # Grafana:   http://localhost:3002 (no login required)
 # Loki API:  http://localhost:3200
+# MLflow UI: http://localhost:5050
 services:
   jaeger:
     image: jaegertracing/jaeger:2.19.0
@@ -40,3 +41,15 @@ services:
     depends_on:
       - loki
       - jaeger
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v2.22.0
+    restart: always
+    ports:
+      - '5050:5000' # 5050 externally — 5000 conflicts with macOS AirPlay
+    environment:
+      MLFLOW_BACKEND_STORE_URI: 'sqlite:///mlflow/mlflow.db'
+      MLFLOW_ARTIFACTS_DESTINATION: '/mlflow/artifacts'
+    command: mlflow server --host 0.0.0.0 --backend-store-uri sqlite:///mlflow/mlflow.db --default-artifact-root /mlflow/artifacts
+    volumes:
+      - ./.mlflow-data:/mlflow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,12 +42,21 @@ services:
       - loki
       - jaeger
 
-  # Experiment tracking for knowledge space V-learning and prompt tuning
+  # Experiment tracking for knowledge space V-learning and prompt tuning.
+  # Uses SQLite backend (single-writer, adequate for local dev).
   mlflow:
     image: ghcr.io/mlflow/mlflow:v2.22.0
     restart: always
     ports:
       - '5050:5000' # 5050 externally — 5000 conflicts with macOS AirPlay
-    command: mlflow server --host 0.0.0.0 --backend-store-uri sqlite:///mlflow/mlflow.db --default-artifact-root /mlflow/artifacts
+    command:
+      - mlflow
+      - server
+      - --host
+      - '0.0.0.0'
+      - --backend-store-uri
+      - sqlite:///mlflow/mlflow.db
+      - --default-artifact-root
+      - /mlflow/artifacts
     volumes:
       - ./.mlflow-data:/mlflow

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -141,7 +141,7 @@ This does four things:
 1. Compiles TypeScript server to `dist/`
 2. Builds the React frontend
 3. Installs a launchd plist to `~/Library/LaunchAgents/com.mitzo.server.plist`
-4. Sets up a podman machine for the observability stack (Jaeger/Grafana/Loki)
+4. Sets up a podman machine for the observability stack (Jaeger/Grafana/Loki/MLflow)
 
 Manage the service:
 
@@ -544,6 +544,7 @@ Mitzo includes a local observability stack for debugging and performance analysi
 | Jaeger  | http://localhost:16686 | Trace viewer                       |
 | Grafana | http://localhost:3002  | Log viewer + dashboards (no login) |
 | Loki    | http://localhost:3200  | Log aggregation backend            |
+| MLflow  | http://localhost:5050  | Experiment tracking                |
 
 ### Quick start
 
@@ -640,7 +641,8 @@ Phone / Laptop (Tailscale)
     Observability (optional, podman)
         ├── Jaeger (OTLP traces)
         ├── Loki (log aggregation)
-        └── Grafana (dashboards)
+        ├── Grafana (dashboards)
+        └── MLflow (experiment tracking)
 ```
 
 The server translates raw SDK stream events into a v2 block lifecycle protocol (`block_start` > `block_delta` > `block_end`). Sessions survive WebSocket disconnects — when your phone reconnects, it reattaches and replays from a snapshot.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -95,7 +95,7 @@ Generate a secret with `openssl rand -hex 32` and paste the output as `AUTH_SECR
 | `CLOUD_ML_REGION`             | `us-east5`              | GCP region for Vertex                                                             |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | —                       | OTLP endpoint for tracing (e.g. `http://localhost:4318`)                          |
 | `LOKI_HOST`                   | —                       | Loki endpoint for log aggregation                                                 |
-| `MLFLOW_TRACKING_URI`         | —                       | MLflow endpoint for experiment tracking (e.g. `http://localhost:5050`)             |
+| `MLFLOW_TRACKING_URI`         | —                       | MLflow endpoint for experiment tracking (e.g. `http://localhost:5050`)            |
 | `CONTEXGIN_URL`               | `http://localhost:8321` | ContexGin goal registry URL                                                       |
 
 ## Step 3: Generate HTTPS certificate

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -95,6 +95,7 @@ Generate a secret with `openssl rand -hex 32` and paste the output as `AUTH_SECR
 | `CLOUD_ML_REGION`             | `us-east5`              | GCP region for Vertex                                                             |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | —                       | OTLP endpoint for tracing (e.g. `http://localhost:4318`)                          |
 | `LOKI_HOST`                   | —                       | Loki endpoint for log aggregation                                                 |
+| `MLFLOW_TRACKING_URI`         | —                       | MLflow endpoint for experiment tracking (e.g. `http://localhost:5050`)             |
 | `CONTEXGIN_URL`               | `http://localhost:8321` | ContexGin goal registry URL                                                       |
 
 ## Step 3: Generate HTTPS certificate

--- a/scripts/ensure-observability.sh
+++ b/scripts/ensure-observability.sh
@@ -22,12 +22,13 @@ fi
 echo "[ensure-observability] Starting observability containers..."
 "$PODMAN" compose -f "$COMPOSE_FILE" up -d 2>&1
 
-# 3. Verify
+# 3. Verify — match both Compose v1 (mitzo_svc_1) and v2 (mitzo-svc-1) naming
 for svc in jaeger loki grafana mlflow; do
-  container="mitzo_${svc}_1"
-  if "$PODMAN" ps --filter "name=$container" --format '{{.Names}}' 2>/dev/null | grep -q "$container"; then
+  # Filter matches any container whose name contains the service name
+  container=$("$PODMAN" ps --filter "name=mitzo.*${svc}" --format '{{.Names}}' 2>/dev/null | head -1)
+  if [ -n "$container" ]; then
     echo "[ensure-observability] $container: running"
   else
-    echo "[ensure-observability] $container: FAILED TO START" >&2
+    echo "[ensure-observability] mitzo_${svc}: FAILED TO START" >&2
   fi
 done

--- a/scripts/ensure-observability.sh
+++ b/scripts/ensure-observability.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Ensure the observability stack (Jaeger + Loki + Grafana) is running.
+# Ensure the observability stack (Jaeger + Loki + Grafana + MLflow) is running.
 # Called by the com.mitzo.podman-machine launchd agent after machine start,
 # and can be run manually: ./scripts/ensure-observability.sh
 set -euo pipefail
@@ -23,7 +23,7 @@ echo "[ensure-observability] Starting observability containers..."
 "$PODMAN" compose -f "$COMPOSE_FILE" up -d 2>&1
 
 # 3. Verify
-for svc in jaeger loki grafana; do
+for svc in jaeger loki grafana mlflow; do
   container="mitzo_${svc}_1"
   if "$PODMAN" ps --filter "name=$container" --format '{{.Names}}' 2>/dev/null | grep -q "$container"; then
     echo "[ensure-observability] $container: running"

--- a/server/__tests__/observability-config.test.ts
+++ b/server/__tests__/observability-config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+
+describe('observability stack config', () => {
+  const EXPECTED_SERVICES = ['jaeger', 'loki', 'grafana', 'mlflow'];
+
+  it('docker-compose.yml defines all expected services', () => {
+    const compose = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8');
+    for (const svc of EXPECTED_SERVICES) {
+      expect(compose).toContain(`  ${svc}:`);
+    }
+  });
+
+  it('ensure-observability.sh verifies all expected services', () => {
+    const script = readFileSync(
+      resolve(ROOT, 'scripts/ensure-observability.sh'),
+      'utf-8',
+    );
+    for (const svc of EXPECTED_SERVICES) {
+      expect(script).toContain(svc);
+    }
+  });
+
+  it('ensure-observability.sh uses flexible container name matching', () => {
+    const script = readFileSync(
+      resolve(ROOT, 'scripts/ensure-observability.sh'),
+      'utf-8',
+    );
+    // Should use --filter pattern, not hardcoded _svc_1 names in commands
+    expect(script).toContain('--filter');
+    // Actual container references use dynamic filter, not hardcoded names
+    expect(script).not.toMatch(/\$\{?PODMAN\}?.*mitzo_\w+_1/);
+  });
+
+  it('docker-compose.yml exposes expected ports', () => {
+    const compose = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8');
+    const expectedPorts = ['4318', '16686', '3200', '3002', '5050'];
+    for (const port of expectedPorts) {
+      expect(compose).toContain(port);
+    }
+  });
+});

--- a/server/__tests__/observability-config.test.ts
+++ b/server/__tests__/observability-config.test.ts
@@ -38,8 +38,8 @@ describe('observability stack config', () => {
   it('gitignore covers all compose data volumes', () => {
     const gitignore = readFileSync(resolve(ROOT, '.gitignore'), 'utf-8');
     const compose = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8');
-    // Extract volume mount patterns like ./.foo-data
-    const volumeMatches = compose.match(/\.\/\.\w[\w-]*data/g) || [];
+    // Extract volume mount patterns like ./.foo-data (anchored to colon boundary)
+    const volumeMatches = compose.match(/\.\/\.\w[\w-]*data\b/g) || [];
     for (const vol of volumeMatches) {
       const dirName = vol.replace('./', '') + '/';
       expect(gitignore).toContain(dirName);

--- a/server/__tests__/observability-config.test.ts
+++ b/server/__tests__/observability-config.test.ts
@@ -35,6 +35,17 @@ describe('observability stack config', () => {
     expect(script).not.toMatch(/\$\{?PODMAN\}?.*mitzo_\w+_1/);
   });
 
+  it('gitignore covers all compose data volumes', () => {
+    const gitignore = readFileSync(resolve(ROOT, '.gitignore'), 'utf-8');
+    const compose = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8');
+    // Extract volume mount patterns like ./.foo-data
+    const volumeMatches = compose.match(/\.\/\.\w[\w-]*data/g) || [];
+    for (const vol of volumeMatches) {
+      const dirName = vol.replace('./', '') + '/';
+      expect(gitignore).toContain(dirName);
+    }
+  });
+
   it('docker-compose.yml exposes expected ports', () => {
     const compose = readFileSync(resolve(ROOT, 'docker-compose.yml'), 'utf-8');
     const expectedPorts = ['4318', '16686', '3200', '3002', '5050'];

--- a/server/__tests__/observability-config.test.ts
+++ b/server/__tests__/observability-config.test.ts
@@ -15,20 +15,14 @@ describe('observability stack config', () => {
   });
 
   it('ensure-observability.sh verifies all expected services', () => {
-    const script = readFileSync(
-      resolve(ROOT, 'scripts/ensure-observability.sh'),
-      'utf-8',
-    );
+    const script = readFileSync(resolve(ROOT, 'scripts/ensure-observability.sh'), 'utf-8');
     for (const svc of EXPECTED_SERVICES) {
       expect(script).toContain(svc);
     }
   });
 
   it('ensure-observability.sh uses flexible container name matching', () => {
-    const script = readFileSync(
-      resolve(ROOT, 'scripts/ensure-observability.sh'),
-      'utf-8',
-    );
+    const script = readFileSync(resolve(ROOT, 'scripts/ensure-observability.sh'), 'utf-8');
     // Should use --filter pattern, not hardcoded _svc_1 names in commands
     expect(script).toContain('--filter');
     // Actual container references use dynamic filter, not hardcoded names


### PR DESCRIPTION
## Summary

- Adds MLflow v2.22.0 container to docker-compose.yml alongside Jaeger, Loki, and Grafana
- Port 5050 externally (avoids macOS AirPlay conflict on 5000)
- SQLite backend + file-based artifact store via Docker volume (`.mlflow-data/`)
- Updates `ensure-observability.sh` to verify MLflow container on startup

## Context

MLflow tracks knowledge space experiments (contrastive learning, V-learning trace efficiency) from the mgmt repo's `knowledge_space/` pipeline. Dual OTel export sends traces to both Jaeger (operational) and MLflow (experiment tracking).

Related: dimakis/mgmt#203

## Test plan

- [ ] `podman compose up -d` — mlflow container starts
- [ ] `curl http://localhost:5050/api/2.0/mlflow/experiments/list` returns 200
- [ ] `./scripts/ensure-observability.sh` — shows mlflow as running
- [ ] MLflow UI accessible at http://localhost:5050

🤖 Generated with [Claude Code](https://claude.com/claude-code)