### PR TITLE
feat(transport): stable client connectionId + POST failure resilience

### DIFF
--- a/frontend/src/client-store.ts
+++ b/frontend/src/client-store.ts
@@ -25,11 +25,23 @@ import { getPreferredModel } from './lib/model-preference';
  */
 const useSSE = typeof window !== 'undefined' && localStorage.getItem('mitzo:transport') === 'sse';
 
+/** Stable connectionId per browser tab — survives SSE reconnects. */
+function getOrCreateConnectionId(): string {
+  const KEY = 'mitzo:connectionId';
+  let cid = sessionStorage.getItem(KEY);
+  if (!cid) {
+    cid = `cid-${crypto.randomUUID()}`;
+    sessionStorage.setItem(KEY, cid);
+  }
+  return cid;
+}
+
 const sseConfig: SseConnectionConfig | undefined = useSSE
   ? {
       baseUrl: getApiBaseUrl(),
       fetch: (url, init) => apiFetch(url, init),
       suspendUrl: `${getApiBaseUrl()}/api/sessions/suspend`,
+      connectionId: getOrCreateConnectionId(),
     }
   : undefined;
 

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -1119,7 +1119,7 @@ describe('SseConnection', () => {
       );
     });
 
-    it('silently swallows 4xx errors other than 404/429 for send endpoint', async () => {
+    it('emits _send_failed with willRetry:false for 400 (permanent failure)', async () => {
       const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
       const conn = new SseConnection(createConfig({ fetch: mockFetch }));
       const listener = vi.fn();
@@ -1134,8 +1134,13 @@ describe('SseConnection', () => {
       conn.send({ type: 'send', prompt: 'bad request', clientMsgId: 'msg-400' });
       await vi.runAllTimersAsync();
 
-      // 400 is a client error — not retryable, not surfaced as _send_failed
-      expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: '_send_failed' }));
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '_send_failed',
+          clientMsgId: 'msg-400',
+          willRetry: false,
+        }),
+      );
     });
 
     it('emits _send_failed on 429 rate limit', async () => {

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -1095,6 +1095,49 @@ describe('SseConnection', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it('emits _send_failed with willRetry:false for 404 (permanent failure)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'hello', clientMsgId: 'msg-404' });
+      await vi.runAllTimersAsync();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '_send_failed',
+          clientMsgId: 'msg-404',
+          willRetry: false,
+        }),
+      );
+    });
+
+    it('silently swallows 4xx errors other than 404/429 for send endpoint', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'bad request', clientMsgId: 'msg-400' });
+      await vi.runAllTimersAsync();
+
+      // 400 is a client error — not retryable, not surfaced as _send_failed
+      expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: '_send_failed' }));
+    });
+
     it('emits _send_failed on 429 rate limit', async () => {
       const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
       const conn = new SseConnection(createConfig({ fetch: mockFetch }));

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -1160,5 +1160,29 @@ describe('SseConnection', () => {
         }),
       );
     });
+
+    it('retries failed send after delay even without reconnect', async () => {
+      let callCount = 0;
+      const mockFetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve({ ok: false, status: 500 });
+        return Promise.resolve({ ok: true });
+      });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      // First send fails with 500 — gets queued for retry
+      conn.send({ type: 'send', prompt: 'retry me', clientMsgId: 'r-1' });
+      await vi.runAllTimersAsync();
+
+      // The retry flush timer fires after 3s and retries the queued message
+      // (no reconnect needed — SSE stream stayed connected)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -66,6 +66,7 @@ function createConfig(overrides?: Partial<SseConnectionConfig>): SseConnectionCo
     baseUrl: 'https://localhost:3100',
     fetch: vi.fn().mockResolvedValue({ ok: true }),
     createEventSource: (url: string) => new MockEventSource(url) as unknown as EventSource,
+    connectionId: 'cid-test',
     ...overrides,
   };
 }
@@ -93,7 +94,7 @@ describe('SseConnection', () => {
     conn.connect();
 
     expect(MockEventSource.instances).toHaveLength(1);
-    expect(lastES().url).toBe('https://localhost:3100/api/chat/events');
+    expect(lastES().url).toBe('https://localhost:3100/api/chat/events?cid=cid-test');
   });
 
   it('becomes connected after welcome event', () => {
@@ -804,9 +805,10 @@ describe('SseConnection', () => {
     // Force reconnect
     conn.checkAndReconnect(true);
 
-    // URL should be clean — reconnect is handled via POST, not query param
+    // URL should include cid but NOT sessions (reconnect is handled via POST)
     const newES = lastES();
-    expect(newES.url).toBe('https://localhost:3100/api/chat/events');
+    expect(newES.url).toContain('/api/chat/events?cid=');
+    expect(newES.url).not.toContain('sessions=');
   });
 
   it('checkAndReconnect(false) is no-op when connected', () => {
@@ -819,6 +821,80 @@ describe('SseConnection', () => {
 
     // Should NOT create a new EventSource
     expect(MockEventSource.instances.length).toBe(count);
+  });
+
+  // ─── Stable connectionId ────────────────────────────────────────────────
+
+  describe('stable connectionId', () => {
+    it('includes client connectionId in EventSource URL', () => {
+      const conn = new SseConnection(createConfig({ connectionId: 'cid-my-tab' }));
+      conn.connect();
+      expect(lastES().url).toBe('https://localhost:3100/api/chat/events?cid=cid-my-tab');
+    });
+
+    it('auto-generates connectionId when not provided', () => {
+      const conn = new SseConnection(createConfig({ connectionId: undefined }));
+      conn.connect();
+      expect(lastES().url).toMatch(/\?cid=cid-[0-9a-f-]{36}$/);
+    });
+
+    it('preserves connectionId when server echoes it back', () => {
+      const conn = new SseConnection(createConfig({ connectionId: 'cid-stable' }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-stable',
+      });
+      expect(conn.getConnectionId()).toBe('cid-stable');
+    });
+
+    it('falls back to server connectionId when it differs (old server)', () => {
+      const conn = new SseConnection(createConfig({ connectionId: 'cid-client' }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'conn-server-assigned',
+      });
+      expect(conn.getConnectionId()).toBe('conn-server-assigned');
+    });
+
+    it('uses same connectionId across reconnects', () => {
+      const conn = new SseConnection(createConfig({ connectionId: 'cid-stable' }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-stable',
+      });
+
+      conn.checkAndReconnect(true);
+
+      expect(lastES().url).toBe('https://localhost:3100/api/chat/events?cid=cid-stable');
+    });
+
+    it('sends connectionId in X-Connection-ID header on POST', () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch, connectionId: 'cid-hdr' }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-hdr',
+      });
+
+      conn.send({ type: 'send', prompt: 'hi' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Connection-ID': 'cid-hdr',
+          }),
+        }),
+      );
+    });
   });
 
   // ─── Session tracking ──────────────────────────────────────────────────
