### PR TITLE
fix(auth): persist internal token across restarts

### DIFF
--- a/server/__tests__/internal-token.test.ts
+++ b/server/__tests__/internal-token.test.ts
@@ -1,29 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { randomBytes } from 'crypto';
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-
-/** Isolated test of loadOrCreateToken logic without importing the module
- *  (which triggers side-effects). We replicate the function locally. */
-const TOKEN_LENGTH = 64;
-
-function loadOrCreateToken(tokenPath: string): string {
-  try {
-    const existing = readFileSync(tokenPath, 'utf-8').trim();
-    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
-      return existing;
-    }
-  } catch {
-    // File doesn't exist or isn't readable — generate a new one
-  }
-
-  const token = randomBytes(32).toString('hex');
-  const dir = tokenPath.substring(0, tokenPath.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(tokenPath, token, { mode: 0o600 });
-  return token;
-}
+import { loadOrCreateToken, TOKEN_LENGTH } from '../internal-token.js';
 
 describe('loadOrCreateToken', () => {
   let testDir: string;
@@ -99,5 +78,20 @@ describe('loadOrCreateToken', () => {
     const second = loadOrCreateToken(tokenPath);
 
     expect(first).toBe(second);
+  });
+
+  it('still returns a token when write fails (non-fatal)', () => {
+    // Point to a path inside a read-only directory
+    const readOnlyDir = join(testDir, 'readonly');
+    mkdirSync(readOnlyDir);
+    chmodSync(readOnlyDir, 0o444);
+    const unwritablePath = join(readOnlyDir, 'subdir', 'token');
+
+    const token = loadOrCreateToken(unwritablePath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).toMatch(/^[0-9a-f]+$/);
+    // Restore permissions for cleanup
+    chmodSync(readOnlyDir, 0o755);
   });
 });

