### PR TITLE
fix(task-board): add spawn kill switch to mobile task board

### DIFF
--- a/frontend/src/pages/TaskBoard.tsx
+++ b/frontend/src/pages/TaskBoard.tsx
@@ -74,6 +74,7 @@ export function TaskBoard() {
     pauseLoop,
     resumeLoop,
     stopLoop,
+    setSpawnEnabled,
     approveTask,
     rejectTask,
     approveSpec,
@@ -104,10 +105,18 @@ export function TaskBoard() {
   const goals = tasks.filter((t) => !t.parentId);
 
   const t1Count = countT1Recursive(tasks);
+  const { spawnEnabled } = loopStatus;
 
   return (
     <div className="task-board-page">
       <PageHeader title="Tasks" badge={t1Count > 0 ? t1Count : tasks.length || undefined}>
+        <button
+          className={`task-board-add-btn ${spawnEnabled ? 'cc-spawn-enabled' : 'cc-spawn-disabled'}`}
+          onClick={() => setSpawnEnabled(!spawnEnabled)}
+          title={spawnEnabled ? 'Disable session spawning' : 'Enable session spawning'}
+        >
+          {spawnEnabled ? '\u26A1' : '\u26D4'}
+        </button>
         <button
           className={`task-board-sort-btn${showAll ? '' : ' task-board-sort-btn--active'}`}
           onClick={() => setShowAll(!showAll)}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1483,6 +1483,9 @@ textarea:focus {
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
+  position: relative;
+  z-index: 20;
+  box-shadow: 0 4px 0 0 var(--surface);
   transition:
     max-height 0.2s,
     padding 0.2s,
@@ -1674,7 +1677,7 @@ textarea:focus {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: var(--space-4) var(--space-3);
+  padding: 0 var(--space-3) var(--space-4);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -2435,8 +2438,10 @@ textarea:focus {
   position: sticky;
   top: 0;
   z-index: 10;
+  margin: -1px calc(-1 * var(--space-3)) 0;
+  padding: 0 var(--space-3);
   border-bottom: 1px solid var(--border);
-  background: var(--bg-primary);
+  background: var(--surface);
 }
 
 .session-banner-header {


### PR DESCRIPTION
## Summary
- The spawn kill switch toggle (⚡/⛔) was only present in `TaskBoardSection.tsx` (desktop collapsible chat view)
- The mobile full-page task board at `pages/TaskBoard.tsx` was missing it entirely
- Adds the same toggle button to the mobile `PageHeader`, reusing the existing `cc-spawn-enabled`/`cc-spawn-disabled` CSS classes (already in global.css)

## Test plan
- [ ] Open mobile task board — verify ⛔ toggle appears in header
- [ ] Tap toggle — verify it switches to ⚡ and back
- [ ] Verify desktop collapsible view still has its own toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)