### PR TITLE
chore(ci): enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable automated dependency update PRs
- Configures three ecosystems:
  - **npm** — weekly on Mondays, with minor+patch updates grouped into single PRs
  - **Docker** — weekly on Mondays for base image updates
  - **GitHub Actions** — weekly on Mondays for CI workflow action versions

## Test plan

- [ ] Verify Dependabot picks up the config after merge (check Settings > Dependabot in the repo)
- [ ] Confirm first batch of PRs arrives on the next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)