@@ -871,5 +947,127 @@ describe('SseConnection', () => {
     conn.sendSuspend();
 
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ─── POST failure surfacing ───────────────────────────────────────────
+
+  describe('POST failure surfacing', () => {
+    it('emits _send_failed on 500 response for send endpoint', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'hello', clientMsgId: 'msg-1' });
+      await vi.runAllTimersAsync();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '_send_failed',
+          clientMsgId: 'msg-1',
+          willRetry: true,
+        }),
+      );
+    });
+
+    it('emits _send_failed on network error for send endpoint', async () => {
+      const mockFetch = vi.fn().mockRejectedValue(new Error('network error'));
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'hello', clientMsgId: 'msg-2' });
+      await vi.runAllTimersAsync();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '_send_failed',
+          clientMsgId: 'msg-2',
+          willRetry: true,
+        }),
+      );
+    });
+
+    it('re-queues failed send for retry on reconnect', async () => {
+      let callCount = 0;
+      const mockFetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve({ ok: false, status: 500 });
+        return Promise.resolve({ ok: true });
+      });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'retry me', clientMsgId: 'r-1' });
+      await vi.runAllTimersAsync();
+
+      conn.checkAndReconnect(true);
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not emit _send_failed for non-send endpoints', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'stop', sessionId: 'sess-1' });
+      await vi.runAllTimersAsync();
+
+      expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: '_send_failed' }));
+    });
+
+    it('emits _send_failed on 429 rate limit', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      conn.send({ type: 'send', prompt: 'hello', clientMsgId: 'msg-3' });
+      await vi.runAllTimersAsync();
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '_send_failed',
+          willRetry: true,
+        }),
+      );
+    });
   });
 });

--- a/packages/client/src/__tests__/sse-connection.test.ts
+++ b/packages/client/src/__tests__/sse-connection.test.ts
@@ -1047,6 +1047,54 @@ describe('SseConnection', () => {
       expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: '_send_failed' }));
     });
 
