### PR TITLE
fix(orchestrator): default session_policy to spawn

### DIFF
--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -727,7 +727,11 @@ describe('TaskOrchestrator', () => {
       });
 
       const goal2 = store.create({ title: 'Goal 2' });
-      const reuse = store.create({ title: 'Reuse task', parentId: goal2.id });
+      const reuse = store.create({
+        title: 'Reuse task',
+        parentId: goal2.id,
+        sessionPolicy: 'reuse',
+      });
 
       // Start goal1 (spawns), stop, start goal2
       orch.start(goal1.id);
@@ -815,6 +819,23 @@ describe('TaskOrchestrator', () => {
       await vi.waitFor(() => {
         expect(spawnSession).toHaveBeenCalledTimes(2);
       });
+    });
+
+    it('auto policy (store default) spawns instead of reusing', async () => {
+      const spawnSession = vi.fn().mockResolvedValue('spawned-client-1');
+      const deps = createTestDeps(store);
+      deps.spawnSession = spawnSession;
+      const orch = new TaskOrchestrator(deps);
+
+      const goal = store.create({ title: 'Goal' });
+      // No explicit sessionPolicy — store defaults to 'auto'
+      const task = store.create({ title: 'Auto task', parentId: goal.id });
+
+      orch.start(goal.id);
+      await vi.waitFor(() => expect(spawnSession).toHaveBeenCalled());
+
+      expect(spawnSession).toHaveBeenCalledWith(task.id, expect.any(String), goal.id);
+      expect(deps.setTaskContext).not.toHaveBeenCalled();
     });
 
     it('reuse policy tasks use pinned session as before', () => {

--- a/server/__tests__/task-orchestrator.test.ts
+++ b/server/__tests__/task-orchestrator.test.ts
@@ -835,6 +835,7 @@ describe('TaskOrchestrator', () => {
       await vi.waitFor(() => expect(spawnSession).toHaveBeenCalled());
 
       expect(spawnSession).toHaveBeenCalledWith(task.id, expect.any(String), goal.id);
+      expect(store.get(task.id)?.status).toBe('active');
       expect(deps.setTaskContext).not.toHaveBeenCalled();
     });
 

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -342,7 +342,10 @@ export class TaskOrchestrator {
 
       case 'agent_work':
       default: {
-        const policy = next.sessionPolicy ?? 'spawn';
+        // Default to spawn: 'auto' and undefined both resolve to 'spawn'
+        // so tasks get dedicated sessions unless explicitly set to 'reuse'.
+        const raw = next.sessionPolicy ?? 'spawn';
+        const policy = raw === 'auto' ? 'spawn' : raw;
 
         if (policy === 'spawn' && this.deps.spawnSession) {
           // Spawn a dedicated headless session for this task

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -342,10 +342,8 @@ export class TaskOrchestrator {
 
       case 'agent_work':
       default: {
-        // Default to spawn: 'auto' and undefined both resolve to 'spawn'
-        // so tasks get dedicated sessions unless explicitly set to 'reuse'.
-        const raw = next.sessionPolicy ?? 'spawn';
-        const policy = raw === 'auto' ? 'spawn' : raw;
+        // Default to spawn so tasks get dedicated sessions unless explicitly 'reuse'.
+        const policy = next.sessionPolicy === 'reuse' ? 'reuse' : 'spawn';
 
         if (policy === 'spawn' && this.deps.spawnSession) {
           // Spawn a dedicated headless session for this task

--- a/server/task-orchestrator.ts
+++ b/server/task-orchestrator.ts
@@ -342,7 +342,7 @@ export class TaskOrchestrator {
 
       case 'agent_work':
       default: {
-        const policy = next.sessionPolicy ?? 'reuse';
+        const policy = next.sessionPolicy ?? 'spawn';
 
         if (policy === 'spawn' && this.deps.spawnSession) {
           // Spawn a dedicated headless session for this task


### PR DESCRIPTION
## Summary

- Flips the default `sessionPolicy` from `reuse` to `spawn` in `TaskOrchestrator.tick()`
- Tasks without an explicit policy now get dedicated headless sessions instead of injecting into the user's active conversation
- The `spawn` infrastructure was already built in PR #377 but was opt-in — this makes it the default
- Explicit `sessionPolicy: 'reuse'` still works for tasks that need it

## Test plan

- [x] All 45 existing orchestrator tests pass (tests that relied on reuse either set `sessionPolicy: 'reuse'` explicitly or don't provide `spawnSession` in deps, so they fall through correctly)
- [ ] Verify task board no longer injects prompts into interactive sessions
- [ ] Verify spawned tasks complete in their own headless sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)