### PR TITLE
fix(ui): opaque session banner + header stacking context

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2429,7 +2429,7 @@ textarea:focus {
   position: sticky;
   top: 0;
   z-index: 10;
-  margin: 0 calc(-1 * var(--space-3));
+  margin: -1px calc(-1 * var(--space-3)) 0;
   padding: 0 var(--space-3);
   border-bottom: 1px solid var(--border);
   background: var(--surface);

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1475,6 +1475,8 @@ textarea:focus {
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  position: relative;
+  z-index: 20;
   transition:
     max-height 0.2s,
     padding 0.2s,
@@ -1666,7 +1668,7 @@ textarea:focus {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: var(--space-4) var(--space-3);
+  padding: 0 var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -2427,8 +2429,10 @@ textarea:focus {
   position: sticky;
   top: 0;
   z-index: 10;
+  margin: 0 calc(-1 * var(--space-3));
+  padding: 0 var(--space-3);
   border-bottom: 1px solid var(--border);
-  background: var(--bg-primary);
+  background: var(--surface);
 }
 
 .session-banner-header {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1477,6 +1477,7 @@ textarea:focus {
   flex-shrink: 0;
   position: relative;
   z-index: 20;
+  box-shadow: 0 4px 0 0 var(--surface);
   transition:
     max-height 0.2s,
     padding 0.2s,


### PR DESCRIPTION
## Summary

- Session banner used undefined `--bg-primary` CSS variable (resolved to `transparent`), causing scrolled content to bleed through
- Header toolbar had no stacking context, so scroll content could render above it
- Top padding on `.chat-messages` created a transparent gap between header and sticky banner

## Changes

- Replace `var(--bg-primary)` with `var(--surface)` on `.session-banner`
- Add `position: relative` + `z-index: 20` to `.chat-header`
- Move top padding from `.chat-messages` to bottom-only, so sticky banner sits flush
- Horizontal negative margin on banner to span full scroll container width

## Test plan

- [ ] Open a session in mobile Safari — no content bleeds through header or banner
- [ ] Scroll up/down — banner sticks flush, no transparent gap
- [ ] Check desktop layout is unaffected
- [ ] Verify keyboard-open state still compacts header correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)