### PR TITLE
fix(telos): promote Telos items to tasks without workloadStore lookup

### DIFF
--- a/frontend/src/pages/TodoDetailView.tsx
+++ b/frontend/src/pages/TodoDetailView.tsx
@@ -116,7 +116,12 @@ export function TodoDetailView() {
       const res = await apiFetch(`/api/workload/items/${currentItem.id}/promote`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ description: '' }),
+        body: JSON.stringify({
+          description: '',
+          title: currentItem.summary,
+          contextHints: currentItem.contextHints,
+          sources: currentItem.sources,
+        }),
       });
 
       if (!res.ok) {

--- a/server/__tests__/workload-routes.test.ts
+++ b/server/__tests__/workload-routes.test.ts
@@ -509,13 +509,56 @@ describe('workload routes', () => {
     expect(res.body.item.goalId).toBe(res.body.task.id);
   });
 
-  it('POST /api/workload/items/:id/promote — returns 404 for missing item', async () => {
+  it('POST /api/workload/items/:id/promote — returns 404 for missing item with no body title', async () => {
     const res = await request(app)
       .post('/api/workload/items/nonexistent-id/promote')
       .set('Cookie', authCookie)
       .send({});
 
     expect(res.status).toBe(404);
+  });
+
+  it('POST /api/workload/items/:id/promote — creates task from body fallback (Telos item)', async () => {
+    const res = await request(app)
+      .post('/api/workload/items/telos-item-123/promote')
+      .set('Cookie', authCookie)
+      .send({
+        title: 'Telos task title',
+        description: 'Extra context',
+        contextHints: {
+          repos: ['mitzo'],
+          taskHint: 'Check the API layer',
+        },
+        sources: [{ type: 'telos', url: 'https://example.com', title: 'Source doc' }],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.task).toMatchObject({
+      title: 'Telos task title',
+      status: 'pending',
+    });
+    expect(res.body.task.description).toContain('Extra context');
+    expect(res.body.task.description).toContain('Check the API layer');
+    expect(res.body.task.annotations).toEqual(
+      expect.arrayContaining([expect.stringContaining('Source doc')]),
+    );
+    expect(res.body.item).toBeUndefined();
+  });
+
+  it('POST /api/workload/items/:id/promote — fallback does not broadcast workload update', async () => {
+    const broadcasts: unknown[] = [];
+    const origBroadcast = (app as any)._workloadBroadcast;
+    (app as any)._workloadBroadcast = (msg: unknown) => broadcasts.push(msg);
+
+    await request(app)
+      .post('/api/workload/items/telos-no-broadcast/promote')
+      .set('Cookie', authCookie)
+      .send({ title: 'No broadcast test' });
+
+    const workloadBroadcasts = broadcasts.filter((b: any) => b.type === 'workload_item_updated');
+    expect(workloadBroadcasts).toHaveLength(0);
+
+    (app as any)._workloadBroadcast = origBroadcast;
   });
 
   it('POST /api/workload/items/:id/promote — broadcasts workload_item_updated', async () => {

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -234,7 +234,6 @@ export const WorkloadItemUpdateBody = z.object({
 
 export const WorkloadPromoteBody = z.object({
   description: z.string().optional(),
-  // Fallback fields for Telos items not in workloadStore
   title: z.string().optional(),
   contextHints: z
     .object({
@@ -254,8 +253,8 @@ export const WorkloadPromoteBody = z.object({
         type: z.string(),
         url: z.string(),
         title: z.string(),
-        author: z.string(),
-        snippet: z.string(),
+        author: z.string().optional(),
+        snippet: z.string().optional(),
       }),
     )
     .optional(),

--- a/server/api-schemas.ts
+++ b/server/api-schemas.ts
@@ -234,6 +234,31 @@ export const WorkloadItemUpdateBody = z.object({
 
 export const WorkloadPromoteBody = z.object({
   description: z.string().optional(),
+  // Fallback fields for Telos items not in workloadStore
+  title: z.string().optional(),
+  contextHints: z
+    .object({
+      repos: z.array(z.string()).optional(),
+      paths: z.array(z.string()).optional(),
+      issues: z.array(z.string()).optional(),
+      docIds: z.array(z.string()).optional(),
+      people: z.array(z.string()).optional(),
+      jiraKeys: z.array(z.string()).optional(),
+      keywords: z.array(z.string()).optional(),
+      taskHint: z.string().optional(),
+    })
+    .optional(),
+  sources: z
+    .array(
+      z.object({
+        type: z.string(),
+        url: z.string(),
+        title: z.string(),
+        author: z.string(),
+        snippet: z.string(),
+      }),
+    )
+    .optional(),
 });
 
 // -- Session creation schemas --

--- a/server/app.ts
+++ b/server/app.ts
@@ -1925,7 +1925,7 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   }
 
   const hints = item?.contextHints ?? body.data.contextHints;
-  const taskHint = hints && 'taskHint' in hints ? (hints.taskHint as string) : undefined;
+  const taskHint = hints?.taskHint ?? undefined;
 
   // Build description from item context
   const descParts: string[] = [];
@@ -1955,8 +1955,8 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
     workloadStore.setGoalId(item.id, task.id);
   }
 
-  const updatedItem = item ? workloadStore.get(item.id) : null;
-  res.status(201).json({ task, item: updatedItem });
+  const updatedItem = item ? workloadStore.get(item.id) : undefined;
+  res.status(201).json(updatedItem ? { task, item: updatedItem } : { task });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
   if (updatedItem) {
     onWorkloadBroadcast?.({ type: 'workload_item_updated', item: updatedItem });

--- a/server/app.ts
+++ b/server/app.ts
@@ -1916,34 +1916,51 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   }
 
   const item = workloadStore.get(req.params.id);
-  if (!item) {
-    res.status(404).json({ error: 'Item not found' });
+
+  // Resolve title and context from workloadStore item or fallback body data (Telos items)
+  const title = item?.title ?? body.data.title;
+  if (!title) {
+    res.status(404).json({ error: 'Item not found and no title provided' });
     return;
   }
+
+  const hints = item?.contextHints ?? body.data.contextHints;
+  const taskHint = hints && 'taskHint' in hints ? (hints.taskHint as string) : undefined;
 
   // Build description from item context
   const descParts: string[] = [];
   if (body.data.description) descParts.push(body.data.description);
-  if (item.contextHints.taskHint) descParts.push(item.contextHints.taskHint);
-  const hintsWithValues = Object.entries(item.contextHints)
-    .filter(([k, v]) => k !== 'taskHint' && Array.isArray(v) && v.length > 0)
-    .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
-  if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
+  if (taskHint) descParts.push(taskHint);
+  if (hints) {
+    const hintsWithValues = Object.entries(hints)
+      .filter(([k, v]) => k !== 'taskHint' && Array.isArray(v) && v.length > 0)
+      .map(([k, v]) => `${k}: ${(v as string[]).join(', ')}`);
+    if (hintsWithValues.length > 0) descParts.push(hintsWithValues.join('\n'));
+  }
+
+  // Build annotations from sources
+  const annotations: string[] = item
+    ? item.sources.map((s) => `Source: [${s.sourceType}] ${s.title} — ${s.url}`)
+    : (body.data.sources ?? []).map((s) => `Source: [${s.type}] ${s.title} — ${s.url}`);
 
   // Create root task (goal) from item
   const task = taskStore.create({
-    title: item.title,
+    title,
     description: descParts.join('\n\n') || undefined,
-    annotations: item.sources.map((s) => `Source: [${s.sourceType}] ${s.title} — ${s.url}`),
+    annotations,
   });
 
-  // Link item to goal
-  workloadStore.setGoalId(item.id, task.id);
+  // Link item to goal only if it exists in workloadStore
+  if (item) {
+    workloadStore.setGoalId(item.id, task.id);
+  }
 
-  const updatedItem = workloadStore.get(item.id);
+  const updatedItem = item ? workloadStore.get(item.id) : null;
   res.status(201).json({ task, item: updatedItem });
   onTaskBroadcast?.({ type: 'task_state', tasks: taskStore.getTree() });
-  onWorkloadBroadcast?.({ type: 'workload_item_updated', item: updatedItem });
+  if (updatedItem) {
+    onWorkloadBroadcast?.({ type: 'workload_item_updated', item: updatedItem });
+  }
 });
 
 // --- Static files ---


### PR DESCRIPTION
## Summary
- Telos items (from Python script via `/api/todos`) were never ingested into `workloadStore`, so "Promote to Tasks" always returned 404 "Item not found"
- Frontend now sends item data (title, contextHints, sources) as fallback fields in the promote POST body
- Backend falls back to body data when `workloadStore.get()` misses, creating the task directly

## Test plan
- [ ] Open a Telos item detail view, tap "Promote to Tasks" -- should create a task and navigate to Task Board
- [ ] Verify workloadStore items still promote correctly (backwards compatible)
- [ ] Verify task title, description, and source annotations carry over from Telos data

🤖 Generated with [Claude Code](https://claude.com/claude-code)