### PR TITLE
fix(client): sync running state on iOS foreground return

### DIFF
--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -1408,4 +1408,30 @@ describe('foreground recovery', () => {
     // running should still be true — stale meta response was discarded
     expect(store.getState().messages.running).toBe(true);
   });
+
+  it('preserves running state when meta fetch fails (network error)', async () => {
+    const transport = mockTransport();
+    const store = createReadyStore(transport);
+
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+      messages: { ...s.messages, running: true },
+    }));
+
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/meta')) {
+        return Promise.reject(new Error('network error'));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+
+    lastWs.simulateMessage({ type: '_foreground' });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // running unchanged — fetch failure is non-fatal
+    expect(store.getState().messages.running).toBe(true);
+  });
 });

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -1310,24 +1310,22 @@ describe('foreground recovery', () => {
     }));
 
     // Mock fetch to return messages for /messages and isActive=false for /meta
-    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation(
-      (url: string) => {
-        if (typeof url === 'string' && url.includes('/meta')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ sessionId: 'sess-1', isActive: false }),
-          });
-        }
-        // /messages endpoint
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/meta')) {
         return Promise.resolve({
           ok: true,
-          json: () =>
-            Promise.resolve([
-              { messageId: 'msg-1', role: 'assistant', blocks: [], isStreaming: false },
-            ]),
+          json: () => Promise.resolve({ sessionId: 'sess-1', isActive: false }),
         });
-      },
-    );
+      }
+      // /messages endpoint
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve([
+            { messageId: 'msg-1', role: 'assistant', blocks: [], isStreaming: false },
+          ]),
+      });
+    });
 
     // Simulate foreground return (iOS Safari coming back from background)
     lastWs.simulateMessage({ type: '_foreground' });
@@ -1347,24 +1345,67 @@ describe('foreground recovery', () => {
       messages: { ...s.messages, running: true },
     }));
 
-    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation(
-      (url: string) => {
-        if (typeof url === 'string' && url.includes('/meta')) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve({ sessionId: 'sess-1', isActive: true }),
-          });
-        }
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/meta')) {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve([]),
+          json: () => Promise.resolve({ sessionId: 'sess-1', isActive: true }),
         });
-      },
-    );
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
 
     lastWs.simulateMessage({ type: '_foreground' });
     await new Promise((r) => setTimeout(r, 50));
 
+    expect(store.getState().messages.running).toBe(true);
+  });
+
+  it('does not clear running when session switches before meta fetch resolves', async () => {
+    const transport = mockTransport();
+    const store = createReadyStore(transport);
+
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-old' },
+      messages: { ...s.messages, running: true },
+    }));
+
+    // Meta fetch for sess-old returns isActive=false, but with a delay
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('/meta')) {
+        return new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: () => Promise.resolve({ sessionId: 'sess-old', isActive: false }),
+              }),
+            30,
+          ),
+        );
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+    });
+
+    // Trigger foreground — meta fetch starts for sess-old
+    lastWs.simulateMessage({ type: '_foreground' });
+
+    // User switches to a new session before meta fetch resolves
+    await store.getState().switchSession('sess-new');
+    store.setState((s) => ({
+      messages: { ...s.messages, running: true },
+    }));
+
+    // Wait for the delayed meta fetch to resolve
+    await new Promise((r) => setTimeout(r, 60));
+
+    // running should still be true — stale meta response was discarded
     expect(store.getState().messages.running).toBe(true);
   });
 });

--- a/packages/client/__tests__/store.test.ts
+++ b/packages/client/__tests__/store.test.ts
@@ -1298,4 +1298,73 @@ describe('foreground recovery', () => {
     expect(state.messages).toHaveLength(1);
     expect(state.messages[0].messageId).toBe('user-1');
   });