--- a/server/__tests__/internal-token.test.ts
+++ b/server/__tests__/internal-token.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/** Isolated test of loadOrCreateToken logic without importing the module
+ *  (which triggers side-effects). We replicate the function locally. */
+const TOKEN_LENGTH = 64;
+
+function loadOrCreateToken(tokenPath: string): string {
+  try {
+    const existing = readFileSync(tokenPath, 'utf-8').trim();
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
+      return existing;
+    }
+  } catch {
+    // File doesn't exist or isn't readable — generate a new one
+  }
+
+  const token = randomBytes(32).toString('hex');
+  const dir = tokenPath.substring(0, tokenPath.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(tokenPath, token, { mode: 0o600 });
+  return token;
+}
+
+describe('loadOrCreateToken', () => {
+  let testDir: string;
+  let tokenPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `mitzo-token-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    tokenPath = join(testDir, 'internal-token');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('generates a new token when file is missing', () => {
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).toMatch(/^[0-9a-f]+$/);
+    expect(existsSync(tokenPath)).toBe(true);
+    expect(readFileSync(tokenPath, 'utf-8')).toBe(token);
+  });
+
+  it('reads existing valid token from disk', () => {
+    const existing = 'a'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, existing);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('accepts uppercase hex tokens', () => {
+    const existing = 'A1B2C3D4'.repeat(8); // 64 chars uppercase hex
+    writeFileSync(tokenPath, existing);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('rejects and regenerates on corrupt file (wrong length)', () => {
+    writeFileSync(tokenPath, 'too-short');
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).not.toBe('too-short');
+  });
+
+  it('rejects and regenerates on non-hex content', () => {
+    const badToken = 'z'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, badToken);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).not.toBe(badToken);
+  });
+
+  it('trims whitespace from token file', () => {
+    const existing = 'b'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, `  ${existing}  \n`);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('returns consistent token across multiple calls', () => {
+    const first = loadOrCreateToken(tokenPath);
+    const second = loadOrCreateToken(tokenPath);
+
+    expect(first).toBe(second);
+  });
+});

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -1,19 +1,35 @@
 import { randomBytes, timingSafeEqual } from 'crypto';
-import { writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-/** Shared token for MCP server → Mitzo API calls (generated once at startup). */
-export const INTERNAL_TOKEN = randomBytes(32).toString('hex');
+const TOKEN_PATH = join(homedir(), '.mitzo', 'internal-token');
+const TOKEN_LENGTH = 64; // 32 bytes as hex
 
-// Persist to ~/.mitzo/internal-token so session hooks can authenticate
-try {
-  const dir = join(homedir(), '.mitzo');
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(join(dir, 'internal-token'), INTERNAL_TOKEN, { mode: 0o600 });
-} catch {
-  // Non-fatal — hooks will fall back gracefully
+/** Load existing token from disk or generate a new one.
+ *  Persists across restarts so external clients (agents, hooks) stay authenticated. */
+function loadOrCreateToken(): string {
+  try {
+    const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-f]+$/.test(existing)) {
+      return existing;
+    }
+  } catch {
+    // File doesn't exist or isn't readable — generate a new one
+  }
+
+  const token = randomBytes(32).toString('hex');
+  try {
+    const dir = join(homedir(), '.mitzo');
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(TOKEN_PATH, token, { mode: 0o600 });
+  } catch {
+    // Non-fatal — hooks will fall back gracefully
+  }
+  return token;
 }
+
+export const INTERNAL_TOKEN = loadOrCreateToken();
 
 /** Constant-time check for internal token validity. */
 export function isValidInternalToken(candidate: string | string[] | undefined): boolean {

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -1,16 +1,17 @@
 import { randomBytes, timingSafeEqual } from 'crypto';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 
 const TOKEN_PATH = join(homedir(), '.mitzo', 'internal-token');
-const TOKEN_LENGTH = 64; // 32 bytes as hex
+export const TOKEN_LENGTH = 64; // 32 bytes as hex
 
 /** Load existing token from disk or generate a new one.
- *  Persists across restarts so external clients (agents, hooks) stay authenticated. */
-function loadOrCreateToken(): string {
+ *  Persists across restarts so external clients (agents, hooks) stay authenticated.
+ *  Accepts an optional path override for testing. */
+export function loadOrCreateToken(tokenPath: string = TOKEN_PATH): string {
   try {
-    const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
+    const existing = readFileSync(tokenPath, 'utf-8').trim();
     if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
       return existing;
     }
@@ -20,9 +21,8 @@ function loadOrCreateToken(): string {
 
   const token = randomBytes(32).toString('hex');
   try {
-    const dir = join(homedir(), '.mitzo');
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-    writeFileSync(TOKEN_PATH, token, { mode: 0o600 });
+    mkdirSync(dirname(tokenPath), { recursive: true, mode: 0o700 });
+    writeFileSync(tokenPath, token, { mode: 0o600 });
   } catch {
     // Non-fatal — hooks will fall back gracefully
   }

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -11,7 +11,7 @@ const TOKEN_LENGTH = 64; // 32 bytes as hex
 function loadOrCreateToken(): string {
   try {
     const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
-    if (existing.length === TOKEN_LENGTH && /^[0-9a-f]+$/.test(existing)) {
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
       return existing;
     }
   } catch {


### PR DESCRIPTION
## Summary

- Read existing token from `~/.mitzo/internal-token` on startup instead of generating a new one every time
- Only generates a fresh token when the file is missing or corrupt (not hex, wrong length)
- Fixes 401 errors for agents, hooks, and the Python `mitzo_client` after every Mitzo restart or crash recovery

## Root cause

`INTERNAL_TOKEN = randomBytes(32).toString('hex')` ran on every import, overwriting the persisted token. Any external client (PR Shepherd, session hooks, CLI) holding the old token got 401'd after a restart. Tonight this broke the Task Board API entirely after a crash + launchd recovery + dev server token collision.

## Test plan

- [x] All 19 auth tests pass
- [ ] Restart Mitzo, verify token file unchanged
- [ ] Verify `mitzo_client` API calls work after restart
- [ ] Delete token file, restart, verify new one generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)