### PR TITLE
fix(frontend): task board scroll, session links, summary display

### DIFF
--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Task, TaskStatus, StageType } from '../types/task';
 import type { TaskDisplayMeta } from '../hooks/useTaskBoard';
 
@@ -51,27 +52,62 @@ interface TaskNodeProps {
   onReject?: (id: string, feedback: string) => void;
 }
 
-function buildContextLine(task: Task, meta?: TaskDisplayMeta): string | null {
+function ContextLine({
+  task,
+  meta,
+  onNavigateSession,
+}: {
+  task: Task;
+  meta?: TaskDisplayMeta;
+  onNavigateSession?: (sessionId: string) => void;
+}) {
+  const dot = ' \u00B7 ';
+
+  const sessionLink =
+    task.sessionId && meta?.sessionHash ? (
+      <a
+        className="task-node-session-link"
+        onClick={(e) => {
+          e.stopPropagation();
+          onNavigateSession?.(task.sessionId!);
+        }}
+      >
+        {meta.sessionHash}
+      </a>
+    ) : null;
+
   switch (task.status) {
-    case 'active': {
-      const parts: string[] = [STATUS_LABELS.active];
-      if (meta?.sessionHash) parts.push(meta.sessionHash);
-      if (meta?.elapsedLabel) parts.push(meta.elapsedLabel);
-      return parts.join(' \u00B7 ');
-    }
+    case 'active':
+      return (
+        <>
+          {STATUS_LABELS.active}
+          {sessionLink && <>{dot}{sessionLink}</>}
+          {meta?.elapsedLabel && `${dot}${meta.elapsedLabel}`}
+        </>
+      );
     case 'pending_review':
-      return 'awaiting approval';
+      return <>awaiting approval{sessionLink && <>{dot}{sessionLink}</>}</>;
     case 'blocked':
-      return meta?.blockerSummary ?? 'blocked';
+      return <>{meta?.blockerSummary ?? 'blocked'}{sessionLink && <>{dot}{sessionLink}</>}</>;
     case 'done':
-      return meta?.completedAgo ? `done \u00B7 ${meta.completedAgo}` : 'done';
+      return (
+        <>
+          {meta?.completedAgo ? `done${dot}${meta.completedAgo}` : 'done'}
+          {sessionLink && <>{dot}{sessionLink}</>}
+        </>
+      );
     case 'failed': {
       const label = meta?.blockerSummary ?? 'failed';
-      return task.retryCount > 0 ? `${label} \u00B7 retry ${task.retryCount}` : label;
+      const retry = task.retryCount > 0 ? `${dot}retry ${task.retryCount}` : '';
+      return <>{label}{retry}{sessionLink && <>{dot}{sessionLink}</>}</>;
     }
     default:
       return null;
   }
+}
+
+function hasContextLine(status: TaskStatus): boolean {
+  return status === 'active' || status === 'pending_review' || status === 'blocked' || status === 'done' || status === 'failed';
 }
 
 function contextColorClass(status: TaskStatus): string {
@@ -97,6 +133,7 @@ export function TaskNode({
   onReject,
 }: TaskNodeProps) {
   const [expanded, setExpanded] = useState(true);
+  const navigate = useNavigate();
   const hasChildren = task.children.length > 0;
   const meta = displayMeta?.get(task.id);
   const isCompact = compact && task.status !== 'active';
@@ -106,11 +143,15 @@ export function TaskNode({
   if (meta?.attendTier === 1) classes.push('task-node--t1');
   if (meta && meta.fadeOpacity <= 0) classes.push('task-node--hidden');
 
-  const contextLine = isCompact ? null : buildContextLine(task, meta);
+  const showContext = !isCompact && hasContextLine(task.status);
   const fadeStyle =
     meta && meta.fadeOpacity < 1 && meta.fadeOpacity > 0
       ? { opacity: meta.fadeOpacity }
       : undefined;
+
+  function handleNavigateSession(sessionId: string) {
+    navigate(`/chat/${sessionId}`);
+  }
 
   return (
     <div className={classes.join(' ')} style={fadeStyle}>
@@ -137,10 +178,13 @@ export function TaskNode({
           >
             {task.title}
           </span>
-          {contextLine && (
+          {showContext && (
             <div className={`task-node-context${contextColorClass(task.status)}`}>
-              {contextLine}
+              <ContextLine task={task} meta={meta} onNavigateSession={handleNavigateSession} />
             </div>
+          )}
+          {task.summary && (
+            <div className="task-node-summary">{task.summary}</div>
           )}
         </div>
         {task.stageType && STAGE_LABELS[task.stageType] && (

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -52,11 +52,11 @@ interface TaskNodeProps {
   onReject?: (id: string, feedback: string) => void;
 }
 
-function ContextLine({ task, meta }: { task: Task; meta?: TaskDisplayMeta }) {
-  const dot = ' \u00B7 ';
-
-  const sessionLink =
-    task.sessionId && meta?.sessionHash ? (
+function SessionSuffix({ task, meta }: { task: Task; meta?: TaskDisplayMeta }) {
+  if (!task.sessionId || !meta?.sessionHash) return null;
+  return (
+    <>
+      {' \u00B7 '}
       <Link
         className="task-node-session-link"
         to={`/chat/${task.sessionId}`}
@@ -64,56 +64,37 @@ function ContextLine({ task, meta }: { task: Task; meta?: TaskDisplayMeta }) {
       >
         {meta.sessionHash}
       </Link>
-    ) : null;
+    </>
+  );
+}
+
+function ContextLine({ task, meta }: { task: Task; meta?: TaskDisplayMeta }): React.ReactNode {
+  const dot = ' \u00B7 ';
+  const suffix = <SessionSuffix task={task} meta={meta} />;
 
   switch (task.status) {
     case 'active':
       return (
         <>
           {STATUS_LABELS.active}
-          {sessionLink && (
-            <>
-              {dot}
-              {sessionLink}
-            </>
-          )}
+          {suffix}
           {meta?.elapsedLabel && `${dot}${meta.elapsedLabel}`}
         </>
       );
     case 'pending_review':
-      return (
-        <>
-          awaiting approval
-          {sessionLink && (
-            <>
-              {dot}
-              {sessionLink}
-            </>
-          )}
-        </>
-      );
+      return <>awaiting approval{suffix}</>;
     case 'blocked':
       return (
         <>
           {meta?.blockerSummary ?? 'blocked'}
-          {sessionLink && (
-            <>
-              {dot}
-              {sessionLink}
-            </>
-          )}
+          {suffix}
         </>
       );
     case 'done':
       return (
         <>
           {meta?.completedAgo ? `done${dot}${meta.completedAgo}` : 'done'}
-          {sessionLink && (
-            <>
-              {dot}
-              {sessionLink}
-            </>
-          )}
+          {suffix}
         </>
       );
     case 'failed': {
@@ -123,12 +104,7 @@ function ContextLine({ task, meta }: { task: Task; meta?: TaskDisplayMeta }) {
         <>
           {label}
           {retry}
-          {sessionLink && (
-            <>
-              {dot}
-              {sessionLink}
-            </>
-          )}
+          {suffix}
         </>
       );
     }
@@ -169,7 +145,7 @@ export function TaskNode({
   if (meta?.attendTier === 1) classes.push('task-node--t1');
   if (meta && meta.fadeOpacity <= 0) classes.push('task-node--hidden');
 
-  const contextLine = !isCompact ? <ContextLine task={task} meta={meta} /> : null;
+  const contextContent = !isCompact ? ContextLine({ task, meta }) : null;
   const fadeStyle =
     meta && meta.fadeOpacity < 1 && meta.fadeOpacity > 0
       ? { opacity: meta.fadeOpacity }
@@ -200,9 +176,9 @@ export function TaskNode({
           >
             {task.title}
           </span>
-          {contextLine && (
+          {contextContent && (
             <div className={`task-node-context${contextColorClass(task.status)}`}>
-              {contextLine}
+              {contextContent}
             </div>
           )}
           {task.summary && <div className="task-node-summary">{task.summary}</div>}

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import type { Task, TaskStatus, StageType } from '../types/task';
 import type { TaskDisplayMeta } from '../hooks/useTaskBoard';
 
@@ -52,28 +52,18 @@ interface TaskNodeProps {
   onReject?: (id: string, feedback: string) => void;
 }
 
-function ContextLine({
-  task,
-  meta,
-  onNavigateSession,
-}: {
-  task: Task;
-  meta?: TaskDisplayMeta;
-  onNavigateSession?: (sessionId: string) => void;
-}) {
+function ContextLine({ task, meta }: { task: Task; meta?: TaskDisplayMeta }) {
   const dot = ' \u00B7 ';
 
   const sessionLink =
     task.sessionId && meta?.sessionHash ? (
-      <a
+      <Link
         className="task-node-session-link"
-        onClick={(e) => {
-          e.stopPropagation();
-          onNavigateSession?.(task.sessionId!);
-        }}
+        to={`/chat/${task.sessionId}`}
+        onClick={(e) => e.stopPropagation()}
       >
         {meta.sessionHash}
-      </a>
+      </Link>
     ) : null;
 
   switch (task.status) {
@@ -147,16 +137,6 @@ function ContextLine({
   }
 }
 
-function hasContextLine(status: TaskStatus): boolean {
-  return (
-    status === 'active' ||
-    status === 'pending_review' ||
-    status === 'blocked' ||
-    status === 'done' ||
-    status === 'failed'
-  );
-}
-
 function contextColorClass(status: TaskStatus): string {
   if (status === 'pending_review') return ' task-node-context--review';
   if (status === 'blocked') return ' task-node-context--blocked';
@@ -180,7 +160,6 @@ export function TaskNode({
   onReject,
 }: TaskNodeProps) {
   const [expanded, setExpanded] = useState(true);
-  const navigate = useNavigate();
   const hasChildren = task.children.length > 0;
   const meta = displayMeta?.get(task.id);
   const isCompact = compact && task.status !== 'active';
@@ -190,15 +169,11 @@ export function TaskNode({
   if (meta?.attendTier === 1) classes.push('task-node--t1');
   if (meta && meta.fadeOpacity <= 0) classes.push('task-node--hidden');
 
-  const showContext = !isCompact && hasContextLine(task.status);
+  const contextLine = !isCompact ? <ContextLine task={task} meta={meta} /> : null;
   const fadeStyle =
     meta && meta.fadeOpacity < 1 && meta.fadeOpacity > 0
       ? { opacity: meta.fadeOpacity }
       : undefined;
-
-  function handleNavigateSession(sessionId: string) {
-    navigate(`/chat/${sessionId}`);
-  }
 
   return (
     <div className={classes.join(' ')} style={fadeStyle}>
@@ -225,9 +200,9 @@ export function TaskNode({
           >
             {task.title}
           </span>
-          {showContext && (
+          {contextLine && (
             <div className={`task-node-context${contextColorClass(task.status)}`}>
-              <ContextLine task={task} meta={meta} onNavigateSession={handleNavigateSession} />
+              {contextLine}
             </div>
           )}
           {task.summary && <div className="task-node-summary">{task.summary}</div>}

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -81,25 +81,66 @@ function ContextLine({
       return (
         <>
           {STATUS_LABELS.active}
-          {sessionLink && <>{dot}{sessionLink}</>}
+          {sessionLink && (
+            <>
+              {dot}
+              {sessionLink}
+            </>
+          )}
           {meta?.elapsedLabel && `${dot}${meta.elapsedLabel}`}
         </>
       );
     case 'pending_review':
-      return <>awaiting approval{sessionLink && <>{dot}{sessionLink}</>}</>;
+      return (
+        <>
+          awaiting approval
+          {sessionLink && (
+            <>
+              {dot}
+              {sessionLink}
+            </>
+          )}
+        </>
+      );
     case 'blocked':
-      return <>{meta?.blockerSummary ?? 'blocked'}{sessionLink && <>{dot}{sessionLink}</>}</>;
+      return (
+        <>
+          {meta?.blockerSummary ?? 'blocked'}
+          {sessionLink && (
+            <>
+              {dot}
+              {sessionLink}
+            </>
+          )}
+        </>
+      );
     case 'done':
       return (
         <>
           {meta?.completedAgo ? `done${dot}${meta.completedAgo}` : 'done'}
-          {sessionLink && <>{dot}{sessionLink}</>}
+          {sessionLink && (
+            <>
+              {dot}
+              {sessionLink}
+            </>
+          )}
         </>
       );
     case 'failed': {
       const label = meta?.blockerSummary ?? 'failed';
       const retry = task.retryCount > 0 ? `${dot}retry ${task.retryCount}` : '';
-      return <>{label}{retry}{sessionLink && <>{dot}{sessionLink}</>}</>;
+      return (
+        <>
+          {label}
+          {retry}
+          {sessionLink && (
+            <>
+              {dot}
+              {sessionLink}
+            </>
+          )}
+        </>
+      );
     }
     default:
       return null;
@@ -107,7 +148,13 @@ function ContextLine({
 }
 
 function hasContextLine(status: TaskStatus): boolean {
-  return status === 'active' || status === 'pending_review' || status === 'blocked' || status === 'done' || status === 'failed';
+  return (
+    status === 'active' ||
+    status === 'pending_review' ||
+    status === 'blocked' ||
+    status === 'done' ||
+    status === 'failed'
+  );
 }
 
 function contextColorClass(status: TaskStatus): string {
@@ -183,9 +230,7 @@ export function TaskNode({
               <ContextLine task={task} meta={meta} onNavigateSession={handleNavigateSession} />
             </div>
           )}
-          {task.summary && (
-            <div className="task-node-summary">{task.summary}</div>
-          )}
+          {task.summary && <div className="task-node-summary">{task.summary}</div>}
         </div>
         {task.stageType && STAGE_LABELS[task.stageType] && (
           <span className={`task-node-stage task-node-stage--${task.stageType}`}>

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import type { Task } from '../../types/task';
+import type { TaskDisplayMeta } from '../../hooks/useTaskBoard';
 import { TaskNode } from '../TaskNode';
 
 afterEach(() => {
@@ -39,17 +41,24 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
-describe('TaskNode', () => {
-  it('renders title', () => {
-    render(
+function renderNode(task: Task, opts: { displayMeta?: Map<string, TaskDisplayMeta> } = {}) {
+  return render(
+    <MemoryRouter>
       <TaskNode
-        task={makeTask({ title: 'My Task' })}
+        task={task}
         depth={0}
+        displayMeta={opts.displayMeta}
         onStatusChange={vi.fn()}
         onDelete={vi.fn()}
         onAddChild={vi.fn()}
-      />,
-    );
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('TaskNode', () => {
+  it('renders title', () => {
+    renderNode(makeTask({ title: 'My Task' }));
     expect(screen.getByText('My Task')).toBeTruthy();
   });
 
@@ -62,15 +71,7 @@ describe('TaskNode', () => {
     ['skipped', '\u2014'],
     ['failed', '\u2717'],
   ] as const)('renders correct label for status %s', (status, expectedIcon) => {
-    const { container } = render(
-      <TaskNode
-        task={makeTask({ status })}
-        depth={0}
-        onStatusChange={vi.fn()}
-        onDelete={vi.fn()}
-        onAddChild={vi.fn()}
-      />,
-    );
+    const { container } = renderNode(makeTask({ status }));
     const statusBtn = container.querySelector('.task-node-status');
     expect(statusBtn?.textContent).toBe(expectedIcon);
   });
@@ -79,15 +80,7 @@ describe('TaskNode', () => {
     const child = makeTask({ id: 'child-1', parentId: 'task-1', title: 'Child task', depth: 1 });
     const task = makeTask({ children: [child] });
 
-    render(
-      <TaskNode
-        task={task}
-        depth={0}
-        onStatusChange={vi.fn()}
-        onDelete={vi.fn()}
-        onAddChild={vi.fn()}
-      />,
-    );
+    renderNode(task);
 
     // Children should be visible by default
     expect(screen.getByText('Child task')).toBeTruthy();
@@ -101,15 +94,7 @@ describe('TaskNode', () => {
   });
 
   it('does not apply inline depth indentation (handled by CSS nesting)', () => {
-    const { container } = render(
-      <TaskNode
-        task={makeTask()}
-        depth={2}
-        onStatusChange={vi.fn()}
-        onDelete={vi.fn()}
-        onAddChild={vi.fn()}
-      />,
-    );
+    const { container } = renderNode(makeTask());
     const node = container.firstElementChild as HTMLElement;
     expect(node.style.paddingLeft).toBe('');
   });
@@ -130,15 +115,7 @@ describe('TaskNode', () => {
     });
     const task = makeTask({ children: [child] });
 
-    render(
-      <TaskNode
-        task={task}
-        depth={0}
-        onStatusChange={vi.fn()}
-        onDelete={vi.fn()}
-        onAddChild={vi.fn()}
-      />,
-    );
+    renderNode(task);
 
     expect(screen.getByText('Child')).toBeTruthy();
     expect(screen.getByText('Grandchild')).toBeTruthy();
@@ -147,13 +124,15 @@ describe('TaskNode', () => {
   it('calls onStatusChange when status icon clicked', () => {
     const onStatusChange = vi.fn();
     const { container } = render(
-      <TaskNode
-        task={makeTask({ id: 'sc-1', status: 'pending' })}
-        depth={0}
-        onStatusChange={onStatusChange}
-        onDelete={vi.fn()}
-        onAddChild={vi.fn()}
-      />,
+      <MemoryRouter>
+        <TaskNode
+          task={makeTask({ id: 'sc-1', status: 'pending' })}
+          depth={0}
+          onStatusChange={onStatusChange}
+          onDelete={vi.fn()}
+          onAddChild={vi.fn()}
+        />
+      </MemoryRouter>,
     );
 
     const statusBtn = container.querySelector('.task-node-status')!;
@@ -164,17 +143,46 @@ describe('TaskNode', () => {
   it('calls onDelete when delete button clicked', () => {
     const onDelete = vi.fn();
     const { container } = render(
-      <TaskNode
-        task={makeTask({ id: 'del-1' })}
-        depth={0}
-        onStatusChange={vi.fn()}
-        onDelete={onDelete}
-        onAddChild={vi.fn()}
-      />,
+      <MemoryRouter>
+        <TaskNode
+          task={makeTask({ id: 'del-1' })}
+          depth={0}
+          onStatusChange={vi.fn()}
+          onDelete={onDelete}
+          onAddChild={vi.fn()}
+        />
+      </MemoryRouter>,
     );
 
     const deleteBtn = container.querySelector('.task-node-action--danger')!;
     fireEvent.click(deleteBtn);
     expect(onDelete).toHaveBeenCalledWith('del-1');
+  });
+
+  it('renders session link for active task with sessionId', () => {
+    const task = makeTask({
+      status: 'active',
+      sessionId: 'abc123def456',
+      claimedAt: Date.now() - 60000,
+    });
+    const meta = new Map<string, TaskDisplayMeta>([
+      [task.id, { attendTier: 3, fadeOpacity: 1, sessionHash: 'abc123', elapsedLabel: '1m' }],
+    ]);
+
+    const { container } = renderNode(task, { displayMeta: meta });
+    const link = container.querySelector('.task-node-session-link') as HTMLAnchorElement;
+    expect(link).toBeTruthy();
+    expect(link.textContent).toBe('abc123');
+    expect(link.getAttribute('href')).toBe('/chat/abc123def456');
+  });
+
+  it('renders summary when present', () => {
+    renderNode(makeTask({ summary: 'Completed the migration successfully' }));
+    expect(screen.getByText('Completed the migration successfully')).toBeTruthy();
+  });
+
+  it('does not render summary when null', () => {
+    const { container } = renderNode(makeTask({ summary: null }));
+    expect(container.querySelector('.task-node-summary')).toBeNull();
   });
 });

--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -171,27 +171,29 @@ export function TaskBoard() {
         />
       )}
 
-      {loading && <p className="task-board-empty">Loading...</p>}
+      <div className="task-board-scroll">
+        {loading && <p className="task-board-empty">Loading...</p>}
 
-      {!loading && tasks.length === 0 && (
-        <EmptyState icon={'\u2610'} title="No tasks yet" subtitle="Add a task to get started" />
-      )}
+        {!loading && tasks.length === 0 && (
+          <EmptyState icon={'\u2610'} title="No tasks yet" subtitle="Add a task to get started" />
+        )}
 
-      <div className="task-board-list">
-        {sortedTasks.map((task) => (
-          <TaskNode
-            key={task.id}
-            task={task}
-            depth={0}
-            activeTaskId={loopStatus.activeTaskId}
-            displayMeta={displayMeta}
-            onStatusChange={handleStatusChange}
-            onDelete={handleDelete}
-            onAddChild={handleAddChild}
-            onApprove={approveTask}
-            onReject={rejectTask}
-          />
-        ))}
+        <div className="task-board-list">
+          {sortedTasks.map((task) => (
+            <TaskNode
+              key={task.id}
+              task={task}
+              depth={0}
+              activeTaskId={loopStatus.activeTaskId}
+              displayMeta={displayMeta}
+              onStatusChange={handleStatusChange}
+              onDelete={handleDelete}
+              onAddChild={handleAddChild}
+              onApprove={approveTask}
+              onReject={rejectTask}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -5631,6 +5631,25 @@ textarea:focus {
   color: var(--task-failed);
 }
 
+.task-node-session-link {
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+}
+.task-node-session-link:hover {
+  text-decoration: underline;
+}
+
+.task-node-summary {
+  font-size: var(--text-xs);
+  color: var(--text-dim);
+  margin-top: 2px;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .task-node-meta {
   font-size: var(--text-xs);
   color: var(--text-dim);


### PR DESCRIPTION
## Summary
- **Scrolling fix**: Wrapped task list in the existing `.task-board-scroll` container (CSS was defined but never used in JSX). Task board now scrolls properly on mobile with momentum scrolling and tab bar padding.
- **Session links**: Session hash in context line is now a clickable link that navigates to `/chat/<sessionId>`. Shown for all statuses, not just active.
- **Summary display**: Renders `task.summary` below the context line when present, giving visibility into task outcomes.

## Test plan
- [ ] Open Task Board on mobile with 6+ tasks, verify scrolling works and bottom tasks are reachable
- [ ] Tap a session hash link on an active task, verify it navigates to the correct chat session
- [ ] Verify done/blocked/failed tasks also show session links when they have a sessionId
- [ ] Verify task summary text appears below context line for tasks that have a summary set

🤖 Generated with [Claude Code](https://claude.com/claude-code)