+
+  it('syncs running state from session meta on foreground when session_end was missed', async () => {
+    const transport = mockTransport();
+    const store = createReadyStore(transport);
+
+    // Set up active session with running=true (agent was processing)
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+      messages: { ...s.messages, running: true },
+    }));
+
+    // Mock fetch to return messages for /messages and isActive=false for /meta
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      (url: string) => {
+        if (typeof url === 'string' && url.includes('/meta')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ sessionId: 'sess-1', isActive: false }),
+          });
+        }
+        // /messages endpoint
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              { messageId: 'msg-1', role: 'assistant', blocks: [], isStreaming: false },
+            ]),
+        });
+      },
+    );
+
+    // Simulate foreground return (iOS Safari coming back from background)
+    lastWs.simulateMessage({ type: '_foreground' });
+
+    // Wait for both async fetches to resolve
+    await vi.waitFor(() => {
+      expect(store.getState().messages.running).toBe(false);
+    });
+  });
+
+  it('does not change running state when session is still active on foreground', async () => {
+    const transport = mockTransport();
+    const store = createReadyStore(transport);
+
+    store.setState((s) => ({
+      sessions: { ...s.sessions, active: 'sess-1' },
+      messages: { ...s.messages, running: true },
+    }));
+
+    (transport.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      (url: string) => {
+        if (typeof url === 'string' && url.includes('/meta')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ sessionId: 'sess-1', isActive: true }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+      },
+    );
+
+    lastWs.simulateMessage({ type: '_foreground' });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(store.getState().messages.running).toBe(true);
+  });
 });

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -226,7 +226,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       .getSessionMeta(sessionId)
       .then((meta) => {
         if (!meta) return;
-        const { messages: msgState } = store.getState();
+        // Guard: if the user switched sessions while the fetch was in flight,
+        // don't apply stale isActive=false to the new session's running state.
+        const { sessions, messages: msgState } = store.getState();
+        if (sessions.active !== sessionId) return;
         if (msgState.running && !meta.isActive) {
           store.setState((s) => ({
             messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: false }),

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -216,6 +216,28 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       });
   }
 
+  /**
+   * Sync running state from server — fixes stale stop button after iOS
+   * backgrounding drops the session_end SSE event. Independent of the
+   * reconnect path so it works even when doReconnectPost has issues.
+   */
+  function syncRunningState(sessionId: string) {
+    api
+      .getSessionMeta(sessionId)
+      .then((meta) => {
+        if (!meta) return;
+        const { messages: msgState } = store.getState();
+        if (msgState.running && !meta.isActive) {
+          store.setState((s) => ({
+            messages: messagesReducer(s.messages, { type: 'SET_RUNNING', running: false }),
+          }));
+        }
+      })
+      .catch(() => {
+        // Non-fatal — running state will correct on next event or user action
+      });
+  }
+
   function clearPendingSendTimer() {
     if (parserState.pendingSendTimer) {
       clearTimeout(parserState.pendingSendTimer);
@@ -701,7 +723,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
     // the REST API if we have an active session but no messages in the store.
     if (msg.type === '_foreground') {
       const { sessions } = store.getState();
-      if (sessions.active) fetchAndRestoreMessages(sessions.active);
+      if (sessions.active) {
+        fetchAndRestoreMessages(sessions.active);
+        syncRunningState(sessions.active);
+      }
       return;
     }
 

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -190,6 +190,7 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
   };
 
   let recoveryInFlight = false;
+  let runningSyncInFlight = false;
 
   function fetchAndRestoreMessages(sessionId: string) {
     if (recoveryInFlight) return;
@@ -216,12 +217,10 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       });
   }
 
-  /**
-   * Sync running state from server — fixes stale stop button after iOS
-   * backgrounding drops the session_end SSE event. Independent of the
-   * reconnect path so it works even when doReconnectPost has issues.
-   */
+  /** Sync running state from server when session_end may have been missed. */
   function syncRunningState(sessionId: string) {
+    if (runningSyncInFlight) return;
+    runningSyncInFlight = true;
     api
       .getSessionMeta(sessionId)
       .then((meta) => {
@@ -238,6 +237,9 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
       })
       .catch(() => {
         // Non-fatal — running state will correct on next event or user action
+      })
+      .finally(() => {
+        runningSyncInFlight = false;
       });
   }
 


### PR DESCRIPTION
## Summary

- Fixes stale stop button when iOS Safari backgrounds during agent processing and the `session_end` SSE event is silently dropped
- On foreground return (`_foreground` event), queries `/api/sessions/:id/meta` and sets `running: false` when `isActive` is false
- Independent of the reconnect path, so it works regardless of `doReconnectPost` issues being fixed in #fix/reconnect-on-stale-post

## Root cause

The `_foreground` handler called `fetchAndRestoreMessages()` which restored messages but never validated `running` state. When SSE `session_end` was lost during iOS background (EventSource appeared alive, so no reconnect triggered), `running` stayed `true` indefinitely, showing the stop/interrupt/queue buttons instead of the send button.

## Test plan

- [x] New test: `syncs running state from session meta on foreground when session_end was missed`
- [x] New test: `does not change running state when session is still active on foreground`
- [x] All 345 client tests pass
- [ ] Manual: background iOS Safari during agent processing, return after agent finishes, verify send button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)