### PR TITLE
fix(task-board): fix orphan detection and add session linking

### DIFF
--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -43,6 +43,8 @@ export interface ChatAreaProps {
   bootContext?: BootContextMeta | null;
   /** Session context string for sticky banner */
   sessionContext?: string | null;
+  /** Source link — Telos item or Task Board goal that spawned this session */
+  sourceLink?: { telosTaskId?: string; goalId?: string } | null;
 }
 
 export function ChatArea({
@@ -56,6 +58,7 @@ export function ChatArea({
   voice,
   bootContext,
   sessionContext,
+  sourceLink,
 }: ChatAreaProps) {
   const internalScrollRef = useRef<HTMLDivElement>(null);
   const scrollRef = externalScrollRef ?? internalScrollRef;
@@ -151,7 +154,11 @@ export function ChatArea({
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
-        <SessionBanner bootContext={bootContext} sessionContext={sessionContext} />
+        <SessionBanner
+          bootContext={bootContext}
+          sessionContext={sessionContext}
+          sourceLink={sourceLink}
+        />
 
         {messages.length === 0 && !current && !running && (
           <p className="chat-empty">Send a message to start</p>

--- a/frontend/src/components/SessionBanner.tsx
+++ b/frontend/src/components/SessionBanner.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { BootContextMeta, SectionMeta } from '@mitzo/client';
 
 interface Props {
   bootContext?: BootContextMeta | null;
   sessionContext?: string | null;
+  sourceLink?: { telosTaskId?: string; goalId?: string } | null;
 }
 
 const KIND_LABELS: Record<string, string> = {
@@ -45,7 +47,8 @@ function summaryLine(text: string): string {
   return first.length > 80 ? first.slice(0, 77) + '...' : first;
 }
 
-export function SessionBanner({ bootContext, sessionContext }: Props) {
+export function SessionBanner({ bootContext, sessionContext, sourceLink }: Props) {
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(false);
   const [showBootDetails, setShowBootDetails] = useState(false);
   const [showTrimmed, setShowTrimmed] = useState(false);
@@ -77,7 +80,13 @@ export function SessionBanner({ bootContext, sessionContext }: Props) {
     setShowModal(false);
   }, [contextKey]);
 
-  if (!bootContext && !sessionContext) return null;
+  if (!bootContext && !sessionContext && !sourceLink) return null;
+
+  // Determine source link label and target
+  const hasGoal = sourceLink?.goalId;
+  const hasTelos = sourceLink?.telosTaskId && sourceLink.telosTaskId !== sourceLink?.goalId;
+  const sourceLinkLabel = hasGoal ? 'Task Board' : hasTelos ? 'Telos' : null;
+  const sourceLinkTarget = hasGoal ? '/tasks' : hasTelos ? '/todos' : null;
 
   const isContexgin = bootContext?.source === 'contexgin';
   const dotClass = isContexgin ? 'session-banner-dot--ok' : 'session-banner-dot--warn';
@@ -108,6 +117,25 @@ export function SessionBanner({ bootContext, sessionContext }: Props) {
             )}
             {sessionContext && (
               <span className="session-banner-context-hint">{summaryLine(sessionContext)}</span>
+            )}
+            {sourceLinkLabel && sourceLinkTarget && (
+              <span
+                className="session-banner-source-link"
+                role="link"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(sourceLinkTarget);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.stopPropagation();
+                    navigate(sourceLinkTarget);
+                  }
+                }}
+              >
+                {sourceLinkLabel}
+              </span>
             )}
           </span>
           <span className="session-banner-chevron">{expanded ? '\u25BE' : '\u25B8'}</span>

--- a/frontend/src/components/TaskNode.tsx
+++ b/frontend/src/components/TaskNode.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import type { Task, TaskStatus, StageType } from '../types/task';
 import type { TaskDisplayMeta } from '../hooks/useTaskBoard';
 
@@ -53,12 +54,9 @@ interface TaskNodeProps {
 
 function buildContextLine(task: Task, meta?: TaskDisplayMeta): string | null {
   switch (task.status) {
-    case 'active': {
-      const parts: string[] = [STATUS_LABELS.active];
-      if (meta?.sessionHash) parts.push(meta.sessionHash);
-      if (meta?.elapsedLabel) parts.push(meta.elapsedLabel);
-      return parts.join(' \u00B7 ');
-    }
+    // 'active' handled inline in JSX for clickable session link
+    case 'active':
+      return null;
     case 'pending_review':
       return 'awaiting approval';
     case 'blocked':
@@ -72,6 +70,52 @@ function buildContextLine(task: Task, meta?: TaskDisplayMeta): string | null {
     default:
       return null;
   }
+}
+
+function ActiveContextLine({
+  meta,
+  navigate,
+}: {
+  meta?: TaskDisplayMeta;
+  navigate: (path: string) => void;
+}) {
+  return (
+    <div className="task-node-context">
+      <span>{STATUS_LABELS.active}</span>
+      {meta?.sessionHash && (
+        <>
+          {' \u00B7 '}
+          {meta.sdkSessionId ? (
+            <span
+              className="task-node-session-link"
+              role="link"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                navigate(`/chat/${meta.sdkSessionId}`);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.stopPropagation();
+                  navigate(`/chat/${meta.sdkSessionId}`);
+                }
+              }}
+            >
+              {meta.sessionHash}
+            </span>
+          ) : (
+            <span>{meta.sessionHash}</span>
+          )}
+        </>
+      )}
+      {meta?.elapsedLabel && (
+        <span>
+          {' \u00B7 '}
+          {meta.elapsedLabel}
+        </span>
+      )}
+    </div>
+  );
 }
 
 function contextColorClass(status: TaskStatus): string {
@@ -96,6 +140,7 @@ export function TaskNode({
   onApprove,
   onReject,
 }: TaskNodeProps) {
+  const navigate = useNavigate();
   const [expanded, setExpanded] = useState(true);
   const hasChildren = task.children.length > 0;
   const meta = displayMeta?.get(task.id);
@@ -137,6 +182,9 @@ export function TaskNode({
           >
             {task.title}
           </span>
+          {task.status === 'active' && !isCompact && (
+            <ActiveContextLine meta={meta} navigate={navigate} />
+          )}
           {contextLine && (
             <div className={`task-node-context${contextColorClass(task.status)}`}>
               {contextLine}

--- a/frontend/src/components/__tests__/SessionBanner.test.tsx
+++ b/frontend/src/components/__tests__/SessionBanner.test.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 vi.mock('@mitzo/client', () => ({}));
 
 import { SessionBanner } from '../SessionBanner';
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 afterEach(() => cleanup());
 
@@ -23,23 +28,25 @@ const bootContext = {
 
 describe('SessionBanner', () => {
   it('returns null when both props are null', () => {
-    const { container } = render(<SessionBanner bootContext={null} sessionContext={null} />);
+    const { container } = renderWithRouter(
+      <SessionBanner bootContext={null} sessionContext={null} />,
+    );
     expect(container.innerHTML).toBe('');
   });
 
   it('renders banner header when bootContext provided', () => {
-    render(<SessionBanner bootContext={bootContext} />);
+    renderWithRouter(<SessionBanner bootContext={bootContext} />);
     expect(screen.getByText(/5 sources/)).toBeTruthy();
     expect(screen.getByText(/4\.2k/)).toBeTruthy();
   });
 
   it('renders session context summary when sessionContext provided', () => {
-    render(<SessionBanner sessionContext="Summary: Build the widget" />);
+    renderWithRouter(<SessionBanner sessionContext="Summary: Build the widget" />);
     expect(screen.getByText(/Build the widget/)).toBeTruthy();
   });
 
   it('expands to show full session context on click', () => {
-    render(<SessionBanner sessionContext="Summary: Build the widget\nStatus: active" />);
+    renderWithRouter(<SessionBanner sessionContext="Summary: Build the widget\nStatus: active" />);
     // Session context text should not be visible initially (collapsed)
     expect(screen.queryByText('Session Context')).toBeNull();
     // Click the banner header to expand
@@ -48,13 +55,15 @@ describe('SessionBanner', () => {
   });
 
   it('renders both boot and session context together', () => {
-    render(<SessionBanner bootContext={bootContext} sessionContext="Summary: Test task" />);
+    renderWithRouter(
+      <SessionBanner bootContext={bootContext} sessionContext="Summary: Test task" />,
+    );
     expect(screen.getByText(/5 sources/)).toBeTruthy();
     expect(screen.getByText(/Test task/)).toBeTruthy();
   });
 
   it('shows boot context details on nested toggle', () => {
-    render(<SessionBanner bootContext={bootContext} />);
+    renderWithRouter(<SessionBanner bootContext={bootContext} />);
     // Expand the banner first
     fireEvent.click(screen.getByRole('button', { name: /5 sources/ }));
     // Now toggle boot context details
@@ -64,7 +73,7 @@ describe('SessionBanner', () => {
   });
 
   it('opens full markdown modal via view-full button', () => {
-    render(<SessionBanner bootContext={bootContext} />);
+    renderWithRouter(<SessionBanner bootContext={bootContext} />);
     // Expand the banner
     fireEvent.click(screen.getByRole('button', { name: /5 sources/ }));
     // Click the ⧉ button
@@ -74,7 +83,7 @@ describe('SessionBanner', () => {
   });
 
   it('closes modal on close button click', () => {
-    render(<SessionBanner bootContext={bootContext} />);
+    renderWithRouter(<SessionBanner bootContext={bootContext} />);
     fireEvent.click(screen.getByRole('button', { name: /5 sources/ }));
     fireEvent.click(screen.getByTitle('View full markdown'));
     expect(screen.getByText('Boot Context (Full Markdown)')).toBeTruthy();
@@ -84,7 +93,7 @@ describe('SessionBanner', () => {
   });
 
   it('closes modal on Escape key', () => {
-    render(<SessionBanner bootContext={bootContext} />);
+    renderWithRouter(<SessionBanner bootContext={bootContext} />);
     fireEvent.click(screen.getByRole('button', { name: /5 sources/ }));
     fireEvent.click(screen.getByTitle('View full markdown'));
     expect(screen.getByText('Boot Context (Full Markdown)')).toBeTruthy();

--- a/frontend/src/components/__tests__/TaskNode.test.tsx
+++ b/frontend/src/components/__tests__/TaskNode.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import type { Task } from '../../types/task';
 import { TaskNode } from '../TaskNode';
 
@@ -16,6 +17,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     description: null,
     status: 'pending',
     sessionId: null,
+    sdkSessionId: null,
     sessionPolicy: 'auto',
     priority: 0,
     depth: 0,
@@ -39,9 +41,13 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+function renderNode(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
 describe('TaskNode', () => {
   it('renders title', () => {
-    render(
+    renderNode(
       <TaskNode
         task={makeTask({ title: 'My Task' })}
         depth={0}
@@ -62,7 +68,7 @@ describe('TaskNode', () => {
     ['skipped', '\u2014'],
     ['failed', '\u2717'],
   ] as const)('renders correct label for status %s', (status, expectedIcon) => {
-    const { container } = render(
+    const { container } = renderNode(
       <TaskNode
         task={makeTask({ status })}
         depth={0}
@@ -79,7 +85,7 @@ describe('TaskNode', () => {
     const child = makeTask({ id: 'child-1', parentId: 'task-1', title: 'Child task', depth: 1 });
     const task = makeTask({ children: [child] });
 
-    render(
+    renderNode(
       <TaskNode
         task={task}
         depth={0}
@@ -101,7 +107,7 @@ describe('TaskNode', () => {
   });
 
   it('does not apply inline depth indentation (handled by CSS nesting)', () => {
-    const { container } = render(
+    const { container } = renderNode(
       <TaskNode
         task={makeTask()}
         depth={2}
@@ -130,7 +136,7 @@ describe('TaskNode', () => {
     });
     const task = makeTask({ children: [child] });
 
-    render(
+    renderNode(
       <TaskNode
         task={task}
         depth={0}
@@ -146,7 +152,7 @@ describe('TaskNode', () => {
 
   it('calls onStatusChange when status icon clicked', () => {
     const onStatusChange = vi.fn();
-    const { container } = render(
+    const { container } = renderNode(
       <TaskNode
         task={makeTask({ id: 'sc-1', status: 'pending' })}
         depth={0}
@@ -163,7 +169,7 @@ describe('TaskNode', () => {
 
   it('calls onDelete when delete button clicked', () => {
     const onDelete = vi.fn();
-    const { container } = render(
+    const { container } = renderNode(
       <TaskNode
         task={makeTask({ id: 'del-1' })}
         depth={0}

--- a/frontend/src/hooks/useTaskBoard.ts
+++ b/frontend/src/hooks/useTaskBoard.ts
@@ -12,6 +12,7 @@ export interface TaskDisplayMeta {
   completedAgo?: string;
   elapsedLabel?: string;
   sessionHash?: string;
+  sdkSessionId?: string;
   blockerSummary?: string;
 }
 
@@ -57,7 +58,10 @@ function buildDisplayMeta(task: Task, now: number): TaskDisplayMeta {
   if (task.status === 'active' && task.claimedAt) {
     meta.elapsedLabel = formatDuration(now - task.claimedAt);
   }
-  if (task.sessionId) {
+  if (task.sdkSessionId) {
+    meta.sessionHash = task.sdkSessionId.slice(0, 6);
+    meta.sdkSessionId = task.sdkSessionId;
+  } else if (task.sessionId) {
     meta.sessionHash = task.sessionId.slice(0, 6);
   }
   if ((task.status === 'blocked' || task.status === 'failed') && task.annotations.length > 0) {

--- a/frontend/src/pages/ChatView.tsx
+++ b/frontend/src/pages/ChatView.tsx
@@ -53,6 +53,7 @@ export function ChatView() {
   const clearPendingSession = useMitzoStore((s) => s.clearPendingSession);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
   const bootContext = useMitzoStore((s) => s.messages.bootContext);
+  const sourceLink = useMitzoStore((s) => s.messages.sourceLink);
   const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
@@ -282,6 +283,7 @@ export function ChatView() {
         voice={voice}
         bootContext={bootContext}
         sessionContext={sessionContext}
+        sourceLink={sourceLink}
       />
 
       <ChatInput

--- a/frontend/src/pages/DesktopChatView.tsx
+++ b/frontend/src/pages/DesktopChatView.tsx
@@ -41,6 +41,7 @@ export function DesktopChatView() {
   const storeFetchSessionMeta = useMitzoStore((s) => s.fetchSessionMeta);
   const sessionContext = useMitzoStore((s) => s.messages.sessionContext);
   const bootContext = useMitzoStore((s) => s.messages.bootContext);
+  const sourceLink = useMitzoStore((s) => s.messages.sourceLink);
   const progressByToolId = useProgressByToolId();
 
   const connected = connection.status === 'connected';
@@ -252,6 +253,7 @@ export function DesktopChatView() {
             voice={voice}
             bootContext={bootContext}
             sessionContext={sessionContext}
+            sourceLink={sourceLink}
           />
           <ScrollFab scrollRef={scrollRef} />
           <ChatInput

--- a/frontend/src/pages/__tests__/TaskBoard.test.tsx
+++ b/frontend/src/pages/__tests__/TaskBoard.test.tsx
@@ -17,6 +17,7 @@ function makeTask(overrides: Partial<Task> = {}): Task {
     description: null,
     status: 'pending',
     sessionId: null,
+    sdkSessionId: null,
     sessionPolicy: 'auto',
     priority: 0,
     depth: 0,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -2494,6 +2494,22 @@ textarea:focus {
   font-style: italic;
 }
 
+.session-banner-source-link {
+  flex-shrink: 0;
+  font-size: var(--text-xxs);
+  color: var(--accent, #6366f1);
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  opacity: 0.85;
+  white-space: nowrap;
+}
+.session-banner-source-link:hover,
+.session-banner-source-link:focus-visible {
+  opacity: 1;
+}
+
 .session-banner-chevron {
   margin-left: auto;
   font-size: 0.6rem;
@@ -5629,6 +5645,19 @@ textarea:focus {
 }
 .task-node-context--failed {
   color: var(--task-failed);
+}
+
+.task-node-session-link {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  color: var(--accent);
+  opacity: 0.85;
+}
+.task-node-session-link:hover,
+.task-node-session-link:focus-visible {
+  opacity: 1;
 }
 
 .task-node-meta {

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -27,6 +27,7 @@ export interface Task {
   description: string | null;
   status: TaskStatus;
   sessionId: string | null;
+  sdkSessionId: string | null;
   sessionPolicy: SessionPolicy;
   priority: number;
   depth: number;

--- a/packages/client/src/api-client.ts
+++ b/packages/client/src/api-client.ts
@@ -57,6 +57,7 @@ export interface SessionMetaResponse {
   totalCostUsd: number;
   numTurns: number;
   telosTaskId: string | null;
+  goalId: string | null;
 }
 
 export interface CalendarData {

--- a/packages/client/src/slices/messages.ts
+++ b/packages/client/src/slices/messages.ts
@@ -59,6 +59,7 @@ export interface MessagesState {
   activeWorktrees: ActiveWorktree[];
   sessionContext: string | null;
   bootContext: BootContextMeta | null;
+  sourceLink: { telosTaskId?: string; goalId?: string } | null;
 }
 
 export const INITIAL_MESSAGES_STATE: MessagesState = {
@@ -72,6 +73,7 @@ export const INITIAL_MESSAGES_STATE: MessagesState = {
   activeWorktrees: [],
   sessionContext: null,
   bootContext: null,
+  sourceLink: null,
 };
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
@@ -166,6 +168,7 @@ export type MessagesAction =
   | { type: 'NATIVE_COMMAND_RESULT'; command: string; content: string }
   | { type: 'SET_SESSION_CONTEXT'; context: string }
   | { type: 'SET_BOOT_CONTEXT'; bootContext: BootContextMeta }
+  | { type: 'SET_SOURCE_LINK'; telosTaskId?: string; goalId?: string }
   | { type: 'CLEAR' };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -461,6 +464,15 @@ export function messagesReducer(state: MessagesState, action: MessagesAction): M
 
     case 'SET_BOOT_CONTEXT':
       return { ...state, bootContext: action.bootContext };
+
+    case 'SET_SOURCE_LINK':
+      return {
+        ...state,
+        sourceLink:
+          action.telosTaskId || action.goalId
+            ? { telosTaskId: action.telosTaskId, goalId: action.goalId }
+            : null,
+      };
 
     case 'CLEAR':
       return { ...INITIAL_MESSAGES_STATE };

--- a/packages/client/src/slices/tasks.ts
+++ b/packages/client/src/slices/tasks.ts
@@ -18,6 +18,7 @@ export interface Task {
   description: string | null;
   status: TaskStatus;
   sessionId: string | null;
+  sdkSessionId: string | null;
   sessionPolicy: SessionPolicy;
   priority: number;
   depth: number;

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -531,6 +531,15 @@ export function createMitzoStore(options: MitzoStoreOptions): StoreApi<MitzoStor
             },
           }));
         }
+        if (meta.telosTaskId || meta.goalId) {
+          set((s) => ({
+            messages: messagesReducer(s.messages, {
+              type: 'SET_SOURCE_LINK',
+              telosTaskId: meta.telosTaskId ?? undefined,
+              goalId: meta.goalId ?? undefined,
+            }),
+          }));
+        }
       } catch {
         // Session meta may not be available — graceful no-op
       }

--- a/server/__tests__/internal-token.test.ts
+++ b/server/__tests__/internal-token.test.ts
@@ -1,29 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { randomBytes } from 'crypto';
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-
-/** Isolated test of loadOrCreateToken logic without importing the module
- *  (which triggers side-effects). We replicate the function locally. */
-const TOKEN_LENGTH = 64;
-
-function loadOrCreateToken(tokenPath: string): string {
-  try {
-    const existing = readFileSync(tokenPath, 'utf-8').trim();
-    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
-      return existing;
-    }
-  } catch {
-    // File doesn't exist or isn't readable — generate a new one
-  }
-
-  const token = randomBytes(32).toString('hex');
-  const dir = tokenPath.substring(0, tokenPath.lastIndexOf('/'));
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(tokenPath, token, { mode: 0o600 });
-  return token;
-}
+import { loadOrCreateToken, TOKEN_LENGTH } from '../internal-token.js';
 
 describe('loadOrCreateToken', () => {
   let testDir: string;
@@ -99,5 +78,20 @@ describe('loadOrCreateToken', () => {
     const second = loadOrCreateToken(tokenPath);
 
     expect(first).toBe(second);
+  });
+
+  it('still returns a token when write fails (non-fatal)', () => {
+    // Point to a path inside a read-only directory
+    const readOnlyDir = join(testDir, 'readonly');
+    mkdirSync(readOnlyDir);
+    chmodSync(readOnlyDir, 0o444);
+    const unwritablePath = join(readOnlyDir, 'subdir', 'token');
+
+    const token = loadOrCreateToken(unwritablePath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).toMatch(/^[0-9a-f]+$/);
+    // Restore permissions for cleanup
+    chmodSync(readOnlyDir, 0o755);
   });
 });

--- a/server/__tests__/internal-token.test.ts
+++ b/server/__tests__/internal-token.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomBytes } from 'crypto';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/** Isolated test of loadOrCreateToken logic without importing the module
+ *  (which triggers side-effects). We replicate the function locally. */
+const TOKEN_LENGTH = 64;
+
+function loadOrCreateToken(tokenPath: string): string {
+  try {
+    const existing = readFileSync(tokenPath, 'utf-8').trim();
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
+      return existing;
+    }
+  } catch {
+    // File doesn't exist or isn't readable — generate a new one
+  }
+
+  const token = randomBytes(32).toString('hex');
+  const dir = tokenPath.substring(0, tokenPath.lastIndexOf('/'));
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(tokenPath, token, { mode: 0o600 });
+  return token;
+}
+
+describe('loadOrCreateToken', () => {
+  let testDir: string;
+  let tokenPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `mitzo-token-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    tokenPath = join(testDir, 'internal-token');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('generates a new token when file is missing', () => {
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).toMatch(/^[0-9a-f]+$/);
+    expect(existsSync(tokenPath)).toBe(true);
+    expect(readFileSync(tokenPath, 'utf-8')).toBe(token);
+  });
+
+  it('reads existing valid token from disk', () => {
+    const existing = 'a'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, existing);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('accepts uppercase hex tokens', () => {
+    const existing = 'A1B2C3D4'.repeat(8); // 64 chars uppercase hex
+    writeFileSync(tokenPath, existing);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('rejects and regenerates on corrupt file (wrong length)', () => {
+    writeFileSync(tokenPath, 'too-short');
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).not.toBe('too-short');
+  });
+
+  it('rejects and regenerates on non-hex content', () => {
+    const badToken = 'z'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, badToken);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toHaveLength(TOKEN_LENGTH);
+    expect(token).not.toBe(badToken);
+  });
+
+  it('trims whitespace from token file', () => {
+    const existing = 'b'.repeat(TOKEN_LENGTH);
+    writeFileSync(tokenPath, `  ${existing}  \n`);
+
+    const token = loadOrCreateToken(tokenPath);
+
+    expect(token).toBe(existing);
+  });
+
+  it('returns consistent token across multiple calls', () => {
+    const first = loadOrCreateToken(tokenPath);
+    const second = loadOrCreateToken(tokenPath);
+
+    expect(first).toBe(second);
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -89,7 +89,7 @@ import type { SkillWatcher } from './skill-watcher.js';
 
 import { mkdirSync } from 'fs';
 import { homedir } from 'os';
-import { TaskStore, type TaskCreateInput, type TaskUpdateInput } from './task-store.js';
+import { TaskStore, type Task, type TaskCreateInput, type TaskUpdateInput } from './task-store.js';
 import { SseRegistry } from '@mitzo/harness';
 import { SessionSseRegistry } from './session-sse-registry.js';
 import { WorkloadStore, type WorkSignal, type TodoItemUpdateInput } from './workload-store.js';
@@ -622,10 +622,21 @@ app.get('/api/service-health', (_req, res) => {
   res.json(healthMonitor?.getSnapshot() ?? { services: [], checkedAt: 0 });
 });
 
+// --- Task Board helpers ---
+
+/** Walk the task tree, attaching the resolved SDK sessionId for frontend linking. */
+function enrichTasksWithSdkSessionId(tasks: Task[]): (Task & { sdkSessionId: string | null })[] {
+  return tasks.map((t) => ({
+    ...t,
+    sdkSessionId: t.sessionId ? (registry.get(t.sessionId)?.sessionId ?? null) : null,
+    children: enrichTasksWithSdkSessionId(t.children),
+  }));
+}
+
 // --- Task Board API ---
 
 app.get('/api/tasks', (_req, res) => {
-  res.json({ tasks: taskStore.getTree() });
+  res.json({ tasks: enrichTasksWithSdkSessionId(taskStore.getTree()) });
 });
 
 app.post('/api/tasks', (req, res) => {
@@ -1221,6 +1232,8 @@ app.get('/api/sessions/:id/meta', (req, res) => {
     totalTokens,
     totalCostUsd: meta.totalCostUsd,
     numTurns: meta.numTurns,
+    telosTaskId: meta.telosTaskId ?? null,
+    goalId: meta.goalId ?? null,
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -222,7 +222,15 @@ const orchestrator = new TaskOrchestrator({
   },
   broadcastTasks: () => {
     const tree = taskStore.getTree();
-    const data = { type: 'task_state', tasks: tree };
+    // Enrich tasks with SDK session IDs so frontend can link to sessions
+    const enrichWithSdkSessionId = (tasks: typeof tree): typeof tree =>
+      tasks.map((t) => ({
+        ...t,
+        sdkSessionId: t.sessionId ? (registry.get(t.sessionId)?.sessionId ?? null) : null,
+        children: enrichWithSdkSessionId(t.children),
+      }));
+    const enrichedTree = enrichWithSdkSessionId(tree);
+    const data = { type: 'task_state', tasks: enrichedTree };
     const msg = JSON.stringify(data);
     wss.clients.forEach((client) => {
       if (v2Sockets.has(client)) return;
@@ -234,8 +242,7 @@ const orchestrator = new TaskOrchestrator({
   getActiveSessionIds: () => {
     const ids = new Set<string>();
     for (const [clientId] of registry.entries()) {
-      const session = registry.get(clientId);
-      if (session?.sessionId) ids.add(session.sessionId);
+      ids.add(clientId);
     }
     return ids;
   },

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -1,19 +1,35 @@
 import { randomBytes, timingSafeEqual } from 'crypto';
-import { writeFileSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-/** Shared token for MCP server → Mitzo API calls (generated once at startup). */
-export const INTERNAL_TOKEN = randomBytes(32).toString('hex');
+const TOKEN_PATH = join(homedir(), '.mitzo', 'internal-token');
+const TOKEN_LENGTH = 64; // 32 bytes as hex
 
-// Persist to ~/.mitzo/internal-token so session hooks can authenticate
-try {
-  const dir = join(homedir(), '.mitzo');
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(join(dir, 'internal-token'), INTERNAL_TOKEN, { mode: 0o600 });
-} catch {
-  // Non-fatal — hooks will fall back gracefully
+/** Load existing token from disk or generate a new one.
+ *  Persists across restarts so external clients (agents, hooks) stay authenticated. */
+function loadOrCreateToken(): string {
+  try {
+    const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-f]+$/.test(existing)) {
+      return existing;
+    }
+  } catch {
+    // File doesn't exist or isn't readable — generate a new one
+  }
+
+  const token = randomBytes(32).toString('hex');
+  try {
+    const dir = join(homedir(), '.mitzo');
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(TOKEN_PATH, token, { mode: 0o600 });
+  } catch {
+    // Non-fatal — hooks will fall back gracefully
+  }
+  return token;
 }
+
+export const INTERNAL_TOKEN = loadOrCreateToken();
 
 /** Constant-time check for internal token validity. */
 export function isValidInternalToken(candidate: string | string[] | undefined): boolean {

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -1,16 +1,17 @@
 import { randomBytes, timingSafeEqual } from 'crypto';
 import { readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 
 const TOKEN_PATH = join(homedir(), '.mitzo', 'internal-token');
-const TOKEN_LENGTH = 64; // 32 bytes as hex
+export const TOKEN_LENGTH = 64; // 32 bytes as hex
 
 /** Load existing token from disk or generate a new one.
- *  Persists across restarts so external clients (agents, hooks) stay authenticated. */
-function loadOrCreateToken(): string {
+ *  Persists across restarts so external clients (agents, hooks) stay authenticated.
+ *  Accepts an optional path override for testing. */
+export function loadOrCreateToken(tokenPath: string = TOKEN_PATH): string {
   try {
-    const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
+    const existing = readFileSync(tokenPath, 'utf-8').trim();
     if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
       return existing;
     }
@@ -20,9 +21,8 @@ function loadOrCreateToken(): string {
 
   const token = randomBytes(32).toString('hex');
   try {
-    const dir = join(homedir(), '.mitzo');
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-    writeFileSync(TOKEN_PATH, token, { mode: 0o600 });
+    mkdirSync(dirname(tokenPath), { recursive: true, mode: 0o700 });
+    writeFileSync(tokenPath, token, { mode: 0o600 });
   } catch {
     // Non-fatal — hooks will fall back gracefully
   }

--- a/server/internal-token.ts
+++ b/server/internal-token.ts
@@ -11,7 +11,7 @@ const TOKEN_LENGTH = 64; // 32 bytes as hex
 function loadOrCreateToken(): string {
   try {
     const existing = readFileSync(TOKEN_PATH, 'utf-8').trim();
-    if (existing.length === TOKEN_LENGTH && /^[0-9a-f]+$/.test(existing)) {
+    if (existing.length === TOKEN_LENGTH && /^[0-9a-fA-F]+$/.test(existing)) {
       return existing;
     }
   } catch {


### PR DESCRIPTION
## Summary

- **Fix orphan detection**: `getActiveSessionIds()` was returning SDK session IDs but task `sessionId` stores client IDs — comparison never matched, so dead tasks stayed "running" forever. Now returns client IDs.
- **Clickable session hash**: Running tasks show a tappable session hash that navigates to the session's chat view. Uses the resolved SDK session ID (enriched on broadcast).
- **Source link in session banner**: Sessions spawned from Telos items or Task Board goals show a tappable link ("Task Board" / "Telos") in the session banner header.

## Test plan

- [x] Task orchestrator orphan detection tests pass (46/46)
- [x] SessionBanner tests pass with router context (9/9)
- [x] TypeScript type check clean on all changed files
- [ ] Manual: start a Task Board goal, verify running tasks show clickable session hash
- [ ] Manual: verify dead tasks get reclaimed (kill a headless session, wait for tick)
- [ ] Manual: verify Telos-spawned session shows "Telos" link in banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)