### PR TITLE
fix(logger): silence pino-loki errors when Loki is unreachable

### DIFF
--- a/server/logger.ts
+++ b/server/logger.ts
@@ -67,6 +67,7 @@ function buildProductionDestination(level: LogLevel): DestinationStream {
         propsToLabels: ['module'],
         batching: true,
         interval: 5,
+        silenceErrors: true,
       },
       level,
     });


### PR DESCRIPTION
## Summary

- Adds `silenceErrors: true` to the pino-loki transport config
- Prevents stderr spam (50+ full stack traces) when Loki container is down or still starting up
- Loki is optional observability infra — file and stdout logging are unaffected

## Context

pino-loki dumps `AggregateError [ECONNREFUSED]` with a full stack trace to stderr on every log line when it can't reach port 3200. This happens during Loki container startup or when the observability stack isn't running. The noise makes it harder to debug actual issues.

## Test plan

- [ ] Verify server starts cleanly without Loki running (no stderr spam)
- [ ] Verify logs still flow to Loki when it's available
- [ ] Existing logger tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)