### PR TITLE
fix(chat): catch ProcessTransport errors on interrupt

### DIFF
--- a/server/chat.ts
+++ b/server/chat.ts
@@ -1273,7 +1273,16 @@ export async function interruptChat(
       );
       await Promise.allSettled(stops);
     }
-    await session.queryInstance.interrupt();
+    try {
+      await session.queryInstance.interrupt();
+    } catch (err: unknown) {
+      // ProcessTransport may already be dead (process exited) — the interrupt
+      // is moot in that case.  Swallow rather than crashing the server.
+      log.warn('interrupt() failed (transport likely dead)', {
+        clientId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
     // Only push to inputQueue on first delivery — a retried interrupt should
     // still call interrupt() (to halt the agent) but not double-queue the prompt.
     if (!isDup) {

--- a/server/ws-handler-v2.ts
+++ b/server/ws-handler-v2.ts
@@ -733,6 +733,12 @@ export function handleInterruptV2(
           msg.contextBlocks,
           msg.clientMsgId,
           msg.model,
+        ).catch((err: unknown) =>
+          log.error('interruptChat failed', {
+            connectionId,
+            sessionId: msg.sessionId,
+            err: err instanceof Error ? err.message : String(err),
+          }),
         );
         log.info('interrupt', { connectionId, sessionId: msg.sessionId });
         return;


### PR DESCRIPTION
## Summary

- Wraps `session.queryInstance.interrupt()` in try/catch in `chat.ts` — when the SDK child process has already exited, the call throws `ProcessTransport is not ready for writing` as an unhandled promise rejection, crashing the Node server
- Adds `.catch()` to the fire-and-forget `interruptChat()` call in `ws-handler-v2.ts` to prevent unhandled rejections from that path
- 4 crashes attributed to this bug across June 22-27 (3 on June 27 alone)

## Test plan

- [ ] Verify server stays up when interrupting a session whose agent process has exited
- [ ] Verify normal interrupt flow still works (send message while agent is generating)
- [ ] Check logs for the new warn message under the dead-transport scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)