### PR TITLE
feat(observability): session context inventory — span attrs + context consumed banner

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -14,7 +14,7 @@ import type {
   StreamingMessage,
   PermissionRequest,
 } from '../types/chat';
-import type { BootContextMeta } from '@mitzo/client';
+import type { BootContextMeta, ContextEntry } from '@mitzo/client';
 import type { ProgressBlock } from '@mitzo/protocol';
 import type { UseVoiceReturn } from '../hooks/useVoice';
 
@@ -43,6 +43,8 @@ export interface ChatAreaProps {
   bootContext?: BootContextMeta | null;
   /** Session context string for sticky banner */
   sessionContext?: string | null;
+  /** Runtime context consumed — files read, searches, fetches (deduped) */
+  contextConsumed?: ContextEntry[];
 }
 
 export function ChatArea({
@@ -56,6 +58,7 @@ export function ChatArea({
   voice,
   bootContext,
   sessionContext,
+  contextConsumed,
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
@@ -151,7 +154,7 @@ export function ChatArea({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        <SessionBanner bootContext={bootContext} sessionContext={sessionContext} />
+        <SessionBanner bootContext={bootContext} sessionContext={sessionContext} contextConsumed={contextConsumed} />
 
         {messages.length === 0 && !current && !running && (
           <p className="chat-empty">Send a message to start</p>

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -154,7 +154,11 @@ export function ChatArea({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        <SessionBanner bootContext={bootContext} sessionContext={sessionContext} contextConsumed={contextConsumed} />
+        <SessionBanner
+          bootContext={bootContext}
+          sessionContext={sessionContext}
+          contextConsumed={contextConsumed}
+        />
 
         {messages.length === 0 && !current && !running && (
           <p className="chat-empty">Send a message to start</p>

--- a/frontend/src/components/SessionBanner.tsx
+++ b/frontend/src/components/SessionBanner.tsx
@@ -78,12 +78,8 @@ function ContextConsumedSection({ entries }: { entries: ContextEntry[] }) {
           setShowContext((c) => !c);
         }}
       >
-        <span className="session-banner-label">
-          Context Consumed ({totalUnique} unique)
-        </span>
-        <span className="session-banner-chevron-inline">
-          {showContext ? '\u25BE' : '\u25B8'}
-        </span>
+        <span className="session-banner-label">Context Consumed ({totalUnique} unique)</span>
+        <span className="session-banner-chevron-inline">{showContext ? '\u25BE' : '\u25B8'}</span>
       </button>
       {showContext && (
         <div className="session-banner-boot-content">

--- a/frontend/src/components/SessionBanner.tsx
+++ b/frontend/src/components/SessionBanner.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react';
-import type { BootContextMeta, SectionMeta } from '@mitzo/client';
+import type { BootContextMeta, SectionMeta, ContextEntry } from '@mitzo/client';
 
 interface Props {
   bootContext?: BootContextMeta | null;
   sessionContext?: string | null;
+  contextConsumed?: ContextEntry[];
 }
 
 const KIND_LABELS: Record<string, string> = {
@@ -45,7 +46,75 @@ function summaryLine(text: string): string {
   return first.length > 80 ? first.slice(0, 77) + '...' : first;
 }
 
-export function SessionBanner({ bootContext, sessionContext }: Props) {
+const CTX_TYPE_LABELS: Record<string, string> = {
+  file_read: 'Files Read',
+  search: 'Searches',
+  web_search: 'Web Searches',
+  web_fetch: 'Web Fetches',
+};
+
+const CTX_TYPE_ORDER = ['file_read', 'search', 'web_search', 'web_fetch'] as const;
+
+function ContextConsumedSection({ entries }: { entries: ContextEntry[] }) {
+  const [showContext, setShowContext] = useState(false);
+
+  if (entries.length === 0) return null;
+
+  const grouped = new Map<string, ContextEntry[]>();
+  for (const e of entries) {
+    const arr = grouped.get(e.type) ?? [];
+    arr.push(e);
+    grouped.set(e.type, arr);
+  }
+
+  const totalUnique = entries.length;
+
+  return (
+    <div className="session-banner-context-consumed">
+      <button
+        className="session-banner-boot-toggle"
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowContext((c) => !c);
+        }}
+      >
+        <span className="session-banner-label">
+          Context Consumed ({totalUnique} unique)
+        </span>
+        <span className="session-banner-chevron-inline">
+          {showContext ? '\u25BE' : '\u25B8'}
+        </span>
+      </button>
+      {showContext && (
+        <div className="session-banner-boot-content">
+          {CTX_TYPE_ORDER.map((type) => {
+            const items = grouped.get(type);
+            if (!items || items.length === 0) return null;
+            return (
+              <div key={type}>
+                <div className="session-banner-sub-label">
+                  {CTX_TYPE_LABELS[type]} ({items.length})
+                </div>
+                {items.map((item, idx) => (
+                  <div key={idx} className="session-banner-source-row">
+                    <span className="session-banner-source-path">
+                      {item.label}
+                      {item.count > 1 && (
+                        <span className="session-banner-section-tokens"> x{item.count}</span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SessionBanner({ bootContext, sessionContext, contextConsumed }: Props) {
   const [expanded, setExpanded] = useState(false);
   const [showBootDetails, setShowBootDetails] = useState(false);
   const [showTrimmed, setShowTrimmed] = useState(false);
@@ -77,7 +146,8 @@ export function SessionBanner({ bootContext, sessionContext }: Props) {
     setShowModal(false);
   }, [contextKey]);
 
-  if (!bootContext && !sessionContext) return null;
+  const hasContext = contextConsumed && contextConsumed.length > 0;
+  if (!bootContext && !sessionContext && !hasContext) return null;
 
   const isContexgin = bootContext?.source === 'contexgin';
   const dotClass = isContexgin ? 'session-banner-dot--ok' : 'session-banner-dot--warn';
@@ -104,6 +174,9 @@ export function SessionBanner({ bootContext, sessionContext }: Props) {
               <span className="session-banner-meta">
                 {bootContext.sourceCount} sources · {tokenLabel}
                 {budgetLabel ? `/${budgetLabel}` : ''}
+                {contextConsumed && contextConsumed.length > 0 && (
+                  <> · {contextConsumed.length} ctx</>
+                )}
               </span>
             )}
             {sessionContext && (
@@ -210,6 +283,11 @@ export function SessionBanner({ bootContext, sessionContext }: Props) {
                   </div>
                 )}
               </div>
+            )}
+
+            {/* Runtime context consumed */}
+            {contextConsumed && contextConsumed.length > 0 && (
+              <ContextConsumedSection entries={contextConsumed} />
             )}
           </div>
         )}

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -53,6 +53,7 @@ export function ChatView() {
   const clearPendingSession = useMitzoStore((s) => s.clearPendingSession);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
   const bootContext = useMitzoStore((s) => s.messages.bootContext);
+  const contextConsumed = useMitzoStore((s) => s.messages.contextConsumed);
   const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
@@ -282,6 +283,7 @@ export function ChatView() {
         voice={voice}
         bootContext={bootContext}
         sessionContext={sessionContext}
+        contextConsumed={contextConsumed}
       />
 
       <ChatInput

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -41,6 +41,7 @@ export function DesktopChatView() {
   const storeFetchSessionMeta = useMitzoStore((s) => s.fetchSessionMeta);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
   const bootContext = useMitzoStore((s) => s.messages.bootContext);
+  const contextConsumed = useMitzoStore((s) => s.messages.contextConsumed);
   const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
@@ -252,6 +253,7 @@ export function DesktopChatView() {
             voice={voice}
             bootContext={bootContext}
             sessionContext={sessionContext}
+            contextConsumed={contextConsumed}
           />
           <ScrollFab scrollRef={scrollRef} />
           <ChatInput

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1672,3 +1672,270 @@ describe('foreground recovery race — full sequence', () => {
     expect(next.current!.messageId).toBe('asst-3');
   });
 });
+
+// ─── Context Consumed ──────────────────────────────────────────────────────
+
+describe('contextConsumed', () => {
+  it('starts empty', () => {
+    expect(INITIAL.contextConsumed).toEqual([]);
+  });
+
+  it('accumulates file reads on BLOCK_END', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 't1',
+      input: '/src/index.ts',
+    });
+
+    expect(state.contextConsumed).toHaveLength(1);
+    expect(state.contextConsumed[0]).toEqual({
+      type: 'file_read',
+      key: '/src/index.ts',
+      label: '/src/index.ts',
+      count: 1,
+    });
+  });
+
+  it('deduplicates repeated reads and increments count', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+
+    // First read
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 't1',
+      input: '/src/index.ts',
+    });
+
+    // Second read of same file
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'tool_use',
+      toolName: 'Read',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 't2',
+      input: '/src/index.ts',
+    });
+
+    expect(state.contextConsumed).toHaveLength(1);
+    expect(state.contextConsumed[0].count).toBe(2);
+  });
+
+  it('tracks multiple context types', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+
+    // Read
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 't1',
+      input: '/src/index.ts',
+    });
+
+    // Grep
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'tool_use',
+      toolName: 'Grep',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b2',
+      blockType: 'tool_use',
+      toolName: 'Grep',
+      toolId: 't2',
+      input: '/TODO/ in /src',
+    });
+
+    // WebFetch
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b3',
+      blockType: 'tool_use',
+      toolName: 'WebFetch',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b3',
+      blockType: 'tool_use',
+      toolName: 'WebFetch',
+      toolId: 't3',
+      input: 'https://example.com',
+    });
+
+    expect(state.contextConsumed).toHaveLength(3);
+    expect(state.contextConsumed.map((e) => e.type)).toEqual([
+      'file_read',
+      'search',
+      'web_fetch',
+    ]);
+  });
+
+  it('ignores non-context tools (Bash, Write, Edit)', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+
+    for (const toolName of ['Bash', 'Write', 'Edit']) {
+      state = messagesReducer(state, {
+        type: 'BLOCK_START',
+        messageId: 'msg-1',
+        blockId: `b-${toolName}`,
+        blockType: 'tool_use',
+        toolName,
+      });
+      state = messagesReducer(state, {
+        type: 'BLOCK_END',
+        messageId: 'msg-1',
+        blockId: `b-${toolName}`,
+        blockType: 'tool_use',
+        toolName,
+        toolId: `t-${toolName}`,
+        input: 'some input',
+      });
+    }
+
+    expect(state.contextConsumed).toHaveLength(0);
+  });
+
+  it('accumulates from subagent tool calls', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'agent-b',
+      blockType: 'tool_use',
+      toolName: 'Agent',
+    });
+    state = messagesReducer(state, {
+      type: 'SUBAGENT_START',
+      parentBlockId: 'agent-b',
+      subagentMessageId: 'sub-msg',
+    });
+    state = messagesReducer(state, {
+      type: 'SUBAGENT_BLOCK_START',
+      parentBlockId: 'agent-b',
+      blockId: 'sub-b1',
+      blockType: 'tool_use',
+      toolName: 'Grep',
+    });
+    state = messagesReducer(state, {
+      type: 'SUBAGENT_BLOCK_END',
+      parentBlockId: 'agent-b',
+      blockId: 'sub-b1',
+      toolName: 'Grep',
+      toolId: 'sub-t1',
+      input: '/error/ in /logs',
+    });
+
+    expect(state.contextConsumed).toHaveLength(1);
+    expect(state.contextConsumed[0]).toEqual({
+      type: 'search',
+      key: '/error/ in /logs',
+      label: '/error/ in /logs',
+      count: 1,
+    });
+  });
+
+  it('rebuilds context on RESTORE', () => {
+    const restored = messagesReducer(INITIAL, {
+      type: 'RESTORE',
+      messages: [
+        {
+          messageId: 'msg-1',
+          role: 'assistant',
+          timestamp: Date.now(),
+          blocks: [
+            {
+              blockId: 'b1',
+              blockType: 'tool_use',
+              content: '',
+              toolName: 'Read',
+              toolId: 't1',
+              toolInput: '/src/app.ts',
+            },
+            {
+              blockId: 'b2',
+              blockType: 'tool_use',
+              content: '',
+              toolName: 'Grep',
+              toolId: 't2',
+              toolInput: '/TODO/ in workspace',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(restored.contextConsumed).toHaveLength(2);
+    expect(restored.contextConsumed[0].type).toBe('file_read');
+    expect(restored.contextConsumed[1].type).toBe('search');
+  });
+
+  it('resets on CLEAR', () => {
+    let state = messagesReducer(INITIAL, { type: 'MESSAGE_START', messageId: 'msg-1' });
+    state = messagesReducer(state, {
+      type: 'BLOCK_START',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+    });
+    state = messagesReducer(state, {
+      type: 'BLOCK_END',
+      messageId: 'msg-1',
+      blockId: 'b1',
+      blockType: 'tool_use',
+      toolName: 'Read',
+      toolId: 't1',
+      input: '/some/file.ts',
+    });
+    expect(state.contextConsumed).toHaveLength(1);
+
+    state = messagesReducer(state, { type: 'CLEAR' });
+    expect(state.contextConsumed).toEqual([]);
+  });
+});

--- a/packages/client/__tests__/messages-slice.test.ts
+++ b/packages/client/__tests__/messages-slice.test.ts
@@ -1809,11 +1809,7 @@ describe('contextConsumed', () => {
     });
 
     expect(state.contextConsumed).toHaveLength(3);
-    expect(state.contextConsumed.map((e) => e.type)).toEqual([
-      'file_read',
-      'search',
-      'web_fetch',
-    ]);
+    expect(state.contextConsumed.map((e) => e.type)).toEqual(['file_read', 'search', 'web_fetch']);
   });
 
   it('ignores non-context tools (Bash, Write, Edit)', () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -24,6 +24,7 @@ export type {
   BootContextMeta,
   BootSourceMeta,
   SectionMeta,
+  ContextEntry,
 } from './slices/messages.js';
 export { messagesReducer, INITIAL_MESSAGES_STATE } from './slices/messages.js';
 export type { SessionsState } from './slices/sessions.js';

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -18,6 +18,68 @@ import type {
   ToolResultImage,
 } from '@mitzo/protocol';
 
+// ─── Context inventory ──────────────────────────────────────────────────────
+
+export interface ContextEntry {
+  type: 'file_read' | 'search' | 'web_search' | 'web_fetch';
+  key: string;
+  label: string;
+  count: number;
+}
+
+function extractContextEntry(
+  toolName?: string,
+  input?: string,
+): { type: ContextEntry['type']; key: string } | null {
+  if (!toolName || !input) return null;
+  switch (toolName) {
+    case 'Read':
+      return input ? { type: 'file_read', key: input } : null;
+    case 'Grep':
+    case 'Glob':
+      return input ? { type: 'search', key: input } : null;
+    case 'WebSearch':
+      return input ? { type: 'web_search', key: input } : null;
+    case 'WebFetch':
+      return input ? { type: 'web_fetch', key: input } : null;
+    default:
+      return null;
+  }
+}
+
+function accumulateContext(
+  existing: ContextEntry[],
+  toolName?: string,
+  input?: string,
+): ContextEntry[] {
+  const entry = extractContextEntry(toolName, input);
+  if (!entry) return existing;
+  const dedupKey = `${entry.type}:${entry.key}`;
+  const idx = existing.findIndex((e) => `${e.type}:${e.key}` === dedupKey);
+  if (idx !== -1) {
+    const updated = [...existing];
+    updated[idx] = { ...updated[idx], count: updated[idx].count + 1 };
+    return updated;
+  }
+  return [...existing, { type: entry.type, key: entry.key, label: entry.key, count: 1 }];
+}
+
+function rebuildContextFromMessages(messages: FinishedMessage[]): ContextEntry[] {
+  let ctx: ContextEntry[] = [];
+  for (const msg of messages) {
+    for (const block of msg.blocks) {
+      ctx = accumulateContext(ctx, block.toolName, block.toolInput);
+      // Include subagent tool calls
+      if (block.subagent && Array.isArray(block.subagent.blocks)) {
+        for (const sub of block.subagent.blocks) {
+          ctx = accumulateContext(ctx, sub.toolName, sub.toolInput);
+        }
+      }
+    }
+  }
+  return ctx;
+}
+
 // ─── State ───────────────────────────────────────────────────────────────────
 
 export interface ActiveWorktree {
@@ -59,6 +121,7 @@ export interface MessagesState {
   activeWorktrees: ActiveWorktree[];
   sessionContext: string | null;
   bootContext: BootContextMeta | null;
+  contextConsumed: ContextEntry[];
 }
 
 export const INITIAL_MESSAGES_STATE: MessagesState = {
@@ -72,6 +135,7 @@ export const INITIAL_MESSAGES_STATE: MessagesState = {
   activeWorktrees: [],
   sessionContext: null,
   bootContext: null,
+  contextConsumed: [],
 };
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -315,6 +379,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
       if (!state.current) return state;
       const block = state.current.blocks.get(action.blockId);
       if (!block) return state;
+      const toolName = action.toolName ?? block.toolName;
       const newBlocks = new Map(state.current.blocks);
       newBlocks.set(action.blockId, {
         ...block,
@@ -324,7 +389,11 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
         ...(action.input ? { toolInput: action.input } : {}),
         ...(action.rawInput ? { rawInput: action.rawInput } : {}),
       });
-      return { ...state, current: { ...state.current, blocks: newBlocks } };
+      return {
+        ...state,
+        current: { ...state.current, blocks: newBlocks },
+        contextConsumed: accumulateContext(state.contextConsumed, toolName, action.input),
+      };
     }
 
     case 'TOOL_RESULT': {
@@ -463,7 +532,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
       return { ...state, bootContext: action.bootContext };
 
     case 'CLEAR':
-      return { ...INITIAL_MESSAGES_STATE };
+      return { ...INITIAL_MESSAGES_STATE, contextConsumed: [] };
 
     case 'RESTORE': {
       const valid = action.messages.filter(
@@ -512,13 +581,23 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
         merged.push(notice);
         const currentStale =
           state.current && merged.some((m) => m.messageId === state.current!.messageId);
-        return { ...state, messages: merged, current: currentStale ? null : state.current };
+        return {
+          ...state,
+          messages: merged,
+          current: currentStale ? null : state.current,
+          contextConsumed: rebuildContextFromMessages(merged),
+        };
       }
       // Clear current if the restored set already contains it (prevents
       // MESSAGE_END from re-inserting a message that RESTORE already has).
       const currentStale =
         state.current && valid.some((m) => m.messageId === state.current!.messageId);
-      return { ...state, messages: valid, current: currentStale ? null : state.current };
+      return {
+        ...state,
+        messages: valid,
+        current: currentStale ? null : state.current,
+        contextConsumed: rebuildContextFromMessages(valid),
+      };
     }
 
     case 'USER_MESSAGE_RECEIVED': {
@@ -681,6 +760,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
 
       const subBlock = sub.blocks.get(action.blockId);
       if (!subBlock) return state;
+      const subToolName = action.toolName ?? subBlock.toolName;
 
       const newSubBlocks = new Map(sub.blocks);
       newSubBlocks.set(action.blockId, {
@@ -698,7 +778,11 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
         subagent: { ...sub, blocks: newSubBlocks },
       });
 
-      return { ...state, current: { ...state.current, blocks: newBlocks } };
+      return {
+        ...state,
+        current: { ...state.current, blocks: newBlocks },
+        contextConsumed: accumulateContext(state.contextConsumed, subToolName, action.input),
+      };
     }
 
     case 'SUBAGENT_TOOL_RESULT': {

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -34,14 +34,14 @@ function extractContextEntry(
   if (!toolName || !input) return null;
   switch (toolName) {
     case 'Read':
-      return input ? { type: 'file_read', key: input } : null;
+      return { type: 'file_read', key: input };
     case 'Grep':
     case 'Glob':
-      return input ? { type: 'search', key: input } : null;
+      return { type: 'search', key: input };
     case 'WebSearch':
-      return input ? { type: 'web_search', key: input } : null;
+      return { type: 'web_search', key: input };
     case 'WebFetch':
-      return input ? { type: 'web_fetch', key: input } : null;
+      return { type: 'web_fetch', key: input };
     default:
       return null;
   }
@@ -532,7 +532,7 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
       return { ...state, bootContext: action.bootContext };
 
     case 'CLEAR':
-      return { ...INITIAL_MESSAGES_STATE, contextConsumed: [] };
+      return { ...INITIAL_MESSAGES_STATE };
 
     case 'RESTORE': {
       const valid = action.messages.filter(

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -279,11 +279,11 @@ describe('getToolInputSpanAttrs', () => {
   });
 
   it('extracts file_path for Write', () => {
-    expect(
-      getToolInputSpanAttrs('Write', { file_path: '/tmp/out.txt', content: 'hello' }),
-    ).toEqual({
-      'tool.input.file_path': '/tmp/out.txt',
-    });
+    expect(getToolInputSpanAttrs('Write', { file_path: '/tmp/out.txt', content: 'hello' })).toEqual(
+      {
+        'tool.input.file_path': '/tmp/out.txt',
+      },
+    );
   });
 
   it('extracts file_path for Edit and StrReplace', () => {

--- a/packages/protocol/__tests__/tool-summary.test.ts
+++ b/packages/protocol/__tests__/tool-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizeToolInput, getRawInput } from '../src/tool-summary.js';
+import { summarizeToolInput, getRawInput, getToolInputSpanAttrs } from '../src/tool-summary.js';
 
 describe('summarizeToolInput', () => {
   it('summarizes Read tool with file path', () => {
@@ -268,5 +268,111 @@ describe('getRawInput', () => {
     expect(result).toEqual({ type: 'agent', description: 'Search' });
     expect(result).not.toHaveProperty('subagent_type');
     expect(result).not.toHaveProperty('prompt');
+  });
+});
+
+describe('getToolInputSpanAttrs', () => {
+  it('extracts file_path for Read', () => {
+    expect(getToolInputSpanAttrs('Read', { file_path: '/src/index.ts' })).toEqual({
+      'tool.input.file_path': '/src/index.ts',
+    });
+  });
+
+  it('extracts file_path for Write', () => {
+    expect(
+      getToolInputSpanAttrs('Write', { file_path: '/tmp/out.txt', content: 'hello' }),
+    ).toEqual({
+      'tool.input.file_path': '/tmp/out.txt',
+    });
+  });
+
+  it('extracts file_path for Edit and StrReplace', () => {
+    expect(getToolInputSpanAttrs('Edit', { file_path: '/a.ts' })).toEqual({
+      'tool.input.file_path': '/a.ts',
+    });
+    expect(getToolInputSpanAttrs('StrReplace', { file_path: '/b.ts' })).toEqual({
+      'tool.input.file_path': '/b.ts',
+    });
+  });
+
+  it('extracts command for Bash and Shell', () => {
+    expect(getToolInputSpanAttrs('Bash', { command: 'npm test' })).toEqual({
+      'tool.input.command': 'npm test',
+    });
+    expect(getToolInputSpanAttrs('Shell', { command: 'ls -la' })).toEqual({
+      'tool.input.command': 'ls -la',
+    });
+  });
+
+  it('extracts pattern and optional path for Glob', () => {
+    expect(getToolInputSpanAttrs('Glob', { pattern: '**/*.ts', path: '/src' })).toEqual({
+      'tool.input.pattern': '**/*.ts',
+      'tool.input.path': '/src',
+    });
+    expect(getToolInputSpanAttrs('Glob', { pattern: '*.js' })).toEqual({
+      'tool.input.pattern': '*.js',
+    });
+  });
+
+  it('extracts pattern and optional path for Grep', () => {
+    expect(getToolInputSpanAttrs('Grep', { pattern: 'TODO', path: '/src' })).toEqual({
+      'tool.input.pattern': 'TODO',
+      'tool.input.path': '/src',
+    });
+    expect(getToolInputSpanAttrs('Grep', { pattern: 'error' })).toEqual({
+      'tool.input.pattern': 'error',
+    });
+  });
+
+  it('extracts query for WebSearch', () => {
+    expect(getToolInputSpanAttrs('WebSearch', { search_term: 'vitest mocking' })).toEqual({
+      'tool.input.query': 'vitest mocking',
+    });
+  });
+
+  it('extracts url for WebFetch', () => {
+    expect(getToolInputSpanAttrs('WebFetch', { url: 'https://example.com' })).toEqual({
+      'tool.input.url': 'https://example.com',
+    });
+  });
+
+  it('extracts description and subagent_type for Agent', () => {
+    expect(
+      getToolInputSpanAttrs('Agent', {
+        description: 'Find transcript',
+        subagent_type: 'Explore',
+        prompt: 'Search for...',
+      }),
+    ).toEqual({
+      'tool.input.description': 'Find transcript',
+      'tool.input.subagent_type': 'Explore',
+    });
+  });
+
+  it('omits subagent_type for Agent when not provided', () => {
+    const attrs = getToolInputSpanAttrs('Agent', { description: 'Search codebase' });
+    expect(attrs).toEqual({ 'tool.input.description': 'Search codebase' });
+    expect(attrs).not.toHaveProperty('tool.input.subagent_type');
+  });
+
+  it('extracts skill for Skill tool', () => {
+    expect(getToolInputSpanAttrs('Skill', { skill: 'commit' })).toEqual({
+      'tool.input.skill': 'commit',
+    });
+  });
+
+  it('returns empty object for unknown tools', () => {
+    expect(getToolInputSpanAttrs('mcp__jira__get_issue', { key: 'FOO-1' })).toEqual({});
+  });
+
+  it('omits empty string values', () => {
+    expect(getToolInputSpanAttrs('Read', { file_path: '' })).toEqual({});
+    expect(getToolInputSpanAttrs('Read', {})).toEqual({});
+  });
+
+  it('truncates long values to 256 chars', () => {
+    const longPath = '/src/' + 'a'.repeat(300) + '.ts';
+    const attrs = getToolInputSpanAttrs('Read', { file_path: longPath });
+    expect(attrs['tool.input.file_path'].length).toBe(256);
   });
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -63,7 +63,7 @@ export {
 } from './constants.js';
 
 // Tool summary
-export { getRawInput, summarizeToolInput } from './tool-summary.js';
+export { getRawInput, getToolInputSpanAttrs, summarizeToolInput } from './tool-summary.js';
 
 // Language detection
 export { languageFromPath } from './language.js';

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -71,7 +71,7 @@ export function getToolInputSpanAttrs(
 ): Record<string, string> {
   const attrs: Record<string, string> = {};
   const set = (key: string, val: unknown) => {
-    const s = String(val || '');
+    const s = String(val ?? '');
     if (s) attrs[`tool.input.${key}`] = s.slice(0, SPAN_ATTR_MAX);
   };
 

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -58,6 +58,66 @@ export function getRawInput(
   }
 }
 
+const SPAN_ATTR_MAX = 256;
+
+/**
+ * Extract structured span attributes from tool input for Jaeger indexing.
+ * Returns flat `tool.input.*` key-value pairs that are searchable/filterable
+ * in Jaeger UI. Values are truncated to keep span metadata lightweight.
+ */
+export function getToolInputSpanAttrs(
+  toolName: string,
+  input: Record<string, unknown>,
+): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const set = (key: string, val: unknown) => {
+    const s = String(val || '');
+    if (s) attrs[`tool.input.${key}`] = s.slice(0, SPAN_ATTR_MAX);
+  };
+
+  switch (toolName) {
+    case 'Read':
+      set('file_path', input.file_path);
+      break;
+    case 'Write':
+      set('file_path', input.file_path);
+      break;
+    case 'Edit':
+    case 'StrReplace':
+      set('file_path', input.file_path);
+      break;
+    case 'Bash':
+    case 'Shell':
+      set('command', input.command);
+      break;
+    case 'Glob':
+      set('pattern', input.pattern);
+      if (input.path) set('path', input.path);
+      break;
+    case 'Grep':
+      set('pattern', input.pattern);
+      if (input.path) set('path', input.path);
+      break;
+    case 'WebSearch':
+      set('query', input.search_term);
+      break;
+    case 'WebFetch':
+      set('url', input.url);
+      break;
+    case 'Agent':
+      set('description', input.description);
+      if (input.subagent_type) set('subagent_type', input.subagent_type);
+      break;
+    case 'Skill':
+      set('skill', input.skill);
+      break;
+    default:
+      break;
+  }
+
+  return attrs;
+}
+
 export function summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
   switch (toolName) {
     case 'Read':

--- a/packages/protocol/src/tool-summary.ts
+++ b/packages/protocol/src/tool-summary.ts
@@ -77,11 +77,7 @@ export function getToolInputSpanAttrs(
 
   switch (toolName) {
     case 'Read':
-      set('file_path', input.file_path);
-      break;
     case 'Write':
-      set('file_path', input.file_path);
-      break;
     case 'Edit':
     case 'StrReplace':
       set('file_path', input.file_path);
@@ -91,9 +87,6 @@ export function getToolInputSpanAttrs(
       set('command', input.command);
       break;
     case 'Glob':
-      set('pattern', input.pattern);
-      if (input.path) set('path', input.path);
-      break;
     case 'Grep':
       set('pattern', input.pattern);
       if (input.path) set('path', input.path);
@@ -120,10 +113,9 @@ export function getToolInputSpanAttrs(
 
 export function summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
   switch (toolName) {
-    case 'Read':
-      return `${input.file_path || ''}`;
     case 'Write':
       return `${input.file_path || ''} (${String(input.content || '').length} chars)`;
+    case 'Read':
     case 'Edit':
     case 'StrReplace':
       return `${input.file_path || ''}`;

--- a/server/query-loop.ts
+++ b/server/query-loop.ts
@@ -1,5 +1,5 @@
 import type { SessionTransport, ConnectionRegistry } from '@mitzo/harness';
-import { summarizeToolInput, getRawInput } from './tool-summary.js';
+import { summarizeToolInput, getRawInput, getToolInputSpanAttrs } from './tool-summary.js';
 import { extractToolResultText, extractToolResultImages } from './content-blocks.js';
 import { storeImage } from './image-store.js';
 import {
@@ -1114,9 +1114,15 @@ async function _runQueryLoopInner(
               log.info('tool call', { clientId, tool: toolEntry.name, toolId: toolEntry.id });
               log.debug('tool call input', { clientId, toolId: toolEntry.id, input: trInput.text });
 
-              // End tool span — record raw input before closing
+              // End tool span — record structured attrs + raw input before closing
               const toolSpan = toolSpans.get(blockId);
               if (toolSpan) {
+                // Searchable/filterable span attributes (indexed by Jaeger)
+                const spanAttrs = getToolInputSpanAttrs(toolEntry.name, toolInput);
+                for (const [k, v] of Object.entries(spanAttrs)) {
+                  toolSpan.setAttribute(k, v);
+                }
+                // Full raw input as event (not indexed, but visible in span detail)
                 toolSpan.addEvent('tool.input', {
                   'tool.name': toolEntry.name,
                   'tool.input': trInput.text,

--- a/server/tool-summary.ts
+++ b/server/tool-summary.ts
@@ -1,4 +1,4 @@
 // Re-export from @mitzo/protocol — this file exists for backwards compatibility
 // during the migration. Server consumers should eventually import from @mitzo/protocol directly.
-export { getRawInput, summarizeToolInput } from '@mitzo/protocol';
+export { getRawInput, getToolInputSpanAttrs, summarizeToolInput } from '@mitzo/protocol';
 export type { RawToolInput } from '@mitzo/protocol';


### PR DESCRIPTION
## Summary

Two independent workstreams for session context inventory:

**WS1: Enriched Jaeger traces**
- New `getToolInputSpanAttrs()` extracts structured, searchable span attributes from tool inputs
- Tool spans carry `tool.input.file_path`, `tool.input.command`, `tool.input.pattern`, `tool.input.path`, `tool.input.query`, `tool.input.url`, `tool.input.description`, `tool.input.subagent_type`, `tool.input.skill`
- Values truncated to 256 chars, indexed by Jaeger for search/filter
- Raw input event preserved for full detail in span view

**WS2: Context consumed in session banner**
- Messages reducer accumulates context consumption from BLOCK_END events (files read, searches, web fetches)
- Deduped by type+key, tracks repeat counts
- Subagent tool calls included
- Rebuilds on RESTORE (reconnect/session switch), resets on CLEAR
- Renders as collapsible "Context Consumed" section in SessionBanner
- Collapsed summary shows unique context count alongside boot context stats

## Test plan
- [x] 15 new tool-summary-attrs tests (all tool types, edge cases, truncation)
- [x] 7 new messages-slice tests (accumulation, dedup, multi-type, subagents, RESTORE, CLEAR)
- [ ] Deploy and verify span attrs appear in Jaeger UI
- [ ] Verify context consumed section renders in session banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)