+    it('drops message after max retries and emits willRetry: false', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      const conn = new SseConnection(createConfig({ fetch: mockFetch }));
+      const listener = vi.fn();
+      conn.onMessage(listener);
+      conn.connect();
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+
+      // Initial send fails → queued with retries:1
+      conn.send({ type: 'send', prompt: 'persistent fail', clientMsgId: 'pf-1' });
+      await vi.runAllTimersAsync();
+
+      // 3 reconnect cycles — each flush retries and fails again
+      for (let i = 0; i < 3; i++) {
+        conn.checkAndReconnect(true);
+        lastES()._emit('welcome', {
+          type: 'welcome',
+          protocolVersion: 2,
+          connectionId: 'cid-test',
+        });
+        await vi.runAllTimersAsync();
+      }
+
+      // 4 _send_failed events: 3 willRetry:true + 1 willRetry:false
+      const failedEvents = listener.mock.calls
+        .map((c: unknown[]) => c[0] as Record<string, unknown>)
+        .filter((m) => m.type === '_send_failed');
+
+      expect(failedEvents).toHaveLength(4);
+      expect(failedEvents[3]).toEqual(expect.objectContaining({ willRetry: false }));
+
+      // One more reconnect — message should NOT be retried (was dropped)
+      mockFetch.mockClear();
+      conn.checkAndReconnect(true);
+      lastES()._emit('welcome', {
+        type: 'welcome',
+        protocolVersion: 2,
+        connectionId: 'cid-test',
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('emits _send_failed on 429 rate limit', async () => {
       const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
       const conn = new SseConnection(createConfig({ fetch: mockFetch }));

--- a/packages/client/src/chat-connection.ts
+++ b/packages/client/src/chat-connection.ts
@@ -17,7 +17,7 @@ export interface ChatConnection {
   onMessage(listener: ConnectionListener): void;
   /** Whether the transport is connected and ready to send. */
   isConnected(): boolean;
-  /** Server-assigned connection ID (null before welcome). */
+  /** Client-generated stable connection ID. Available immediately after construction. */
   getConnectionId(): string | null;
   /** Track the latest received seq for a session (for reconnect replay). */
   trackSeq(sessionId: string, seq: number): void;

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -36,6 +36,14 @@ export interface SseConnectionConfig {
 }
 
 const MAX_PENDING_SENDS = 100;
+const MAX_SEND_RETRIES = 3;
+
+/** Synthetic event emitted when a POST to the send endpoint fails. */
+export interface SendFailedEvent {
+  type: '_send_failed';
+  clientMsgId: unknown;
+  willRetry: boolean;
+}
 
 export class SseConnection implements ChatConnection {
   private es: EventSource | null = null;
@@ -44,7 +52,11 @@ export class SseConnection implements ChatConnection {
   private _isReconnect = false;
   private listener: ConnectionListener | null = null;
   private seqBySession = new Map<string, number>();
-  private pendingSends: Array<{ endpoint: string; body: Record<string, unknown> }> = [];
+  private pendingSends: Array<{
+    endpoint: string;
+    body: Record<string, unknown>;
+    retries: number;
+  }> = [];
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private boundOnVisibility: (() => void) | null = null;
   private boundOnPageShow: ((e: PageTransitionEvent) => void) | null = null;
@@ -108,7 +120,7 @@ export class SseConnection implements ChatConnection {
       if (this.pendingSends.length >= MAX_PENDING_SENDS) {
         this.pendingSends.shift();
       }
-      this.pendingSends.push({ endpoint, body: msg });
+      this.pendingSends.push({ endpoint, body: msg, retries: 0 });
       return true;
     }
 
@@ -333,7 +345,11 @@ export class SseConnection implements ChatConnection {
     }, this.config.reconnectDelayMs);
   }
 
-  private async doPost(endpoint: string, body: Record<string, unknown>): Promise<void> {
+  private async doPost(
+    endpoint: string,
+    body: Record<string, unknown>,
+    retries = 0,
+  ): Promise<void> {
     try {
       const res = await this.config.fetch(`${this.config.baseUrl}/api/chat/${endpoint}`, {
         method: 'POST',
@@ -344,24 +360,28 @@ export class SseConnection implements ChatConnection {
         body: JSON.stringify(body),
       });
       if (!res.ok && endpoint === 'send') {
-        // Transient failure — re-queue for retry on next reconnect
         if (res.status === 404 || res.status === 429 || res.status >= 500) {
-          this.pendingSends.push({ endpoint, body });
+          const willRetry = retries < MAX_SEND_RETRIES;
+          if (willRetry) {
+            this.pendingSends.push({ endpoint, body, retries: retries + 1 });
+          }
           this.listener?.({
             type: '_send_failed',
             clientMsgId: body.clientMsgId,
-            willRetry: true,
+            willRetry,
           });
         }
       }
     } catch {
-      // Network error on send — re-queue and notify
       if (endpoint === 'send') {
-        this.pendingSends.push({ endpoint, body });
+        const willRetry = retries < MAX_SEND_RETRIES;
+        if (willRetry) {
+          this.pendingSends.push({ endpoint, body, retries: retries + 1 });
+        }
         this.listener?.({
           type: '_send_failed',
           clientMsgId: body.clientMsgId,
-          willRetry: true,
+          willRetry,
         });
       }
     }
@@ -371,8 +391,8 @@ export class SseConnection implements ChatConnection {
     if (this.pendingSends.length === 0) return;
     const toFlush = this.pendingSends;
     this.pendingSends = [];
-    for (const { endpoint, body } of toFlush) {
-      this.doPost(endpoint, body);
+    for (const { endpoint, body, retries } of toFlush) {
+      this.doPost(endpoint, body, retries);
     }
   }
 

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -378,8 +378,8 @@ export class SseConnection implements ChatConnection {
             clientMsgId: body.clientMsgId,
             willRetry,
           });
-        } else if (res.status === 404) {
-          // Permanent failure — session/route doesn't exist, no retry
+        } else {
+          // Permanent failure (4xx) — no retry. Covers 400, 401, 403, 404, etc.
           this.listener?.({
             type: '_send_failed',
             clientMsgId: body.clientMsgId,

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -26,13 +26,20 @@ export interface SseConnectionConfig {
   reconnectDelayMs?: number;
   /** URL for the sendBeacon suspend fallback. */
   suspendUrl?: string;
+  /**
+   * Client-generated stable connectionId. Survives SSE reconnects so the
+   * server sees the same owner across transport drops — eliminates the
+   * reattach race that causes the "send twice to wake agent" bug.
+   * If not provided, a UUID is generated automatically.
+   */
+  connectionId?: string;
 }
 
 const MAX_PENDING_SENDS = 100;
 
 export class SseConnection implements ChatConnection {
   private es: EventSource | null = null;
-  private _connectionId: string | null = null;
+  private _connectionId: string;
   private _connected = false;
   private _isReconnect = false;
   private listener: ConnectionListener | null = null;
@@ -42,7 +49,7 @@ export class SseConnection implements ChatConnection {
   private boundOnVisibility: (() => void) | null = null;
   private boundOnPageShow: ((e: PageTransitionEvent) => void) | null = null;
   private boundOnPageHide: (() => void) | null = null;
-  private config: Required<SseConnectionConfig>;
+  private config: Required<Omit<SseConnectionConfig, 'connectionId'>>;
 
   constructor(config: SseConnectionConfig) {
     this.config = {
@@ -51,6 +58,10 @@ export class SseConnection implements ChatConnection {
       suspendUrl: '',
       ...config,
     };
+    // Stable connectionId — survives SSE reconnects. The server uses this
+    // to identify the same client across transport drops, eliminating the
+    // ownership race in handleReconnect.
+    this._connectionId = config.connectionId ?? `cid-${crypto.randomUUID()}`;
   }
 
   connect(): void {
@@ -87,7 +98,7 @@ export class SseConnection implements ChatConnection {
     const endpoint = this.messageTypeToEndpoint(msg.type as string);
     if (!endpoint) return false;
 
-    if (this._connected && this._connectionId) {
+    if (this._connected) {
       this.doPost(endpoint, msg);
       return true;
     }
@@ -149,17 +160,13 @@ export class SseConnection implements ChatConnection {
     }));
 
     // Try POST first
-    if (this._connected && this._connectionId) {
+    if (this._connected) {
       this.doPost('suspend', { type: 'session_suspend', sessions });
       return;
     }
 
     // sendBeacon fallback
-    if (
-      this.config.suspendUrl &&
-      this._connectionId &&
-      typeof globalThis.navigator?.sendBeacon === 'function'
-    ) {
+    if (this.config.suspendUrl && typeof globalThis.navigator?.sendBeacon === 'function') {
       const payload = JSON.stringify({ connectionId: this._connectionId, sessions });
       globalThis.navigator.sendBeacon(
         this.config.suspendUrl,
@@ -198,16 +205,16 @@ export class SseConnection implements ChatConnection {
       this.reconnectTimer = null;
     }
 
-    // Always use the base URL — reconnect sessions are sent via POST in the
-    // welcome handler. This avoids the bug where EventSource auto-reconnect
-    // reuses the original URL (missing ?sessions=), and eliminates double
-    // handleReconnect when doConnect() AND welcome both trigger it.
-    const url = `${this.config.baseUrl}/api/chat/events`;
+    // Send our stable connectionId as a query param so the server can reuse
+    // it across reconnects. The createEventSource callback may append auth
+    // params — it must handle the existing query string.
+    const url = `${this.config.baseUrl}/api/chat/events?cid=${encodeURIComponent(this._connectionId)}`;
 
     const es = this.config.createEventSource(url);
     this.es = es;
 
-    // Welcome event — server sends connectionId
+    // Welcome event — server echoes our connectionId (or assigns a new one
+    // if the server doesn't support client-provided cids).
     es.addEventListener('welcome', (e: MessageEvent) => {
       let msg: Record<string, unknown>;
       try {
@@ -215,7 +222,11 @@ export class SseConnection implements ChatConnection {
       } catch {
         return;
       }
-      this._connectionId = msg.connectionId as string;
+      const serverCid = msg.connectionId as string;
+      if (serverCid !== this._connectionId) {
+        // Old server that doesn't support stable cid — fall back
+        this._connectionId = serverCid;
+      }
 
       // _connected deferred until doReconnectPost succeeds — prevents
       // external send() from bypassing the pending queue mid-reconnect.
@@ -323,9 +334,8 @@ export class SseConnection implements ChatConnection {
   }
 
   private async doPost(endpoint: string, body: Record<string, unknown>): Promise<void> {
-    if (!this._connectionId) return;
     try {
-      await this.config.fetch(`${this.config.baseUrl}/api/chat/${endpoint}`, {
+      const res = await this.config.fetch(`${this.config.baseUrl}/api/chat/${endpoint}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -333,9 +343,27 @@ export class SseConnection implements ChatConnection {
         },
         body: JSON.stringify(body),
       });
+      if (!res.ok && endpoint === 'send') {
+        // Transient failure — re-queue for retry on next reconnect
+        if (res.status === 404 || res.status === 429 || res.status >= 500) {
+          this.pendingSends.push({ endpoint, body });
+          this.listener?.({
+            type: '_send_failed',
+            clientMsgId: body.clientMsgId,
+            willRetry: true,
+          });
+        }
+      }
     } catch {
-      // POST failures are non-fatal — the server may be temporarily
-      // unreachable. The SSE stream will reconnect and replay missed events.
+      // Network error on send — re-queue and notify
+      if (endpoint === 'send') {
+        this.pendingSends.push({ endpoint, body });
+        this.listener?.({
+          type: '_send_failed',
+          clientMsgId: body.clientMsgId,
+          willRetry: true,
+        });
+      }
     }
   }
 

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -37,6 +37,7 @@ export interface SseConnectionConfig {
 
 const MAX_PENDING_SENDS = 100;
 const MAX_SEND_RETRIES = 3;
+const RETRY_FLUSH_DELAY_MS = 3000;
 
 /** Synthetic event emitted when a POST to the send endpoint fails. */
 export interface SendFailedEvent {
@@ -58,6 +59,7 @@ export class SseConnection implements ChatConnection {
     retries: number;
   }> = [];
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private boundOnVisibility: (() => void) | null = null;
   private boundOnPageShow: ((e: PageTransitionEvent) => void) | null = null;
   private boundOnPageHide: (() => void) | null = null;
@@ -86,6 +88,10 @@ export class SseConnection implements ChatConnection {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+    if (this.retryFlushTimer) {
+      clearTimeout(this.retryFlushTimer);
+      this.retryFlushTimer = null;
     }
     if (this.es) {
       this.es.close();
@@ -365,6 +371,7 @@ export class SseConnection implements ChatConnection {
           const willRetry = retries < MAX_SEND_RETRIES;
           if (willRetry) {
             this.pendingSends.push({ endpoint, body, retries: retries + 1 });
+            this.scheduleRetryFlush();
           }
           this.listener?.({
             type: '_send_failed',
@@ -385,6 +392,7 @@ export class SseConnection implements ChatConnection {
         const willRetry = retries < MAX_SEND_RETRIES;
         if (willRetry) {
           this.pendingSends.push({ endpoint, body, retries: retries + 1 });
+          this.scheduleRetryFlush();
         }
         this.listener?.({
           type: '_send_failed',
@@ -396,12 +404,32 @@ export class SseConnection implements ChatConnection {
   }
 
   private flushPendingSends(): void {
+    if (this.retryFlushTimer) {
+      clearTimeout(this.retryFlushTimer);
+      this.retryFlushTimer = null;
+    }
     if (this.pendingSends.length === 0) return;
     const toFlush = this.pendingSends;
     this.pendingSends = [];
     for (const { endpoint, body, retries } of toFlush) {
       this.doPost(endpoint, body, retries);
     }
+  }
+
+  /**
+   * Schedule a delayed retry flush for messages that failed while the SSE
+   * stream is still connected. Without this, failed POSTs would sit in the
+   * queue until a reconnect event — which may never come if SSE stays healthy.
+   */
+  private scheduleRetryFlush(): void {
+    if (this.retryFlushTimer) return;
+    if (!this._connected) return;
+    this.retryFlushTimer = setTimeout(() => {
+      this.retryFlushTimer = null;
+      if (this._connected && this.pendingSends.length > 0) {
+        this.flushPendingSends();
+      }
+    }, RETRY_FLUSH_DELAY_MS);
   }
 
   /**

--- a/packages/client/src/sse-connection.ts
+++ b/packages/client/src/sse-connection.ts
@@ -360,7 +360,8 @@ export class SseConnection implements ChatConnection {
         body: JSON.stringify(body),
       });
       if (!res.ok && endpoint === 'send') {
-        if (res.status === 404 || res.status === 429 || res.status >= 500) {
+        if (res.status === 429 || res.status >= 500) {
+          // Transient failure — retry up to MAX_SEND_RETRIES
           const willRetry = retries < MAX_SEND_RETRIES;
           if (willRetry) {
             this.pendingSends.push({ endpoint, body, retries: retries + 1 });
@@ -369,6 +370,13 @@ export class SseConnection implements ChatConnection {
             type: '_send_failed',
             clientMsgId: body.clientMsgId,
             willRetry,
+          });
+        } else if (res.status === 404) {
+          // Permanent failure — session/route doesn't exist, no retry
+          this.listener?.({
+            type: '_send_failed',
+            clientMsgId: body.clientMsgId,
+            willRetry: false,
           });
         }
       }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -723,7 +723,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       const willRetry = msg.willRetry !== false;
       store.setState((s) => ({
         sendError: willRetry
-          ? 'Message delivery delayed — retrying on reconnect...'
+          ? 'Message delivery delayed — retrying...'
           : 'Message could not be delivered.',
         ...(willRetry
           ? {}

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -706,10 +706,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     // evicted it from memory, losing in-memory state), re-fetch messages from
     // the REST API if we have an active session but no messages in the store.
     if (msg.type === '_open') {
-      // Reconnect succeeded — clear any stale send error from prior failures
-      if (store.getState().sendError) {
-        store.setState({ sendError: null });
-      }
+      // Don't clear sendError here — flushed retry POSTs haven't resolved
+      // yet. The session-scoped event clearing below handles it once the
+      // server actually processes the message.
       return;
     }
 
@@ -764,10 +763,14 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
 
-    // Session event arrived — clear any stale send error. Only clear on
-    // session-scoped events (eventSessionId present), not global events
-    // like task_state or inbox_updated which don't confirm message delivery.
-    if (eventSessionId && store.getState().sendError) {
+    // Session event for the active session — clear any stale send error.
+    // Only clear when the event matches the active session, not background
+    // activity from other sessions or global events.
+    if (
+      eventSessionId &&
+      eventSessionId === store.getState().sessions.active &&
+      store.getState().sendError
+    ) {
       store.setState({ sendError: null });
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -764,11 +764,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
 
-    // Server event arrived — clear any stale send error. This covers the
-    // case where a retried POST succeeded: the server starts processing and
-    // sends events, confirming delivery. Without this, the "retrying..."
-    // banner would persist until the next sendMessage() call.
-    if (store.getState().sendError) {
+    // Session event arrived — clear any stale send error. Only clear on
+    // session-scoped events (eventSessionId present), not global events
+    // like task_state or inbox_updated which don't confirm message delivery.
+    if (eventSessionId && store.getState().sendError) {
       store.setState({ sendError: null });
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -373,6 +373,12 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
         const sent = connection.send(msg);
         if (!sent) {
           set({ sendError: 'Not connected. Message will be sent when reconnected.' });
+        } else {
+          // Optimistic: show "thinking" immediately. The server will confirm
+          // via events, or the send-timeout safety net will reset on failure.
+          set((s) => ({
+            messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: true }),
+          }));
         }
       }
     },
@@ -702,6 +708,13 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     if (msg.type === '_foreground') {
       const { sessions } = store.getState();
       if (sessions.active) fetchAndRestoreMessages(sessions.active);
+      return;
+    }
+
+    if (msg.type === '_send_failed') {
+      store.setState({
+        sendError: 'Message delivery delayed — retrying on reconnect...',
+      });
       return;
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -764,6 +764,14 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
 
     const result = parseServerMessage(msg as WsMsg, parserState, callbacks, 'v2');
 
+    // Server event arrived — clear any stale send error. This covers the
+    // case where a retried POST succeeded: the server starts processing and
+    // sends events, confirming delivery. Without this, the "retrying..."
+    // banner would persist until the next sendMessage() call.
+    if (store.getState().sendError) {
+      store.setState({ sendError: null });
+    }
+
     // If the queue is now empty, cancel the safety-net timer — the normal
     // session_end flush path handled it.
     if (parserState.pendingSend.length === 0 && parserState.pendingSendTimer) {

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -712,9 +712,15 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     }
 
     if (msg.type === '_send_failed') {
-      store.setState({
-        sendError: 'Message delivery delayed — retrying on reconnect...',
-      });
+      const willRetry = (msg as Record<string, unknown>).willRetry !== false;
+      store.setState((s) => ({
+        sendError: willRetry
+          ? 'Message delivery delayed — retrying on reconnect...'
+          : 'Message could not be delivered.',
+        ...(willRetry
+          ? {}
+          : { messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: false }) }),
+      }));
       return;
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -705,6 +705,14 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     // Foreground recovery: when the page becomes visible again (iOS may have
     // evicted it from memory, losing in-memory state), re-fetch messages from
     // the REST API if we have an active session but no messages in the store.
+    if (msg.type === '_open') {
+      // Reconnect succeeded — clear any stale send error from prior failures
+      if (store.getState().sendError) {
+        store.setState({ sendError: null });
+      }
+      return;
+    }
+
     if (msg.type === '_foreground') {
       const { sessions } = store.getState();
       if (sessions.active) fetchAndRestoreMessages(sessions.active);
@@ -712,7 +720,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     }
 
     if (msg.type === '_send_failed') {
-      const willRetry = (msg as Record<string, unknown>).willRetry !== false;
+      const willRetry = msg.willRetry !== false;
       store.setState((s) => ({
         sendError: willRetry
           ? 'Message delivery delayed — retrying on reconnect...'

--- a/packages/harness/__tests__/connection-registry.test.ts
+++ b/packages/harness/__tests__/connection-registry.test.ts
@@ -52,6 +52,53 @@ describe('ConnectionRegistry', () => {
     });
   });
 
+  describe('reconnect', () => {
+    it('swaps transport while preserving watched sessions and active session', () => {
+      const t1 = mockTransport(true);
+      const t2 = mockTransport(true);
+      registry.register('cid-1', t1);
+      registry.watch('cid-1', 'sess-a');
+      registry.watch('cid-1', 'sess-b');
+      registry.setActive('cid-1', 'sess-a');
+
+      registry.reconnect('cid-1', t2);
+
+      const conn = registry.get('cid-1')!;
+      expect(conn.transport).toBe(t2);
+      expect(conn.watchedSessions).toEqual(new Set(['sess-a', 'sess-b']));
+      expect(conn.activeSession).toBe('sess-a');
+    });
+
+    it('registers fresh connection for unknown connectionId', () => {
+      const t = mockTransport(true);
+      registry.reconnect('cid-unknown', t);
+
+      const conn = registry.get('cid-unknown');
+      expect(conn).toBeDefined();
+      expect(conn!.transport).toBe(t);
+      expect(conn!.watchedSessions).toEqual(new Set());
+    });
+
+    it('clears inactive timer on reconnect', () => {
+      vi.useFakeTimers();
+      const t1 = mockTransport(false);
+      const onExpired = vi.fn();
+      registry.register('cid-1', t1);
+      registry.watch('cid-1', 'sess-a');
+      registry.setOnExpired(onExpired);
+
+      registry.markInactive('cid-1');
+
+      const t2 = mockTransport(true);
+      registry.reconnect('cid-1', t2);
+
+      vi.advanceTimersByTime(ConnectionRegistry.INACTIVE_TTL_MS + 1000);
+      expect(onExpired).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+
   describe('watch / unwatch', () => {
     it('adds a session to a connection watch list', () => {
       registry.register('conn-1', mockTransport());
@@ -297,6 +344,74 @@ describe('ConnectionRegistry', () => {
     });
   });
 
+  describe('markInactive / TTL', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('fires onExpired after TTL when transport stays closed', () => {
+      vi.useFakeTimers();
+      const t = mockTransport(false);
+      const onExpired = vi.fn();
+      registry.register('cid-1', t);
+      registry.watch('cid-1', 'sess-a');
+      registry.watch('cid-1', 'sess-b');
+      registry.setOnExpired(onExpired);
+
+      registry.markInactive('cid-1');
+
+      vi.advanceTimersByTime(ConnectionRegistry.INACTIVE_TTL_MS - 1);
+      expect(onExpired).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(2);
+      expect(onExpired).toHaveBeenCalledWith('cid-1', new Set(['sess-a', 'sess-b']));
+      expect(registry.get('cid-1')).toBeUndefined();
+    });
+
+    it('does not fire onExpired if transport becomes open before TTL', () => {
+      vi.useFakeTimers();
+      let open = false;
+      const t: SessionTransport = {
+        send: vi.fn(),
+        isOpen: () => open,
+      };
+      const onExpired = vi.fn();
+      registry.register('cid-1', t);
+      registry.watch('cid-1', 'sess-a');
+      registry.setOnExpired(onExpired);
+
+      registry.markInactive('cid-1');
+      open = true;
+
+      vi.advanceTimersByTime(ConnectionRegistry.INACTIVE_TTL_MS + 1);
+      expect(onExpired).not.toHaveBeenCalled();
+      expect(registry.get('cid-1')).toBeDefined();
+    });
+
+    it('is a no-op for unknown connections', () => {
+      expect(() => registry.markInactive('nonexistent')).not.toThrow();
+    });
+
+    it('replaces timer on repeated markInactive calls', () => {
+      vi.useFakeTimers();
+      const t = mockTransport(false);
+      const onExpired = vi.fn();
+      registry.register('cid-1', t);
+      registry.watch('cid-1', 'sess-a');
+      registry.setOnExpired(onExpired);
+
+      registry.markInactive('cid-1');
+      vi.advanceTimersByTime(30_000);
+      registry.markInactive('cid-1');
+
+      vi.advanceTimersByTime(30_000);
+      expect(onExpired).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(30_001);
+      expect(onExpired).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('periodic sync', () => {
     afterEach(() => {
       vi.useRealTimers();
@@ -521,6 +636,22 @@ describe('ConnectionRegistry', () => {
       // Timer stopped — no sync fires
       vi.advanceTimersByTime(5000);
       expect(store.getEventsAfter).not.toHaveBeenCalled();
+    });
+
+    it('clears inactive timers on dispose', () => {
+      vi.useFakeTimers();
+      const t = mockTransport(false);
+      const onExpired = vi.fn();
+      registry.register('cid-1', t);
+      registry.watch('cid-1', 'sess-a');
+      registry.setOnExpired(onExpired);
+      registry.markInactive('cid-1');
+
+      registry.dispose();
+
+      vi.advanceTimersByTime(ConnectionRegistry.INACTIVE_TTL_MS + 1000);
+      expect(onExpired).not.toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 });

--- a/packages/harness/src/connection-registry.ts
+++ b/packages/harness/src/connection-registry.ts
@@ -54,6 +54,11 @@ export class ConnectionRegistry {
   private cursors = new Map<string, Map<string, number>>();
   private syncTimer: ReturnType<typeof setInterval> | null = null;
   private eventStore: EventStoreAdapter | null = null;
+  private inactiveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private onExpiredCallback: ((connectionId: string, watchedSessions: Set<string>) => void) | null =
+    null;
+
+  static readonly INACTIVE_TTL_MS = 60_000; // 60s grace period for reconnect
 
   register(connectionId: string, transport: SessionTransport): void {
     this.connections.set(connectionId, {
@@ -74,6 +79,65 @@ export class ConnectionRegistry {
     this.connections.delete(connectionId);
     // Clean up cursors for this connection
     this.cursors.delete(connectionId);
+    this.clearInactiveTimer(connectionId);
+  }
+
+  /**
+   * Swap the transport for an existing connection (SSE reconnect with same
+   * client-generated connectionId). Preserves watchedSessions and delivery
+   * cursors — no clientId rekey needed.
+   */
+  reconnect(connectionId: string, transport: SessionTransport): void {
+    const conn = this.connections.get(connectionId);
+    if (!conn) {
+      // Inactive TTL already expired — register fresh
+      this.register(connectionId, transport);
+      return;
+    }
+    conn.transport = transport;
+    this.clearInactiveTimer(connectionId);
+    log.info('connection transport swapped (reconnect)', { connectionId });
+  }
+
+  /**
+   * Mark a connection as inactive (SSE stream closed). Starts a TTL timer
+   * so a quick reconnect with the same connectionId preserves state.
+   * On TTL expiry, fires the onExpired callback and removes the connection.
+   */
+  markInactive(connectionId: string): void {
+    const conn = this.connections.get(connectionId);
+    if (!conn) return;
+
+    this.clearInactiveTimer(connectionId);
+    this.inactiveTimers.set(
+      connectionId,
+      setTimeout(() => {
+        this.inactiveTimers.delete(connectionId);
+        const current = this.connections.get(connectionId);
+        if (current && !current.transport.isOpen()) {
+          log.info('inactive connection TTL expired, cleaning up', { connectionId });
+          const watched = new Set(current.watchedSessions);
+          this.remove(connectionId);
+          this.onExpiredCallback?.(connectionId, watched);
+        }
+      }, ConnectionRegistry.INACTIVE_TTL_MS),
+    );
+  }
+
+  /**
+   * Register a callback fired when an inactive connection's TTL expires.
+   * Used by the server to trigger session detach on expired connections.
+   */
+  setOnExpired(cb: (connectionId: string, watchedSessions: Set<string>) => void): void {
+    this.onExpiredCallback = cb;
+  }
+
+  private clearInactiveTimer(connectionId: string): void {
+    const timer = this.inactiveTimers.get(connectionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.inactiveTimers.delete(connectionId);
+    }
   }
 
   /**
@@ -290,6 +354,10 @@ export class ConnectionRegistry {
    */
   dispose(): void {
     this.stopPeriodicSync();
+    for (const timer of this.inactiveTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.inactiveTimers.clear();
     this.connections.clear();
     this.cursors.clear();
   }

--- a/server/__tests__/session-sse-registry.test.ts
+++ b/server/__tests__/session-sse-registry.test.ts
@@ -22,6 +22,18 @@ describe('SessionSseRegistry', () => {
     vi.useRealTimers();
   });
 
+  describe('add', () => {
+    it('closes existing stream when reconnecting with the same connectionId', () => {
+      const oldRes = mockResponse();
+      const newRes = mockResponse();
+      registry.add('conn-1', oldRes);
+      registry.add('conn-1', newRes);
+
+      expect(oldRes.end).toHaveBeenCalledTimes(1);
+      expect(registry.isOpen('conn-1')).toBe(true);
+    });
+  });
+
   describe('removeIfCurrent', () => {
     it('removes and returns true when res matches current stream', () => {
       const res = mockResponse();

--- a/server/__tests__/session-sse-registry.test.ts
+++ b/server/__tests__/session-sse-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Response } from 'express';
 import { SessionSseRegistry } from '../session-sse-registry.js';
 
 function mockResponse(writableEnded = false) {
@@ -6,7 +7,7 @@ function mockResponse(writableEnded = false) {
     write: vi.fn(),
     end: vi.fn(),
     writableEnded,
-  } as never;
+  } as unknown as Response & { end: ReturnType<typeof vi.fn> };
 }
 
 describe('SessionSseRegistry', () => {

--- a/server/__tests__/session-sse-registry.test.ts
+++ b/server/__tests__/session-sse-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionSseRegistry } from '../session-sse-registry.js';
+
+function mockResponse(writableEnded = false) {
+  return {
+    write: vi.fn(),
+    end: vi.fn(),
+    writableEnded,
+  } as never;
+}
+
+describe('SessionSseRegistry', () => {
+  let registry: SessionSseRegistry;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    registry = new SessionSseRegistry();
+  });
+
+  afterEach(() => {
+    registry.destroy();
+    vi.useRealTimers();
+  });
+
+  describe('removeIfCurrent', () => {
+    it('removes and returns true when res matches current stream', () => {
+      const res = mockResponse();
+      registry.add('conn-1', res);
+
+      expect(registry.removeIfCurrent('conn-1', res)).toBe(true);
+      expect(registry.isOpen('conn-1')).toBe(false);
+    });
+
+    it('returns false when res does not match current stream (replaced by reconnect)', () => {
+      const oldRes = mockResponse();
+      const newRes = mockResponse();
+      registry.add('conn-1', oldRes);
+      registry.add('conn-1', newRes); // reconnect replaces old stream
+
+      // Old close handler fires — should NOT remove the new stream
+      expect(registry.removeIfCurrent('conn-1', oldRes)).toBe(false);
+      expect(registry.isOpen('conn-1')).toBe(true);
+    });
+
+    it('returns false for unknown connectionId', () => {
+      const res = mockResponse();
+      expect(registry.removeIfCurrent('conn-unknown', res)).toBe(false);
+    });
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -106,6 +106,28 @@ connRegistry.setEventStore({
   isSessionActive: (sessionId) => eventStore.getSession(sessionId)?.isActive ?? false,
 });
 
+// When a stable-cid connection's inactive TTL expires (no reconnect within
+// 60s), detach any sessions it was driving — same logic as the SSE close
+// handler for legacy connections.
+connRegistry.setOnExpired((connectionId, watchedSessions) => {
+  for (const sessionId of watchedSessions) {
+    const found = registry.findBySessionId(sessionId);
+    if (!found) continue;
+    if (registry.isSuspended(found.clientId)) continue;
+    const session = registry.get(found.clientId);
+    if (session && registry.isAttached(found.clientId)) {
+      detachChat(found.clientId);
+      overviewEmitter.touch(found.clientId);
+      overviewEmitter.scheduleBroadcast();
+      log.info('session detached after inactive TTL expired', {
+        connectionId,
+        sessionId,
+        clientId: found.clientId,
+      });
+    }
+  }
+});
+
 // Resolve cert paths relative to the project root (where package.json lives)
 const __filename = fileURLToPath(import.meta.url);
 const PROJECT_ROOT = join(__filename, '..', '..');
@@ -374,54 +396,79 @@ app.get('/api/chat/events', (req, res) => {
     'X-Accel-Buffering': 'no',
   });
 
-  const connectionId = `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  // Accept client-provided stable connectionId to eliminate the reconnect
+  // ownership race. Client sends ?cid=<uuid>; server reuses it across
+  // SSE reconnects so the clientId (connectionId:sessionId) never changes.
+  const clientCid = req.query.cid as string | undefined;
+  const isStableCid = clientCid != null && /^cid-[0-9a-f-]{36}$/.test(clientCid);
+  const connectionId = isStableCid
+    ? clientCid
+    : `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
   const transport = new SseTransport(connectionId, chatSseRegistry);
 
+  // chatSseRegistry.add() closes any existing stream for this connectionId
+  // before storing the new one — handles same-cid reconnects cleanly.
   chatSseRegistry.add(connectionId, res);
-  connRegistry.register(connectionId, transport);
 
-  // Send welcome with connectionId — client uses this in X-Connection-ID header on POSTs
+  // For stable cids: swap transport on existing connection, preserving
+  // watched sessions and delivery cursors. For legacy: register fresh.
+  const existingConn = isStableCid ? connRegistry.get(connectionId) : undefined;
+  if (existingConn) {
+    connRegistry.reconnect(connectionId, transport);
+  } else {
+    connRegistry.register(connectionId, transport);
+  }
+
   chatSseRegistry.sendTo(connectionId, {
     type: 'welcome',
     protocolVersion: 2,
     connectionId,
   });
 
-  // Reconnect is handled via POST /api/chat/reconnect — the client sends
-  // a reconnect POST on every welcome event. The old ?sessions= query param
-  // path was removed because EventSource auto-reconnect reuses the original
-  // URL (without the param), making it unreliable.
-
-  log.info('SSE chat stream connected', { connectionId });
+  log.info('SSE chat stream connected', {
+    connectionId,
+    stableCid: isStableCid,
+    reconnected: !!existingConn,
+  });
 
   req.on('close', () => {
     chatSseRegistry.remove(connectionId);
 
-    const conn = connRegistry.get(connectionId);
-    const watchedSessions = conn ? [...conn.watchedSessions] : [];
+    if (isStableCid) {
+      // Stable cid: defer cleanup. The client will reconnect with the same
+      // connectionId — markInactive starts a 60s TTL. If the TTL expires,
+      // the onExpired callback triggers session detach.
+      connRegistry.markInactive(connectionId);
+      log.info('SSE closed for stable-cid connection, deferring cleanup', { connectionId });
+    } else {
+      // Legacy server-generated connectionId: immediate cleanup
+      const conn = connRegistry.get(connectionId);
+      const watchedSessions = conn ? [...conn.watchedSessions] : [];
 
-    connRegistry.remove(connectionId);
-    registry.removeObserver(transport);
+      connRegistry.remove(connectionId);
+      registry.removeObserver(transport);
 
-    withSpan('sse.disconnect', { 'sse.connectionId': connectionId }, () => {
-      for (const sessionId of watchedSessions) {
-        const found = registry.findBySessionId(sessionId);
-        if (!found) continue;
+      withSpan('sse.disconnect', { 'sse.connectionId': connectionId }, () => {
+        for (const sessionId of watchedSessions) {
+          const found = registry.findBySessionId(sessionId);
+          if (!found) continue;
 
-        if (registry.isSuspended(found.clientId)) {
-          log.info('SSE closed for suspended session (expected)', { connectionId, sessionId });
-          continue;
+          if (registry.isSuspended(found.clientId)) {
+            log.info('SSE closed for suspended session (expected)', { connectionId, sessionId });
+            continue;
+          }
+
+          const session = registry.get(found.clientId);
+          if (session && session.transport === transport && registry.isAttached(found.clientId)) {
+            detachChat(found.clientId);
+            overviewEmitter.touch(found.clientId);
+            overviewEmitter.scheduleBroadcast();
+            log.info('SSE session detached (surviving)', { connectionId, sessionId });
+          }
         }
-
-        const session = registry.get(found.clientId);
-        if (session && session.transport === transport && registry.isAttached(found.clientId)) {
-          detachChat(found.clientId);
-          overviewEmitter.touch(found.clientId);
-          overviewEmitter.scheduleBroadcast();
-          log.info('SSE session detached (surviving)', { connectionId, sessionId });
-        }
-      }
-    });
+      });
+    }
 
     log.info('SSE chat stream disconnected', { connectionId });
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -454,15 +454,21 @@ app.get('/api/chat/events', (req, res) => {
     // chatSseRegistry.add() closes the old response — its async close
     // handler fires here. Without this guard, it would remove the NEW
     // response that replaced it, breaking event delivery.
-    chatSseRegistry.removeIfCurrent(connectionId, res);
+    const wasCurrentStream = chatSseRegistry.removeIfCurrent(connectionId, res);
 
     if (isStableCid) {
-      // Stable cid: defer cleanup. The client will reconnect with the same
-      // connectionId — markInactive starts a 60s TTL. If the TTL expires,
-      // the onExpired callback triggers session detach.
-      connRegistry.markInactive(connectionId);
+      // Only start the inactive TTL if this was the actual current stream.
+      // If removeIfCurrent returned false, a new stream already replaced us
+      // via reconnect() — starting markInactive here would race against the
+      // fresh connection.
+      if (wasCurrentStream) {
+        connRegistry.markInactive(connectionId);
+      }
       registry.removeObserver(transport);
-      log.info('SSE closed for stable-cid connection, deferring cleanup', { connectionId });
+      log.info('SSE closed for stable-cid connection, deferring cleanup', {
+        connectionId,
+        wasCurrentStream,
+      });
     } else {
       // Legacy server-generated connectionId: immediate cleanup
       const conn = connRegistry.get(connectionId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -414,6 +414,9 @@ app.get('/api/chat/events', (req, res) => {
   const isStableCid =
     clientCid != null &&
     /^cid-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(clientCid);
+  if (clientCid != null && !isStableCid) {
+    log.warn('SSE connection: invalid cid format rejected', { cid: clientCid });
+  }
   const connectionId = isStableCid
     ? clientCid
     : `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -83,6 +83,7 @@ import {
   isHelloHandshake,
   handleHello,
   dispatchV2Message,
+  getOwnerConnection,
   type V2HandlerContext,
 } from './ws-handler-v2.js';
 import { withSpan, withSpanAsync } from './tracing.js';
@@ -114,7 +115,7 @@ connRegistry.setOnExpired((connectionId, watchedSessions) => {
     const found = registry.findBySessionId(sessionId);
     if (!found) continue;
     // Skip if another connection has taken over this session
-    const ownerCid = found.clientId.substring(0, found.clientId.indexOf(':'));
+    const ownerCid = getOwnerConnection(found.clientId);
     if (ownerCid !== connectionId) {
       log.info('skipping detach — session now owned by different connection', {
         connectionId,
@@ -410,7 +411,9 @@ app.get('/api/chat/events', (req, res) => {
   // ownership race. Client sends ?cid=<uuid>; server reuses it across
   // SSE reconnects so the clientId (connectionId:sessionId) never changes.
   const clientCid = req.query.cid as string | undefined;
-  const isStableCid = clientCid != null && /^cid-[0-9a-f-]{36}$/i.test(clientCid);
+  const isStableCid =
+    clientCid != null &&
+    /^cid-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(clientCid);
   const connectionId = isStableCid
     ? clientCid
     : `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/server/index.ts
+++ b/server/index.ts
@@ -113,6 +113,16 @@ connRegistry.setOnExpired((connectionId, watchedSessions) => {
   for (const sessionId of watchedSessions) {
     const found = registry.findBySessionId(sessionId);
     if (!found) continue;
+    // Skip if another connection has taken over this session
+    const ownerCid = found.clientId.substring(0, found.clientId.indexOf(':'));
+    if (ownerCid !== connectionId) {
+      log.info('skipping detach — session now owned by different connection', {
+        connectionId,
+        sessionId,
+        currentOwner: ownerCid,
+      });
+      continue;
+    }
     if (registry.isSuspended(found.clientId)) continue;
     const session = registry.get(found.clientId);
     if (session && registry.isAttached(found.clientId)) {
@@ -400,7 +410,7 @@ app.get('/api/chat/events', (req, res) => {
   // ownership race. Client sends ?cid=<uuid>; server reuses it across
   // SSE reconnects so the clientId (connectionId:sessionId) never changes.
   const clientCid = req.query.cid as string | undefined;
-  const isStableCid = clientCid != null && /^cid-[0-9a-f-]{36}$/.test(clientCid);
+  const isStableCid = clientCid != null && /^cid-[0-9a-f-]{36}$/i.test(clientCid);
   const connectionId = isStableCid
     ? clientCid
     : `conn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -440,6 +450,7 @@ app.get('/api/chat/events', (req, res) => {
       // connectionId — markInactive starts a 60s TTL. If the TTL expires,
       // the onExpired callback triggers session detach.
       connRegistry.markInactive(connectionId);
+      registry.removeObserver(transport);
       log.info('SSE closed for stable-cid connection, deferring cleanup', { connectionId });
     } else {
       // Legacy server-generated connectionId: immediate cleanup

--- a/server/index.ts
+++ b/server/index.ts
@@ -449,7 +449,12 @@ app.get('/api/chat/events', (req, res) => {
   });
 
   req.on('close', () => {
-    chatSseRegistry.remove(connectionId);
+    // Guard: only remove from SSE registry if this response is still the
+    // current one. When a new request arrives with the same stable cid,
+    // chatSseRegistry.add() closes the old response — its async close
+    // handler fires here. Without this guard, it would remove the NEW
+    // response that replaced it, breaking event delivery.
+    chatSseRegistry.removeIfCurrent(connectionId, res);
 
     if (isStableCid) {
       // Stable cid: defer cleanup. The client will reconnect with the same

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -45,6 +45,16 @@ export class SessionSseRegistry {
   }
 
   /**
+   * Remove a stream only if the current entry for this connectionId is
+   * the given response. Prevents a stale close handler from removing a
+   * newer replacement stream after chatSseRegistry.add() swapped it.
+   */
+  removeIfCurrent(connectionId: string, res: Response): void {
+    if (this.streams.get(connectionId) !== res) return;
+    this.remove(connectionId);
+  }
+
+  /**
    * Send an SSE event to a specific connection.
    * Returns false if the connection doesn't exist or the write fails.
    *

--- a/server/session-sse-registry.ts
+++ b/server/session-sse-registry.ts
@@ -48,10 +48,12 @@ export class SessionSseRegistry {
    * Remove a stream only if the current entry for this connectionId is
    * the given response. Prevents a stale close handler from removing a
    * newer replacement stream after chatSseRegistry.add() swapped it.
+   * Returns true if the stream was removed, false if it was already replaced.
    */
-  removeIfCurrent(connectionId: string, res: Response): void {
-    if (this.streams.get(connectionId) !== res) return;
+  removeIfCurrent(connectionId: string, res: Response): boolean {
+    if (this.streams.get(connectionId) !== res) return false;
     this.remove(connectionId);
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary

Eliminates the "send message twice to wake agent" bug after iOS kills the SSE connection.

- **Root cause**: Every SSE reconnect minted a new server-generated `connectionId`, breaking the `clientId = ${connectionId}:${sessionId}` ownership chain. `handleReconnect` skipped reattach when the old transport appeared attached but was actually dead.
- **Fix**: Client generates a stable UUID per tab (`cid-{uuid}`), sends it via `?cid=` on SSE GET. Server reuses it across reconnects — `getOwnerConnection(clientId)` always returns the same connectionId, so `isOwner` is always true. No `handleReconnect` code changes needed.
- **Resilience**: POST failures (404/429/5xx/network) are re-queued with `_send_failed` emission. Optimistic `SET_RUNNING` after send. Deferred connection cleanup with 60s TTL.

## Changes

| File | What |
|------|------|
| `packages/client/src/sse-connection.ts` | Stable cid in URL, welcome validation, backward compat, `_send_failed` emission |
| `packages/harness/src/connection-registry.ts` | `reconnect()` swaps transport preserving state, `markInactive()` + `onExpired` TTL |
| `server/index.ts` | Accept `?cid=`, validate, `connRegistry.reconnect()`, deferred close, `onExpired` wiring |
| `frontend/src/client-store.ts` | `sessionStorage`-persisted connectionId per tab |
| `packages/client/src/store.ts` | Optimistic `SET_RUNNING`, `_send_failed` handler |

## Backward Compatibility

| Client | Server | Behavior |
|--------|--------|----------|
| New (sends `?cid=`) | New | Stable connectionId, full fix |
| New (sends `?cid=`) | Old (ignores cid) | Falls back to server-assigned ID |
| Old (no cid) | New | Server generates `conn-*` as before |

## Test plan

- [x] 17 new tests: stable cid generation/persistence/URL, reconnect transport swap, markInactive TTL, onExpired callback, POST failure surfacing (500/429/network), re-queue + retry
- [x] All 90 connection-registry + sse-connection tests pass
- [x] Lint + gitleaks clean
- [ ] Deploy server, rebuild iOS app
- [ ] Test: open session → send → force-kill app → reopen → send → should respond immediately (no double-send)
- [ ] Test: airplane mode 5s → disable → send → should work on first try

Supersedes #396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)