### PR TITLE
fix: workload promote test and status code

### DIFF
--- a/server/__tests__/workload-routes.test.ts
+++ b/server/__tests__/workload-routes.test.ts
@@ -518,6 +518,15 @@ describe('workload routes', () => {
     expect(res.status).toBe(404);
   });
 
+  it('POST /api/workload/items/:id/promote — returns 404 for missing item with description but no title', async () => {
+    const res = await request(app)
+      .post('/api/workload/items/nonexistent-id/promote')
+      .set('Cookie', authCookie)
+      .send({ description: 'has context but no title' });
+
+    expect(res.status).toBe(404);
+  });
+
   it('POST /api/workload/items/:id/promote — creates task from body fallback (Telos item)', async () => {
     const res = await request(app)
       .post('/api/workload/items/telos-item-123/promote')
@@ -546,9 +555,9 @@ describe('workload routes', () => {
   });
 
   it('POST /api/workload/items/:id/promote — fallback does not broadcast workload update', async () => {
+    const { setWorkloadBroadcast } = await import('../app.js');
     const broadcasts: unknown[] = [];
-    const origBroadcast = (app as any)._workloadBroadcast;
-    (app as any)._workloadBroadcast = (msg: unknown) => broadcasts.push(msg);
+    setWorkloadBroadcast((msg: Record<string, unknown>) => broadcasts.push(msg));
 
     await request(app)
       .post('/api/workload/items/telos-no-broadcast/promote')
@@ -558,7 +567,8 @@ describe('workload routes', () => {
     const workloadBroadcasts = broadcasts.filter((b: any) => b.type === 'workload_item_updated');
     expect(workloadBroadcasts).toHaveLength(0);
 
-    (app as any)._workloadBroadcast = origBroadcast;
+    // Reset — no broadcast callback in test environment
+    setWorkloadBroadcast(() => {});
   });
 
   it('POST /api/workload/items/:id/promote — broadcasts workload_item_updated', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -1921,7 +1921,8 @@ app.post('/api/workload/items/:id/promote', (req, res) => {
   // Resolve title and context from workloadStore item or fallback body data (Telos items)
   const title = item?.title ?? body.data.title;
   if (!title) {
-    res.status(404).json({ error: 'Item not found and no title provided' });
+    const status = item ? 400 : 404;
+    res.status(status).json({ error: item ? 'No title provided' : 'Item not found and no title provided' });
     return;
   }
 


### PR DESCRIPTION
## Summary

- Fix vacuous broadcast test: `setWorkloadBroadcast()` instead of monkey-patching non-existent `app._workloadBroadcast`
- Add missing test for promote with description but no title
- Return 400 (not 404) when item exists but has no title

Pre-existing issues flagged by Centaur on PR #428.

## Test plan

- [x] workload-routes tests pass (25/25)

🤖 Generated with [Claude Code](https://claude.com/claude-code)